### PR TITLE
config: Deprecate build.spec.additionalTrustedCA

### DIFF
--- a/config/v1/types_build.go
+++ b/config/v1/types_build.go
@@ -22,6 +22,11 @@ type BuildSpec struct {
 	// AdditionalTrustedCA is a reference to a ConfigMap containing additional CAs that
 	// should be trusted for image pushes and pulls during builds.
 	// The namespace for this config map is openshift-config.
+	//
+	// Deprecated: this reference is not used in OpenShift builds.
+	// Configure additional CAs by setting the `spec.additionalTrustedCA` ConfigMap
+	// reference on the `image.config.openshift.io/cluster` object instead.
+	//
 	// +optional
 	AdditionalTrustedCA ConfigMapNameReference `json:"additionalTrustedCA"`
 	// BuildDefaults controls the default information for Builds

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -365,7 +365,7 @@ func (BuildOverrides) SwaggerDoc() map[string]string {
 }
 
 var map_BuildSpec = map[string]string{
-	"additionalTrustedCA": "AdditionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted for image pushes and pulls during builds. The namespace for this config map is openshift-config.",
+	"additionalTrustedCA": "AdditionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted for image pushes and pulls during builds. The namespace for this config map is openshift-config.\n\nDeprecated: this reference is not used in OpenShift builds. Configure additional CAs by setting the `spec.additionalTrustedCA` ConfigMap reference on the `image.config.openshift.io/cluster` object instead.",
 	"buildDefaults":       "BuildDefaults controls the default information for Builds",
 	"buildOverrides":      "BuildOverrides controls override settings for builds",
 }


### PR DESCRIPTION
AdditionalTrustedCAs referenced in build.config.openshift.io/cluster were never used in OpenShift 4.1.
Mark existing field as deprecated and schedule for future removal.