### PR TITLE
config/operator: fix omitempty, +optional, +nullable without behaviour change

### DIFF
--- a/config/v1/types.go
+++ b/config/v1/types.go
@@ -49,7 +49,8 @@ type ServingInfo struct {
 	// this is anonymous so that we can inline it for serialization
 	CertInfo `json:",inline"`
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
-	ClientCA string `json:"clientCA"`
+	// +optional
+	ClientCA string `json:"clientCA,omitempty"`
 	// NamedCertificates is a list of certificates to use to secure requests to specific hostnames
 	NamedCertificates []NamedCertificate `json:"namedCertificates,omitempty"`
 	// MinTLSVersion is the minimum TLS version supported.

--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -12,8 +12,10 @@ import (
 type APIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              APIServerSpec   `json:"spec"`
-	Status            APIServerStatus `json:"status"`
+	// +required
+	Spec APIServerSpec `json:"spec"`
+	// +optional
+	Status APIServerStatus `json:"status"`
 }
 
 type APIServerSpec struct {

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -13,8 +13,10 @@ type Authentication struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +required
 	Spec AuthenticationSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status AuthenticationStatus `json:"status"`
 }
 

--- a/config/v1/types_build.go
+++ b/config/v1/types_build.go
@@ -15,7 +15,7 @@ type Build struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec holds user-settable values for the build controller configuration
 	// +optional
-	Spec BuildSpec `json:"spec,omitempty"`
+	Spec BuildSpec `json:"spec"`
 }
 
 type BuildSpec struct {
@@ -23,13 +23,13 @@ type BuildSpec struct {
 	// should be trusted for image pushes and pulls during builds.
 	// The namespace for this config map is openshift-config.
 	// +optional
-	AdditionalTrustedCA ConfigMapNameReference `json:"additionalTrustedCA,omitempty"`
+	AdditionalTrustedCA ConfigMapNameReference `json:"additionalTrustedCA"`
 	// BuildDefaults controls the default information for Builds
 	// +optional
-	BuildDefaults BuildDefaults `json:"buildDefaults,omitempty"`
+	BuildDefaults BuildDefaults `json:"buildDefaults"`
 	// BuildOverrides controls override settings for builds
 	// +optional
-	BuildOverrides BuildOverrides `json:"buildOverrides,omitempty"`
+	BuildOverrides BuildOverrides `json:"buildOverrides"`
 }
 
 type BuildDefaults struct {
@@ -61,7 +61,7 @@ type BuildDefaults struct {
 
 	// Resources defines resource requirements to execute the build.
 	// +optional
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources"`
 }
 
 type ImageLabel struct {

--- a/config/v1/types_build.go
+++ b/config/v1/types_build.go
@@ -14,7 +14,7 @@ type Build struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec holds user-settable values for the build controller configuration
-	// +optional
+	// +required
 	Spec BuildSpec `json:"spec"`
 }
 

--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -17,10 +17,12 @@ type ClusterOperator struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	// spec hold the intent of how this operator should behave.
+	// +required
 	Spec ClusterOperatorSpec `json:"spec"`
 
 	// status holds the information about the state of an operator.  It is consistent with status information across
 	// the kube ecosystem.
+	// +optional
 	Status ClusterOperatorStatus `json:"status"`
 }
 

--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -49,7 +49,9 @@ type ClusterOperatorStatus struct {
 
 	// extension contains any additional status information specific to the
 	// operator which owns this status object.
-	Extension runtime.RawExtension `json:"extension,omitempty"`
+	// +nullable
+	// +optional
+	Extension runtime.RawExtension `json:"extension"`
 }
 
 type OperandVersion struct {

--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -34,18 +34,21 @@ type ClusterOperatorStatus struct {
 	// conditions describes the state of the operator's reconciliation functionality.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
-	Conditions []ClusterOperatorStatusCondition `json:"conditions"  patchStrategy:"merge" patchMergeKey:"type"`
+	// +optional
+	Conditions []ClusterOperatorStatusCondition `json:"conditions,omitempty"  patchStrategy:"merge" patchMergeKey:"type"`
 
 	// versions is a slice of operand version tuples.  Operators which manage multiple operands will have multiple
 	// entries in the array.  If an operator is Available, it must have at least one entry.  You must report the version of
 	// the operator itself with the name "operator".
-	Versions []OperandVersion `json:"versions"`
+	// +optional
+	Versions []OperandVersion `json:"versions,omitempty"`
 
 	// relatedObjects is a list of objects that are "interesting" or related to this operator.  Common uses are:
 	// 1. the detailed resource driving the operator
 	// 2. operator namespaces
 	// 3. operand namespaces
-	RelatedObjects []ObjectReference `json:"relatedObjects"`
+	// +optional
+	RelatedObjects []ObjectReference `json:"relatedObjects,omitempty"`
 
 	// extension contains any additional status information specific to the
 	// operator which owns this status object.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -46,19 +46,19 @@ type ClusterVersionSpec struct {
 	// rollbacks will succeed.
 	//
 	// +optional
-	DesiredUpdate *Update `json:"desiredUpdate"`
+	DesiredUpdate *Update `json:"desiredUpdate,omitempty"`
 
 	// upstream may be used to specify the preferred update server. By default
 	// it will use the appropriate update server for the cluster and region.
 	//
 	// +optional
-	Upstream URL `json:"upstream"`
+	Upstream URL `json:"upstream,omitempty"`
 	// channel is an identifier for explicitly requesting that a non-default
 	// set of updates be applied to this cluster. The default channel will be
 	// contain stable updates that are appropriate for production clusters.
 	//
 	// +optional
-	Channel string `json:"channel"`
+	Channel string `json:"channel,omitempty"`
 
 	// overrides is list of overides for components that are managed by
 	// cluster version operator. Marking a component unmanaged will prevent
@@ -86,7 +86,8 @@ type ClusterVersionStatus struct {
 	// Completed if the rollout completed - if an update was failing or halfway
 	// applied the state will be Partial. Only a limited amount of update history
 	// is preserved.
-	History []UpdateHistory `json:"history"`
+	// +optional
+	History []UpdateHistory `json:"history,omitempty"`
 
 	// observedGeneration reports which version of the spec is being synced.
 	// If this value is not equal to metadata.generation, then the desired
@@ -105,13 +106,15 @@ type ClusterVersionStatus struct {
 	// by a temporary or permanent error. Conditions are only valid for the
 	// current desiredUpdate when metadata.generation is equal to
 	// status.generation.
-	Conditions []ClusterOperatorStatusCondition `json:"conditions"`
+	// +optional
+	Conditions []ClusterOperatorStatusCondition `json:"conditions,omitempty"`
 
 	// availableUpdates contains the list of updates that are appropriate
 	// for this cluster. This list may be empty if no updates are recommended,
 	// if the update service is unavailable, or if an invalid channel has
 	// been specified.
-	AvailableUpdates []Update `json:"availableUpdates"`
+	// +optional
+	AvailableUpdates []Update `json:"availableUpdates,omitempty"`
 }
 
 // UpdateState is a constant representing whether an update was successfully
@@ -141,7 +144,8 @@ type UpdateHistory struct {
 	// that is currently being applied will have a null completion time.
 	// Completion time will always be set for entries that are not the current
 	// update (usually to the started time of the next update).
-	CompletionTime *metav1.Time `json:"completionTime"`
+	// +optional
+	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 
 	// version is a semantic versioning identifying the update version. If the
 	// requested image does not define a version, or if a failure occurs

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -16,9 +16,11 @@ type ClusterVersion struct {
 
 	// spec is the desired state of the cluster version - the operator will work
 	// to ensure that the desired version is applied to the cluster.
+	// +required
 	Spec ClusterVersionSpec `json:"spec"`
 	// status contains information about the available updates and any in-progress
 	// updates.
+	// +optional
 	Status ClusterVersionStatus `json:"status"`
 }
 

--- a/config/v1/types_console.go
+++ b/config/v1/types_console.go
@@ -20,7 +20,7 @@ type Console struct {
 
 type ConsoleSpec struct {
 	// +optional
-	Authentication ConsoleAuthentication `json:"authentication,omitempty"`
+	Authentication ConsoleAuthentication `json:"authentication"`
 }
 
 type ConsoleStatus struct {

--- a/config/v1/types_console.go
+++ b/config/v1/types_console.go
@@ -13,8 +13,10 @@ type Console struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +required
 	Spec ConsoleSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status ConsoleStatus `json:"status"`
 }
 

--- a/config/v1/types_dns.go
+++ b/config/v1/types_dns.go
@@ -14,8 +14,10 @@ type DNS struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +required
 	Spec DNSSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status DNSStatus `json:"status"`
 }
 

--- a/config/v1/types_features.go
+++ b/config/v1/types_features.go
@@ -13,8 +13,10 @@ type Features struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +required
 	Spec FeaturesSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status FeaturesStatus `json:"status"`
 }
 

--- a/config/v1/types_image.go
+++ b/config/v1/types_image.go
@@ -25,25 +25,29 @@ type ImageSpec struct {
 	// permission to create Images or ImageStreamMappings via the API are not affected by
 	// this policy - typically only administrators or system integrations will have those
 	// permissions.
+	// +optional
 	AllowedRegistriesForImport []RegistryLocation `json:"allowedRegistriesForImport,omitempty"`
 
 	// externalRegistryHostnames provides the hostnames for the default external image
 	// registry. The external hostname should be set only when the image registry
 	// is exposed externally. The first value is used in 'publicDockerImageRepository'
 	// field in ImageStreams. The value must be in "hostname[:port]" format.
+	// +optional
 	ExternalRegistryHostnames []string `json:"externalRegistryHostnames,omitempty"`
 
 	// AdditionalTrustedCA is a reference to a ConfigMap containing additional CAs that
 	// should be trusted during imagestream import, pod image pull, and imageregistry
 	// pullthrough.
 	// The namespace for this config map is openshift-config.
-	AdditionalTrustedCA ConfigMapNameReference `json:"additionalTrustedCA,omitempty"`
+	// +optional
+	AdditionalTrustedCA ConfigMapNameReference `json:"additionalTrustedCA"`
 
 	// RegistrySources contains configuration that determines how the container runtime
 	// should treat individual registries when accessing images for builds+pods. (e.g.
 	// whether or not to allow insecure access).  It does not contain configuration for the
 	// internal cluster registry.
-	RegistrySources RegistrySources `json:"registrySources,omitempty"`
+	// +optional
+	RegistrySources RegistrySources `json:"registrySources"`
 }
 
 type ImageStatus struct {
@@ -53,12 +57,14 @@ type ImageStatus struct {
 	// registry. The value must be in "hostname[:port]" format.
 	// For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY
 	// environment variable but this setting overrides the environment variable.
+	// +optional
 	InternalRegistryHostname string `json:"internalRegistryHostname,omitempty"`
 
 	// externalRegistryHostnames provides the hostnames for the default external image
 	// registry. The external hostname should be set only when the image registry
 	// is exposed externally. The first value is used in 'publicDockerImageRepository'
 	// field in ImageStreams. The value must be in "hostname[:port]" format.
+	// +optional
 	ExternalRegistryHostnames []string `json:"externalRegistryHostnames,omitempty"`
 }
 
@@ -80,6 +86,7 @@ type RegistryLocation struct {
 	DomainName string `json:"domainName"`
 	// Insecure indicates whether the registry is secure (https) or insecure (http)
 	// By default (if not specified) the registry is assumed as secure.
+	// +optional
 	Insecure bool `json:"insecure,omitempty"`
 }
 

--- a/config/v1/types_image.go
+++ b/config/v1/types_image.go
@@ -13,8 +13,10 @@ type Image struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +required
 	Spec ImageSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status ImageStatus `json:"status"`
 }
 

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -13,8 +13,10 @@ type Infrastructure struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +required
 	Spec InfrastructureSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status InfrastructureStatus `json:"status"`
 }
 

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -14,8 +14,10 @@ type Ingress struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +required
 	Spec IngressSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status IngressStatus `json:"status"`
 }
 

--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -14,8 +14,10 @@ type Network struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration.
+	// +required
 	Spec NetworkSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status NetworkStatus `json:"status"`
 }
 

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -15,8 +15,9 @@ type OAuth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +required
 	Spec OAuthSpec `json:"spec"`
-
+	// +optional
 	Status OAuthStatus `json:"status"`
 }
 

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -332,18 +332,18 @@ type LDAPAttributeMapping struct {
 	// preferredUsername is the list of attributes whose values should be used as the preferred username.
 	// LDAP standard login attribute is "uid"
 	// +optional
-	PreferredUsername []string `json:"preferredUsername"`
+	PreferredUsername []string `json:"preferredUsername,omitempty"`
 
 	// name is the list of attributes whose values should be used as the display name. Optional.
 	// If unspecified, no display name is set for the identity
 	// LDAP standard display name attribute is "cn"
 	// +optional
-	Name []string `json:"name"`
+	Name []string `json:"name,omitempty"`
 
 	// email is the list of attributes whose values should be used as the email address. Optional.
 	// If unspecified, no email is set for the identity
 	// +optional
-	Email []string `json:"email"`
+	Email []string `json:"email,omitempty"`
 }
 
 // KeystonePasswordIdentityProvider provides identities for users authenticating using keystone password credentials
@@ -394,7 +394,7 @@ type RequestHeaderIdentityProvider struct {
 	// clientCommonNames is an optional list of common names to require a match from. If empty, any
 	// client certificate validated against the clientCA bundle is considered authoritative.
 	// +optional
-	ClientCommonNames []string `json:"clientCommonNames"`
+	ClientCommonNames []string `json:"clientCommonNames,omitempty"`
 
 	// headers is the set of headers to check for identity information
 	Headers []string `json:"headers"`
@@ -422,11 +422,11 @@ type GitHubIdentityProvider struct {
 
 	// organizations optionally restricts which organizations are allowed to log in
 	// +optional
-	Organizations []string `json:"organizations"`
+	Organizations []string `json:"organizations,omitempty"`
 
 	// teams optionally restricts which teams are allowed to log in. Format is <org>/<team>.
 	// +optional
-	Teams []string `json:"teams"`
+	Teams []string `json:"teams,omitempty"`
 
 	// hostname is the optional domain (e.g. "mycompany.com") for use with a hosted instance of
 	// GitHub Enterprise.
@@ -510,11 +510,11 @@ type OpenIDIdentityProvider struct {
 
 	// extraScopes are any scopes to request in addition to the standard "openid" scope.
 	// +optional
-	ExtraScopes []string `json:"extraScopes"`
+	ExtraScopes []string `json:"extraScopes,omitempty"`
 
 	// extraAuthorizeParameters are any custom parameters to add to the authorize request.
 	// +optional
-	ExtraAuthorizeParameters map[string]string `json:"extraAuthorizeParameters"`
+	ExtraAuthorizeParameters map[string]string `json:"extraAuthorizeParameters,omitempty"`
 
 	// urls to use to authenticate
 	URLs OpenIDURLs `json:"urls"`
@@ -552,17 +552,17 @@ type OpenIDClaims struct {
 	// preferredUsername is the list of claims whose values should be used as the preferred username.
 	// If unspecified, the preferred username is determined from the value of the sub claim
 	// +optional
-	PreferredUsername []string `json:"preferredUsername"`
+	PreferredUsername []string `json:"preferredUsername,omitempty"`
 
 	// name is the list of claims whose values should be used as the display name. Optional.
 	// If unspecified, no display name is set for the identity
 	// +optional
-	Name []string `json:"name"`
+	Name []string `json:"name,omitempty"`
 
 	// email is the list of claims whose values should be used as the email address. Optional.
 	// If unspecified, no email is set for the identity
 	// +optional
-	Email []string `json:"email"`
+	Email []string `json:"email,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -89,7 +89,7 @@ type OAuthTemplates struct {
 	// If unspecified, the default login page is used.
 	// The namespace for this secret is openshift-config.
 	// +optional
-	Login SecretNameReference `json:"login,omitempty"`
+	Login SecretNameReference `json:"login"`
 
 	// providerSelection is the name of a secret that specifies a go template to use to render
 	// the provider selection page.
@@ -99,7 +99,7 @@ type OAuthTemplates struct {
 	// If unspecified, the default provider selection page is used.
 	// The namespace for this secret is openshift-config.
 	// +optional
-	ProviderSelection SecretNameReference `json:"providerSelection,omitempty"`
+	ProviderSelection SecretNameReference `json:"providerSelection"`
 
 	// error is the name of a secret that specifies a go template to use to render error pages
 	// during the authentication or grant flow.
@@ -109,7 +109,7 @@ type OAuthTemplates struct {
 	// If unspecified, the default error page is used.
 	// The namespace for this secret is openshift-config.
 	// +optional
-	Error SecretNameReference `json:"error,omitempty"`
+	Error SecretNameReference `json:"error"`
 }
 
 // IdentityProvider provides identities for users authenticating using credentials
@@ -129,7 +129,7 @@ type IdentityProvider struct {
 	// mappingMethod determines how identities from this provider are mapped to users
 	// Defaults to "claim"
 	// +optional
-	MappingMethod MappingMethodType `json:"mappingMethod"`
+	MappingMethod MappingMethodType `json:"mappingMethod,omitempty"`
 
 	IdentityProviderConfig `json:",inline"`
 }

--- a/config/v1/types_project.go
+++ b/config/v1/types_project.go
@@ -35,7 +35,7 @@ type ProjectSpec struct {
 	// If it is not specified, a default template is used.
 	//
 	// +optional
-	ProjectRequestTemplate TemplateReference `json:"projectRequestTemplate,omitempty"`
+	ProjectRequestTemplate TemplateReference `json:"projectRequestTemplate"`
 }
 
 type ProjectStatus struct {

--- a/config/v1/types_project.go
+++ b/config/v1/types_project.go
@@ -13,8 +13,10 @@ type Project struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +required
 	Spec ProjectSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status ProjectStatus `json:"status"`
 }
 

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -18,12 +18,15 @@ type Proxy struct {
 
 type ProxySpec struct {
 	// httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
+	// +optional
 	HTTPProxy string `json:"httpProxy,omitempty"`
 
 	// httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
+	// +optional
 	HTTPSProxy string `json:"httpsProxy,omitempty"`
 
 	// noProxy is the list of domains for which the proxy should not be used.  Empty means unset and will not result in an env var.
+	// +optional
 	NoProxy string `json:"noProxy,omitempty"`
 }
 

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -13,6 +13,7 @@ type Proxy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec holds user-settable values for the proxy configuration
+	// +required
 	Spec ProxySpec `json:"spec"`
 }
 

--- a/config/v1/types_scheduling.go
+++ b/config/v1/types_scheduling.go
@@ -13,8 +13,10 @@ type Scheduler struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +required
 	Spec SchedulerSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status SchedulerStatus `json:"status"`
 }
 

--- a/config/v1/types_scheduling.go
+++ b/config/v1/types_scheduling.go
@@ -24,7 +24,7 @@ type SchedulerSpec struct {
 	// scheduler will default to use DefaultAlgorithmProvider.
 	// The namespace for this configmap is openshift-config.
 	// +optional
-	Policy ConfigMapNameReference `json:"policy,omitempty"`
+	Policy ConfigMapNameReference `json:"policy"`
 }
 
 type SchedulerStatus struct {

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -11,6 +11,7 @@ type MyOperatorResource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +required
 	Spec   MyOperatorResourceSpec   `json:"spec"`
 	Status MyOperatorResourceStatus `json:"status"`
 }

--- a/operator/v1/types_authentication.go
+++ b/operator/v1/types_authentication.go
@@ -13,7 +13,9 @@ type Authentication struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +required
 	Spec   AuthenticationSpec   `json:"spec,omitempty"`
+	// +optional
 	Status AuthenticationStatus `json:"status,omitempty"`
 }
 

--- a/operator/v1/types_console.go
+++ b/operator/v1/types_console.go
@@ -18,7 +18,8 @@ type ConsoleSpec struct {
 	OperatorSpec `json:",inline"`
 	// customization is used to optionally provide a small set of
 	// customization options to the web console.
-	Customization ConsoleCustomization `json:"customization,omitempty"`
+	// +optional
+	Customization ConsoleCustomization `json:"customization"`
 }
 
 type ConsoleStatus struct {

--- a/operator/v1/types_console.go
+++ b/operator/v1/types_console.go
@@ -10,7 +10,9 @@ type Console struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +required
 	Spec   ConsoleSpec   `json:"spec,omitempty"`
+	// +optional
 	Status ConsoleStatus `json:"status,omitempty"`
 }
 

--- a/operator/v1/types_etcd.go
+++ b/operator/v1/types_etcd.go
@@ -13,7 +13,9 @@ type Etcd struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +required
 	Spec   EtcdSpec   `json:"spec"`
+	// +optional
 	Status EtcdStatus `json:"status"`
 }
 

--- a/operator/v1/types_kubeapiserver.go
+++ b/operator/v1/types_kubeapiserver.go
@@ -13,7 +13,9 @@ type KubeAPIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +required
 	Spec   KubeAPIServerSpec   `json:"spec"`
+	// +optional
 	Status KubeAPIServerStatus `json:"status"`
 }
 

--- a/operator/v1/types_kubecontrollermanager.go
+++ b/operator/v1/types_kubecontrollermanager.go
@@ -13,7 +13,9 @@ type KubeControllerManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +required
 	Spec   KubeControllerManagerSpec   `json:"spec"`
+	// +optional
 	Status KubeControllerManagerStatus `json:"status"`
 }
 

--- a/operator/v1/types_openshiftapiserver.go
+++ b/operator/v1/types_openshiftapiserver.go
@@ -13,7 +13,9 @@ type OpenShiftAPIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +required
 	Spec   OpenShiftAPIServerSpec   `json:"spec"`
+	// +optional
 	Status OpenShiftAPIServerStatus `json:"status"`
 }
 

--- a/operator/v1/types_openshiftcontrollermanager.go
+++ b/operator/v1/types_openshiftcontrollermanager.go
@@ -13,7 +13,9 @@ type OpenShiftControllerManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +required
 	Spec   OpenShiftControllerManagerSpec   `json:"spec"`
+	// +optional
 	Status OpenShiftControllerManagerStatus `json:"status"`
 }
 

--- a/operator/v1/types_scheduler.go
+++ b/operator/v1/types_scheduler.go
@@ -13,7 +13,9 @@ type KubeScheduler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +required
 	Spec   KubeSchedulerSpec   `json:"spec"`
+	// +optional
 	Status KubeSchedulerStatus `json:"status"`
 }
 

--- a/operator/v1/types_serviceca.go
+++ b/operator/v1/types_serviceca.go
@@ -13,7 +13,9 @@ type ServiceCA struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +required
 	Spec   ServiceCASpec   `json:"spec"`
+	// +optional
 	Status ServiceCAStatus `json:"status"`
 }
 

--- a/operator/v1/types_servicecatalogapiserver.go
+++ b/operator/v1/types_servicecatalogapiserver.go
@@ -13,8 +13,10 @@ type ServiceCatalogAPIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ServiceCatalogAPIServerSpec   `json:"spec,omitempty"`
-	Status ServiceCatalogAPIServerStatus `json:"status,omitempty"`
+	// +required
+	Spec   ServiceCatalogAPIServerSpec   `json:"spec"`
+	// +optional
+	Status ServiceCatalogAPIServerStatus `json:"status"`
 }
 
 type ServiceCatalogAPIServerSpec struct {

--- a/operator/v1/types_servicecatalogcontrollermanager.go
+++ b/operator/v1/types_servicecatalogcontrollermanager.go
@@ -13,8 +13,10 @@ type ServiceCatalogControllerManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ServiceCatalogControllerManagerSpec   `json:"spec,omitempty"`
-	Status ServiceCatalogControllerManagerStatus `json:"status,omitempty"`
+	// +required
+	Spec ServiceCatalogControllerManagerSpec `json:"spec"`
+	// +optional
+	Status ServiceCatalogControllerManagerStatus `json:"status"`
 }
 
 type ServiceCatalogControllerManagerSpec struct {


### PR DESCRIPTION
Second PR with changes which
- **do not change serialization behavour**
- but where the API owners should check (independently from the PR) whether they really means what they specified (e.g. optional, but no pointer to structs).

This updates the `omitempty`, `// +optional`, `// +nullable` (soon a new tag for CRD validation schema generation) tags on all config/v1 and operator/v1 types which either belong to the master team or are uncontroversial. The others are pushed into separate PRs for the respective teams.

This were the rules:
- no `omitempty` for non-pointer structs
- added `// +optional` where we had `omitempty`
- added `// +nullable` where we have `// +optional`, but due to overrides of `JSONMarshal` we cannot apply omitempty.