### PR TITLE
config/v1/types_cluster_operator: "the kube ecosystem" -> "the Kubernetes ecosystem"

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -67,7 +67,7 @@ spec:
           type: object
         status:
           description: status holds the information about the state of an operator.  It
-            is consistent with status information across the kube ecosystem.
+            is consistent with status information across the Kubernetes ecosystem.
           type: object
           properties:
             conditions:

--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -22,7 +22,7 @@ type ClusterOperator struct {
 	Spec ClusterOperatorSpec `json:"spec"`
 
 	// status holds the information about the state of an operator.  It is consistent with status information across
-	// the kube ecosystem.
+	// the Kubernetes ecosystem.
 	// +optional
 	Status ClusterOperatorStatus `json:"status"`
 }

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -379,7 +379,7 @@ func (ImageLabel) SwaggerDoc() map[string]string {
 var map_ClusterOperator = map[string]string{
 	"":       "ClusterOperator is the Custom Resource object which holds the current state of an operator. This object is used by operators to convey their state to the rest of the cluster.",
 	"spec":   "spec hold the intent of how this operator should behave.",
-	"status": "status holds the information about the state of an operator.  It is consistent with status information across the kube ecosystem.",
+	"status": "status holds the information about the state of an operator.  It is consistent with status information across the Kubernetes ecosystem.",
 }
 
 func (ClusterOperator) SwaggerDoc() map[string]string {


### PR DESCRIPTION
The abbreviated wording was originally from 898d7e3b7c (#127).  But using the full name in these docs gives readers one less abbreviation to recognize.