### PR TITLE
APIServer: fix first-letter case of AdditionalCORSAllowedOrigins

### DIFF
--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -35,7 +35,7 @@ type APIServerSpec struct {
 	// server from JavaScript applications.
 	// The values are regular expressions that correspond to the Golang regular expression language.
 	// +optional
-	AdditionalCORSAllowedOrigins []string `json:additionalCORSAllowedOrigins,omitempty`
+	AdditionalCORSAllowedOrigins []string `json:"additionalCORSAllowedOrigins,omitempty"`
 }
 
 type APIServerServingCerts struct {

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -273,7 +273,7 @@ func (APIServerServingCerts) SwaggerDoc() map[string]string {
 var map_APIServerSpec = map[string]string{
 	"servingCerts":                 "servingCert is the TLS cert info for serving secure traffic. If not specified, operator managed certificates will be used for serving secure traffic.",
 	"clientCA":                     "clientCA references a ConfigMap containing a certificate bundle for the signers that will be recognized for incoming client certificates in addition to the operator managed signers. If this is empty, then only operator managed signers are valid. You usually only have to set this if you have your own PKI you wish to honor client certificates from. The ConfigMap must exist in the openshift-config namespace and contain the following required fields: - ConfigMap.Data[\"ca-bundle.crt\"] - CA bundle.",
-	"AdditionalCORSAllowedOrigins": "additionalCORSAllowedOrigins lists additional, user-defined regular expressions describing hosts for which the API server allows access using the CORS headers. This may be needed to access the API and the integrated OAuth server from JavaScript applications. The values are regular expressions that correspond to the Golang regular expression language.",
+	"additionalCORSAllowedOrigins": "additionalCORSAllowedOrigins lists additional, user-defined regular expressions describing hosts for which the API server allows access using the CORS headers. This may be needed to access the API and the integrated OAuth server from JavaScript applications. The values are regular expressions that correspond to the Golang regular expression language.",
 }
 
 func (APIServerSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
The missing quotes in `json` tag caused it to be ignored.