### PR TITLE
add status conditions to match CVO ClusterOperator

### DIFF
--- a/operator/v1alpha1/types.go
+++ b/operator/v1alpha1/types.go
@@ -53,8 +53,13 @@ const (
 	ConditionFalse   ConditionStatus = "False"
 	ConditionUnknown ConditionStatus = "Unknown"
 
-	OperatorStatusTypeAvailable      = "Available"
-	OperatorStatusTypeMigrating      = "Migrating"
+	// these conditions match the conditions for the ClusterOperator type.
+	OperatorStatusTypeAvailable   = "Available"
+	OperatorStatusTypeProgressing = "Progressing"
+	OperatorStatusTypeFailing     = "Failing"
+
+	OperatorStatusTypeMigrating = "Migrating"
+	// TODO this is going to be removed
 	OperatorStatusTypeSyncSuccessful = "SyncSuccessful"
 )
 


### PR DESCRIPTION
This allows for an easy transition from one to the other and the conditions themselves make sense