### PR TITLE
Bug 1693685: Fixing build retention API doc

### DIFF
--- a/build/v1/generated.proto
+++ b/build/v1/generated.proto
@@ -110,11 +110,13 @@ message BuildConfigSpec {
   optional CommonSpec commonSpec = 3;
 
   // successfulBuildsHistoryLimit is the number of old successful builds to retain.
-  // If not specified, all successful builds are retained.
+  // When a BuildConfig is created, the 5 most recent successful builds are retained unless this value is set.
+  // If removed after the BuildConfig has been created, all successful builds are retained.
   optional int32 successfulBuildsHistoryLimit = 4;
 
   // failedBuildsHistoryLimit is the number of old failed builds to retain.
-  // If not specified, all failed builds are retained.
+  // When a BuildConfig is created, the 5 most recent failed builds are retained unless this value is set.
+  // If removed after the BuildConfig has been created, all failed builds are retained.
   optional int32 failedBuildsHistoryLimit = 5;
 }
 

--- a/build/v1/types.go
+++ b/build/v1/types.go
@@ -902,11 +902,13 @@ type BuildConfigSpec struct {
 	CommonSpec `json:",inline" protobuf:"bytes,3,opt,name=commonSpec"`
 
 	// successfulBuildsHistoryLimit is the number of old successful builds to retain.
-	// If not specified, all successful builds are retained.
+	// When a BuildConfig is created, the 5 most recent successful builds are retained unless this value is set.
+	// If removed after the BuildConfig has been created, all successful builds are retained.
 	SuccessfulBuildsHistoryLimit *int32 `json:"successfulBuildsHistoryLimit,omitempty" protobuf:"varint,4,opt,name=successfulBuildsHistoryLimit"`
 
 	// failedBuildsHistoryLimit is the number of old failed builds to retain.
-	// If not specified, all failed builds are retained.
+	// When a BuildConfig is created, the 5 most recent failed builds are retained unless this value is set.
+	// If removed after the BuildConfig has been created, all failed builds are retained.
 	FailedBuildsHistoryLimit *int32 `json:"failedBuildsHistoryLimit,omitempty" protobuf:"varint,5,opt,name=failedBuildsHistoryLimit"`
 }
 

--- a/build/v1/zz_generated.swagger_doc_generated.go
+++ b/build/v1/zz_generated.swagger_doc_generated.go
@@ -80,8 +80,8 @@ var map_BuildConfigSpec = map[string]string{
 	"":                             "BuildConfigSpec describes when and how builds are created",
 	"triggers":                     "triggers determine how new Builds can be launched from a BuildConfig. If no triggers are defined, a new build can only occur as a result of an explicit client build creation.",
 	"runPolicy":                    "RunPolicy describes how the new build created from this build configuration will be scheduled for execution. This is optional, if not specified we default to \"Serial\".",
-	"successfulBuildsHistoryLimit": "successfulBuildsHistoryLimit is the number of old successful builds to retain. If not specified, all successful builds are retained.",
-	"failedBuildsHistoryLimit":     "failedBuildsHistoryLimit is the number of old failed builds to retain. If not specified, all failed builds are retained.",
+	"successfulBuildsHistoryLimit": "successfulBuildsHistoryLimit is the number of old successful builds to retain. When a BuildConfig is created, the 5 most recent successful builds are retained unless this value is set. If removed after the BuildConfig has been created, all successful builds are retained.",
+	"failedBuildsHistoryLimit":     "failedBuildsHistoryLimit is the number of old failed builds to retain. When a BuildConfig is created, the 5 most recent failed builds are retained unless this value is set. If removed after the BuildConfig has been created, all failed builds are retained.",
 }
 
 func (BuildConfigSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
In 3.11 and above, only the 5 most recent builds of each category
are retained.

Partially fixes [bug 1693685](https://bugzilla.redhat.com/show_bug.cgi?id=1693685).