### PR TITLE
config/v1/types_infrastructure: Split apiServerURL intro external/internal

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -52,10 +52,16 @@ type InfrastructureStatus struct {
 	// For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
 	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain"`
 
-	// apiServerURL is a valid URL with scheme(http/https), address and port.
-	// apiServerURL can be used by components like kubelet on machines, to contact the `apisever`
-	// using the infrastructure provider rather than the kubernetes networking.
+	// apiServerURL is a valid URI with scheme(http/https), address and
+	// port.  apiServerURL can be used by components like the web console
+	// to tell users where to find the Kubernetes API.
 	APIServerURL string `json:"apiServerURL"`
+
+	// apiServerInternalURL is a valid URI with scheme(http/https),
+	// address and port.  apiServerInternalURL can be used by components
+	// like kubelets, to contact the Kubernetes API server using the
+	// infrastructure provider rather than Kubernetes networking.
+	APIServerInternalURL string `json:"apiServerInternalURI"`
 }
 
 // PlatformType is a specific supported infrastructure provider.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -729,11 +729,12 @@ func (InfrastructureSpec) SwaggerDoc() map[string]string {
 }
 
 var map_InfrastructureStatus = map[string]string{
-	"":                    "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
-	"infrastructureName":  "infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.",
-	"platform":            "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
-	"etcdDiscoveryDomain": "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
-	"apiServerURL":        "apiServerURL is a valid URL with scheme(http/https), address and port. apiServerURL can be used by components like kubelet on machines, to contact the `apisever` using the infrastructure provider rather than the kubernetes networking.",
+	"":                     "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
+	"infrastructureName":   "infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.",
+	"platform":             "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
+	"etcdDiscoveryDomain":  "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
+	"apiServerURL":         "apiServerURL is a valid URI with scheme(http/https), address and port.  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.",
+	"apiServerInternalURI": "apiServerInternalURL is a valid URI with scheme(http/https), address and port.  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.",
 }
 
 func (InfrastructureStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
The kubelet ([via the machine-config operator][1]) and [Kubernetes API-server operator][2] need the internal API URI.  [The console operator][3] and [authentication operator][4] need the external URI. Since the `api-int` split (e.g. openshift/installer@13e4b702f7, openshift/installer#1601), those are two different things, so we need two different properties.

I've deprecated the old property because it was ambiguous.  We can drop it if/when we ever cut a v2 of this type.

I've avoided leading with `External` or `Internal` so these properties will all alphabetize together when rendering YAML, etc.

I've avoided `Public`, because that is often used in a public/private` dichotomy for security.  The split was motivated by separating X.509 chains of trust, but the URIs themselves are not sensitive.

I've also taken the opportunity to change from URL to the more-generic URI, because we don't need to make a point of locator-ness and [RFCs][5] [recommend][6] using the more generic label.

We need this to address the 4.1-blocking [rhbz#1706689][7], although this API change on its own is not sufficient to fix the bug.

[1]: https://github.com/openshift/machine-config-operator/blob/2bd29e5005fb6f438f1b1c512176c3f7e5cf9e47/pkg/operator/operator.go#L393
[2]: https://github.com/openshift/cluster-kube-apiserver-operator/blob/cbcb3f403f674dd8d0b590d770c0ebf6ecb75f17/pkg/operator/certrotationcontroller/externalloadbalancer.go#L18
[3]: https://github.com/openshift/console-operator/blob/fc721a6990b6ca27efb60062cf5e9d620ec0ab01/pkg/console/subresource/configmap/configmap.go#L59
[4]: https://github.com/openshift/cluster-authentication-operator/blob/96643e4b29452f9ad20f7b90fc0794ffc3006fa2/pkg/operator2/oauth.go#L117
[5]: https://tools.ietf.org/html/rfc3305#section-2.2
[6]: https://tools.ietf.org/html/rfc3986#section-1.1.3
[7]: https://bugzilla.redhat.com/show_bug.cgi?id=1706689