### PR TITLE
Make config/v1 package default to optional in kubebuilder

### DIFF
--- a/config/v1/doc.go
+++ b/config/v1/doc.go
@@ -2,6 +2,7 @@
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:openapi-gen=true
 
+// +kubebuilder:validation:Optional
 // +groupName=config.openshift.io
 // Package v1 is the v1 version of the API.
 package v1


### PR DESCRIPTION
This adds the package-level `optional` tag, defaulting every field to `optional` unless explicitly set with `+kubebuilder:validation:Required`

Note that this will make *all* fields optional, and component owners should take care to verify that their fields are appropriately marked. See https://jira.coreos.com/browse/MSTR-790