### PR TITLE
Bug 1743302: Add KuryrConfig.OpenStackServiceNetwork for CNO

### DIFF
--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -236,6 +236,20 @@ type KuryrConfig struct {
 	// The port kuryr-controller will listen for readiness and liveness requests.
 	// +optional
 	ControllerProbesPort *uint32 `json:"controllerProbesPort,omitempty"`
+
+	// openStackServiceNetwork contains the CIDR of network from which to allocate IPs for
+	// OpenStack Octavia's Amphora VMs. Please note that with Amphora driver Octavia uses
+	// two IPs from that network for each loadbalancer - one given by OpenShift and second
+	// for VRRP connections. As the first one is managed by OpenShift's and second by Neutron's
+	// IPAMs, those need to come from different pools. Therefore `openStackServiceNetwork`
+	// needs to be at least twice the size of `serviceNetwork`, and whole `serviceNetwork`
+	// must be overlapping with `openStackServiceNetwork`. cluster-network-operator will then
+	// make sure VRRP IPs are taken from the ranges inside `openStackServiceNetwork` that
+	// are not overlapping with `serviceNetwork`, effectivly preventing conflicts. If not set
+	// cluster-network-operator will use `serviceNetwork` expanded by decrementing the prefix
+	// size by 1.
+	// +optional
+	OpenStackServiceNetwork string `json:"openStackServiceNetwork,omitempty"`
 }
 
 // ovnKubernetesConfig is the proposed configuration parameters for networks

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -401,9 +401,10 @@ func (IPAMConfig) SwaggerDoc() map[string]string {
 }
 
 var map_KuryrConfig = map[string]string{
-	"":                     "KuryrConfig configures the Kuryr-Kubernetes SDN",
-	"daemonProbesPort":     "The port kuryr-daemon will listen for readiness and liveness requests.",
-	"controllerProbesPort": "The port kuryr-controller will listen for readiness and liveness requests.",
+	"":                        "KuryrConfig configures the Kuryr-Kubernetes SDN",
+	"daemonProbesPort":        "The port kuryr-daemon will listen for readiness and liveness requests.",
+	"controllerProbesPort":    "The port kuryr-controller will listen for readiness and liveness requests.",
+	"openStackServiceNetwork": "openStackServiceNetwork contains the CIDR of network from which to allocate IPs for OpenStack Octavia's Amphora VMs. Please note that with Amphora driver Octavia uses two IPs from that network for each loadbalancer - one given by OpenShift and second for VRRP connections. As the first one is managed by OpenShift's and second by Neutron's IPAMs, those need to come from different pools. Therefore `openStackServiceNetwork` needs to be at least twice the size of `serviceNetwork`, and whole `serviceNetwork` must be overlapping with `openStackServiceNetwork`. cluster-network-operator will then make sure VRRP IPs are taken from the ranges inside `openStackServiceNetwork` that are not overlapping with `serviceNetwork`, effectivly preventing conflicts. If not set cluster-network-operator will use `serviceNetwork` expanded by decrementing the prefix size by 1.",
 }
 
 func (KuryrConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Trying to apply OpenStack Octavia to OpenShift networking models we
realized that the subnet for OpenShift Services created in OpenStack
needs to be twice the size of the subnet used by OpenShift, as Octavia
uses 2 IP's per loadbalancer - VIP (i.e. the one assigned to a Service
by OpenShift) and VRRP that is assigned by Neutron.

To address this OpenStackServiceNetwork setting is added to KuryrConfig
to serve as this broader OpenStack network CIDR. If not set
cluster-network-operator will set it to ServiceNetwork expanded by one
bit.