### PR TITLE
quota: make namespaces and labelselector optional and nullable

### DIFF
--- a/quota/v1/generated.proto
+++ b/quota/v1/generated.proto
@@ -62,9 +62,13 @@ message ClusterResourceQuotaList {
 // the project must match both restrictions.
 message ClusterResourceQuotaSelector {
   // LabelSelector is used to select projects by label.
+  // +optional
+  // +nullable
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labels = 1;
 
   // AnnotationSelector is used to select projects by annotation.
+  // +optional
+  // +nullable
   map<string, string> annotations = 2;
 }
 
@@ -88,6 +92,8 @@ message ClusterResourceQuotaStatus {
   // Namespaces slices the usage by project.  This division allows for quick resolution of
   // deletion reconciliation inside of a single project without requiring a recalculation
   // across all projects.  This can be used to pull the deltas for a given project.
+  // +optional
+  // +nullable
   repeated ResourceQuotaStatusByNamespace namespaces = 2;
 }
 

--- a/quota/v1/types.go
+++ b/quota/v1/types.go
@@ -40,9 +40,13 @@ type ClusterResourceQuotaSpec struct {
 // the project must match both restrictions.
 type ClusterResourceQuotaSelector struct {
 	// LabelSelector is used to select projects by label.
+	// +optional
+	// +nullable
 	LabelSelector *metav1.LabelSelector `json:"labels" protobuf:"bytes,1,opt,name=labels"`
 
 	// AnnotationSelector is used to select projects by annotation.
+	// +optional
+	// +nullable
 	AnnotationSelector map[string]string `json:"annotations" protobuf:"bytes,2,rep,name=annotations"`
 }
 
@@ -54,6 +58,8 @@ type ClusterResourceQuotaStatus struct {
 	// Namespaces slices the usage by project.  This division allows for quick resolution of
 	// deletion reconciliation inside of a single project without requiring a recalculation
 	// across all projects.  This can be used to pull the deltas for a given project.
+	// +optional
+	// +nullable
 	Namespaces ResourceQuotasStatusByNamespace `json:"namespaces" protobuf:"bytes,2,rep,name=namespaces"`
 }
 


### PR DESCRIPTION
Prevent this error:

```
❯ oc create clusterquota for-user-3 \                                                                                                                                                                                                                                                                                                                                    ✘
     --project-annotation-selector openshift.io/requester=foo \
     --hard pods=10 \
     --hard secrets=20
The ClusterResourceQuota "for-user-3" is invalid: []: Invalid value: map[string]interface {}{"kind":"ClusterResourceQuota", "apiVersion":"quota.openshift.io/v1", "metadata":map[string]interface {}{"uid":"1a4f3b42-5152-11e9-a8b1-0e719a5075b6", "name":"for-user-3", "creationTimestamp":"2019-03-28T12:07:48Z", "generation":1}, "spec":map[string]interface {}{"selector":map[string]interface {}{"annotations":map[string]interface {}{"openshift.io/requester":"foo"}, "labels":interface {}(nil)}, "quota":map[string]interface {}{"hard":map[string]interface {}{"pods":"10", "secrets":"20"}}}, "status":map[string]interface {}{"total":map[string]interface {}{}, "namespaces":interface {}(nil)}}: validation failure list:
spec.selector.labels in body must be of type object: "null"
status.namespaces in body must be of type array: "null"
```