### PR TITLE
Remove unnecessary scheduling features

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -74,6 +74,9 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		},
 		Disabled: []string{
 			"LocalStorageCapacityIsolation", // sig-pod, sjenning
+			"ResourceQuotaScopeSelectors",   // sig-pod, ravig
+			"TaintNodesByCondition",         // sig-pod, ravig
+			"TaintBasedEvictions",           // sig-pod, ravig
 		},
 	},
 	TechPreviewNoUpgrade: &FeatureGateEnabledDisabled{
@@ -85,6 +88,9 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		},
 		Disabled: []string{
 			"LocalStorageCapacityIsolation", // sig-pod, sjenning
+			"ResourceQuotaScopeSelectors",   // sig-pod, ravig
+                        "TaintNodesByCondition",         // sig-pod, ravig
+                        "TaintBasedEvictions",           // sig-pod, ravig
 		},
 	},
 }


### PR DESCRIPTION
As of now even though following are beta upstream, I don't see much value in enabling the following features.

- `ResourceQuotaScopeSelectors` will be GA in 1.15. In the current state, it's not quite useful for us.
- `TaintNodesByCondition` has a 5%(approximate number) chance that node controller and kubelet will race. There are folks who started using this in upstream but this is something that needs some thorough discussion.
- `TaintBasedEvictions` is something that we wanted to use internally for draining but we haven't started using it. So, wanted to postpone it to next release.

/cc @sjenning @derekwaynecarr 