### PR TITLE
Remove ExperimentalCriticalPodAnnotation from featureflags

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -99,12 +99,11 @@ type FeatureGateEnabledDisabled struct {
 var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	Default: {
 		Enabled: []string{
-			"ExperimentalCriticalPodAnnotation", // sig-pod, sjenning
-			"RotateKubeletServerCertificate",    // sig-pod, sjenning
-			"SupportPodPidsLimit",               // sig-pod, sjenning
-			"TLSSecurityProfile",                // sig-network, danehans
-			"NodeDisruptionExclusion",           // sig-scheduling, ccoleman
-			"ServiceNodeExclusion",              // sig-scheduling, ccoleman
+			"RotateKubeletServerCertificate", // sig-pod, sjenning
+			"SupportPodPidsLimit",            // sig-pod, sjenning
+			"TLSSecurityProfile",             // sig-network, danehans
+			"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
+			"ServiceNodeExclusion",           // sig-scheduling, ccoleman
 		},
 		Disabled: []string{
 			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
@@ -116,12 +115,11 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	},
 	TechPreviewNoUpgrade: {
 		Enabled: []string{
-			"ExperimentalCriticalPodAnnotation", // sig-pod, sjenning
-			"RotateKubeletServerCertificate",    // sig-pod, sjenning
-			"SupportPodPidsLimit",               // sig-pod, sjenning
-			"TLSSecurityProfile",                // sig-network, danehans
-			"NodeDisruptionExclusion",           // sig-scheduling, ccoleman
-			"ServiceNodeExclusion",              // sig-scheduling, ccoleman
+			"RotateKubeletServerCertificate", // sig-pod, sjenning
+			"SupportPodPidsLimit",            // sig-pod, sjenning
+			"TLSSecurityProfile",             // sig-network, danehans
+			"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
+			"ServiceNodeExclusion",           // sig-scheduling, ccoleman
 		},
 		Disabled: []string{
 			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
@@ -129,12 +127,11 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	},
 	LatencySensitive: {
 		Enabled: []string{
-			"ExperimentalCriticalPodAnnotation", // sig-pod, sjenning
-			"RotateKubeletServerCertificate",    // sig-pod, sjenning
-			"SupportPodPidsLimit",               // sig-pod, sjenning
-			"TopologyManager",                   // sig-pod, sjenning
-			"NodeDisruptionExclusion",           // sig-scheduling, ccoleman
-			"ServiceNodeExclusion",              // sig-scheduling, ccoleman
+			"RotateKubeletServerCertificate", // sig-pod, sjenning
+			"SupportPodPidsLimit",            // sig-pod, sjenning
+			"TopologyManager",                // sig-pod, sjenning
+			"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
+			"ServiceNodeExclusion",           // sig-scheduling, ccoleman
 		},
 		Disabled: []string{
 			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman


### PR DESCRIPTION
ExperimentalCriticalPodAnnotation is not used anymore within Kubernetes 1.16. On Windows, this is reported to cause the Kubelet to exit.

@deads2k @sjenning @ravisantoshgudimetla 