### PR TITLE
Add ImageContentSourcePolicy to register.go

### DIFF
--- a/operator/v1alpha1/register.go
+++ b/operator/v1alpha1/register.go
@@ -33,6 +33,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 
 	scheme.AddKnownTypes(GroupVersion,
 		&GenericOperatorConfig{},
+		&ImageContentSourcePolicy{},
+		&ImageContentSourcePolicyList{},
 	)
 
 	return nil


### PR DESCRIPTION
Add the new api definition from https://github.com/openshift/api/pull/354 to register.go.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>