### PR TITLE
operator/dns: fix openapi spec for required fields

### DIFF
--- a/operator/v1/types_dns.go
+++ b/operator/v1/types_dns.go
@@ -49,6 +49,9 @@ type DNSStatus struct {
 	// Example: dig foo.com @<service IP>
 	//
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+	//
+	// +kubebuilder:validation:Required
+	// +required
 	ClusterIP string `json:"clusterIP"`
 
 	// clusterDomain is the local cluster DNS domain suffix for DNS services.
@@ -57,6 +60,9 @@ type DNSStatus struct {
 	// Example: "cluster.local"
 	//
 	// More info: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service
+	//
+	// +kubebuilder:validation:Required
+	// +required
 	ClusterDomain string `json:"clusterDomain"`
 
 	// conditions provide information about the state of the DNS on the cluster.


### PR DESCRIPTION
These fields should be required. We've been persisting them as required[1],
and metadata should reflect that.

[1] https://github.com/openshift/cluster-dns-operator/blob/release-4.2/manifests/0000_70_dns-operator_00-custom-resource-definition.yaml