### PR TITLE
operator/dns: add kubebuilder tags

### DIFF
--- a/operator/v1/types_dns.go
+++ b/operator/v1/types_dns.go
@@ -7,6 +7,9 @@ import (
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=dnses,scope=Cluster
+// +kubebuilder:subresource:status
 
 // DNS manages the CoreDNS component to provide a name resolution service
 // for pods and services in the cluster.
@@ -72,6 +75,7 @@ type DNSStatus struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
 
 // DNSList contains a list of DNS
 type DNSList struct {


### PR DESCRIPTION
Uses the new `scope` marker introduced in https://github.com/kubernetes-sigs/controller-tools/pull/220