### PR TITLE
Fix the ConfigMapReference key json

### DIFF
--- a/config/v1/types.go
+++ b/config/v1/types.go
@@ -9,7 +9,7 @@ import (
 type ConfigMapReference struct {
 	Name string `json:"name"`
 	// Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.
-	Key string `json:"filename,omitempty"`
+	Key string `json:"key,omitempty"`
 }
 
 // LocalSecretReference references a secret within the local namespace

--- a/config/v1/types_swagger_doc_generated.go
+++ b/config/v1/types_swagger_doc_generated.go
@@ -61,8 +61,8 @@ func (ClientConnectionOverrides) SwaggerDoc() map[string]string {
 }
 
 var map_ConfigMapReference = map[string]string{
-	"":         "ConfigMapReference references a configmap in the openshift-config namespace.",
-	"filename": "Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.",
+	"":    "ConfigMapReference references a configmap in the openshift-config namespace.",
+	"key": "Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.",
 }
 
 func (ConfigMapReference) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Spotted by @enj, we were trying to figure out why changes to the authentication config object were not being picked up by its lister.
@deads2k @bparees 