### PR TITLE
Add cloud provider name to infra config

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -25,7 +25,13 @@ type InfrastructureSpec struct {
 }
 
 type InfrastructureStatus struct {
-	// type
+	// cloudProvider is the IaaS provider that is running the cluster.
+	//
+	// Valid values are:
+	// - aws
+	// - openstack
+	// +optional
+	CloudProvider string `json:"cloudProvider,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Add a CloudProvider field to the infra config. This value is needed by at least:

* kubelet
* kube-controller-manager
* kube-apiserver
* openshift-ingress-operator

This change does not intend to address the cloud provider configuration file
API.

/cc @openshift/sig-network-edge @derekwaynecarr @deads2k @rajatchopra @flaper87 @smarterclayton 