### PR TITLE
operator/v1: add omitempty where applicable

### DIFF
--- a/config/v1/types.go
+++ b/config/v1/types.go
@@ -51,7 +51,7 @@ type ServingInfo struct {
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
 	ClientCA string `json:"clientCA"`
 	// NamedCertificates is a list of certificates to use to secure requests to specific hostnames
-	NamedCertificates []NamedCertificate `json:"namedCertificates"`
+	NamedCertificates []NamedCertificate `json:"namedCertificates,omitempty"`
 	// MinTLSVersion is the minimum TLS version supported.
 	// Values must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants
 	MinTLSVersion string `json:"minTLSVersion,omitempty"`
@@ -72,7 +72,7 @@ type CertInfo struct {
 type NamedCertificate struct {
 	// Names is a list of DNS names this certificate should be used to secure
 	// A name can be a normal DNS name, or can contain leading wildcard segments.
-	Names []string `json:"names"`
+	Names []string `json:"names,omitempty"`
 	// CertInfo is the TLS cert info for serving secure traffic
 	CertInfo `json:",inline"`
 }
@@ -92,16 +92,19 @@ type LeaderElection struct {
 	// maximum duration that a leader can be stopped before it is replaced
 	// by another candidate. This is only applicable if leader election is
 	// enabled.
-	LeaseDuration metav1.Duration `json:"leaseDuration,omitempty"`
+	// +nullable
+	LeaseDuration metav1.Duration `json:"leaseDuration"`
 	// renewDeadline is the interval between attempts by the acting master to
 	// renew a leadership slot before it stops leading. This must be less
 	// than or equal to the lease duration. This is only applicable if leader
 	// election is enabled.
-	RenewDeadline metav1.Duration `json:"renewDeadline,omitempty"`
+	// +nullable
+	RenewDeadline metav1.Duration `json:"renewDeadline"`
 	// retryPeriod is the duration the clients should wait between attempting
 	// acquisition and renewal of a leadership. This is only applicable if
 	// leader election is enabled.
-	RetryPeriod metav1.Duration `json:"retryPeriod,omitempty"`
+	// +nullable
+	RetryPeriod metav1.Duration `json:"retryPeriod"`
 }
 
 // StringSource allows specifying a string inline, or externally via env var or file.
@@ -138,16 +141,16 @@ type RemoteConnectionInfo struct {
 }
 
 type AdmissionConfig struct {
-	PluginConfig map[string]AdmissionPluginConfig `json:"pluginConfig"`
+	PluginConfig map[string]AdmissionPluginConfig `json:"pluginConfig,omitempty"`
 
 	// enabledPlugins is a list of admission plugins that must be on in addition to the default list.
 	// Some admission plugins are disabled by default, but certain configurations require them.  This is fairly uncommon
 	// and can result in performance penalties and unexpected behavior.
-	EnabledAdmissionPlugins []string `json:"enabledPlugins"`
+	EnabledAdmissionPlugins []string `json:"enabledPlugins,omitempty"`
 
 	// disabledPlugins is a list of admission plugins that must be off.  Putting something in this list
 	// is almost always a mistake and likely to result in cluster instability.
-	DisabledAdmissionPlugins []string `json:"disabledPlugins"`
+	DisabledAdmissionPlugins []string `json:"disabledPlugins,omitempty"`
 }
 
 // AdmissionPluginConfig holds the necessary configuration options for admission plugins
@@ -158,6 +161,7 @@ type AdmissionPluginConfig struct {
 
 	// Configuration is an embedded configuration object to be used as the plugin's
 	// configuration. If present, it will be used instead of the path to the configuration file.
+	// +nullable
 	Configuration runtime.RawExtension `json:"configuration"`
 }
 
@@ -200,6 +204,7 @@ type AuditConfig struct {
 	// PolicyConfiguration is an embedded policy configuration object to be used
 	// as the audit policy configuration. If present, it will be used instead of
 	// the path to the policy file.
+	// +nullable
 	PolicyConfiguration runtime.RawExtension `json:"policyConfiguration"`
 
 	// Format of saved audits (legacy or json).
@@ -214,7 +219,7 @@ type AuditConfig struct {
 // EtcdConnectionInfo holds information necessary for connecting to an etcd server
 type EtcdConnectionInfo struct {
 	// URLs are the URLs for etcd
-	URLs []string `json:"urls"`
+	URLs []string `json:"urls,omitempty"`
 	// CA is a file containing trusted roots for the etcd server certificates
 	CA string `json:"ca"`
 	// CertInfo is the TLS client cert information for securing communication to etcd
@@ -249,7 +254,7 @@ type GenericAPIServerConfig struct {
 	AdmissionConfig AdmissionConfig `json:"admission"`
 
 	// TODO remove this.  We need a cut-over or we'll have a gap.
-	AdmissionPluginConfig map[string]AdmissionPluginConfig `json:"admissionPluginConfig"`
+	AdmissionPluginConfig map[string]AdmissionPluginConfig `json:"admissionPluginConfig,omitempty"`
 
 	KubeClientConfig KubeClientConfig `json:"kubeClientConfig"`
 }
@@ -279,15 +284,15 @@ type ClientConnectionOverrides struct {
 // GenericControllerConfig provides information to configure a controller
 type GenericControllerConfig struct {
 	// ServingInfo is the HTTP serving information for the controller's endpoints
-	ServingInfo HTTPServingInfo `json:"servingInfo,omitempty"`
+	ServingInfo HTTPServingInfo `json:"servingInfo"`
 
 	// leaderElection provides information to elect a leader. Only override this if you have a specific need
-	LeaderElection LeaderElection `json:"leaderElection,omitempty"`
+	LeaderElection LeaderElection `json:"leaderElection"`
 
 	// authentication allows configuration of authentication for the endpoints
-	Authentication DelegatedAuthentication `json:"authentication,omitempty"`
+	Authentication DelegatedAuthentication `json:"authentication"`
 	// authorization allows configuration of authentication for the endpoints
-	Authorization DelegatedAuthorization `json:"authorization,omitempty"`
+	Authorization DelegatedAuthorization `json:"authorization"`
 }
 
 // DelegatedAuthentication allows authentication to be disabled.

--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -20,14 +20,14 @@ type APIServerSpec struct {
 	// servingCert is the TLS cert info for serving secure traffic. If not specified, operator managed certificates
 	// will be used for serving secure traffic.
 	// +optional
-	ServingCerts APIServerServingCerts `json:"servingCerts,omitempty"`
+	ServingCerts APIServerServingCerts `json:"servingCerts"`
 	// clientCA references a ConfigMap containing a certificate bundle for the signers that will be recognized for
 	// incoming client certificates in addition to the operator managed signers. If this is empty, then only operator managed signers are valid.
 	// You usually only have to set this if you have your own PKI you wish to honor client certificates from.
 	// The ConfigMap must exist in the openshift-config namespace and contain the following required fields:
 	// - ConfigMap.Data["ca-bundle.crt"] - CA bundle.
 	// +optional
-	ClientCA ConfigMapNameReference `json:"clientCA,omitempty"`
+	ClientCA ConfigMapNameReference `json:"clientCA"`
 }
 
 type APIServerServingCerts struct {
@@ -39,7 +39,7 @@ type APIServerServingCerts struct {
 	// - Secret.Data["tls.key"] - TLS private key.
 	// - Secret.Data["tls.crt"] - TLS certificate.
 	// +optional
-	DefaultServingCertificate SecretNameReference `json:"defaultServingCertificate,omitempty"`
+	DefaultServingCertificate SecretNameReference `json:"defaultServingCertificate"`
 	// namedCertificates references secrets containing the TLS cert info for serving secure traffic to specific hostnames.
 	// If no named certificates are provided, or no named certificates match the server name as understood by a client,
 	// the defaultServingCertificate will be used.
@@ -53,7 +53,7 @@ type APIServerNamedServingCert struct {
 	// serve secure traffic. If no names are provided, the implicit names will be extracted from the certificates.
 	// Exact names trump over wildcard names. Explicit names defined here trump over extracted implicit names.
 	// +optional
-	Names []string `json:"names"`
+	Names []string `json:"names,omitempty"`
 	// servingCertificate references a kubernetes.io/tls type secret containing the TLS cert info for serving secure traffic.
 	// The secret must exist in the openshift-config namespace and contain the following required fields:
 	// - Secret.Data["tls.key"] - TLS private key.
@@ -68,6 +68,6 @@ type APIServerStatus struct {
 
 type APIServerList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []APIServer `json:"items"`
 }

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -45,7 +45,7 @@ type AuthenticationSpec struct {
 	// honor bearer tokens that are provisioned by an external authentication service.
 	// The namespace for these secrets is openshift-config.
 	// +optional
-	WebhookTokenAuthenticators []WebhookTokenAuthenticator `json:"webhookTokenAuthenticators"`
+	WebhookTokenAuthenticators []WebhookTokenAuthenticator `json:"webhookTokenAuthenticators,omitempty"`
 }
 
 type AuthenticationStatus struct {
@@ -73,7 +73,7 @@ type AuthenticationStatus struct {
 type AuthenticationList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 
 	Items []Authentication `json:"items"`
 }

--- a/config/v1/types_build.go
+++ b/config/v1/types_build.go
@@ -95,6 +95,6 @@ type BuildOverrides struct {
 type BuildList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Build `json:"items"`
 }

--- a/config/v1/types_console.go
+++ b/config/v1/types_console.go
@@ -34,7 +34,7 @@ type ConsoleStatus struct {
 type ConsoleList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Console `json:"items"`
 }
 

--- a/config/v1/types_dns.go
+++ b/config/v1/types_dns.go
@@ -71,6 +71,6 @@ type DNSStatus struct {
 type DNSList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []DNS `json:"items"`
 }

--- a/config/v1/types_features.go
+++ b/config/v1/types_features.go
@@ -40,7 +40,7 @@ type FeaturesStatus struct {
 type FeaturesList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Features `json:"items"`
 }
 

--- a/config/v1/types_image.go
+++ b/config/v1/types_image.go
@@ -67,7 +67,7 @@ type ImageStatus struct {
 type ImageList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Image `json:"items"`
 }
 

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -79,6 +79,6 @@ const (
 type InfrastructureList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Infrastructure `json:"items"`
 }

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -34,6 +34,6 @@ type IngressStatus struct {
 type IngressList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Ingress `json:"items"`
 }

--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -70,6 +70,6 @@ type ClusterNetworkEntry struct {
 type NetworkList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Network `json:"items"`
 }

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -569,7 +569,7 @@ type OpenIDClaims struct {
 
 type OAuthList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 
 	Items []OAuth `json:"items"`
 }

--- a/config/v1/types_project.go
+++ b/config/v1/types_project.go
@@ -46,6 +46,6 @@ type ProjectStatus struct {
 type ProjectList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Project `json:"items"`
 }

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -32,6 +32,6 @@ type ProxySpec struct {
 type ProxyList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Proxy `json:"items"`
 }

--- a/config/v1/types_scheduling.go
+++ b/config/v1/types_scheduling.go
@@ -35,6 +35,6 @@ type SchedulingStatus struct {
 type SchedulingList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	Items           []Scheduling `json:"items"`
 }

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -52,7 +52,7 @@ type OperatorSpec struct {
 
 	// operandSpecs provide customization for functional units within the component
 	// +optional
-	OperandSpecs []OperandSpec `json:"operandSpecs"`
+	OperandSpecs []OperandSpec `json:"operandSpecs,omitempty"`
 
 	// unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override
 	// it will end up overlaying in the following order:
@@ -60,11 +60,13 @@ type OperatorSpec struct {
 	// 2. observedConfig
 	// 3. unsupportedConfigOverrides
 	// +optional
+	// +nullable
 	UnsupportedConfigOverrides runtime.RawExtension `json:"unsupportedConfigOverrides"`
 
 	// observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because
 	// it is an input to the level for the operator
 	// +optional
+	// +nullable
 	ObservedConfig runtime.RawExtension `json:"observedConfig"`
 }
 
@@ -100,13 +102,13 @@ type OperandSpec struct {
 
 	// operandContainerSpecs are per-container options
 	// +optional
-	OperandContainerSpecs []OperandContainerSpec `json:"operandContainerSpecs"`
+	OperandContainerSpecs []OperandContainerSpec `json:"operandContainerSpecs,omitempty"`
 
 	// unsupportedResourcePatches are applied to the workload resource for this unit. This is an unsupported
 	// workaround if anything needs to be modified on the workload that is not otherwise configurable.
 	// TODO Decide: alternatively, we could simply include a RawExtension which is used in place of the "normal" default manifest
 	// +optional
-	UnsupportedResourcePatches []ResourcePatch `json:"unsupportedResourcePatches"`
+	UnsupportedResourcePatches []ResourcePatch `json:"unsupportedResourcePatches,omitempty"`
 }
 
 type OperandContainerSpec struct {
@@ -184,11 +186,11 @@ const (
 
 // StaticPodOperatorSpec is spec for controllers that manage static pods.
 type StaticPodOperatorSpec struct {
-	OperatorSpec           `json:",inline"`
+	OperatorSpec `json:",inline"`
 
 	// failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api
 	// -1 = unlimited, 0 or unset = 5 (default)
-	FailedRevisionLimit    int32 `json:"failedRevisionLimit,omitempty"`
+	FailedRevisionLimit int32 `json:"failedRevisionLimit,omitempty"`
 	// succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api
 	// -1 = unlimited, 0 or unset = 5 (default)
 	SucceededRevisionLimit int32 `json:"succeededRevisionLimit,omitempty"`
@@ -203,7 +205,7 @@ type StaticPodOperatorStatus struct {
 	LatestAvailableRevision int32 `json:"latestAvailableRevision"`
 
 	// nodeStatuses track the deployment values and errors across individual nodes
-	NodeStatuses []NodeStatus `json:"nodeStatuses"`
+	NodeStatuses []NodeStatus `json:"nodeStatuses,omitempty"`
 }
 
 // NodeStatus provides information about the current state of a particular node managed by this operator.
@@ -214,10 +216,10 @@ type NodeStatus struct {
 	// currentRevision is the generation of the most recently successful deployment
 	CurrentRevision int32 `json:"currentRevision"`
 	// targetRevision is the generation of the deployment we're trying to apply
-	TargetRevision int32 `json:"targetRevision"`
+	TargetRevision int32 `json:"targetRevision,omitempty"`
 	// lastFailedRevision is the generation of the deployment we tried and failed to deploy.
-	LastFailedRevision int32 `json:"lastFailedRevision"`
+	LastFailedRevision int32 `json:"lastFailedRevision,omitempty"`
 
 	// lastFailedRevisionErrors is a list of the errors during the failed deployment referenced in lastFailedRevision
-	LastFailedRevisionErrors []string `json:"lastFailedRevisionErrors"`
+	LastFailedRevisionErrors []string `json:"lastFailedRevisionErrors,omitempty"`
 }

--- a/operator/v1/types_authentication.go
+++ b/operator/v1/types_authentication.go
@@ -30,7 +30,7 @@ type AuthenticationStatus struct {
 // AuthenticationList is a collection of items
 type AuthenticationList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 
 	Items []Authentication `json:"items"`
 }

--- a/operator/v1/types_console.go
+++ b/operator/v1/types_console.go
@@ -58,7 +58,7 @@ const (
 
 type ConsoleList struct {
 	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 
 	Items []Console `json:"items"`
 }

--- a/operator/v1/types_etcd.go
+++ b/operator/v1/types_etcd.go
@@ -36,7 +36,7 @@ type EtcdStatus struct {
 type EtcdList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	// Items contains the items
 	Items []Etcd `json:"items"`
 }

--- a/operator/v1/types_kubeapiserver.go
+++ b/operator/v1/types_kubeapiserver.go
@@ -36,7 +36,7 @@ type KubeAPIServerStatus struct {
 type KubeAPIServerList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	// Items contains the items
 	Items []KubeAPIServer `json:"items"`
 }

--- a/operator/v1/types_kubecontrollermanager.go
+++ b/operator/v1/types_kubecontrollermanager.go
@@ -36,7 +36,7 @@ type KubeControllerManagerStatus struct {
 type KubeControllerManagerList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	// Items contains the items
 	Items []KubeControllerManager `json:"items"`
 }

--- a/operator/v1/types_openshiftapiserver.go
+++ b/operator/v1/types_openshiftapiserver.go
@@ -31,7 +31,7 @@ type OpenShiftAPIServerStatus struct {
 type OpenShiftAPIServerList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	// Items contains the items
 	Items []OpenShiftAPIServer `json:"items"`
 }

--- a/operator/v1/types_openshiftcontrollermanager.go
+++ b/operator/v1/types_openshiftcontrollermanager.go
@@ -31,7 +31,7 @@ type OpenShiftControllerManagerStatus struct {
 type OpenShiftControllerManagerList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	// Items contains the items
 	Items []OpenShiftControllerManager `json:"items"`
 }

--- a/operator/v1/types_scheduler.go
+++ b/operator/v1/types_scheduler.go
@@ -36,7 +36,7 @@ type KubeSchedulerStatus struct {
 type KubeSchedulerList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	// Items contains the items
 	Items []KubeScheduler `json:"items"`
 }

--- a/operator/v1/types_serviceca.go
+++ b/operator/v1/types_serviceca.go
@@ -31,7 +31,7 @@ type ServiceCAStatus struct {
 type ServiceCAList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	// Items contains the items
 	Items []ServiceCA `json:"items"`
 }

--- a/operator/v1/types_servicecatalogapiserver.go
+++ b/operator/v1/types_servicecatalogapiserver.go
@@ -31,7 +31,7 @@ type ServiceCatalogAPIServerStatus struct {
 type ServiceCatalogAPIServerList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	// Items contains the items
 	Items []ServiceCatalogAPIServer `json:"items"`
 }

--- a/operator/v1/types_servicecatalogcontrollermanager.go
+++ b/operator/v1/types_servicecatalogcontrollermanager.go
@@ -31,7 +31,7 @@ type ServiceCatalogControllerManagerStatus struct {
 type ServiceCatalogControllerManagerList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.ListMeta `json:"metadata"`
 	// Items contains the items
 	Items []ServiceCatalogControllerManager `json:"items"`
 }


### PR DESCRIPTION
This updates the `omitempty`, `// +optional`, `// +nullable` (soon a new tag for CRD validation schema generation) tags on all config/v1 and operator/v1 types which either belong to the master team or are uncontroversial. The others are pushed into separate PRs for the respective teams.

This were the rules:
- no `omitempty` for non-pointer structs
- added `// +optional` where we had `omitempty`
- added `// +nullable` where we have `// +optional`, but due to overrides of `JSONMarshal` we cannot apply omitempty.



Otherwise we get invalid `null` values during serialization.