### PR TITLE
Add kubebuilder singular tag to kubeapiserver

### DIFF
--- a/operator/v1/types_kubeapiserver.go
+++ b/operator/v1/types_kubeapiserver.go
@@ -8,6 +8,7 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// +kubebuilder:singular=kubeapiserver
 // KubeAPIServer provides information to configure an operator to manage kube-apiserver.
 type KubeAPIServer struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Adds a kubebuilder tag which will include the singular name when generating CRDs