### PR TITLE
route/v1: add omitempty to subdomain struct tag

### DIFF
--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -84,7 +84,7 @@ type RouteSpec struct {
 	// `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.
 	//
 	// +optional
-	Subdomain string `json:"subdomain" protobuf:"bytes,8,opt,name=subdomain"`
+	Subdomain string `json:"subdomain,omitempty" protobuf:"bytes,8,opt,name=subdomain"`
 
 	// path that the router watches for, to route traffic for to the service. Optional
 	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"`


### PR DESCRIPTION
Add omitempty to the json struct tag to avoid emitting empty subdomain
strings when the new optional subdomain attribute is not set.

Fixes #404