### PR TITLE
operator: add imagePullPolicy to allow override the operator image pull policy

### DIFF
--- a/operator/v1alpha1/types.go
+++ b/operator/v1alpha1/types.go
@@ -26,6 +26,10 @@ type OperatorSpec struct {
 	// imagePullSpec is the image to use for the component.
 	ImagePullSpec string `json:"imagePullSpec"`
 
+	// imagePullPolicy specifies the image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified,
+	// or IfNotPresent otherwise.
+	ImagePullPolicy string `json:"imagePullPolicy"`
+
 	// version is the desired state in major.minor.micro-patch.  Usually patch is ignored.
 	Version string `json:"version"`
 

--- a/operator/v1alpha1/types_swagger_doc_generated.go
+++ b/operator/v1alpha1/types_swagger_doc_generated.go
@@ -76,6 +76,7 @@ var map_OperatorSpec = map[string]string{
 	"":                "OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included inside of the Spec struct for you particular operator.",
 	"managementState": "managementState indicates whether and how the operator should manage the component",
 	"imagePullSpec":   "imagePullSpec is the image to use for the component.",
+	"imagePullPolicy": "imagePullPolicy specifies the image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
 	"version":         "version is the desired state in major.minor.micro-patch.  Usually patch is ignored.",
 	"logging":         "logging contains glog parameters for the component pods.  It's always a command line arg for the moment",
 }


### PR DESCRIPTION
This field will allow admins to override the default imagePullPolicy for operator controlled pod templates.

/cc @deads2k 
/cc @sttts 