### PR TITLE
Stop generating faulty UpdateScale method

### DIFF
--- a/apps/v1/register.go
+++ b/apps/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,7 +35,6 @@ func addLegacyKnownTypes(scheme *runtime.Scheme) error {
 		&DeploymentRequest{},
 		&DeploymentLog{},
 		&DeploymentLogOptions{},
-		&extensionsv1beta1.Scale{},
 	}
 	scheme.AddKnownTypes(LegacySchemeGroupVersion, types...)
 	return nil
@@ -51,7 +49,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&DeploymentRequest{},
 		&DeploymentLog{},
 		&DeploymentLogOptions{},
-		&extensionsv1beta1.Scale{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil


### PR DESCRIPTION
Generated UpdateScale methods are faulty (they attempt to convert to the containing GV). Will follow up with a move of this into a hand-written extension