### PR TITLE
Update old +required tags with +kubebuilder:validation:Required

### DIFF
--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -12,6 +12,7 @@ import (
 type APIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// +kubebuilder:validation:Required
 	// +required
 	Spec APIServerSpec `json:"spec"`
 	// +optional

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -13,6 +13,7 @@ type Authentication struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec AuthenticationSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_build.go
+++ b/config/v1/types_build.go
@@ -14,6 +14,7 @@ type Build struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec holds user-settable values for the build controller configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec BuildSpec `json:"spec"`
 }

--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -17,6 +17,7 @@ type ClusterOperator struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	// spec hold the intent of how this operator should behave.
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ClusterOperatorSpec `json:"spec"`
 

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -16,6 +16,7 @@ type ClusterVersion struct {
 
 	// spec is the desired state of the cluster version - the operator will work
 	// to ensure that the desired version is applied to the cluster.
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ClusterVersionSpec `json:"spec"`
 	// status contains information about the available updates and any in-progress

--- a/config/v1/types_console.go
+++ b/config/v1/types_console.go
@@ -13,6 +13,7 @@ type Console struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ConsoleSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_dns.go
+++ b/config/v1/types_dns.go
@@ -14,6 +14,7 @@ type DNS struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec DNSSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -13,6 +13,7 @@ type FeatureGate struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec FeatureGateSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_image.go
+++ b/config/v1/types_image.go
@@ -13,6 +13,7 @@ type Image struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ImageSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -13,6 +13,7 @@ type Infrastructure struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec InfrastructureSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -14,6 +14,7 @@ type Ingress struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec IngressSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -14,6 +14,7 @@ type Network struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration.
+	// +kubebuilder:validation:Required
 	// +required
 	Spec NetworkSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -15,6 +15,7 @@ type OAuth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec OAuthSpec `json:"spec"`
 	// +optional

--- a/config/v1/types_project.go
+++ b/config/v1/types_project.go
@@ -13,6 +13,7 @@ type Project struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ProjectSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -13,6 +13,7 @@ type Proxy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec holds user-settable values for the proxy configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ProxySpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/config/v1/types_scheduling.go
+++ b/config/v1/types_scheduling.go
@@ -13,6 +13,7 @@ type Scheduler struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec SchedulerSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
@@ -49,15 +50,15 @@ type SchedulerSpec struct {
 	// +optional
 	DefaultNodeSelector string `json:"defaultNodeSelector,omitempty"`
 	// MastersSchedulable allows masters nodes to be schedulable. When this flag is
-        // turned on, all the master nodes in the cluster will be made schedulable,
-        // so that workload pods can run on them. The default value for this field is false,
-        // meaning none of the master nodes are schedulable.
-        // Important Note: Once the workload pods start running on the master nodes,
-        // extreme care must be taken to ensure that cluster-critical control plane components
-        // are not impacted.
-        // Please turn on this field after doing due diligence.
-        // +optional
-        MastersSchedulable bool `json:"mastersSchedulable"`
+	// turned on, all the master nodes in the cluster will be made schedulable,
+	// so that workload pods can run on them. The default value for this field is false,
+	// meaning none of the master nodes are schedulable.
+	// Important Note: Once the workload pods start running on the master nodes,
+	// extreme care must be taken to ensure that cluster-critical control plane components
+	// are not impacted.
+	// Please turn on this field after doing due diligence.
+	// +optional
+	MastersSchedulable bool `json:"mastersSchedulable"`
 }
 
 type SchedulerStatus struct {

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -10,6 +10,7 @@ type MyOperatorResource struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec   MyOperatorResourceSpec   `json:"spec"`
 	Status MyOperatorResourceStatus `json:"status"`

--- a/operator/v1/types_authentication.go
+++ b/operator/v1/types_authentication.go
@@ -13,6 +13,7 @@ type Authentication struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec AuthenticationSpec `json:"spec,omitempty"`
 	// +optional

--- a/operator/v1/types_console.go
+++ b/operator/v1/types_console.go
@@ -15,6 +15,7 @@ type Console struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ConsoleSpec `json:"spec,omitempty"`
 	// +optional

--- a/operator/v1/types_etcd.go
+++ b/operator/v1/types_etcd.go
@@ -13,6 +13,7 @@ type Etcd struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec EtcdSpec `json:"spec"`
 	// +optional

--- a/operator/v1/types_kubeapiserver.go
+++ b/operator/v1/types_kubeapiserver.go
@@ -13,6 +13,7 @@ type KubeAPIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec KubeAPIServerSpec `json:"spec"`
 	// +optional

--- a/operator/v1/types_kubecontrollermanager.go
+++ b/operator/v1/types_kubecontrollermanager.go
@@ -13,6 +13,7 @@ type KubeControllerManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec KubeControllerManagerSpec `json:"spec"`
 	// +optional

--- a/operator/v1/types_openshiftapiserver.go
+++ b/operator/v1/types_openshiftapiserver.go
@@ -13,6 +13,7 @@ type OpenShiftAPIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec OpenShiftAPIServerSpec `json:"spec"`
 	// +optional

--- a/operator/v1/types_openshiftcontrollermanager.go
+++ b/operator/v1/types_openshiftcontrollermanager.go
@@ -13,6 +13,7 @@ type OpenShiftControllerManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec OpenShiftControllerManagerSpec `json:"spec"`
 	// +optional

--- a/operator/v1/types_scheduler.go
+++ b/operator/v1/types_scheduler.go
@@ -13,6 +13,7 @@ type KubeScheduler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec KubeSchedulerSpec `json:"spec"`
 	// +optional

--- a/operator/v1/types_serviceca.go
+++ b/operator/v1/types_serviceca.go
@@ -14,6 +14,7 @@ type ServiceCA struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	//spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ServiceCASpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.

--- a/operator/v1/types_servicecatalogapiserver.go
+++ b/operator/v1/types_servicecatalogapiserver.go
@@ -13,6 +13,7 @@ type ServiceCatalogAPIServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ServiceCatalogAPIServerSpec `json:"spec"`
 	// +optional

--- a/operator/v1/types_servicecatalogcontrollermanager.go
+++ b/operator/v1/types_servicecatalogcontrollermanager.go
@@ -13,6 +13,7 @@ type ServiceCatalogControllerManager struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ServiceCatalogControllerManagerSpec `json:"spec"`
 	// +optional

--- a/operator/v1alpha1/types_image_content_source_policy.go
+++ b/operator/v1alpha1/types_image_content_source_policy.go
@@ -14,6 +14,7 @@ type ImageContentSourcePolicy struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
+	// +kubebuilder:validation:Required
 	// +required
 	Spec ImageContentSourcePolicySpec `json:"spec"`
 }


### PR DESCRIPTION
We added the `+required` tag in our original fork of the upstream CRD generator, because in their version everything was required. Now the CRD generator has `// +kubebuilder:validation:Required` as an available tag