### PR TITLE
operator/v1: add latestAvailableRevisionReason

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -185,6 +185,10 @@ type StaticPodOperatorStatus struct {
 	// +optional
 	LatestAvailableRevision int32 `json:"latestAvailableRevision,omitEmpty"`
 
+	// latestAvailableRevisionReason describe the detailed reason for the most recent deployment
+	// +optional
+	LatestAvailableRevisionReason string `json:"latestAvailableRevisionReason,omitEmpty"`
+
 	// nodeStatuses track the deployment values and errors across individual nodes
 	// +optional
 	NodeStatuses []NodeStatus `json:"nodeStatuses,omitempty"`

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -91,9 +91,10 @@ func (StaticPodOperatorSpec) SwaggerDoc() map[string]string {
 }
 
 var map_StaticPodOperatorStatus = map[string]string{
-	"":                        "StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual node status must be tracked.",
-	"latestAvailableRevision": "latestAvailableRevision is the deploymentID of the most recent deployment",
-	"nodeStatuses":            "nodeStatuses track the deployment values and errors across individual nodes",
+	"":                              "StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual node status must be tracked.",
+	"latestAvailableRevision":       "latestAvailableRevision is the deploymentID of the most recent deployment",
+	"latestAvailableRevisionReason": "latestAvailableRevisionReason describe the detailed reason for the most recent deployment",
+	"nodeStatuses":                  "nodeStatuses track the deployment values and errors across individual nodes",
 }
 
 func (StaticPodOperatorStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This came from https://github.com/openshift/library-go/pull/384

Basically, today we don't have great history of why the revision N happened. We report the reason via events which are TTL or to the operator logs (kind of TTL as well).

We should persist the reason of why revision N happened inside the installer pod. The linked PR does that via pod annotation. The reason can be just message or a JSON patch of config that cause the change.

The installer pods are pruned, but we keep several revisions around, which should be enough for debugging.

The field in this PR is required to share the reason between the revision controller and the installer controller.

/cc @deads2k 
/cc @sttts 
/cc @openshift/sig-master 