### PR TITLE
Remove wildcard comments from proxy.

### DIFF
--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -31,10 +31,7 @@ type ProxySpec struct {
 	HTTPSProxy string `json:"httpsProxy,omitempty"`
 
 	// noProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used.
-	// Each name is matched as either a domain which contains the host name as a suffix, or the host name itself.
-	// For instance, example.com would match example.com, example.com:80, and www.example.com.
-	// Wildcard(*) characters are not accepted, except a single * character which matches all hosts
-	// and effectively disables the proxy. Empty means unset and will not result in an env var.
+	// Empty means unset and will not result in an env var.
 	// +optional
 	NoProxy string `json:"noProxy,omitempty"`
 }

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1119,7 +1119,7 @@ var map_ProxySpec = map[string]string{
 	"":           "ProxySpec contains cluster proxy creation configuration.",
 	"httpProxy":  "httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.",
 	"httpsProxy": "httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.",
-	"noProxy":    "noProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used. Each name is matched as either a domain which contains the host name as a suffix, or the host name itself. For instance, example.com would match example.com, example.com:80, and www.example.com. Wildcard(*) characters are not accepted, except a single * character which matches all hosts and effectively disables the proxy. Empty means unset and will not result in an env var.",
+	"noProxy":    "noProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used. Empty means unset and will not result in an env var.",
 }
 
 func (ProxySpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Comments regarding behavior of wildcard characters in noProxy were added prematurely. The behavior is based on 3.11 docs, but perhaps we want a different standard. Remove them until behavior is decided.

/cc @abhinavdahiya @staebler @danehans 