### PR TITLE
add coarse grained logging desires to operator API

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -44,6 +44,10 @@ type OperatorSpec struct {
 	// managementState indicates whether and how the operator should manage the component
 	ManagementState ManagementState `json:"managementState"`
 
+	// logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a
+	// simple way to manage coarse grained logging choices that operators have to interpret for their operands.
+	LogLevel LogLevel `json:"logLevel"`
+
 	// operandSpecs provide customization for functional units within the component
 	OperandSpecs []OperandSpec `json:"operandSpecs"`
 
@@ -58,6 +62,23 @@ type OperatorSpec struct {
 	// it is an input to the level for the operator
 	ObservedConfig runtime.RawExtension `json:"observedConfig"`
 }
+
+type LogLevel string
+
+var (
+	// Normal is the default.  Normal, working log information, everything is fine, but helpful notices for auditing or common operations.  In kube, this is probably glog=2.
+	Normal LogLevel = "Normal"
+
+	// Debug is used when something went wrong.  Even common operations may be logged, and less helpful but more quantity of notices.  In kube, this is probably glog=4.
+	Debug LogLevel = "Debug"
+
+	// Trace is used when something went really badly and even more verbose logs are needed.  Logging every function call as part of a common operation, to tracing execution of a query.  In kube, this is probably glog=6.
+	Trace LogLevel = "Trace"
+
+	// TraceAll is used when something is broken at the level of API content/decoding.  It will dump complete body content.  If you turn this on in a production cluster
+	// prepare from serious performance issues and massive amounts of logs.  In kube, this is probably glog=8.
+	TraceAll LogLevel = "TraceAll"
+)
 
 // ResourcePatch is a way to represent the patch you would issue to `kubectl patch` in the API
 type ResourcePatch struct {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -77,6 +77,7 @@ func (OperatorCondition) SwaggerDoc() map[string]string {
 var map_OperatorSpec = map[string]string{
 	"":                           "OperatorSpec contains common fields operators need.  It is intended to be anonymous included inside of the Spec struct for your particular operator.",
 	"managementState":            "managementState indicates whether and how the operator should manage the component",
+	"logLevel":                   "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands.",
 	"operandSpecs":               "operandSpecs provide customization for functional units within the component",
 	"unsupportedConfigOverrides": "unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides",
 	"observedConfig":             "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",


### PR DESCRIPTION
Logging intent is valuable.  This provides a very coarse grained, "try to log like this" that doesn't map to any "real" logging that we have.  It does not allow targeted logging for particular operands or containers there-in.  

This could be an alternative to detailed logging if we were willing to force detailed logging to make an operator upgradeable=false.  It could be a default if we still want to keep the detailed logging options.  `vmodule` is a super useful thing on the kube binaries and generally packages selection is a handy thing.

@jwforres @derekwaynecarr we've talked about this many times.  I would probably keep both.