### PR TITLE
Add UseMDNS member to baremetal platform status

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -182,6 +182,12 @@ type BareMetalPlatformStatus struct {
 	// datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames
 	// to the nodes in the cluster.
 	NodeDNSIP string `json:"nodeDNSIP,omitempty"`
+
+	// UseMDNS indicates where baremetal mDNS services should be deployed.
+	// See the documentation of the corresponding install-config member at
+	// https://github.com/openshift/installer/blob/master/pkg/types/baremetal/platform.go
+	// for details on which values are recognized.
+	UseMDNS string `json:"useMDNS,omitempty"`
 }
 
 // OpenStackPlatformStatus holds the current status of the OpenStack infrastructure provider.


### PR DESCRIPTION
We've had new use cases presented where our mDNS services cannot be
used and are not needed, so we need a way to disable them in those
deployments. This member will allow us to specify whether they should
be deployed on all nodes, no nodes, or just masters.