### PR TITLE
config/v1/types_cluster_operator: Fix "spec hold the" typo

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -63,7 +63,7 @@ spec:
         metadata:
           type: object
         spec:
-          description: spec hold the intent of how this operator should behave.
+          description: spec holds configuration that could apply to any operator.
           type: object
         status:
           description: status holds the information about the state of an operator.  It

--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -16,7 +16,7 @@ type ClusterOperator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	// spec hold the intent of how this operator should behave.
+	// spec holds configuration that could apply to any operator.
 	// +kubebuilder:validation:Required
 	// +required
 	Spec ClusterOperatorSpec `json:"spec"`

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -378,7 +378,7 @@ func (ImageLabel) SwaggerDoc() map[string]string {
 
 var map_ClusterOperator = map[string]string{
 	"":       "ClusterOperator is the Custom Resource object which holds the current state of an operator. This object is used by operators to convey their state to the rest of the cluster.",
-	"spec":   "spec hold the intent of how this operator should behave.",
+	"spec":   "spec holds configuration that could apply to any operator.",
 	"status": "status holds the information about the state of an operator.  It is consistent with status information across the Kubernetes ecosystem.",
 }
 


### PR DESCRIPTION
The typo was originally from 898d7e3b7c (#127).  The "any operator" bit explains why we don't want, for example, ingress-operator specific config in here.  The later `ClusterOperatorSpec` comment goes into more detail on that with its `pause` hypothetical, but a bit of extra hinting can't hurt ;).