### PR TITLE
config/v1/types_cluster_operator: Fix "Degraded indicated" -> "Degraded indicates"

### DIFF
--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -149,11 +149,7 @@ const (
 	// a previously known state.
 	OperatorProgressing ClusterStatusConditionType = "Progressing"
 
-	// Degraded indicates that the operand is not functioning completely. An example of a degraded state
-	// would be if there should be 5 copies of the operand running but only 4 are running. It may still be available,
-	// but it is degraded
-
-	// Degraded indicated that the operator's current state does not match its
+	// Degraded indicates that the operator's current state does not match its
 	// desired state over a period of time resulting in a lower quality of service.
 	// The period of time may vary by component, but a Degraded state represents
 	// persistent observation of a condition.  As a result, a component should not


### PR DESCRIPTION
And drop the earlier, orphaned comment block.  Both of these issues slipped through my earlier 40c55f8085 (#501).

Oops, @soltysh, sorry I missed these.  Can you take another look?

/assign @soltysh