### PR TITLE
Bug 1756141: Remove incorrect optional tag from new ingress field

### DIFF
--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -188,7 +188,6 @@ type LoadBalancerStrategy struct {
 	// scope indicates the scope at which the load balancer is exposed.
 	// Possible values are "External" and "Internal".  The default is
 	// "External".
-	// +optional
 	Scope LoadBalancerScope `json:"scope"`
 }
 


### PR DESCRIPTION
`loadBalancer` is a new field that contains `scope`, and `loadBalancer` is
optional (correct). However, `loadBalancer.scope` _should_ be required. This
commit fixes that.