### PR TITLE
Add CRDs for network.openshift.io/v1 types

### DIFF
--- a/network/v1/types.yaml
+++ b/network/v1/types.yaml
@@ -1,0 +1,191 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusternetworks.network.openshift.io
+spec:
+  group: network.openshift.io
+  version: v1
+  scope: Cluster
+  names:
+    kind: ClusterNetwork
+    singular: clusternetwork
+    plural: clusternetworks
+  validation:
+    # As compared to ValidateClusterNetwork, this does not validate that:
+    #   - the hostSubnetLengths are valid for their CIDRs
+    #   - the cluster/service networks do not overlap
+    #   - .network and .hostsubnetlength are set if name == 'default'
+    #   - .network and .hostsubnetlength are either unset, or equal to
+    #     .clusterNetworks[0].CIDR and .clusterNetworks[0].hostSubnetLength
+    openAPIV3Schema:
+      properties:
+        network:
+          type: string
+          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([1-9]|[12][0-9]|3[0-2])$'
+        hostsubnetlength:
+          type: integer
+          minimum: 2
+          maximum: 30
+        serviceNetwork:
+          type: string
+          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([1-9]|[12][0-9]|3[0-2])$'
+        pluginName:
+          type: string
+        clusterNetworks:
+          type: array
+          items:
+            type: object
+            properties:
+              CIDR:
+                type: string
+                pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([1-9]|[12][0-9]|3[0-2])$'
+              hostSubnetLength:
+                type: integer
+                minimum: 2
+                maximum: 30
+        vxlanPort:
+          type: integer
+          minimum: 1
+          maximum: 65535
+  additionalPrinterColumns:
+  - name: Cluster Network
+    type: string
+    description: The primary cluster network CIDR
+    JSONPath: .network
+  - name: Service Network
+    type: string
+    description: The service network CIDR
+    JSONPath: .serviceNetwork
+  - name: Plugin Name
+    type: string
+    description: The OpenShift SDN network plug-in in use
+    JSONPath: .pluginName
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hostsubnets.network.openshift.io
+spec:
+  group: network.openshift.io
+  version: v1
+  scope: Cluster
+  names:
+    kind: HostSubnet
+    singular: hostsubnet
+    plural: hostsubnets
+  validation:
+    # As compared to ValidateHostSubnet, this does not validate that:
+    #   - .host == .name
+    #   - either .subnet is set or the assign-subnet annotation is present
+    # As compared to ValidateHostSubnetUpdate, this does not validate that:
+    #   - .subnet is not changed on an existing object
+    openAPIV3Schema:
+      properties:
+        host:
+          type: string
+          pattern: '^[a-z0-9.-]+$'
+        hostIP:
+          type: string
+          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
+        subnet:
+          type: string
+          pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([1-9]|[12][0-9]|3[0-2])$'
+        egressIPs:
+          type: array
+          items:
+            type: string
+            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
+        egressCIDRs:
+          type: array
+          items:
+            type: string
+            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([1-9]|[12][0-9]|3[0-2])$'
+  additionalPrinterColumns:
+  - name: Host
+    type: string
+    description: The name of the node
+    JSONPath: .host
+  - name: Host IP
+    type: string
+    description: The IP address to be used as a VTEP by other nodes in the overlay network
+    JSONPath: .hostIP
+  - name: Subnet
+    type: string
+    description: The CIDR range of the overlay network assigned to the node for its pods
+    JSONPath: .subnet
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: netnamespaces.network.openshift.io
+spec:
+  group: network.openshift.io
+  version: v1
+  scope: Cluster
+  names:
+    kind: NetNamespace
+    singular: netnamespace
+    plural: netnamespaces
+  validation:
+    # As compared to ValidateNetNamespace, this does not validate that:
+    #   - .netname == .name
+    #   - .netid is not 1-9
+    openAPIV3Schema:
+      properties:
+        netname:
+          type: string
+          pattern: '^[a-z0-9.-]+$'
+        netid:
+          type: integer
+          minimum: 0
+          maximum: 16777215
+        egressIPs:
+          type: array
+          items:
+            type: string
+            pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$'
+  additionalPrinterColumns:
+  - name: NetID
+    type: integer
+    description: The network identifier of the network namespace
+    JSONPath: .netid
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: egressnetworkpolicies.network.openshift.io
+spec:
+  group: network.openshift.io
+  version: v1
+  scope: Cluster
+  names:
+    kind: EgressNetworkPolicy
+    singular: egressnetworkpolicy
+    plural: egressnetworkpolicies
+  validation:
+    # This should be mostly equivalent to ValidateEgressNetworkPolicy
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            egress:
+              type: array
+              maxItems: 50
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                    pattern: '^Allow|Deny$'
+                  to:
+                    type: object
+                    minProperties: 1
+                    maxProperties: 1
+                    properties:
+                      cidrSelector:
+                        type: string
+                        pattern: '^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([1-9]|[12][0-9]|3[0-2])$'
+                      dnsName:
+                        type: string
+                        pattern: '^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$'


### PR DESCRIPTION
https://github.com/openshift/cluster-network-operator/ needs to install these CRDs, but it doesn't seem like it makes sense for them to live there...
