### PR TITLE
add internal registry hostname to serviceaccount controller config

### DIFF
--- a/openshiftcontrolplane/v1/types.go
+++ b/openshiftcontrolplane/v1/types.go
@@ -215,6 +215,11 @@ type ServiceAccountControllerConfig struct {
 type DockerPullSecretControllerConfig struct {
 	// registryURLs is a list of urls that the docker pull secrets should be valid for.
 	RegistryURLs []string `json:"registryURLs"`
+
+	// internalRegistryHostname is the hostname for the default internal image
+	// registry. The value must be in "hostname[:port]" format.  Docker pull secrets
+	// will be generated for this registry.
+	InternalRegistryHostname string `json:"internalRegistryHostname"`
 }
 
 type ImageImportControllerConfig struct {

--- a/openshiftcontrolplane/v1/types_swagger_doc_generated.go
+++ b/openshiftcontrolplane/v1/types_swagger_doc_generated.go
@@ -60,7 +60,8 @@ func (ClusterNetworkEntry) SwaggerDoc() map[string]string {
 }
 
 var map_DockerPullSecretControllerConfig = map[string]string{
-	"registryURLs": "registryURLs is a list of urls that the docker pull secrets should be valid for.",
+	"registryURLs":             "registryURLs is a list of urls that the docker pull secrets should be valid for.",
+	"internalRegistryHostname": "internalRegistryHostname is the hostname for the default internal image registry. The value must be in \"hostname[:port]\" format.  Docker pull secrets will be generated for this registry.",
 }
 
 func (DockerPullSecretControllerConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
gives us a place to update the controller config such that we can trigger a controller manager rollout when the internal registryhostname changes, and sets us up to later implement https://jira.coreos.com/browse/DEVEXP-190
