### PR TITLE
operator/ingress: add kubebuilder markers

### DIFF
--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -8,6 +8,9 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.availableReplicas,selectorpath=.status.labelSelector
 
 // IngressController describes a managed ingress controller for the cluster. The
 // controller can service OpenShift Route and Kubernetes Ingress resources.
@@ -278,6 +281,7 @@ type IngressControllerStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
 
 // IngressControllerList contains a list of IngressControllers.
 type IngressControllerList struct {


### PR DESCRIPTION
Add kubebuilder markers to support upstream controller-runtime
generation tooling.