### PR TITLE
featuregates: Disable legacy node role exclusion for masters

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -104,9 +104,12 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"RotateKubeletServerCertificate",    // sig-pod, sjenning
 			"SupportPodPidsLimit",               // sig-pod, sjenning
 			"TLSSecurityProfile",                // sig-network, danehans
+			"NodeDisruptionExclusion",           // sig-scheduling, ccoleman
+			"ServiceNodeExclusion",              // sig-scheduling, ccoleman
 		},
 		Disabled: []string{
 			"LocalStorageCapacityIsolation", // sig-pod, sjenning
+			"LegacyNodeRoleBehavior",        // sig-scheduling, ccoleman
 		},
 	},
 	CustomNoUpgrade: {
@@ -119,9 +122,12 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"RotateKubeletServerCertificate",    // sig-pod, sjenning
 			"SupportPodPidsLimit",               // sig-pod, sjenning
 			"TLSSecurityProfile",                // sig-network, danehans
+			"NodeDisruptionExclusion",           // sig-scheduling, ccoleman
+			"ServiceNodeExclusion",              // sig-scheduling, ccoleman
 		},
 		Disabled: []string{
 			"LocalStorageCapacityIsolation", // sig-pod, sjenning
+			"LegacyNodeRoleBehavior",        // sig-scheduling, ccoleman
 		},
 	},
 	LatencySensitive: {
@@ -130,9 +136,12 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"RotateKubeletServerCertificate",    // sig-pod, sjenning
 			"SupportPodPidsLimit",               // sig-pod, sjenning
 			"TopologyManager",                   // sig-pod, sjenning
+			"NodeDisruptionExclusion",           // sig-scheduling, ccoleman
+			"ServiceNodeExclusion",              // sig-scheduling, ccoleman
 		},
 		Disabled: []string{
 			"LocalStorageCapacityIsolation", // sig-pod, sjenning
+			"LegacyNodeRoleBehavior",        // sig-scheduling, ccoleman
 		},
 	},
 }


### PR DESCRIPTION
Allows masters to host end-user workloads on clouds by making masters able to be targeted by service load balancers. Disabling the legacy gate disables the logic that excluded them previously.

See https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/2019-07-16-node-role-label-use.md
and the [compact clusters proposal](https://github.com/openshift/enhancements/pull/48) for more context.