### PR TITLE
Bug 1749581: operator/ingress: Fix scale kubebuilder marker

### DIFF
--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -10,7 +10,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.availableReplicas,selectorpath=.status.labelSelector
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.availableReplicas,selectorpath=.status.selector
 
 // IngressController describes a managed ingress controller for the cluster. The
 // controller can service OpenShift Route and Kubernetes Ingress resources.


### PR DESCRIPTION
* `operator/v1/types_ingress.go`: Fix the kubebuilder marker for the IngressController resource's scale subresource's `labelSelectorPath` field.