### PR TITLE
ForceRedeploymentReason is now duplicated, causes openapi failure

### DIFF
--- a/operator/v1/types_etcd.go
+++ b/operator/v1/types_etcd.go
@@ -21,11 +21,6 @@ type Etcd struct {
 
 type EtcdSpec struct {
 	StaticPodOperatorSpec `json:",inline"`
-
-	// forceRedeploymentReason can be used to force the redeployment of the kube-apiserver by providing a unique string.
-	// This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work
-	// this time instead of failing again on the same config.
-	ForceRedeploymentReason string `json:"forceRedeploymentReason"`
 }
 
 type EtcdStatus struct {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -188,14 +188,6 @@ func (EtcdList) SwaggerDoc() map[string]string {
 	return map_EtcdList
 }
 
-var map_EtcdSpec = map[string]string{
-	"forceRedeploymentReason": "forceRedeploymentReason can be used to force the redeployment of the kube-apiserver by providing a unique string. This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work this time instead of failing again on the same config.",
-}
-
-func (EtcdSpec) SwaggerDoc() map[string]string {
-	return map_EtcdSpec
-}
-
 var map_EndpointPublishingStrategy = map[string]string{
 	"":     "EndpointPublishingStrategy is a way to publish the endpoints of an IngressController, and represents the type and any additional configuration for a specific type.",
 	"type": "type is the publishing strategy to use. Valid values are:\n\n* LoadBalancerService\n\nPublishes the ingress controller using a Kubernetes LoadBalancer Service.\n\nIn this configuration, the ingress controller deployment uses container networking. A LoadBalancer Service is created to publish the deployment.\n\nSee: https://kubernetes.io/docs/concepts/services-networking/#loadbalancer\n\nIf domain is set, a wildcard DNS record will be managed to point at the LoadBalancer Service's external name. DNS records are managed only in DNS zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone.\n\nWildcard DNS management is currently supported only on the AWS platform.\n\n* HostNetwork\n\nPublishes the ingress controller on node ports where the ingress controller is deployed.\n\nIn this configuration, the ingress controller deployment uses host networking, bound to node ports 80 and 443. The user is responsible for configuring an external load balancer to publish the ingress controller via the node ports.\n\n* Private\n\nDoes not publish the ingress controller.\n\nIn this configuration, the ingress controller deployment uses container networking, and is not explicitly published. The user must manually publish the ingress controller.",


### PR DESCRIPTION
The field is duplicated on etcd, which causes origin openapi gen
to fail because of the inline field.