### PR TITLE
[3.11] Bug 1690066: Add BuildPodEvicted Status Reason

### DIFF
--- a/build/v1/consts.go
+++ b/build/v1/consts.go
@@ -87,7 +87,11 @@ const (
 	// StatusReasonOutOfMemoryKilled indicates that the build pod was killed for its memory consumption
 	StatusReasonOutOfMemoryKilled StatusReason = "OutOfMemoryKilled"
 
-	// StatusCannotRetrieveServiceAccount is the reason associated with a failure
+	// StatusReasonCannotRetrieveServiceAccount is the reason associated with a failure
 	// to look up the service account associated with the BuildConfig.
 	StatusReasonCannotRetrieveServiceAccount StatusReason = "CannotRetrieveServiceAccount"
+
+	// StatusReasonBuildPodEvicted is the reason a build fails due to the build pod being evicted
+	// from its node
+	StatusReasonBuildPodEvicted StatusReason = "BuildPodEvicted"
 )


### PR DESCRIPTION
New reason code indicating a build failed due to its pod being evicted.