### PR TITLE
add image signature constant

### DIFF
--- a/image/v1/consts.go
+++ b/image/v1/consts.go
@@ -63,4 +63,7 @@ const (
 	// Limit that applies to image streams. Used with a max[resource] LimitRangeItem to set the maximum number
 	// of resource. Where the resource is one of "openshift.io/images" and "openshift.io/image-tags".
 	LimitTypeImageStream corev1.LimitType = "openshift.io/ImageStream"
+
+	// The supported type of image signature.
+	ImageSignatureTypeAtomicImageV1 string = "AtomicImageV1"
 )


### PR DESCRIPTION
this is used to interlock between controller and API.  It's a current API contract.