### PR TITLE
Bug 1767926: Fix targetResource in ConsoleYAMLSample CRD

### DIFF
--- a/console/v1/0000_10_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_consoleyamlsample.crd.yaml
@@ -46,24 +46,31 @@ spec:
           type: object
           required:
           - description
+          - targetResource
           - title
           - yaml
           properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
             description:
               description: description of the YAML sample.
               type: string
               pattern: ^(.|\s)*\S(.|\s)*$
-            kind:
-              description: 'Kind is a string value representing the REST resource
-                this object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase. More
-                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
+            targetResource:
+              description: targetResource contains apiVersion and kind of the resource
+                YAML sample is representating.
+              type: object
+              properties:
+                apiVersion:
+                  description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the
+                    latest internal value, and may reject unrecognized values. More
+                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                  type: string
+                kind:
+                  description: 'Kind is a string value representing the REST resource
+                    this object represents. Servers may infer this from the endpoint
+                    the client submits requests to. Cannot be updated. In CamelCase.
+                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
             title:
               description: title of the YAML sample.
               type: string

--- a/console/v1/types_console_yaml_sample.go
+++ b/console/v1/types_console_yaml_sample.go
@@ -20,7 +20,7 @@ type ConsoleYAMLSample struct {
 type ConsoleYAMLSampleSpec struct {
 	// targetResource contains apiVersion and kind of the resource
 	// YAML sample is representating.
-	TargetResource metav1.TypeMeta `json:",targetResource"`
+	TargetResource metav1.TypeMeta `json:"targetResource"`
 	// title of the YAML sample.
 	Title ConsoleYAMLSampleTitle `json:"title"`
 	// description of the YAML sample.

--- a/console/v1/zz_generated.swagger_doc_generated.go
+++ b/console/v1/zz_generated.swagger_doc_generated.go
@@ -138,7 +138,7 @@ func (ConsoleYAMLSample) SwaggerDoc() map[string]string {
 
 var map_ConsoleYAMLSampleSpec = map[string]string{
 	"":               "ConsoleYAMLSampleSpec is the desired YAML sample configuration. Samples will appear with their descriptions in a samples sidebar when creating a resources in the web console.",
-	"TargetResource": "targetResource contains apiVersion and kind of the resource YAML sample is representating.",
+	"targetResource": "targetResource contains apiVersion and kind of the resource YAML sample is representating.",
 	"title":          "title of the YAML sample.",
 	"description":    "description of the YAML sample.",
 	"yaml":           "yaml is the YAML sample to display.",

--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -194,6 +194,15 @@ spec:
                       type: integer
                       format: int32
                       minimum: 0
+                    enablePortPoolsPrepopulation:
+                      description: enablePortPoolsPrepopulation when true will make
+                        Kuryr prepopulate each newly created port pool with a minimum
+                        number of ports. Kuryr uses Neutron port pooling to fight
+                        the fact that it takes a significant amount of time to create
+                        one. Instead of creating it when pod is being deployed, Kuryr
+                        keeps a number of ports ready to be attached to pods. By default
+                        port prepopulation is disabled.
+                      type: boolean
                     openStackServiceNetwork:
                       description: openStackServiceNetwork contains the CIDR of network
                         from which to allocate IPs for OpenStack Octavia's Amphora
@@ -210,6 +219,30 @@ spec:
                         conflicts. If not set cluster-network-operator will use `serviceNetwork`
                         expanded by decrementing the prefix size by 1.
                       type: string
+                    poolBatchPorts:
+                      description: poolBatchPorts sets a number of ports that should
+                        be created in a single batch request to extend the port pool.
+                        The default is 3. For more information about port pools see
+                        enablePortPoolsPrepopulation setting.
+                      type: integer
+                      minimum: 0
+                    poolMaxPorts:
+                      description: poolMaxPorts sets a maximum number of free ports
+                        that are being kept in a port pool. If the number of ports
+                        exceeds this setting, free ports will get deleted. Setting
+                        0 will disable this upper bound, effectively preventing pools
+                        from shrinking and this is the default value. For more information
+                        about port pools see enablePortPoolsPrepopulation setting.
+                      type: integer
+                      minimum: 0
+                    poolMinPorts:
+                      description: poolMinPorts sets a minimum number of free ports
+                        that should be kept in a port pool. If the number of ports
+                        is lower than this setting, new ports will get created and
+                        added to pool. The default is 1. For more information about
+                        port pools see enablePortPoolsPrepopulation setting.
+                      type: integer
+                      minimum: 1
                 openshiftSDNConfig:
                   description: openShiftSDNConfig configures the openshift-sdn plugin
                   type: object
@@ -319,6 +352,12 @@ spec:
                     type: array
                     items:
                       type: string
+            logLevel:
+              description: logLevel allows configuring the logging level of the components
+                deployed by the operator. Currently only Kuryr SDN is affected by
+                this setting. Please note that turning on extensive logging may affect
+                performance. The default value is "Normal".
+              type: string
             serviceNetwork:
               description: serviceNetwork is the ip address pool to use for Service
                 IPs Currently, all existing network providers only support a single


### PR DESCRIPTION
- Fix missing targetResource for consoleyamlsample
- regen CRDs

/assign @spadgett @bparees 

/cc @soltysh @dulek  
fyi the `cluster-network-operator` CRD also updated from `make update-codegen-crds`. 