### PR TITLE
Add InfrastructureName.

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -43,11 +43,6 @@ type InfrastructureStatus struct {
 	// not support that platform.
 	Platform PlatformType `json:"platform,omitempty"`
 
-	// platformStatus holds status informations that are specific to the underlying
-	// infrastructure provider of the cluster.
-	// +optional
-	PlatformStatus *PlatformStatus `json:"platformStatus,omitempty"`
-
 	// etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering
 	// etcd servers and clients.
 	// For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
@@ -84,21 +79,6 @@ const (
 	// VSpherePlatformType represents VMWare vSphere infrastructure.
 	VSpherePlatformType PlatformType = "VSphere"
 )
-
-// PlatformStatus holds the current status specific to the underlying infrastructure provider
-// of the current cluster. Since these are used at status-level for the underlying cluster, it
-// is supposed that only one of the status structs is set.
-type PlatformStatus struct {
-	// AWSPlatformStatus contains settings specific to the Amazon Web Services infrastructure provider.
-	// +optional
-	AWSPlatformStatus *AWSPlatformStatus `json:"awsPlatformStatus,omitempty"`
-}
-
-// AWSPlatformStatus holds the current status of the Amazon Web Services infrastructure provider.
-type AWSPlatformStatus struct {
-	// tags holds key and value pairs that are set as tags in the AWS resources created by the cluster.
-	Tags map[string]string `json:"tags,omitempty"`
-}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -28,6 +28,11 @@ type InfrastructureSpec struct {
 
 // InfrastructureStatus describes the infrastructure the cluster is leveraging.
 type InfrastructureStatus struct {
+	// infrastructureName uniquely identifies a cluster with a human friendly name.
+	// Once set it should not be changed. Must be of max length 27 and must have only
+	// alphanumeric or hyphen characters.
+	InfrastructureName string `json:"infrastructureName"`
+
 	// platform is the underlying infrastructure provider for the cluster. This
 	// value controls whether infrastructure automation such as service load
 	// balancers, dynamic volume provisioning, machine creation and deletion, and
@@ -37,6 +42,11 @@ type InfrastructureStatus struct {
 	// all platforms, and must handle unrecognized platforms as None if they do
 	// not support that platform.
 	Platform PlatformType `json:"platform,omitempty"`
+
+	// platformStatus holds status informations that are specific to the underlying
+	// infrastructure provider of the cluster.
+	// +optional
+	PlatformStatus *PlatformStatus `json:"platformStatus,omitempty"`
 
 	// etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering
 	// etcd servers and clients.
@@ -53,27 +63,42 @@ type InfrastructureStatus struct {
 type PlatformType string
 
 const (
-	// AWSPlatform represents Amazon Web Services infrastructure.
-	AWSPlatform PlatformType = "AWS"
+	// AWSPlatformType represents Amazon Web Services infrastructure.
+	AWSPlatformType PlatformType = "AWS"
 
-	// AzurePlatform represents Microsoft Azure infrastructure.
-	AzurePlatform PlatformType = "Azure"
+	// AzurePlatformType represents Microsoft Azure infrastructure.
+	AzurePlatformType PlatformType = "Azure"
 
-	// GCPPlatform represents Google Cloud Platform infrastructure.
-	GCPPlatform PlatformType = "GCP"
+	// GCPPlatformType represents Google Cloud Platform infrastructure.
+	GCPPlatformType PlatformType = "GCP"
 
-	// LibvirtPlatform represents libvirt infrastructure.
-	LibvirtPlatform PlatformType = "Libvirt"
+	// LibvirtPlatformType represents libvirt infrastructure.
+	LibvirtPlatformType PlatformType = "Libvirt"
 
-	// OpenStackPlatform represents OpenStack infrastructure.
-	OpenStackPlatform PlatformType = "OpenStack"
+	// OpenStackPlatformType represents OpenStack infrastructure.
+	OpenStackPlatformType PlatformType = "OpenStack"
 
-	// NonePlatform means there is no infrastructure provider.
-	NonePlatform PlatformType = "None"
+	// NonePlatformType means there is no infrastructure provider.
+	NonePlatformType PlatformType = "None"
 
-	// VSpherePlatform represents VMWare vSphere infrastructure.
-	VSpherePlatform PlatformType = "VSphere"
+	// VSpherePlatformType represents VMWare vSphere infrastructure.
+	VSpherePlatformType PlatformType = "VSphere"
 )
+
+// PlatformStatus holds the current status specific to the underlying infrastructure provider
+// of the current cluster. Since these are used at status-level for the underlying cluster, it
+// is supposed that only one of the status structs is set.
+type PlatformStatus struct {
+	// AWSPlatformStatus contains settings specific to the Amazon Web Services infrastructure provider.
+	// +optional
+	AWSPlatformStatus *AWSPlatformStatus `json:"awsPlatformStatus,omitempty"`
+}
+
+// AWSPlatformStatus holds the current status of the Amazon Web Services infrastructure provider.
+type AWSPlatformStatus struct {
+	// tags holds key and value pairs that are set as tags in the AWS resources created by the cluster.
+	Tags map[string]string `json:"tags,omitempty"`
+}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -727,6 +727,7 @@ func (InfrastructureSpec) SwaggerDoc() map[string]string {
 
 var map_InfrastructureStatus = map[string]string{
 	"":                    "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
+	"infrastructureName":  "infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.",
 	"platform":            "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
 	"etcdDiscoveryDomain": "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
 	"apiServerURL":        "apiServerURL is a valid URL with scheme(http/https), address and port. apiServerURL can be used by components like kubelet on machines, to contact the `apisever` using the infrastructure provider rather than the kubernetes networking.",


### PR DESCRIPTION
Picking up where @fabianofranz  had to leave off in https://github.com/openshift/api/pull/231.

Adding InfrastructureName will give components the information they need to tag cloud resources consistently. (kubernetes.io/cluster/[infraname] = owned)

The controversial arbitrary AWS tagging is removed based on the comments in that PR.

I was going to move this back to Spec because it does not feel like Status to me, but I saw PlatformType is already Status and thus I think this ship has already sailed. 

CC @abhinavdahiya @wking @derekwaynecarr @smarterclayton 