### PR TITLE
Add useful Kuryr settings

### DIFF
--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -69,6 +69,13 @@ type NetworkSpec struct {
 	// If not specified, sensible defaults will be chosen by OpenShift directly.
 	// Not consumed by all network providers - currently only openshift-sdn.
 	KubeProxyConfig *ProxyConfig `json:"kubeProxyConfig,omitempty"`
+
+	// logLevel allows configuring the logging level of the components deployed
+	// by the operator. Currently only Kuryr SDN is affected by this setting.
+	// Please note that turning on extensive logging may affect performance.
+	// The default value is "Normal".
+	// +optional
+	LogLevel LogLevel `json:"logLevel"`
 }
 
 // ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size
@@ -256,6 +263,38 @@ type KuryrConfig struct {
 	// size by 1.
 	// +optional
 	OpenStackServiceNetwork string `json:"openStackServiceNetwork,omitempty"`
+
+	// enablePortPoolsPrepopulation when true will make Kuryr prepopulate each newly created port
+	// pool with a minimum number of ports. Kuryr uses Neutron port pooling to fight the fact
+	// that it takes a significant amount of time to create one. Instead of creating it when
+	// pod is being deployed, Kuryr keeps a number of ports ready to be attached to pods. By
+	// default port prepopulation is disabled.
+	// +optional
+	EnablePortPoolsPrepopulation bool `json:"enablePortPoolsPrepopulation,omitempty"`
+
+	// poolMaxPorts sets a maximum number of free ports that are being kept in a port pool.
+	// If the number of ports exceeds this setting, free ports will get deleted. Setting 0
+	// will disable this upper bound, effectively preventing pools from shrinking and this
+	// is the default value. For more information about port pools see
+	// enablePortPoolsPrepopulation setting.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	PoolMaxPorts uint `json:"poolMaxPorts,omitempty"`
+
+	// poolMinPorts sets a minimum number of free ports that should be kept in a port pool.
+	// If the number of ports is lower than this setting, new ports will get created and
+	// added to pool. The default is 1. For more information about port pools see
+	// enablePortPoolsPrepopulation setting.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	PoolMinPorts uint `json:"poolMinPorts,omitempty"`
+
+	// poolBatchPorts sets a number of ports that should be created in a single batch request
+	// to extend the port pool. The default is 3. For more information about port pools see
+	// enablePortPoolsPrepopulation setting.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	PoolBatchPorts *uint `json:"poolBatchPorts,omitempty"`
 }
 
 // ovnKubernetesConfig contains the configuration parameters for networks

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -1147,6 +1147,11 @@ func (in *KuryrConfig) DeepCopyInto(out *KuryrConfig) {
 		*out = new(uint32)
 		**out = **in
 	}
+	if in.PoolBatchPorts != nil {
+		in, out := &in.PoolBatchPorts, &out.PoolBatchPorts
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -426,10 +426,14 @@ func (IPAMConfig) SwaggerDoc() map[string]string {
 }
 
 var map_KuryrConfig = map[string]string{
-	"":                        "KuryrConfig configures the Kuryr-Kubernetes SDN",
-	"daemonProbesPort":        "The port kuryr-daemon will listen for readiness and liveness requests.",
-	"controllerProbesPort":    "The port kuryr-controller will listen for readiness and liveness requests.",
-	"openStackServiceNetwork": "openStackServiceNetwork contains the CIDR of network from which to allocate IPs for OpenStack Octavia's Amphora VMs. Please note that with Amphora driver Octavia uses two IPs from that network for each loadbalancer - one given by OpenShift and second for VRRP connections. As the first one is managed by OpenShift's and second by Neutron's IPAMs, those need to come from different pools. Therefore `openStackServiceNetwork` needs to be at least twice the size of `serviceNetwork`, and whole `serviceNetwork` must be overlapping with `openStackServiceNetwork`. cluster-network-operator will then make sure VRRP IPs are taken from the ranges inside `openStackServiceNetwork` that are not overlapping with `serviceNetwork`, effectivly preventing conflicts. If not set cluster-network-operator will use `serviceNetwork` expanded by decrementing the prefix size by 1.",
+	"":                             "KuryrConfig configures the Kuryr-Kubernetes SDN",
+	"daemonProbesPort":             "The port kuryr-daemon will listen for readiness and liveness requests.",
+	"controllerProbesPort":         "The port kuryr-controller will listen for readiness and liveness requests.",
+	"openStackServiceNetwork":      "openStackServiceNetwork contains the CIDR of network from which to allocate IPs for OpenStack Octavia's Amphora VMs. Please note that with Amphora driver Octavia uses two IPs from that network for each loadbalancer - one given by OpenShift and second for VRRP connections. As the first one is managed by OpenShift's and second by Neutron's IPAMs, those need to come from different pools. Therefore `openStackServiceNetwork` needs to be at least twice the size of `serviceNetwork`, and whole `serviceNetwork` must be overlapping with `openStackServiceNetwork`. cluster-network-operator will then make sure VRRP IPs are taken from the ranges inside `openStackServiceNetwork` that are not overlapping with `serviceNetwork`, effectivly preventing conflicts. If not set cluster-network-operator will use `serviceNetwork` expanded by decrementing the prefix size by 1.",
+	"enablePortPoolsPrepopulation": "enablePortPoolsPrepopulation when true will make Kuryr prepopulate each newly created port pool with a minimum number of ports. Kuryr uses Neutron port pooling to fight the fact that it takes a significant amount of time to create one. Instead of creating it when pod is being deployed, Kuryr keeps a number of ports ready to be attached to pods. By default port prepopulation is disabled.",
+	"poolMaxPorts":                 "poolMaxPorts sets a maximum number of free ports that are being kept in a port pool. If the number of ports exceeds this setting, free ports will get deleted. Setting 0 will disable this upper bound, effectively preventing pools from shrinking and this is the default value. For more information about port pools see enablePortPoolsPrepopulation setting.",
+	"poolMinPorts":                 "poolMinPorts sets a minimum number of free ports that should be kept in a port pool. If the number of ports is lower than this setting, new ports will get created and added to pool. The default is 1. For more information about port pools see enablePortPoolsPrepopulation setting.",
+	"poolBatchPorts":               "poolBatchPorts sets a number of ports that should be created in a single batch request to extend the port pool. The default is 3. For more information about port pools see enablePortPoolsPrepopulation setting.",
 }
 
 func (KuryrConfig) SwaggerDoc() map[string]string {
@@ -461,6 +465,7 @@ var map_NetworkSpec = map[string]string{
 	"disableMultiNetwork": "disableMultiNetwork specifies whether or not multiple pod network support should be disabled. If unset, this property defaults to 'false' and multiple network support is enabled.",
 	"deployKubeProxy":     "deployKubeProxy specifies whether or not a standalone kube-proxy should be deployed by the operator. Some network providers include kube-proxy or similar functionality. If unset, the plugin will attempt to select the correct value, which is false when OpenShift SDN and ovn-kubernetes are used and true otherwise.",
 	"kubeProxyConfig":     "kubeProxyConfig lets us configure desired proxy configuration. If not specified, sensible defaults will be chosen by OpenShift directly. Not consumed by all network providers - currently only openshift-sdn.",
+	"logLevel":            "logLevel allows configuring the logging level of the components deployed by the operator. Currently only Kuryr SDN is affected by this setting. Please note that turning on extensive logging may affect performance. The default value is \"Normal\".",
 }
 
 func (NetworkSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This commit adds several settings to KuryrConfig structure that might be
useful for the user to fine-tune his cluster. In particular:

* EnableDebug - ability to enable debug logs on kuryr-kubernetes that
  might be useful to debug complex issues.
* EnablePortPoolsPrepopulation, PoolMaxPorts, PoolMinPorts, PoolBatchPorts -
  settings related to port pools feature. It might be useful to
  fine-tune those values depending on how the OpenShift cluster is used.