### PR TITLE
add option to enable oapi if needed

### DIFF
--- a/openshiftcontrolplane/v1/types.go
+++ b/openshiftcontrolplane/v1/types.go
@@ -38,6 +38,12 @@ type OpenShiftAPIServerConfig struct {
 	// TODO this needs to become a normal plugin config
 	CloudProviderFile string `json:"cloudProviderFile"`
 
+	// enableDeprecatedOAPIThatWillBeRemovedVerySoon allows the openshift-apiserver to serve oapi endpoints.  This option
+	// is going away along with the entire API. Consider yourself warned again.
+	// Deprecated
+	// +optional
+	EnableOAPI bool `json:"enableDeprecatedOAPIThatWillBeRemovedVerySoon"`
+
 	// TODO this needs to be removed.
 	APIServerArguments map[string][]string `json:"apiServerArguments"`
 }

--- a/openshiftcontrolplane/v1/zz_generated.swagger_doc_generated.go
+++ b/openshiftcontrolplane/v1/zz_generated.swagger_doc_generated.go
@@ -131,12 +131,13 @@ func (NetworkControllerConfig) SwaggerDoc() map[string]string {
 }
 
 var map_OpenShiftAPIServerConfig = map[string]string{
-	"imagePolicyConfig":              "imagePolicyConfig feeds the image policy admission plugin",
-	"projectConfig":                  "projectConfig feeds an admission plugin",
-	"routingConfig":                  "routingConfig holds information about routing and route generation",
-	"serviceAccountOAuthGrantMethod": "serviceAccountOAuthGrantMethod is used for determining client authorization for service account oauth client. It must be either: deny, prompt, or \"\"",
-	"jenkinsPipelineConfig":          "jenkinsPipelineConfig holds information about the default Jenkins template used for JenkinsPipeline build strategy.",
-	"cloudProviderFile":              "cloudProviderFile points to the cloud config file",
+	"imagePolicyConfig":                             "imagePolicyConfig feeds the image policy admission plugin",
+	"projectConfig":                                 "projectConfig feeds an admission plugin",
+	"routingConfig":                                 "routingConfig holds information about routing and route generation",
+	"serviceAccountOAuthGrantMethod":                "serviceAccountOAuthGrantMethod is used for determining client authorization for service account oauth client. It must be either: deny, prompt, or \"\"",
+	"jenkinsPipelineConfig":                         "jenkinsPipelineConfig holds information about the default Jenkins template used for JenkinsPipeline build strategy.",
+	"cloudProviderFile":                             "cloudProviderFile points to the cloud config file",
+	"enableDeprecatedOAPIThatWillBeRemovedVerySoon": "enableDeprecatedOAPIThatWillBeRemovedVerySoon allows the openshift-apiserver to serve oapi endpoints.  This option is going away along with the entire API. Consider yourself warned again. Deprecated",
 }
 
 func (OpenShiftAPIServerConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
/oapi should be disabled by default with a backup option to re-enable if absolutely needed.  

/assign @soltysh @sttts 