### PR TITLE
Bug 1768542: Add `snippet` flag to ConsoleYAMLSample CRD

### DIFF
--- a/console/v1/0000_10_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_consoleyamlsample.crd.yaml
@@ -54,6 +54,11 @@ spec:
               description: description of the YAML sample.
               type: string
               pattern: ^(.|\s)*\S(.|\s)*$
+            snippet:
+              description: snippet indicates that the YAML sample is not the full
+                YAML resource definition, but a fragment that can be inserted into
+                the existing YAML document at the user's cursor.
+              type: boolean
             targetResource:
               description: targetResource contains apiVersion and kind of the resource
                 YAML sample is representating.

--- a/console/v1/types_console_yaml_sample.go
+++ b/console/v1/types_console_yaml_sample.go
@@ -27,6 +27,11 @@ type ConsoleYAMLSampleSpec struct {
 	Description ConsoleYAMLSampleDescription `json:"description"`
 	// yaml is the YAML sample to display.
 	YAML ConsoleYAMLSampleYAML `json:"yaml"`
+	// snippet indicates that the YAML sample is not the full YAML resource
+	// definition, but a fragment that can be inserted into the existing
+	// YAML document at the user's cursor.
+	// +optional
+	Snippet bool `json:"snippet"`
 }
 
 // ConsoleYAMLSampleTitle of the YAML sample.

--- a/console/v1/zz_generated.swagger_doc_generated.go
+++ b/console/v1/zz_generated.swagger_doc_generated.go
@@ -142,6 +142,7 @@ var map_ConsoleYAMLSampleSpec = map[string]string{
 	"title":          "title of the YAML sample.",
 	"description":    "description of the YAML sample.",
 	"yaml":           "yaml is the YAML sample to display.",
+	"snippet":        "snippet indicates that the YAML sample is not the full YAML resource definition, but a fragment that can be inserted into the existing YAML document at the user's cursor.",
 }
 
 func (ConsoleYAMLSampleSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Snippets let you insert a partial YAML definition at the user's cursor in the console YAML editor.

/assign @bparees @benjaminapetersen 
cc @andrewballantyne @christianvogt @sspeiche 