### PR TITLE
Fix capitalization of vxlanPort

### DIFF
--- a/openshiftcontrolplane/v1/types.go
+++ b/openshiftcontrolplane/v1/types.go
@@ -199,7 +199,7 @@ type NetworkControllerConfig struct {
 	// clusterNetworks contains a list of cluster networks that defines the global overlay networks L3 space.
 	ClusterNetworks    []ClusterNetworkEntry `json:"clusterNetworks"`
 	ServiceNetworkCIDR string                `json:"serviceNetworkCIDR"`
-	VXLANPort          uint32                `json:"vxLANPort"`
+	VXLANPort          uint32                `json:"vxlanPort"`
 }
 
 type ServiceAccountControllerConfig struct {


### PR DESCRIPTION
VXLAN is "VXLAN", so the initial-lowercase version of `NetworkControllerConfig.VXLANPort` should be `vxlanPort`, not `vxLANPort` (which then also makes it consistent with the corresponding network.openshift.io type).

Nothing is using the json/yaml form yet so there are no repo synchronization issues, assuming this merges soon.