### PR TITLE
Set Authentication.config spec to optional

### DIFF
--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -26,6 +26,7 @@ type AuthenticationSpec struct {
 	// type identifies the cluster managed, user facing authentication mode in use.
 	// Specifically, it manages the component that responds to login attempts.
 	// The default is IntegratedOAuth.
+	// +optional
 	Type AuthenticationType `json:"type"`
 
 	// oauthMetadata contains the discovery endpoint data for OAuth 2.0


### PR DESCRIPTION
This would fix errors such as 
```
E0723 20:07:40.063285       1 task.go:77] error running apply for authentication "cluster" (12 of 429): Authentication.config.openshift.io "cluster" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"config.openshift.io/v1", "kind":"Authentication", "metadata":map[string]interface {}{"annotations":map[string]interface {}{"release.openshift.io/create-only":"true"}, "creationTimestamp":"2019-07-23T20:07:40Z", "generation":1, "name":"cluster", "uid":"85ec4bdd-ad85-11e9-97b9-0a76db41383e"}, "spec":map[string]interface {}{}}: validation failure list:
spec.type in body is required
```