### PR TITLE
auth: add scopes key

### DIFF
--- a/authorization/v1/types.go
+++ b/authorization/v1/types.go
@@ -21,6 +21,8 @@ const (
 	GroupKind = "Group"
 	// UserKind is string representation of kind used in role binding subjects that represents the "user".
 	UserKind = "User"
+
+	ScopesKey = "scopes.authorization.openshift.io"
 )
 
 // PolicyRule holds information that describes a policy rule, but does not contain information


### PR DESCRIPTION
Part of existing internal API. Moving this to external api means we can make authorized in Origin not depend on openshift internal APIs.

/cc @deads2k 