### PR TITLE
Update comments/docs on console resources

### DIFF
--- a/config/v1/types_console.go
+++ b/config/v1/types_console.go
@@ -6,7 +6,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Console holds cluster-wide information about Console.  The canonical name is `cluster`
+// Console holds cluster-wide information about Console.  The canonical name is `cluster`.
 type Console struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -20,11 +20,13 @@ type Console struct {
 	Status ConsoleStatus `json:"status"`
 }
 
+// ConsoleSpec is the specification of the desired behavior of the Console.
 type ConsoleSpec struct {
 	// +optional
 	Authentication ConsoleAuthentication `json:"authentication"`
 }
 
+// ConsoleStatus defines the observed status of the Console.
 type ConsoleStatus struct {
 	// The URL for the console. This will be derived from the host for the route that
 	// is created for the console.
@@ -40,6 +42,7 @@ type ConsoleList struct {
 	Items           []Console `json:"items"`
 }
 
+// ConsoleAuthentication defines a list of optional configuration for console authentication.
 type ConsoleAuthentication struct {
 	// An optional, absolute URL to redirect web browsers to after logging out of
 	// the console. If not specified, it will redirect to the default login page.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -539,7 +539,7 @@ func (UpdateHistory) SwaggerDoc() map[string]string {
 }
 
 var map_Console = map[string]string{
-	"":         "Console holds cluster-wide information about Console.  The canonical name is `cluster`",
+	"":         "Console holds cluster-wide information about Console.  The canonical name is `cluster`.",
 	"metadata": "Standard object's metadata.",
 	"spec":     "spec holds user settable values for configuration",
 	"status":   "status holds observed values from the cluster. They may not be overridden.",
@@ -550,6 +550,7 @@ func (Console) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleAuthentication = map[string]string{
+	"":               "ConsoleAuthentication defines a list of optional configuration for console authentication.",
 	"logoutRedirect": "An optional, absolute URL to redirect web browsers to after logging out of the console. If not specified, it will redirect to the default login page. This is required when using an identity provider that supports single sign-on (SSO) such as: - OpenID (Keycloak, Azure) - RequestHeader (GSSAPI, SSPI, SAML) - OAuth (GitHub, GitLab, Google) Logging out of the console will destroy the user's token. The logoutRedirect provides the user the option to perform single logout (SLO) through the identity provider to destroy their single sign-on session.",
 }
 
@@ -565,7 +566,16 @@ func (ConsoleList) SwaggerDoc() map[string]string {
 	return map_ConsoleList
 }
 
+var map_ConsoleSpec = map[string]string{
+	"": "ConsoleSpec is the specification of the desired behavior of the Console.",
+}
+
+func (ConsoleSpec) SwaggerDoc() map[string]string {
+	return map_ConsoleSpec
+}
+
 var map_ConsoleStatus = map[string]string{
+	"":           "ConsoleStatus defines the observed status of the Console.",
 	"consoleURL": "The URL for the console. This will be derived from the host for the route that is created for the console.",
 }
 

--- a/operator/v1/types_console.go
+++ b/operator/v1/types_console.go
@@ -10,6 +10,7 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Console provides a means to configure an operator to manage the console.
 type Console struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -20,6 +21,7 @@ type Console struct {
 	Status ConsoleStatus `json:"status,omitempty"`
 }
 
+// ConsoleSpec is the specification of the desired behavior of the Console.
 type ConsoleSpec struct {
 	OperatorSpec `json:",inline"`
 	// customization is used to optionally provide a small set of
@@ -30,10 +32,13 @@ type ConsoleSpec struct {
 	Providers ConsoleProviders `json:"providers"`
 }
 
+// ConsoleStatus defines the observed status of the Console.
 type ConsoleStatus struct {
 	OperatorStatus `json:",inline"`
 }
 
+// ConsoleProviders defines a list of optional additional providers of
+// functionality to the console.
 type ConsoleProviders struct {
 	// statuspage contains ID for statuspage.io page that provides status info about.
 	// +optional
@@ -46,6 +51,7 @@ type StatuspageProvider struct {
 	PageID string `json:"pageID"`
 }
 
+// ConsoleCustomization defines a list of optional configuration for the console UI.
 type ConsoleCustomization struct {
 	// brand is the default branding of the web console which can be overridden by
 	// providing the brand field.  There is a limited set of specific brand options.
@@ -74,7 +80,7 @@ type ConsoleCustomization struct {
 	CustomLogoFile v1.ConfigMapFileReference `json:"customLogoFile,omitempty"`
 }
 
-// Brand is a specific supported brand within the console
+// Brand is a specific supported brand within the console.
 type Brand string
 
 const (

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -117,7 +117,16 @@ func (AuthenticationList) SwaggerDoc() map[string]string {
 	return map_AuthenticationList
 }
 
+var map_Console = map[string]string{
+	"": "Console provides a means to configure an operator to manage the console.",
+}
+
+func (Console) SwaggerDoc() map[string]string {
+	return map_Console
+}
+
 var map_ConsoleCustomization = map[string]string{
+	"":                     "ConsoleCustomization defines a list of optional configuration for the console UI.",
 	"brand":                "brand is the default branding of the web console which can be overridden by providing the brand field.  There is a limited set of specific brand options. This field controls elements of the console such as the logo. Invalid value will prevent a console rollout.",
 	"documentationBaseURL": "documentationBaseURL links to external documentation are shown in various sections of the web console.  Providing documentationBaseURL will override the default documentation URL. Invalid value will prevent a console rollout.",
 	"customProductName":    "customProductName is the name that will be displayed in page titles, logo alt text, and the about dialog instead of the normal OpenShift product name.",
@@ -129,6 +138,7 @@ func (ConsoleCustomization) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleProviders = map[string]string{
+	"":           "ConsoleProviders defines a list of optional additional providers of functionality to the console.",
 	"statuspage": "statuspage contains ID for statuspage.io page that provides status info about.",
 }
 
@@ -137,12 +147,21 @@ func (ConsoleProviders) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleSpec = map[string]string{
+	"":              "ConsoleSpec is the specification of the desired behavior of the Console.",
 	"customization": "customization is used to optionally provide a small set of customization options to the web console.",
 	"providers":     "providers contains configuration for using specific service providers.",
 }
 
 func (ConsoleSpec) SwaggerDoc() map[string]string {
 	return map_ConsoleSpec
+}
+
+var map_ConsoleStatus = map[string]string{
+	"": "ConsoleStatus defines the observed status of the Console.",
+}
+
+func (ConsoleStatus) SwaggerDoc() map[string]string {
+	return map_ConsoleStatus
 }
 
 var map_StatuspageProvider = map[string]string{


### PR DESCRIPTION
Updates the console API resources documentation.  For the most part, this covers generic fields such as `spec` and `status`.

/assign @spadgett 