### PR TITLE
Set Operator API to default Optional

### DIFF
--- a/operator/v1/doc.go
+++ b/operator/v1/doc.go
@@ -2,5 +2,6 @@
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:openapi-gen=true
 
+// +kubebuilder:validation:Optional
 // +groupName=operator.openshift.io
 package v1


### PR DESCRIPTION
With the new version of the kubebuilder CRD generator, there is the option to set a default "required" status for fields at the package level (see https://github.com/kubernetes-sigs/controller-tools/pull/211). We have a couple generators we currently use which were specifically patched to assume everything is optional unless explicitly marked as required (this was necessary because the old kubebuilder generator did the opposite). However with this new functionality we can move toward using the upstream tool by simply setting the `+kubebuilder:validation:Optional` package-level marker.