### PR TITLE
make various fields optional

### DIFF
--- a/apps/v1/generated.pb.go
+++ b/apps/v1/generated.pb.go
@@ -34,21 +34,27 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import k8s_io_api_core_v1 "k8s.io/api/core/v1"
-import k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	proto "github.com/gogo/protobuf/proto"
 
-import k8s_io_apimachinery_pkg_util_intstr "k8s.io/apimachinery/pkg/util/intstr"
+	math "math"
 
-import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+	k8s_io_api_core_v1 "k8s.io/api/core/v1"
 
-import strings "strings"
-import reflect "reflect"
+	k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-import io "io"
+	k8s_io_apimachinery_pkg_util_intstr "k8s.io/apimachinery/pkg/util/intstr"
+
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/authorization/v1/generated.pb.go
+++ b/authorization/v1/generated.pb.go
@@ -46,18 +46,25 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import k8s_io_api_core_v1 "k8s.io/api/core/v1"
-import k8s_io_api_rbac_v1 "k8s.io/api/rbac/v1"
-import k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	proto "github.com/gogo/protobuf/proto"
 
-import strings "strings"
-import reflect "reflect"
+	math "math"
 
-import io "io"
+	k8s_io_api_core_v1 "k8s.io/api/core/v1"
+
+	k8s_io_api_rbac_v1 "k8s.io/api/rbac/v1"
+
+	k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/build/v1/generated.pb.go
+++ b/build/v1/generated.pb.go
@@ -65,21 +65,27 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import k8s_io_api_core_v1 "k8s.io/api/core/v1"
-import k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	proto "github.com/gogo/protobuf/proto"
 
-import time "time"
+	math "math"
 
-import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+	k8s_io_api_core_v1 "k8s.io/api/core/v1"
 
-import strings "strings"
-import reflect "reflect"
+	k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-import io "io"
+	time "time"
+
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/build/v1/types.go
+++ b/build/v1/types.go
@@ -84,7 +84,7 @@ type CommonSpec struct {
 	// If nil, it can be overridden by default build nodeselector values for the cluster.
 	// If set to an empty map or a map with any values, default build nodeselector values
 	// are ignored.
-	NodeSelector OptionalNodeSelector `json:"nodeSelector" protobuf:"bytes,9,name=nodeSelector"`
+	NodeSelector OptionalNodeSelector `json:"nodeSelector,omitempty" protobuf:"bytes,9,name=nodeSelector"`
 }
 
 // BuildTriggerCause holds information about a triggered build. It is used for
@@ -882,7 +882,7 @@ type BuildConfig struct {
 	// to trigger them.
 	Spec BuildConfigSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 	// status holds any relevant information about a build config
-	Status BuildConfigStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+	Status BuildConfigStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // BuildConfigSpec describes when and how builds are created
@@ -891,7 +891,7 @@ type BuildConfigSpec struct {
 	//triggers determine how new Builds can be launched from a BuildConfig. If
 	//no triggers are defined, a new build can only occur as a result of an
 	//explicit client build creation.
-	Triggers []BuildTriggerPolicy `json:"triggers" protobuf:"bytes,1,rep,name=triggers"`
+	Triggers []BuildTriggerPolicy `json:"triggers,omitempty" protobuf:"bytes,1,rep,name=triggers"`
 
 	// RunPolicy describes how the new build created from this build
 	// configuration will be scheduled for execution.

--- a/image/v1/generated.pb.go
+++ b/image/v1/generated.pb.go
@@ -45,19 +45,25 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import k8s_io_api_core_v1 "k8s.io/api/core/v1"
-import k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	proto "github.com/gogo/protobuf/proto"
 
-import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+	math "math"
 
-import strings "strings"
-import reflect "reflect"
+	k8s_io_api_core_v1 "k8s.io/api/core/v1"
 
-import io "io"
+	k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/network/v1/generated.pb.go
+++ b/network/v1/generated.pb.go
@@ -23,14 +23,19 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import strings "strings"
-import reflect "reflect"
+	proto "github.com/gogo/protobuf/proto"
 
-import io "io"
+	math "math"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/oauth/v1/generated.pb.go
+++ b/oauth/v1/generated.pb.go
@@ -23,14 +23,19 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import strings "strings"
-import reflect "reflect"
+	proto "github.com/gogo/protobuf/proto"
 
-import io "io"
+	math "math"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/project/v1/generated.pb.go
+++ b/project/v1/generated.pb.go
@@ -16,16 +16,21 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import k8s_io_api_core_v1 "k8s.io/api/core/v1"
+	proto "github.com/gogo/protobuf/proto"
 
-import strings "strings"
-import reflect "reflect"
+	math "math"
 
-import io "io"
+	k8s_io_api_core_v1 "k8s.io/api/core/v1"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/quota/v1/generated.pb.go
+++ b/quota/v1/generated.pb.go
@@ -19,18 +19,23 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	proto "github.com/gogo/protobuf/proto"
 
-import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+	math "math"
 
-import strings "strings"
-import reflect "reflect"
+	k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-import io "io"
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/route/v1/generated.pb.go
+++ b/route/v1/generated.pb.go
@@ -21,18 +21,23 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	proto "github.com/gogo/protobuf/proto"
 
-import k8s_io_api_core_v1 "k8s.io/api/core/v1"
+	math "math"
 
-import strings "strings"
-import reflect "reflect"
+	k8s_io_apimachinery_pkg_apis_meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-import io "io"
+	k8s_io_api_core_v1 "k8s.io/api/core/v1"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -34,7 +34,7 @@ type Route struct {
 	// spec is the desired state of the route
 	Spec RouteSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 	// status is the current state of the route
-	Status RouteStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+	Status RouteStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/security/v1/generated.pb.go
+++ b/security/v1/generated.pb.go
@@ -30,16 +30,21 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import k8s_io_api_core_v1 "k8s.io/api/core/v1"
+	proto "github.com/gogo/protobuf/proto"
 
-import strings "strings"
-import reflect "reflect"
+	math "math"
 
-import io "io"
+	k8s_io_api_core_v1 "k8s.io/api/core/v1"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/template/v1/generated.pb.go
+++ b/template/v1/generated.pb.go
@@ -25,20 +25,25 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import k8s_io_api_core_v1 "k8s.io/api/core/v1"
+	proto "github.com/gogo/protobuf/proto"
 
-import k8s_io_apimachinery_pkg_runtime "k8s.io/apimachinery/pkg/runtime"
+	math "math"
 
-import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+	k8s_io_api_core_v1 "k8s.io/api/core/v1"
 
-import strings "strings"
-import reflect "reflect"
+	k8s_io_apimachinery_pkg_runtime "k8s.io/apimachinery/pkg/runtime"
 
-import io "io"
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal

--- a/user/v1/generated.pb.go
+++ b/user/v1/generated.pb.go
@@ -19,16 +19,21 @@
 */
 package v1
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
 
-import github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+	proto "github.com/gogo/protobuf/proto"
 
-import strings "strings"
-import reflect "reflect"
+	math "math"
 
-import io "io"
+	github_com_gogo_protobuf_sortkeys "github.com/gogo/protobuf/sortkeys"
+
+	strings "strings"
+
+	reflect "reflect"
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal


### PR DESCRIPTION
Currently the Status field of Route objects is not tagged with `omitempty`. This causes various validation tools to fail when no status field is specified.

Fixes #410 