### PR TITLE
config: Remove Namespace for Config References

### DIFF
--- a/config/v1/types.go
+++ b/config/v1/types.go
@@ -5,10 +5,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// ConfigMapReference references the location of a configmap.
+// ConfigMapReference references a configmap in the openshift-config namespace.
 type ConfigMapReference struct {
-	Namespace string `json:"namespace"`
-	Name      string `json:"name"`
+	Name string `json:"name"`
 	// Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.
 	Key string `json:"filename,omitempty"`
 }

--- a/config/v1/types_swagger_doc_generated.go
+++ b/config/v1/types_swagger_doc_generated.go
@@ -61,7 +61,7 @@ func (ClientConnectionOverrides) SwaggerDoc() map[string]string {
 }
 
 var map_ConfigMapReference = map[string]string{
-	"":         "ConfigMapReference references the location of a configmap.",
+	"":         "ConfigMapReference references a configmap in the openshift-config namespace.",
 	"filename": "Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.",
 }
 


### PR DESCRIPTION
Cluster admin provided ConfigMaps and other entities must to reside
in the `openshift-config` namespace.