### PR TITLE
operator/ingress: remove unnecessary +nullable markers

### DIFF
--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -249,19 +249,16 @@ type EndpointPublishingStrategy struct {
 	// loadBalancer holds parameters for the load balancer. Present only if
 	// type is LoadBalancerService.
 	// +optional
-	// +nullable
 	LoadBalancer *LoadBalancerStrategy `json:"loadBalancer,omitempty"`
 
 	// hostNetwork holds parameters for the HostNetwork endpoint publishing
 	// strategy. Present only if type is HostNetwork.
 	// +optional
-	// +nullable
 	HostNetwork *HostNetworkStrategy `json:"hostNetwork,omitempty"`
 
 	// private holds parameters for the Private endpoint publishing
 	// strategy. Present only if type is Private.
 	// +optional
-	// +nullable
 	Private *PrivateStrategy `json:"private,omitempty"`
 }
 


### PR DESCRIPTION
The `+nullable` markers removed in this commit were never actually used
in the CRD we publish (See the history of [1] for evidence). Use of these
markers was actually a mistake (`omitempty` is sufficient).

[1] https://github.com/openshift/cluster-ingress-operator/blob/master/manifests/00-custom-resource-definition.yaml

@sttts @deads2k @damemi @Miciah 