### PR TITLE
fix route/OWNERS

### DIFF
--- a/route/OWNERS
+++ b/route/OWNERS
@@ -1,4 +1,5 @@
 reviewers:
-  - danwinship
-  - dcbw
+  - ironcladlou
   - knobunc
+  - pravisankar
+  - Miciah


### PR DESCRIPTION
route/ is owned by @openshift/sig-network-edge not sig-network

(copied contents from cluster-ingress-operator, minus ramr who's gone now, right?)