### PR TITLE
operator/ingress: make .spec.endpointPublishingStrategy.type required

### DIFF
--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -244,6 +244,8 @@ type EndpointPublishingStrategy struct {
 	// networking, and is not explicitly published. The user must manually publish
 	// the ingress controller.
 	// +unionDiscriminator
+	// +kubebuilder:validation:Required
+	// +required
 	Type EndpointPublishingStrategyType `json:"type"`
 
 	// loadBalancer holds parameters for the load balancer. Present only if


### PR DESCRIPTION
The `.spec.endpointPublishingStrategy.type` is intended to be required (and
that's how the field is persisted in 4.1). In the operator.openshift.io group,
fields are optional by default[1]. Use an explicit marker to maintain
compatibility.

[1] https://github.com/openshift/api/blob/master/operator/v1/doc.go