### PR TITLE
config/v1: add networkResourceGroupName for azure platform

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -142,6 +142,11 @@ type AWSPlatformStatus struct {
 type AzurePlatformStatus struct {
 	// resourceGroupName is the Resource Group for new Azure resources created for the cluster.
 	ResourceGroupName string `json:"resourceGroupName"`
+
+	// networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster.
+	// If empty, the value is same as ResourceGroupName.
+	// +optional
+	NetworkResourceGroupName string `json:"networkResourceGroupName,omitempty"`
 }
 
 // GCPPlatformStatus holds the current status of the Google Cloud Platform infrastructure provider.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -739,8 +739,9 @@ func (AWSPlatformStatus) SwaggerDoc() map[string]string {
 }
 
 var map_AzurePlatformStatus = map[string]string{
-	"":                  "AzurePlatformStatus holds the current status of the Azure infrastructure provider.",
-	"resourceGroupName": "resourceGroupName is the Resource Group for new Azure resources created for the cluster.",
+	"":                         "AzurePlatformStatus holds the current status of the Azure infrastructure provider.",
+	"resourceGroupName":        "resourceGroupName is the Resource Group for new Azure resources created for the cluster.",
+	"networkResourceGroupName": "networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster. If empty, the value is same as ResourceGroupName.",
 }
 
 func (AzurePlatformStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
The newtork resources like Virtual Network and Subnets are created currently for each cluster in the cluster's resource group.

To support reusing exisitng Virtual network and Subnets for OpenShift clusters, the cluster uses pre-existing ones in a separate resource group.

`networkResourceGroupName` is the resource group that contains the Virtual network and subnets for the cluster.

The resource group for network resources is the same as cluster unless specifically specified, therefore, this field is optional.

This is based on work in PR https://github.com/openshift/installer/pull/2441

A consumer of the field is https://github.com/openshift/cloud-credential-operator/pull/122