### PR TITLE
Bug 1758434: re-enable LocalStorageCapacityIsolation

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -108,8 +108,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"ServiceNodeExclusion",              // sig-scheduling, ccoleman
 		},
 		Disabled: []string{
-			"LocalStorageCapacityIsolation", // sig-pod, sjenning
-			"LegacyNodeRoleBehavior",        // sig-scheduling, ccoleman
+			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
 		},
 	},
 	CustomNoUpgrade: {
@@ -126,8 +125,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"ServiceNodeExclusion",              // sig-scheduling, ccoleman
 		},
 		Disabled: []string{
-			"LocalStorageCapacityIsolation", // sig-pod, sjenning
-			"LegacyNodeRoleBehavior",        // sig-scheduling, ccoleman
+			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
 		},
 	},
 	LatencySensitive: {
@@ -140,8 +138,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"ServiceNodeExclusion",              // sig-scheduling, ccoleman
 		},
 		Disabled: []string{
-			"LocalStorageCapacityIsolation", // sig-pod, sjenning
-			"LegacyNodeRoleBehavior",        // sig-scheduling, ccoleman
+			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
 		},
 	},
 }


### PR DESCRIPTION
Talked to @sjenning about why LocalStorageCapacityIsolation is disabled. It was disabled for something to do with the Online use case, but we can re-enable it again.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1758434