### PR TITLE
add status subresource to samples config crd

### DIFF
--- a/samples/v1/0000_10_samplesconfig.crd.yaml
+++ b/samples/v1/0000_10_samplesconfig.crd.yaml
@@ -7,6 +7,8 @@ metadata:
     description: Extension for configuring openshif samples operator.
 spec:
   scope: Cluster
+  subresources:
+    status: {}
   preserveUnknownFields: false
   group: samples.operator.openshift.io
   versions:


### PR DESCRIPTION
/assign @bparees 
/assign @adambkaplan 

forgot to include https://github.com/openshift/cluster-samples-operator/blob/master/manifests/00-crd.yaml#L14-L15 when moving the samples operator config crd to openshift/api