### PR TITLE
fix type registration for templates

### DIFF
--- a/template/v1/register.go
+++ b/template/v1/register.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,7 +36,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&TemplateInstanceList{},
 		&BrokerTemplateInstance{},
 		&BrokerTemplateInstanceList{},
-		&corev1.List{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil


### PR DESCRIPTION
Templates should not be registering List as part of their API group.  Lists are always v1.

/assign @liggitt 