### PR TITLE
Add base domain to DNS config

### DIFF
--- a/config/v1/types_dns.go
+++ b/config/v1/types_dns.go
@@ -20,8 +20,11 @@ type DNS struct {
 }
 
 type DNSSpec struct {
-	// BaseDomain is the base domain of the cluster. All managed DNS records will
+	// baseDomain is the base domain of the cluster. All managed DNS records will
 	// be sub-domains of this base.
+	//
+	// For example, given the base domain `openshift.example.com`, an API server
+	// DNS record may be created for `cluster-api.openshift.example.com`.
 	BaseDomain string `json:"baseDomain"`
 }
 

--- a/config/v1/types_dns.go
+++ b/config/v1/types_dns.go
@@ -20,6 +20,9 @@ type DNS struct {
 }
 
 type DNSSpec struct {
+	// BaseDomain is the base domain of the cluster. All managed DNS records will
+	// be sub-domains of this base.
+	BaseDomain string `json:"baseDomain"`
 }
 
 type DNSStatus struct {


### PR DESCRIPTION
Add base domain to the DNS config type. This value is useful to any component
which implements DNS management for the cluster. For example,
cluster-ingress-operator manages wildcard DNS records for routing within the
base domain.

/cc @openshift/sig-network-edge @derekwaynecarr @deads2k @rajatchopra @crawford @smarterclayton 