### PR TITLE
Add missing kubebuilder tag for SecurityContextConstraint

### DIFF
--- a/security/v1/generated.proto
+++ b/security/v1/generated.proto
@@ -178,6 +178,7 @@ message SELinuxContextStrategyOptions {
 // That exposure is deprecated and will be removed in a future release - users
 // should instead use the security.openshift.io group to manage
 // SecurityContextConstraints.
+// +kubebuilder:singular=securitycontextconstraint
 message SecurityContextConstraints {
   // Standard object's metadata.
   // More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata

--- a/security/v1/types.go
+++ b/security/v1/types.go
@@ -20,6 +20,7 @@ var AllowAllCapabilities corev1.Capability = "*"
 // That exposure is deprecated and will be removed in a future release - users
 // should instead use the security.openshift.io group to manage
 // SecurityContextConstraints.
+// +kubebuilder:singular=securitycontextconstraint
 type SecurityContextConstraints struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.


### PR DESCRIPTION
These should be set for CRD generators (see https://github.com/openshift/cluster-config-operator/pull/53)