### PR TITLE
add annotations uses by oas and ocm to communicate about scc

### DIFF
--- a/security/v1/consts.go
+++ b/security/v1/consts.go
@@ -1,0 +1,10 @@
+package v1
+
+const (
+	UIDRangeAnnotation = "openshift.io/sa.scc.uid-range"
+	// SupplementalGroupsAnnotation contains a comma delimited list of allocated supplemental groups
+	// for the namespace.  Groups are in the form of a Block which supports {start}/{length} or {start}-{end}
+	SupplementalGroupsAnnotation = "openshift.io/sa.scc.supplemental-groups"
+	MCSAnnotation                = "openshift.io/sa.scc.mcs"
+	ValidatedSCCAnnotation       = "openshift.io/scc"
+)


### PR DESCRIPTION
These are the ones that we use today.
