### PR TITLE
add kubebuilder annotations for network types

### DIFF
--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -71,6 +71,7 @@ type ClusterNetworkEntry struct {
 	CIDR string `json:"cidr"`
 
 	// The size (prefix) of block to allocate to each node.
+	// +kubebuilder:validation:Minimum=0
 	HostPrefix uint32 `json:"hostPrefix"`
 }
 

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -76,6 +76,7 @@ type NetworkSpec struct {
 // Not all network providers support multiple ClusterNetworks
 type ClusterNetworkEntry struct {
 	CIDR       string `json:"cidr"`
+	// +kubebuilder:validation:Minimum=0
 	HostPrefix uint32 `json:"hostPrefix"`
 }
 
@@ -117,6 +118,7 @@ type SimpleMacvlanConfig struct {
 
 	// mtu is the mtu to use for the macvlan interface. if unset, host's
 	// kernel will select the value.
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MTU uint32 `json:"mtu,omitempty"`
 }
@@ -209,11 +211,13 @@ type OpenShiftSDNConfig struct {
 	Mode SDNMode `json:"mode"`
 
 	// vxlanPort is the port to use for all vxlan packets. The default is 4789.
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	VXLANPort *uint32 `json:"vxlanPort,omitempty"`
 
 	// mtu is the mtu to use for the tunnel interface. Defaults to 1450 if unset.
 	// This must be 50 bytes smaller than the machine's uplink.
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	MTU *uint32 `json:"mtu,omitempty"`
 
@@ -230,10 +234,12 @@ type OpenShiftSDNConfig struct {
 // KuryrConfig configures the Kuryr-Kubernetes SDN
 type KuryrConfig struct {
 	// The port kuryr-daemon will listen for readiness and liveness requests.
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	DaemonProbesPort *uint32 `json:"daemonProbesPort,omitempty"`
 
 	// The port kuryr-controller will listen for readiness and liveness requests.
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	ControllerProbesPort *uint32 `json:"controllerProbesPort,omitempty"`
 }
@@ -244,6 +250,8 @@ type OVNKubernetesConfig struct {
 	// mtu is the MTU to use for the tunnel interface. This must be 100
 	// bytes smaller than the uplink mtu.
 	// Default is 1400
+	// +kubebuilder:validation:Minimum=0
+	// +optional
 	MTU *uint32 `json:"mtu,omitempty"`
 }
 


### PR DESCRIPTION
cluster-config-operator generates CRDs for the config types, but it doesn't enforce that `uint32` fields have non-negative values, which can cause problems by letting people create objects that can't be unmarshaled into their corresponding golang types (https://github.com/openshift/cluster-network-operator/issues/69).

I filed https://github.com/openshift/crd-schema-gen/issues/9 about doing this automatically so this may become unnecessary eventually.