### PR TITLE
Add pattern check for ConsoleAuthentication

### DIFF
--- a/config/v1/types_console.go
+++ b/config/v1/types_console.go
@@ -52,5 +52,6 @@ type ConsoleAuthentication struct {
 	// provides the user the option to perform single logout (SLO) through the identity
 	// provider to destroy their single sign-on session.
 	// +optional
+	// +kubebuilder:validation:Pattern=^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$
 	LogoutRedirect string `json:"logoutRedirect,omitempty"`
 }


### PR DESCRIPTION
Add pattern match for urls created for logoutRedirect (type ConsoleAuthentication).
Example URLs:
1) https://redhat.com/logout.html (valid)
2) https://localhost/logout.php (valid)
3) redhat.com/logout.html (invalid, no https)
