### PR TITLE
include builds in list of image pulls impacted by image config resource

### DIFF
--- a/config/v1/types_image.go
+++ b/config/v1/types_image.go
@@ -22,7 +22,7 @@ type Image struct {
 }
 
 type ImageSpec struct {
-	// AllowedRegistriesForImport limits the container image registries that normal users may import
+	// allowedRegistriesForImport limits the container image registries that normal users may import
 	// images from. Set this list to the registries that you trust to contain valid Docker
 	// images and that you want applications to be able to import from. Users with
 	// permission to create Images or ImageStreamMappings via the API are not affected by
@@ -38,14 +38,14 @@ type ImageSpec struct {
 	// +optional
 	ExternalRegistryHostnames []string `json:"externalRegistryHostnames,omitempty"`
 
-	// AdditionalTrustedCA is a reference to a ConfigMap containing additional CAs that
-	// should be trusted during imagestream import, pod image pull, and imageregistry
-	// pullthrough.
+	// additionalTrustedCA is a reference to a ConfigMap containing additional CAs that
+	// should be trusted during imagestream import, pod image pull, build image pull, and
+	// imageregistry pullthrough.
 	// The namespace for this config map is openshift-config.
 	// +optional
 	AdditionalTrustedCA ConfigMapNameReference `json:"additionalTrustedCA"`
 
-	// RegistrySources contains configuration that determines how the container runtime
+	// registrySources contains configuration that determines how the container runtime
 	// should treat individual registries when accessing images for builds+pods. (e.g.
 	// whether or not to allow insecure access).  It does not contain configuration for the
 	// internal cluster registry.
@@ -55,10 +55,10 @@ type ImageSpec struct {
 
 type ImageStatus struct {
 
-	// this value is set by the image registry operator which controls the internal registry hostname
-	// InternalRegistryHostname sets the hostname for the default internal image
+	// internalRegistryHostname sets the hostname for the default internal image
 	// registry. The value must be in "hostname[:port]" format.
-	// For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY
+	// This value is set by the image registry operator which controls the internal registry
+	// hostname. For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY
 	// environment variable but this setting overrides the environment variable.
 	// +optional
 	InternalRegistryHostname string `json:"internalRegistryHostname,omitempty"`
@@ -83,11 +83,11 @@ type ImageList struct {
 // RegistryLocation contains a location of the registry specified by the registry domain
 // name. The domain name might include wildcards, like '*' or '??'.
 type RegistryLocation struct {
-	// DomainName specifies a domain name for the registry
+	// domainName specifies a domain name for the registry
 	// In case the registry use non-standard (80 or 443) port, the port should be included
 	// in the domain name as well.
 	DomainName string `json:"domainName"`
-	// Insecure indicates whether the registry is secure (https) or insecure (http)
+	// insecure indicates whether the registry is secure (https) or insecure (http)
 	// By default (if not specified) the registry is assumed as secure.
 	// +optional
 	Insecure bool `json:"insecure,omitempty"`
@@ -95,15 +95,15 @@ type RegistryLocation struct {
 
 // RegistrySources holds cluster-wide information about how to handle the registries config.
 type RegistrySources struct {
-	// InsecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.
+	// insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.
 	// +optional
 	InsecureRegistries []string `json:"insecureRegistries,omitempty"`
-	// BlockedRegistries are blacklisted from image pull/push. All other registries are allowed.
+	// blockedRegistries are blacklisted from image pull/push. All other registries are allowed.
 	//
 	// Only one of BlockedRegistries or AllowedRegistries may be set.
 	// +optional
 	BlockedRegistries []string `json:"blockedRegistries,omitempty"`
-	// AllowedRegistries are whitelisted for image pull/push. All other registries are blocked.
+	// allowedRegistries are whitelisted for image pull/push. All other registries are blocked.
 	//
 	// Only one of BlockedRegistries or AllowedRegistries may be set.
 	// +optional

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -679,10 +679,10 @@ func (ImageList) SwaggerDoc() map[string]string {
 }
 
 var map_ImageSpec = map[string]string{
-	"allowedRegistriesForImport": "AllowedRegistriesForImport limits the container image registries that normal users may import images from. Set this list to the registries that you trust to contain valid Docker images and that you want applications to be able to import from. Users with permission to create Images or ImageStreamMappings via the API are not affected by this policy - typically only administrators or system integrations will have those permissions.",
+	"allowedRegistriesForImport": "allowedRegistriesForImport limits the container image registries that normal users may import images from. Set this list to the registries that you trust to contain valid Docker images and that you want applications to be able to import from. Users with permission to create Images or ImageStreamMappings via the API are not affected by this policy - typically only administrators or system integrations will have those permissions.",
 	"externalRegistryHostnames":  "externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in \"hostname[:port]\" format.",
-	"additionalTrustedCA":        "AdditionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted during imagestream import, pod image pull, and imageregistry pullthrough. The namespace for this config map is openshift-config.",
-	"registrySources":            "RegistrySources contains configuration that determines how the container runtime should treat individual registries when accessing images for builds+pods. (e.g. whether or not to allow insecure access).  It does not contain configuration for the internal cluster registry.",
+	"additionalTrustedCA":        "additionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted during imagestream import, pod image pull, build image pull, and imageregistry pullthrough. The namespace for this config map is openshift-config.",
+	"registrySources":            "registrySources contains configuration that determines how the container runtime should treat individual registries when accessing images for builds+pods. (e.g. whether or not to allow insecure access).  It does not contain configuration for the internal cluster registry.",
 }
 
 func (ImageSpec) SwaggerDoc() map[string]string {
@@ -690,7 +690,7 @@ func (ImageSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ImageStatus = map[string]string{
-	"internalRegistryHostname":  "this value is set by the image registry operator which controls the internal registry hostname InternalRegistryHostname sets the hostname for the default internal image registry. The value must be in \"hostname[:port]\" format. For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but this setting overrides the environment variable.",
+	"internalRegistryHostname":  "internalRegistryHostname sets the hostname for the default internal image registry. The value must be in \"hostname[:port]\" format. This value is set by the image registry operator which controls the internal registry hostname. For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but this setting overrides the environment variable.",
 	"externalRegistryHostnames": "externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in \"hostname[:port]\" format.",
 }
 
@@ -700,8 +700,8 @@ func (ImageStatus) SwaggerDoc() map[string]string {
 
 var map_RegistryLocation = map[string]string{
 	"":           "RegistryLocation contains a location of the registry specified by the registry domain name. The domain name might include wildcards, like '*' or '??'.",
-	"domainName": "DomainName specifies a domain name for the registry In case the registry use non-standard (80 or 443) port, the port should be included in the domain name as well.",
-	"insecure":   "Insecure indicates whether the registry is secure (https) or insecure (http) By default (if not specified) the registry is assumed as secure.",
+	"domainName": "domainName specifies a domain name for the registry In case the registry use non-standard (80 or 443) port, the port should be included in the domain name as well.",
+	"insecure":   "insecure indicates whether the registry is secure (https) or insecure (http) By default (if not specified) the registry is assumed as secure.",
 }
 
 func (RegistryLocation) SwaggerDoc() map[string]string {
@@ -710,9 +710,9 @@ func (RegistryLocation) SwaggerDoc() map[string]string {
 
 var map_RegistrySources = map[string]string{
 	"":                   "RegistrySources holds cluster-wide information about how to handle the registries config.",
-	"insecureRegistries": "InsecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.",
-	"blockedRegistries":  "BlockedRegistries are blacklisted from image pull/push. All other registries are allowed.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
-	"allowedRegistries":  "AllowedRegistries are whitelisted for image pull/push. All other registries are blocked.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
+	"insecureRegistries": "insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.",
+	"blockedRegistries":  "blockedRegistries are blacklisted from image pull/push. All other registries are allowed.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
+	"allowedRegistries":  "allowedRegistries are whitelisted for image pull/push. All other registries are blocked.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
 }
 
 func (RegistrySources) SwaggerDoc() map[string]string {


### PR DESCRIPTION
also fixes the casing of the field names in the godoc.
