### PR TITLE
add metav1 to config to allow working client

### DIFF
--- a/config/v1/register.go
+++ b/config/v1/register.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -34,5 +35,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&Build{},
 		&BuildList{},
 	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
 	return nil
 }


### PR DESCRIPTION
The metav1 types need to be added to the scheme for the generated clients to function.

/assign @bparees @juanvallejo 