### PR TITLE
Route: Fix InsecureEdgeTerminationPolicy enum

### DIFF
--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -229,6 +229,15 @@ const (
 	TLSTerminationPassthrough TLSTerminationType = "passthrough"
 	// TLSTerminationReencrypt terminate encryption at the edge router and re-encrypt it with a new certificate supplied by the destination
 	TLSTerminationReencrypt TLSTerminationType = "reencrypt"
+
+	// InsecureEdgeTerminationPolicyNone disables insecure connections for an edge-terminated route.
+	InsecureEdgeTerminationPolicyNone InsecureEdgeTerminationPolicyType = "None"
+	// InsecureEdgeTerminationPolicyAllow allows insecure connections for an edge-terminated route.
+	InsecureEdgeTerminationPolicyAllow InsecureEdgeTerminationPolicyType = "Allow"
+	// InsecureEdgeTerminationPolicyRedirect redirects insecure connections for an edge-terminated route.
+	// As an example, for routers that support HTTP and HTTPS, the
+	// insecure HTTP connections will be redirected to use HTTPS.
+	InsecureEdgeTerminationPolicyRedirect InsecureEdgeTerminationPolicyType = "Redirect"
 )
 
 // WildcardPolicyType indicates the type of wildcard support needed by routes.


### PR DESCRIPTION
We have lost this whole enum when moving to `openshift/api`.

Fixes https://github.com/openshift/api/issues/26