### PR TITLE
list doesn't make sense for subresources

### DIFF
--- a/image/v1/types.go
+++ b/image/v1/types.go
@@ -158,7 +158,7 @@ type ImageStreamList struct {
 }
 
 // +genclient
-// +genclient:method=Secrets,verb=list,subresource=secrets,result=k8s.io/api/core/v1.Secret
+// +genclient:method=Secrets,verb=get,subresource=secrets,result=k8s.io/api/core/v1.SecretList
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ImageStream stores a mapping of tags to images, metadata overrides that are applied


### PR DESCRIPTION
Fixes the verb and type for imagestream/secrets

/assign @liggitt 