### PR TITLE
Enable SCTP feature gate

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -103,6 +103,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"SupportPodPidsLimit",            // sig-pod, sjenning
 			"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
 			"ServiceNodeExclusion",           // sig-scheduling, ccoleman
+			"SCTPSupport",                    // sig-network, ccallend
 		},
 		Disabled: []string{
 			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman


### PR DESCRIPTION
This adds the SCTPSupport to the enabled-by-default feature gate flags.