### PR TITLE
operator: add missing markers to condition type

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -145,7 +145,11 @@ var (
 
 // OperatorCondition is just the standard condition fields.
 type OperatorCondition struct {
+	// +kubebuilder:validation:Required
+	// +required
 	Type               string          `json:"type"`
+	// +kubebuilder:validation:Required
+	// +required
 	Status             ConditionStatus `json:"status"`
 	LastTransitionTime metav1.Time     `json:"lastTransitionTime,omitempty"`
 	Reason             string          `json:"reason,omitempty"`


### PR DESCRIPTION
@sttts @deads2k @damemi @Miciah 

See https://github.com/openshift/cluster-ingress-operator/pull/301#pullrequestreview-292514256.

I think the ingress and dns APIs are the only consumers of this type, and we've been persisting them as optional in 4.1 ([example](https://github.com/openshift/cluster-ingress-operator/blob/release-4.1/manifests/00-custom-resource-definition.yaml#L133)) and switched them to required in 4.2 ([example](https://github.com/openshift/cluster-ingress-operator/blob/release-4.2/manifests/00-custom-resource-definition.yaml#L708)).

Since we own the only known consumers, we can deal with any cleanup (and upgrade testing has not revealed any issues).