### PR TITLE
operator/ingress: Delete +optional marker on type

### DIFF
--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -243,7 +243,6 @@ type EndpointPublishingStrategy struct {
 	// networking, and is not explicitly published. The user must manually publish
 	// the ingress controller.
 	// +unionDiscriminator
-	// +optional
 	Type EndpointPublishingStrategyType `json:"type"`
 
 	// loadBalancer holds parameters for the load balancer. Present only if


### PR DESCRIPTION
Make the `type` field of the endpoint publishing strategy for an IngressController resource a required field.

The `type` field is a union discriminator field, and the KEP for union types [states](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190325-unions.md#go-tags) that a union discriminator field "CAN be optional".  The IngressController resource's `spec.endpointPublishingStrategy` field is optional, so if it is specified, then it is reasonable to expect an explicit value be specified for `spec.endpointPublishingStrategy.type`, and the ingress operator will always set an explicit value for the `status.endpointPublishingStrategy.type` field.

The ingress operator currently has a CRD that was generated using controller-tools v0.2.0-beta.1, which ignores the `+optional` marker, with the result that [`spec.endpointPublishingStrategy.type` is required](https://github.com/openshift/cluster-ingress-operator/commit/b32cee9f939fe14019c9fafaa2ae0aa4b02961bd#diff-1b0497d8867a90088e4614b2e61dc496R40).  controller-tools v0.2.0-beta.3 and newer respects the `+optional` marker (https://github.com/kubernetes-sigs/controller-tools/pull/211/commits/fcf42052ecd83a24c911f5aace1df34d451b8e21), with the result that regenerating the CRD with the current API would cause the field to become no longer required.  Because the current CRD specifies the field to be required, it is safe to remove the `+optional` marker now so that the field will continue to be required when the CRD is regenerated using newer controller-tools.

* `operator/v1/types_ingress.go` (`EndpointPublishingStrategy`): Remove the `+optional` marker on the `type` field.