### PR TITLE
config/v1: add `etcd discovery domain` and `apiserver url` to Infrastructure status.

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -35,6 +35,16 @@ type InfrastructureStatus struct {
 	// all platforms, and must handle unrecognized platforms as None if they do
 	// not support that platform.
 	Platform PlatformType `json:"platform,omitempty"`
+
+	// etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering
+	// etcd servers and clients.
+	// For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
+	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain"`
+
+	// apiServerURL is a valid URL with scheme(http/https), address and port.
+	// apiServerURL can be used by components like kubelet on machines, to contact the `apisever`
+	// using the infrastructure provider rather than the kubernetes networking.
+	APIServerURL string `json:"apiServerURL"`
 }
 
 // PlatformType is a specific supported infrastructure provider.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -677,8 +677,10 @@ func (InfrastructureSpec) SwaggerDoc() map[string]string {
 }
 
 var map_InfrastructureStatus = map[string]string{
-	"":         "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
-	"platform": "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
+	"":                    "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
+	"platform":            "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
+	"etcdDiscoveryDomain": "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
+	"apiServerURL":        "apiServerURL is a valid URL with scheme(http/https), address and port. apiServerURL can be used by components like kubelet on machines, to contact the `apisever` using the infrastructure provider rather than the kubernetes networking.",
 }
 
 func (InfrastructureStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
- the etcd members on master machines use the `etcd discovery domain` to bootstrap the etcd cluster.
- `apiserver url` Machine Config Operator currently programs the kubelets on machines to contact `https://<cluster_name>-api.<base_domain>:6443`.
   To move the Machine Config Operator to use these global configs, it requires `cluster_name` while `base_domain` is already present in `DNS`. But adding `cluster_name` to
   these global configs is not ideal, so `apiserver url` is chosen, which is available at install-time.

/cc @smarterclayton @deads2k 