### PR TITLE
add log level for operator

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -54,6 +54,11 @@ type OperatorSpec struct {
 	// +optional
 	LogLevel LogLevel `json:"logLevel"`
 
+	// operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a
+	// simple way to manage coarse grained logging choices that operators have to interpret for themselves.
+	// +optional
+	OperatorLogLevel LogLevel `json:"operatorLogLevel"`
+
 	// operandSpecs provide customization for functional units within the component
 	// +optional
 	OperandSpecs []OperandSpec `json:"operandSpecs,omitempty"`

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -78,6 +78,7 @@ var map_OperatorSpec = map[string]string{
 	"":                           "OperatorSpec contains common fields operators need.  It is intended to be anonymous included inside of the Spec struct for your particular operator.",
 	"managementState":            "managementState indicates whether and how the operator should manage the component",
 	"logLevel":                   "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands.",
+	"operatorLogLevel":           "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves.",
 	"operandSpecs":               "operandSpecs provide customization for functional units within the component",
 	"unsupportedConfigOverrides": "unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides",
 	"observedConfig":             "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",


### PR DESCRIPTION
This allows an operator to look up the desired level and log at that level.  We will plumb this into the installer and pruner pods too.  We can be dynamic to avoid conflicting with the CVO deployment values

/assign @mfojtik 
@derekwaynecarr @smarterclayton as discussed.
@sjenning it's getting better....