### PR TITLE
operator: fix kubebuilder validation marker location

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -23,6 +23,7 @@ type MyOperatorResourceStatus struct {
 	OperatorStatus `json:",inline"`
 }
 
+// +kubebuilder:validation:Pattern=^(Managed|Unmanaged|Force|Removed)$
 type ManagementState string
 
 var (
@@ -45,7 +46,6 @@ var (
 // inside of the Spec struct for your particular operator.
 type OperatorSpec struct {
 	// managementState indicates whether and how the operator should manage the component
-	// +kubebuilder:validation:Pattern=^(Managed|Unmanaged|Force|Removed)$
 	ManagementState ManagementState `json:"managementState"`
 
 	// logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a


### PR DESCRIPTION
Move the kubebuilder validation marker location for ManagementState
to the type definition where it belongs.

Fixes this error with [controller-tools@v0.2.0-beta.1](https://github.com/kubernetes-sigs/controller-tools/tree/v0.2.0-beta.1):

```
$ GOFLAGS=-mod=vendor go run sigs.k8s.io/controller-tools/cmd/controller-gen crd:trivialVersions=true paths=./vendor/github.com/openshift/api/operator/v1
/Users/dmace/Projects/ingress-operator/vendor/github.com/openshift/api/operator/v1/types.go:49:2: must apply pattern to a string
Error: not all generators ran succesfully
```

cc @deads2k @sttts @damemi @openshift/sig-network-edge 