### PR TITLE
switch build ca ref to configmap ref only (no key)

### DIFF
--- a/config/v1/types_build.go
+++ b/config/v1/types_build.go
@@ -23,7 +23,7 @@ type BuildSpec struct {
 	// should be trusted for image pushes and pulls during builds.
 	// The namespace for this config map is openshift-config.
 	// +optional
-	AdditionalTrustedCA ConfigMapFileReference `json:"additionalTrustedCA,omitempty"`
+	AdditionalTrustedCA ConfigMapNameReference `json:"additionalTrustedCA,omitempty"`
 	// BuildDefaults controls the default information for Builds
 	// +optional
 	BuildDefaults BuildDefaults `json:"buildDefaults,omitempty"`


### PR DESCRIPTION
we don't respect the key field anyway so allowing users to specify it is misleading.
