### PR TITLE
network: add 'Namespace' field for AdditionalNetworks

### DIFF
--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -108,6 +108,10 @@ type AdditionalNetworkDefinition struct {
 	// This must be unique.
 	Name string `json:"name"`
 
+	// namespace is the namespace of the network. This will be populated in the resulting CRD
+	// If not given the network will be created in the default namespace.
+	Namespace string `json:"namespace,omitempty"`
+
 	// rawCNIConfig is the raw CNI configuration json to create in the
 	// NetworkAttachmentDefinition CRD
 	RawCNIConfig string `json:"rawCNIConfig"`

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -301,6 +301,7 @@ var map_AdditionalNetworkDefinition = map[string]string{
 	"":             "AdditionalNetworkDefinition configures an extra network that is available but not created by default. Instead, pods must request them by name. type must be specified, along with exactly one \"Config\" that matches the type.",
 	"type":         "type is the type of network The only supported value is NetworkTypeRaw",
 	"name":         "name is the name of the network. This will be populated in the resulting CRD This must be unique.",
+	"namespace":    "namespace is the namespace of the network. This will be populated in the resulting CRD If not given the network will be created in the default namespace.",
 	"rawCNIConfig": "rawCNIConfig is the raw CNI configuration json to create in the NetworkAttachmentDefinition CRD",
 }
 


### PR DESCRIPTION
The objects obviously exist within a namespace and authorization for
attaching additional networks to pods is based on namespace isolation
in Multus. Therefore additional networks that are created at install
time may need to be created in different namespaces.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1679946

@danwinship @squeed @s1061123 @dougbtv 