### PR TITLE
switch build config format back to old style selector

### DIFF
--- a/openshiftcontrolplane/v1/types.go
+++ b/openshiftcontrolplane/v1/types.go
@@ -262,7 +262,7 @@ type BuildDefaultsConfig struct {
 	ImageLabels []buildv1.ImageLabel `json:"imageLabels,omitempty"`
 
 	// nodeSelector is a selector which must be true for the build pod to fit on a node
-	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// annotations are annotations that will be added to the build pod
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/openshiftcontrolplane/v1/zz_generated.deepcopy.go
+++ b/openshiftcontrolplane/v1/zz_generated.deepcopy.go
@@ -8,7 +8,6 @@ import (
 	build_v1 "github.com/openshift/api/build/v1"
 	config_v1 "github.com/openshift/api/config/v1"
 	core_v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -94,11 +93,9 @@ func (in *BuildDefaultsConfig) DeepCopyInto(out *BuildDefaultsConfig) {
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	if in.Annotations != nil {


### PR DESCRIPTION
switches the on disk format back the old selector so that https://github.com/openshift/origin/pull/21429 can land to unstick the rebase.

The change to the new selector was correct, but the receiving code isn't ready yet.

/assign @bparees @adambkaplan 