### PR TITLE
config: Clarify operand version for release payload

### DIFF
--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -63,9 +63,9 @@ type OperandVersion struct {
 	// name is the name of the particular operand this version is for.  It usually matches container images, not operators.
 	Name string `json:"name"`
 
-	// version indicates which version of a particular operand is currently being manage.  It must always match the Available
-	// condition.  If 1.0.0 is Available, then this must indicate 1.0.0 even if the operator is trying to rollout
-	// 1.1.0
+	// version indicates which version of a particular operand is currently being managed.  When set by an operator, it must
+	// match the Available condition.  The only time it is allowed not to match Available is in a release payload manifest.
+	// If 1.0.0 is Available, then this must indicate 1.0.0 even if the operator is trying to rollout 1.1.0
 	Version string `json:"version"`
 }
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -448,7 +448,7 @@ func (ObjectReference) SwaggerDoc() map[string]string {
 
 var map_OperandVersion = map[string]string{
 	"name":    "name is the name of the particular operand this version is for.  It usually matches container images, not operators.",
-	"version": "version indicates which version of a particular operand is currently being manage.  It must always match the Available condition.  If 1.0.0 is Available, then this must indicate 1.0.0 even if the operator is trying to rollout 1.1.0",
+	"version": "version indicates which version of a particular operand is currently being managed.  When set by an operator, it must match the Available condition.  The only time it is allowed not to match Available is in a release payload manifest. If 1.0.0 is Available, then this must indicate 1.0.0 even if the operator is trying to rollout 1.1.0",
 }
 
 func (OperandVersion) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Fix a false statement in the godoc for `OperandVersion`.

Before this change, the godoc said that `version` must match the `Available` condition, which is a false statement in the case of a manifest in a release payload, which necessarily does _not_ have an `Available` condition but _must_ have `version` set.  Following the old godoc literally will trigger fallback mode in CVO.

This commit changes the godoc to state (1) that `version` must match `Available` only in the case that an operator sets `version` and (2) that `version` is allowed not to match `Available` only in the case that it is in a release payload manifest.

* `config/v1/types_cluster_operator.go` (`OperandVersion`): Clarify that `version` need not match the `Available` condition in a release payload manifest.
* `config/v1/zz_generated.swagger_doc_generated.go`: Regenerate.