### PR TITLE
Add check to verify no metadata descriptions in CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ verify-scripts:
 	bash -x hack/verify-deepcopy.sh
 	bash -x hack/verify-protobuf.sh
 	bash -x hack/verify-swagger-docs.sh
+	bash -x hack/verify-crds.sh
 .PHONY: verify-scripts
 verify: verify-scripts
 

--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ ! -f ./_output/tools/bin/yq ]; then
+    mkdir -p ./_output/tools/bin
+    curl -s -f -L https://github.com/mikefarah/yq/releases/download/2.4.0/yq_$(go env GOHOSTOS)_$(go env GOHOSTARCH) -o ./_output/tools/bin/yq
+    chmod +x ./_output/tools/bin/yq
+fi
+
+FILES="config/v1/*.crd.yaml
+authorization/v1/*.crd.yaml
+console/v1/*.crd.yaml
+operator/v1alpha1/*.crd.yaml
+quota/v1/*.crd.yaml
+security/v1/*.crd.yaml
+"
+for f in $FILES
+do
+    if [[ $(./_output/tools/bin/yq r $f spec.validation.openAPIV3Schema.properties.metadata.description) != "null" ]]; then
+      echo "Error: cannot have a metadata description in $f"
+      exit 1  
+    fi
+done


### PR DESCRIPTION
This simply loops through the CRD yamls and uses `yq` (checked and downloaded the same way as in our `update-codegen` make targets) to see if any value is set for `metadata.description`. `yq` returns "null" if the value does not exist