### PR TITLE
Add check in hack/verify-crds that pruning is enabled

### DIFF
--- a/console/v1/0000_10_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_consoleyamlsample.crd.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   scope: Cluster
   group: console.openshift.io
+  preserveUnknownField: false
   versions:
   - name: v1
     served: true

--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -13,10 +13,21 @@ operator/v1alpha1/*.crd.yaml
 quota/v1/*.crd.yaml
 security/v1/*.crd.yaml
 "
+FAILS=false
 for f in $FILES
 do
     if [[ $(./_output/tools/bin/yq r $f spec.validation.openAPIV3Schema.properties.metadata.description) != "null" ]]; then
-      echo "Error: cannot have a metadata description in $f"
-      exit 1  
+        echo "Error: cannot have a metadata description in $f"
+        FAILS=true
+    fi
+
+    if [[ $(./_output/tools/bin/yq r $f spec.preserveUnknownField) == "null" ]]; then
+        echo "Error: pruning not enabled (spec.preserveUnknownField != false) in $f"
+        FAILS=true
     fi
 done
+
+if [ "$FAILS" = true ] ; then
+    exit 1
+fi
+


### PR DESCRIPTION
As requested in https://github.com/openshift/api/pull/490

This also adds pruning to the one console crd that was missing it, and makes a minor tweak to the verify script to print all failing CRDs before returning an error