### PR TITLE
fix registration for served API

### DIFF
--- a/servicecertsigner/v1alpha1/register.go
+++ b/servicecertsigner/v1alpha1/register.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -23,6 +24,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ServiceCertSignerOperatorConfig{},
 		&ServiceCertSignerOperatorConfigList{},
 	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 
 	return nil
 }


### PR DESCRIPTION
When an API has a client, you need to register the metav1 with the types or the client can't send.

@sttts seems like the client-generation should handle this for me in the client scheme, doesn't it?  It's directly related to the client, not to the actual types I manage.