### PR TITLE
Make ProjectRequestMessage optional

### DIFF
--- a/config/v1/types_project.go
+++ b/config/v1/types_project.go
@@ -31,6 +31,7 @@ type TemplateReference struct {
 // ProjectSpec holds the project creation configuration.
 type ProjectSpec struct {
 	// projectRequestMessage is the string presented to a user if they are unable to request a project via the projectrequest api endpoint
+	// +optional
 	ProjectRequestMessage string `json:"projectRequestMessage"`
 
 	// projectRequestTemplate is the template to use for creating projects in response to projectrequest.


### PR DESCRIPTION
Breaks CI in https://github.com/openshift/cluster-config-operator/pull/70:
```
E0716 17:39:25.132096       1 task.go:77] error running apply for project "cluster" (22 of 426): Project.config.openshift.io "cluster" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"config.openshift.io/v1", "kind":"Project", "metadata":map[string]interface {}{"annotations":map[string]interface {}{"release.openshift.io/create-only":"true"}, "creationTimestamp":"2019-07-16T17:39:25Z", "generation":1, "name":"cluster", "uid":"a73d4dc7-a7f0-11e9-ba6c-1283e1202cf4"}, "spec":map[string]interface {}{}}: validation failure list:
spec.projectRequestMessage in body is required
```