### PR TITLE
Add RevisionHistoryLimit to OperatorSpec

### DIFF
--- a/operator/v1alpha1/types.go
+++ b/operator/v1alpha1/types.go
@@ -35,6 +35,9 @@ type OperatorSpec struct {
 
 	// logging contains glog parameters for the component pods.  It's always a command line arg for the moment
 	Logging LoggingConfig `json:"logging,omitempty"`
+
+	// revisionHistoryLimit is the number of installer pod attempts to keep a record of (0 being unlimited)
+	RevisionHistoryLimit int `json:"revisionHistoryLimit,omitempty"`
 }
 
 // LoggingConfig holds information about configuring logging

--- a/operator/v1alpha1/types_swagger_doc_generated.go
+++ b/operator/v1alpha1/types_swagger_doc_generated.go
@@ -86,12 +86,13 @@ func (OperatorCondition) SwaggerDoc() map[string]string {
 }
 
 var map_OperatorSpec = map[string]string{
-	"":                "OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included inside of the Spec struct for you particular operator.",
-	"managementState": "managementState indicates whether and how the operator should manage the component",
-	"imagePullSpec":   "imagePullSpec is the image to use for the component.",
-	"imagePullPolicy": "imagePullPolicy specifies the image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
-	"version":         "version is the desired state in major.minor.micro-patch.  Usually patch is ignored.",
-	"logging":         "logging contains glog parameters for the component pods.  It's always a command line arg for the moment",
+	"":                     "OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included inside of the Spec struct for you particular operator.",
+	"managementState":      "managementState indicates whether and how the operator should manage the component",
+	"imagePullSpec":        "imagePullSpec is the image to use for the component.",
+	"imagePullPolicy":      "imagePullPolicy specifies the image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+	"version":              "version is the desired state in major.minor.micro-patch.  Usually patch is ignored.",
+	"logging":              "logging contains glog parameters for the component pods.  It's always a command line arg for the moment",
+	"revisionHistoryLimit": "revisionHistoryLimit is the number of installer pod attempts to keep a record of (0 being unlimited)",
 }
 
 func (OperatorSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Adds a field to `OperatorSpec` which allows specification of a number of installer revisions to keep a history of, defaulting to 0=unlimited