### PR TITLE
bug 1683055: Add spec and status comments/description for serviceca operator type

### DIFF
--- a/operator/v1/types_serviceca.go
+++ b/operator/v1/types_serviceca.go
@@ -14,8 +14,10 @@ type ServiceCA struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	// +required
+	//spec holds user settable values for configuration
 	Spec   ServiceCASpec   `json:"spec"`
 	// +optional
+	// status holds observed values from the cluster. They may not be overridden.
 	Status ServiceCAStatus `json:"status"`
 }
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -505,7 +505,9 @@ func (KubeSchedulerSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ServiceCA = map[string]string{
-	"": "ServiceCA provides information to configure an operator to manage the service cert controllers",
+	"":       "ServiceCA provides information to configure an operator to manage the service cert controllers",
+	"spec":   "spec holds user settable values for configuration",
+	"status": "status holds observed values from the cluster. They may not be overridden.",
 }
 
 func (ServiceCA) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This should resolve: https://bugzilla.redhat.com/show_bug.cgi?id=1683055
testing now