### PR TITLE
Generate consoleyamlsamples.console.openshift.io CRD

### DIFF
--- a/console/v1/0000_10_config-operator_01_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_config-operator_01_consoleyamlsample.crd.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleyamlsamples.console.openshift.io
+  annotations:
+    displayName: ConsoleYAMLSample
+    description: Extension for configuring openshift web console YAML samples.
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  names:
+    plural: consoleyamlsamples
+    singular: consoleyamlsample
+    kind: ConsoleYAMLSample
+    listKind: ConsoleYAMLSampleList
+  "validation":
+    "openAPIV3Schema":
+      description: ConsoleYAMLSample is an extension for customizing OpenShift web
+        console YAML samples.
+      type: object
+      required:
+      - metadata
+      - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleYAMLSampleSpec is the desired YAML sample configuration.
+            Samples will appear with their descriptions in a samples sidebar when
+            creating a resources in the web console.
+          type: object
+          required:
+          - description
+          - title
+          - yaml
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            description:
+              description: description of the YAML sample.
+              type: string
+              pattern: ^(.|\s)*\S(.|\s)*$
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            title:
+              description: title of the YAML sample.
+              type: string
+              pattern: ^(.|\s)*\S(.|\s)*$
+            yaml:
+              description: yaml is the YAML sample to display.
+              type: string
+              pattern: ^(.|\s)*\S(.|\s)*$


### PR DESCRIPTION
We are missing one of our extension CRDs from the generated set in `/console` subdirectory.

/cc @spadgett @bparees 

@damemi 