### PR TITLE
kubebuilder tag needs to be on the type itself

### DIFF
--- a/console/v1/types_console_link.go
+++ b/console/v1/types_console_link.go
@@ -18,7 +18,6 @@ type ConsoleLink struct {
 type ConsoleLinkSpec struct {
 	Link `json:",inline"`
 	// location determines which location in the console the link will be appended to (ApplicationMenu, HelpMenu, UserMenu, NamespaceDashboard).
-	// +kubebuilder:validation:Pattern=^(ApplicationMenu|HelpMenu|UserMenu|NamespaceDashboard)$
 	Location ConsoleLinkLocation `json:"location"`
 	// applicationMenu holds information about section and icon used for the link in the
 	// application menu, and it is applicable only when location is set to ApplicationMenu.
@@ -52,6 +51,7 @@ type NamespaceDashboardSpec struct {
 }
 
 // ConsoleLinkLocationSelector is a set of possible menu targets to which a link may be appended.
+// +kubebuilder:validation:Pattern=^(ApplicationMenu|HelpMenu|UserMenu|NamespaceDashboard)$
 type ConsoleLinkLocation string
 
 const (

--- a/console/v1/types_console_notification.go
+++ b/console/v1/types_console_notification.go
@@ -20,7 +20,6 @@ type ConsoleNotificationSpec struct {
 	Text string `json:"text"`
 	// location is the location of the notification in the console.
 	// +optional
-	// +kubebuilder:validation:Pattern=^(BannerTop|BannerBottom|BannerTopBottom)$
 	Location ConsoleNotificationLocation `json:"location,omitempty"`
 	// link is an object that holds notification link details.
 	// +optional
@@ -35,6 +34,7 @@ type ConsoleNotificationSpec struct {
 
 // ConsoleNotificationLocationSelector is a set of possible notification targets
 // to which a notification may be appended.
+// +kubebuilder:validation:Pattern=^(BannerTop|BannerBottom|BannerTopBottom)$
 type ConsoleNotificationLocation string
 
 const (


### PR DESCRIPTION
One more update for this,  the `+kubebuilder` tag needs to be on the type itself.

- Related to https://github.com/openshift/cluster-config-operator/pull/101 which fixes a codegen issue that will enable:
- [ ] TODO: CRD regenerate for console resources

/cc @spadgett @bparees 
/assign @damemi 