### PR TITLE
Update Dockerfile.build to fedora:29 base

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM fedora:28
+FROM fedora:29
 
 ENV GOPATH=/go
 ENV PATH=/go/bin:$PATH

--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -11,6 +11,7 @@ install the platform appropriate Protobuf package for your OS:
   https://github.com/google/protobuf/releases
 
 To skip protobuf generation, set \$PROTO_OPTIONAL."
+  exit 1
 fi
 
 rm -rf go-to-protobuf


### PR DESCRIPTION
The first commit in this PR updates the base image of `Dockerfile.build` from fedora:28 to fedora:29.

Currently with the f28 base, `make generate-with-container` fails with this error:
`go/src/golang.org/x/tools/internal/lsp/source/symbols.go:226:18: ti.EmbeddedType undefined (type *types.Interface has no field or method EmbeddedType)`
Updating to f29 fixes that issue.
Additionally, Fedora 28 EOLs at the end of this month.

The second commit adds an `exit 1` to `hack/update-protobuf.sh` to bail out if the protoc version is not correct. Previously it only showed the message in terminal and continued generating anyway.