### PR TITLE
Remove useUsernameIdentity from KeystoneIdentityProvider

### DIFF
--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -354,10 +354,11 @@ type KeystoneIdentityProvider struct {
 	// domainName is required for keystone v3
 	DomainName string `json:"domainName"`
 
+	// TODO if we ever add support for 3.11 to 4.0 upgrades, add this configuration
 	// useUsernameIdentity indicates that users should be authenticated by username, not keystone ID
 	// DEPRECATED - only use this option for legacy systems to ensure backwards compatibility
 	// +optional
-	UseUsernameIdentity bool `json:"useUsernameIdentity"`
+	// UseUsernameIdentity bool `json:"useUsernameIdentity"`
 }
 
 // RequestHeaderIdentityProvider provides identities for users authenticating using request header credentials

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -787,9 +787,8 @@ func (IdentityProviderConfig) SwaggerDoc() map[string]string {
 }
 
 var map_KeystoneIdentityProvider = map[string]string{
-	"":                    "KeystonePasswordIdentityProvider provides identities for users authenticating using keystone password credentials",
-	"domainName":          "domainName is required for keystone v3",
-	"useUsernameIdentity": "useUsernameIdentity indicates that users should be authenticated by username, not keystone ID DEPRECATED - only use this option for legacy systems to ensure backwards compatibility",
+	"":           "KeystonePasswordIdentityProvider provides identities for users authenticating using keystone password credentials",
+	"domainName": "domainName is required for keystone v3",
 }
 
 func (KeystoneIdentityProvider) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This field is only necessary if we plan on supporting 3.11 to 4.0
upgrades.  Since that is currently not the case, it should be
removed from the top level config.  Note that this does not remove
any of the wiring in osin that is required to support the legacy
path.  Thus if we ever decide to support 3.11 to 4.0 upgrades, we
will add this field back and rewire it through the operator.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@openshift/sig-auth @openshift/api-reviewers  