### PR TITLE
Make config.NetworkStatus fields omitempty

### DIFF
--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -44,19 +44,17 @@ type NetworkSpec struct {
 // NetworkStatus is the current network configuration.
 type NetworkStatus struct {
 	// IP address pool to use for pod IPs.
-	// +nullable
-	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork"`
+	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork,omitempty"`
 
 	// IP address pool for services.
 	// Currently, we only support a single entry here.
-	// +nullable
-	ServiceNetwork []string `json:"serviceNetwork"`
+	ServiceNetwork []string `json:"serviceNetwork,omitempty"`
 
 	// NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
-	NetworkType string `json:"networkType"`
+	NetworkType string `json:"networkType,omitempty"`
 
 	// ClusterNetworkMTU is the MTU for inter-pod networking.
-	ClusterNetworkMTU int `json:"clusterNetworkMTU"`
+	ClusterNetworkMTU int `json:"clusterNetworkMTU,omitempty"`
 }
 
 // ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs


### PR DESCRIPTION
This changes it so that a network config with no status marshals to:

        status: {}

rather than

        status:
          clusterNetwork: null
          clusterNetworkMTU: 0
          networkType: ""
          serviceNetwork: null

Replaces #237. We will need to pull this update into the installer and the network operator, and then should not need https://github.com/openshift/cluster-config-operator/pull/23 because the existing CRD allows all of the status fields to be missing. I don't think anything besides the installer and CNO marshals this type, so nothing else needs to be updated urgently.

I felt a little bit weird about marking an int32 field as `omitempty`, but there's plenty of precedent (eg, `DeploymentStatus` and `DaemonSetStatus`), and `0` is not a valid value for the field.

@sttts 