### PR TITLE
fix order of comments in serviceca operator type

### DIFF
--- a/operator/v1/types_serviceca.go
+++ b/operator/v1/types_serviceca.go
@@ -13,11 +13,11 @@ type ServiceCA struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	// +required
 	//spec holds user settable values for configuration
+	// +required
 	Spec ServiceCASpec `json:"spec"`
-	// +optional
 	// status holds observed values from the cluster. They may not be overridden.
+	// +optional
 	Status ServiceCAStatus `json:"status"`
 }
 


### PR DESCRIPTION
The order of comments _I believe_ needs to be 
```
// description
// +required|optional
```
and not the other way around 
_sigh_ 
bug 1683055