### PR TITLE
add more nullable tags for SCCs take 3

### DIFF
--- a/security/v1/generated.proto
+++ b/security/v1/generated.proto
@@ -189,6 +189,7 @@ message SecurityContextConstraints {
   // for multiple SCCs are equal they will be sorted from most restrictive to
   // least restrictive. If both priorities and restrictions are equal the
   // SCCs will be sorted by name.
+  // +nullable
   optional int32 priority = 2;
 
   // AllowPrivilegedContainer determines if a container can request to be run as privileged.
@@ -197,16 +198,19 @@ message SecurityContextConstraints {
   // DefaultAddCapabilities is the default set of capabilities that will be added to the container
   // unless the pod spec specifically drops the capability.  You may not list a capabiility in both
   // DefaultAddCapabilities and RequiredDropCapabilities.
+  // +nullable
   repeated string defaultAddCapabilities = 4;
 
   // RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
   // are required to be dropped and cannot be added.
+  // +nullable
   repeated string requiredDropCapabilities = 5;
 
   // AllowedCapabilities is a list of capabilities that can be requested to add to the container.
   // Capabilities in this field maybe added at the pod author's discretion.
   // You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
   // To allow all capabilities you may use '*'.
+  // +nullable
   repeated string allowedCapabilities = 6;
 
   // AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
@@ -216,6 +220,7 @@ message SecurityContextConstraints {
   // Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
   // of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
   // To allow no volumes, set to ["none"].
+  // +nullable
   repeated string volumes = 8;
 
   // AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all

--- a/security/v1/types.go
+++ b/security/v1/types.go
@@ -32,6 +32,7 @@ type SecurityContextConstraints struct {
 	// for multiple SCCs are equal they will be sorted from most restrictive to
 	// least restrictive. If both priorities and restrictions are equal the
 	// SCCs will be sorted by name.
+	// +nullable
 	Priority *int32 `json:"priority" protobuf:"varint,2,opt,name=priority"`
 
 	// AllowPrivilegedContainer determines if a container can request to be run as privileged.
@@ -39,14 +40,17 @@ type SecurityContextConstraints struct {
 	// DefaultAddCapabilities is the default set of capabilities that will be added to the container
 	// unless the pod spec specifically drops the capability.  You may not list a capabiility in both
 	// DefaultAddCapabilities and RequiredDropCapabilities.
+	// +nullable
 	DefaultAddCapabilities []corev1.Capability `json:"defaultAddCapabilities" protobuf:"bytes,4,rep,name=defaultAddCapabilities,casttype=Capability"`
 	// RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
 	// are required to be dropped and cannot be added.
+	// +nullable
 	RequiredDropCapabilities []corev1.Capability `json:"requiredDropCapabilities" protobuf:"bytes,5,rep,name=requiredDropCapabilities,casttype=Capability"`
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
 	// Capabilities in this field maybe added at the pod author's discretion.
 	// You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
 	// To allow all capabilities you may use '*'.
+	// +nullable
 	AllowedCapabilities []corev1.Capability `json:"allowedCapabilities" protobuf:"bytes,6,rep,name=allowedCapabilities,casttype=Capability"`
 	// AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
 	// +k8s:conversion-gen=false
@@ -54,6 +58,7 @@ type SecurityContextConstraints struct {
 	// Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names
 	// of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*".
 	// To allow no volumes, set to ["none"].
+	// +nullable
 	Volumes []FSType `json:"volumes" protobuf:"bytes,8,rep,name=volumes,casttype=FSType"`
 	// AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all
 	// Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes


### PR DESCRIPTION
@deads I'll fix vendor in cluster-config-op when this merges
@enj these were causing validation errors 
`openshift_apiserver.go:609] unable to create default security context constraint`

```
priority in body must be of type integer: "null"
defaultAddCapabilities in body must be of type array: "null"
allowedCapabilities in body must be of type array: "null"
```