### PR TITLE
add more build constants that are API

### DIFF
--- a/build/v1/consts.go
+++ b/build/v1/consts.go
@@ -7,14 +7,58 @@ const (
 	// BuildConfigAnnotation is an annotation that identifies the BuildConfig that a Build was created from
 	BuildConfigAnnotation = "openshift.io/build-config.name"
 
+	// BuildCloneAnnotation is an annotation whose value is the name of the build this build was cloned from
+	BuildCloneAnnotation = "openshift.io/build.clone-of"
+
+	// BuildNumberAnnotation is an annotation whose value is the sequential number for this Build
+	BuildNumberAnnotation = "openshift.io/build.number"
+
+	// BuildPodNameAnnotation is an annotation whose value is the name of the pod running this build
+	BuildPodNameAnnotation = "openshift.io/build.pod-name"
+
 	// BuildConfigLabel is the key of a Build label whose value is the ID of a BuildConfig
 	// on which the Build is based. NOTE: The value for this label may not contain the entire
 	// BuildConfig name because it will be truncated to maximum label length.
 	BuildConfigLabel = "openshift.io/build-config.name"
 
+	// BuildJenkinsStatusJSONAnnotation is an annotation holding the Jenkins status information
+	BuildJenkinsStatusJSONAnnotation = "openshift.io/jenkins-status-json"
+
+	// BuildJenkinsLogURLAnnotation is an annotation holding a link to the raw Jenkins build console log
+	BuildJenkinsLogURLAnnotation = "openshift.io/jenkins-log-url"
+
+	// BuildJenkinsConsoleLogURLAnnotation is an annotation holding a link to the Jenkins build console log (including Jenkins chrome wrappering)
+	BuildJenkinsConsoleLogURLAnnotation = "openshift.io/jenkins-console-log-url"
+
 	// BuildJenkinsBlueOceanLogURLAnnotation is an annotation holding a link to the Jenkins build console log via the Jenkins BlueOcean UI Plugin
 	BuildJenkinsBlueOceanLogURLAnnotation = "openshift.io/jenkins-blueocean-log-url"
 
+	// BuildJenkinsBuildURIAnnotation is an annotation holding a link to the Jenkins build
+	BuildJenkinsBuildURIAnnotation = "openshift.io/jenkins-build-uri"
+
+	// BuildSourceSecretMatchURIAnnotationPrefix is a prefix for annotations on a Secret which indicate a source URI against which the Secret can be used
+	BuildSourceSecretMatchURIAnnotationPrefix = "build.openshift.io/source-secret-match-uri-"
+
+	// BuildConfigPausedAnnotation is an annotation that marks a BuildConfig as paused.
+	// New Builds cannot be instantiated from a paused BuildConfig.
+	BuildConfigPausedAnnotation = "openshift.io/build-config.paused"
+)
+
+const (
+	// BuildLabel is the key of a Pod label whose value is the Name of a Build which is run.
+	// NOTE: The value for this label may not contain the entire Build name because it will be
+	// truncated to maximum label length.
+	BuildLabel = "openshift.io/build.name"
+
+	// BuildRunPolicyLabel represents the start policy used to to start the build.
+	BuildRunPolicyLabel = "openshift.io/build.start-policy"
+
+	// BuildConfigLabelDeprecated was used as BuildConfigLabel before adding namespaces.
+	// We keep it for backward compatibility.
+	BuildConfigLabelDeprecated = "buildconfig"
+)
+
+const (
 	// StatusReasonError is a generic reason for a build error condition.
 	StatusReasonError StatusReason = "Error"
 


### PR DESCRIPTION
These represent the current state of API annotations from builds.