### PR TITLE
Add validation patterns to console-operator structs

### DIFF
--- a/operator/v1/0000_70_console-operator.crd.yaml
+++ b/operator/v1/0000_70_console-operator.crd.yaml
@@ -54,6 +54,7 @@ spec:
                     the console such as the logo. Invalid value will prevent a console
                     rollout.
                   type: string
+                  pattern: ^$|^(ocp|origin|okd|dedicated|online|azure)$
                 customLogoFile:
                   description: 'customLogoFile replaces the default OpenShift logo
                     in the masthead and about dialog. It is a reference to a ConfigMap
@@ -83,6 +84,7 @@ spec:
                     will override the default documentation URL. Invalid value will
                     prevent a console rollout.
                   type: string
+                  pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))\/$
             logLevel:
               description: logLevel is an intent based logging for an overall component.  It
                 does not give fine grained control, but it is a simple way to manage

--- a/operator/v1/types_console.go
+++ b/operator/v1/types_console.go
@@ -3,7 +3,7 @@ package v1
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 // +genclient
@@ -63,6 +63,7 @@ type ConsoleCustomization struct {
 	// of the web console.  Providing documentationBaseURL will override the default
 	// documentation URL.
 	// Invalid value will prevent a console rollout.
+	// +kubebuilder:validation:Pattern=`^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))\/$`
 	DocumentationBaseURL string `json:"documentationBaseURL,omitempty"`
 	// customProductName is the name that will be displayed in page titles, logo alt text, and the about dialog
 	// instead of the normal OpenShift product name.
@@ -78,10 +79,11 @@ type ConsoleCustomization struct {
 	// Dimensions: Max height of 68px and max width of 200px
 	// SVG format preferred
 	// +optional
-	CustomLogoFile v1.ConfigMapFileReference `json:"customLogoFile,omitempty"`
+	CustomLogoFile configv1.ConfigMapFileReference `json:"customLogoFile,omitempty"`
 }
 
 // Brand is a specific supported brand within the console.
+// +kubebuilder:validation:Pattern=`^$|^(ocp|origin|okd|dedicated|online|azure)$`
 type Brand string
 
 const (


### PR DESCRIPTION
Add validation patterns to console operator structs to reflect in generated console operator CRD.
This gets us to the point that this resources is consumable. 

Follows #486. 

/cc @spadgett @damemi @bparees 

[Original CRD](https://github.com/openshift/console-operator/blob/master/manifests/00-crd-operator-config.yaml) from `console-operator` repo:

```yaml
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: consoles.operator.openshift.io
spec:
  scope: Cluster
  group: operator.openshift.io
  names:
    kind: Console
    listKind: ConsoleList
    plural: consoles
    singular: console
  subresources:
    status: {}
  versions:
    - name: v1
      served: true
      storage: true
  validation:
    openAPIV3Schema:
      properties:
        spec:
          properties:
            managementState:
              pattern: ^(Managed|Unmanaged|Removed|Forced)$
              type: string
              description: ManagementState indicates whether and how the operator
                should manage the component
            customization:
              properties:
                documentationBaseURL:
                  pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))\/$
                  type: string
                  description: Documentation base url can optionally be set but must end in a trailing slash
                brand:
                  pattern: ^$|^(ocp|origin|okd|dedicated|online|azure)$
                  type: string
                  description: Brand may be optionally set to one of six values - azure|dedicated|ocp|okd|online|origin
            providers:
              properties:
                statuspage:
                  properties:
                    pageID:
                      type: string
                      description: Contains ID for statuspage.io page that provides status info about.
```

