### PR TITLE
operator/ingress: add tolerations

### DIFF
--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -137,6 +137,16 @@ type NodePlacement struct {
 	//
 	// +optional
 	NodeSelector *metav1.LabelSelector `json:"nodeSelector,omitempty"`
+
+	// tolerations is a list of tolerations applied to ingress controller
+	// deployments.
+	//
+	// The default is an empty list.
+	//
+	// See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+	//
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // EndpointPublishingStrategyType is a way to publish ingress controller endpoints.

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -1108,6 +1108,13 @@ func (in *NodePlacement) DeepCopyInto(out *NodePlacement) {
 		*out = new(metav1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -283,6 +283,7 @@ func (IngressControllerStatus) SwaggerDoc() map[string]string {
 var map_NodePlacement = map[string]string{
 	"":             "NodePlacement describes node scheduling configuration for an ingress controller.",
 	"nodeSelector": "nodeSelector is the node selector applied to ingress controller deployments.\n\nIf unset, the default is:\n\n  beta.kubernetes.io/os: linux\n  node-role.kubernetes.io/worker: ''\n\nIf set, the specified selector is used and replaces the default.",
+	"tolerations":  "tolerations is a list of tolerations applied to ingress controller deployments.\n\nThe default is an empty list.\n\nSee https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/",
 }
 
 func (NodePlacement) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Expose configuration for ingresscontroller deployment tolerations.

/cc @openshift/sig-network-edge @smarterclayton @mcurry-rh @thoraxe 