### PR TITLE
config/network: update docs to reflect externalip default-deny

### DIFF
--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -6,8 +6,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc. 
-// Please view network.spec for an explanation on what applies when configuring this resource. 
+// Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc.
+// Please view network.spec for an explanation on what applies when configuring this resource.
 type Network struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -30,13 +30,13 @@ type Network struct {
 // consume the NetworkStatus, as it indicates the currently deployed configuration.
 // Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.
 type NetworkSpec struct {
-	// IP address pool to use for pod IPs. 
-	// This field is immutable after installation. 
+	// IP address pool to use for pod IPs.
+	// This field is immutable after installation.
 	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork"`
 
 	// IP address pool for services.
 	// Currently, we only support a single entry here.
-	// This field is immutable after installation. 
+	// This field is immutable after installation.
 	ServiceNetwork []string `json:"serviceNetwork"`
 
 	// NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN).
@@ -44,11 +44,12 @@ type NetworkSpec struct {
 	// or else no networking will be installed.
 	// Currently supported values are:
 	// - OpenShiftSDN
-	// This field is immutable after installation. 
+	// This field is immutable after installation.
 	NetworkType string `json:"networkType"`
 
 	// externalIP defines configuration for controllers that
-	// affect Service.ExternalIP
+	// affect Service.ExternalIP. If nil, then ExternalIP is
+	// not allowed to be set.
 	// +optional
 	ExternalIP *ExternalIPConfig `json:"externalIP,omitempty"`
 }
@@ -83,8 +84,7 @@ type ClusterNetworkEntry struct {
 // of a Service resource.
 type ExternalIPConfig struct {
 	// policy is a set of restrictions applied to the ExternalIP field.
-	// If nil, any value is allowed for an ExternalIP. If the empty/zero
-	// policy is supplied, then ExternalIP is not allowed to be set.
+	// If nil or empty, then ExternalIP is not allowed to be set.
 	// +optional
 	Policy *ExternalIPPolicy `json:"policy,omitempty"`
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -866,7 +866,7 @@ func (ClusterNetworkEntry) SwaggerDoc() map[string]string {
 
 var map_ExternalIPConfig = map[string]string{
 	"":                "ExternalIPConfig specifies some IP blocks relevant for the ExternalIP field of a Service resource.",
-	"policy":          "policy is a set of restrictions applied to the ExternalIP field. If nil, any value is allowed for an ExternalIP. If the empty/zero policy is supplied, then ExternalIP is not allowed to be set.",
+	"policy":          "policy is a set of restrictions applied to the ExternalIP field. If nil or empty, then ExternalIP is not allowed to be set.",
 	"autoAssignCIDRs": "autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called \"IngressIPs\". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.",
 }
 
@@ -908,7 +908,7 @@ var map_NetworkSpec = map[string]string{
 	"clusterNetwork": "IP address pool to use for pod IPs. This field is immutable after installation.",
 	"serviceNetwork": "IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.",
 	"networkType":    "NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.",
-	"externalIP":     "externalIP defines configuration for controllers that affect Service.ExternalIP",
+	"externalIP":     "externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.",
 }
 
 func (NetworkSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
In https://github.com/openshift/cluster-kube-apiserver-operator/pull/564 we changed this (because it was a bad idea).