### PR TITLE
operator/v1: remove optional from managementState

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -34,8 +34,11 @@ var (
 	// It will only upgrade the component if it is safe to do so
 	Managed ManagementState = "Managed"
 	// Unmanaged means that the operator will not take any action related to the component
+	// Some operators might not support this management state as it might damage the cluster and lead to manual recovery.
 	Unmanaged ManagementState = "Unmanaged"
 	// Removed means that the operator is actively managing its resources and trying to remove all traces of the component
+	// Some operators (like kube-apiserver-operator) might not support this management state as removing the API server will
+	// brick the cluster.
 	Removed ManagementState = "Removed"
 )
 
@@ -43,7 +46,6 @@ var (
 // inside of the Spec struct for your particular operator.
 type OperatorSpec struct {
 	// managementState indicates whether and how the operator should manage the component
-	// +optional
 	// +kubebuilder:validation:Pattern=^Managed|Unmanaged|Force|Removed$
 	ManagementState ManagementState `json:"managementState"`
 


### PR DESCRIPTION
The `managementState` should not be `+optional` is there are only 3 supported values and an empty string is ambiguous.

Once https://github.com/openshift/kubernetes-sigs-controller-tools/pull/4 will land, we can restrict allowed values for each individual operator. 

/cc @sttts 
/cc @deads2k 
/cc @enj 