### PR TITLE
image: Improve godoc for image types

### DIFF
--- a/image/v1/generated.proto
+++ b/image/v1/generated.proto
@@ -32,6 +32,13 @@ message DockerImageReference {
 }
 
 // Image is an immutable representation of a container image and metadata at a point in time.
+// Images are named by taking a hash of their contents (metadata and content) and any change
+// in format, content, or metadata results in a new name. The images resource is primarily
+// for use by cluster administrators and integrations like the cluster image registry - end
+// users instead access images via the imagestreamtags or imagestreamimages resources. While
+// image metadata is stored in the API, any integration that implements the container image
+// registry API must provide its own storage for the raw manifest data, image config, and
+// layer contents.
 message Image {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -197,9 +204,20 @@ message ImageSignature {
   optional SignatureSubject issuedTo = 9;
 }
 
-// ImageStream stores a mapping of tags to images, metadata overrides that are applied
+// An ImageStream stores a mapping of tags to images, metadata overrides that are applied
 // when images are tagged in a stream, and an optional reference to a container image
-// repository on a registry.
+// repository on a registry. Users typically update the spec.tags field to point to external
+// images which are imported from container registries using credentials in your namespace
+// with the pull secret type, or to existing image stream tags and images which are
+// immediately accessible for tagging or pulling. The history of images applied to a tag
+// is visible in the status.tags field and any user who can view an image stream is allowed
+// to tag that image into their own image streams. Access to pull images from the integrated
+// registry is granted by having the "get imagestreams/layers" permission on a given image
+// stream. Users may remove a tag by deleting the imagestreamtag resource, which causes both
+// spec and status for that tag to be removed. Image stream history is retained until an
+// administrator runs the prune operation, which removes references that are no longer in
+// use. To preserve a historical image, ensure there is a tag in spec pointing to that image
+// by its digest.
 message ImageStream {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -211,6 +229,17 @@ message ImageStream {
 }
 
 // ImageStreamImage represents an Image that is retrieved by image name from an ImageStream.
+// User interfaces and regular users can use this resource to access the metadata details of
+// a tagged image in the image stream history for viewing, since Image resources are not
+// directly accessible to end users. A not found error will be returned if no such image is
+// referenced by a tag within the ImageStream. Images are created when spec tags are set on
+// an image stream that represent an image in an external registry, when pushing to the
+// integrated registry, or when tagging an existing image from one image stream to another.
+// The name of an image stream image is in the form "<STREAM>@<DIGEST>", where the digest is
+// the content addressible identifier for the image (sha256:xxxxx...). You can use
+// ImageStreamImages as the from.kind of an image stream spec tag to reference an image
+// exactly. The only operations supported on the imagestreamimage endpoint are retrieving
+// the image.
 message ImageStreamImage {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -283,8 +312,14 @@ message ImageStreamList {
   repeated ImageStream items = 2;
 }
 
-// ImageStreamMapping represents a mapping from a single tag to a container image as
-// well as the reference to the container image stream the image came from.
+// ImageStreamMapping represents a mapping from a single image stream tag to a container
+// image as well as the reference to the container image stream the image came from. This
+// resource is used by privileged integrators to create an image resource and to associate
+// it with an image stream in the status tags field. Creating an ImageStreamMapping will
+// allow any user who can view the image stream to tag or pull that image, so only create
+// mappings where the user has proven they have access to the image contents directly.
+// The only operation supported for this resource is create and the metadata name and
+// namespace should be set to the image stream containing the tag that should be updated.
 message ImageStreamMapping {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
@@ -330,6 +365,13 @@ message ImageStreamStatus {
 }
 
 // ImageStreamTag represents an Image that is retrieved by tag name from an ImageStream.
+// Use this resource to interact with the tags and images in an image stream by tag, or
+// to see the image details for a particular tag. The image associated with this resource
+// is the most recently successfully tagged, imported, or pushed image (as described in the
+// image stream status.tags.items list for this tag). If an import is in progress or has
+// failed the previous image will be shown. Deleting an image stream tag clears both the
+// status and spec fields of an image stream. If no image can be retrieved for a given tag,
+// a not found error will be returned.
 message ImageStreamTag {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 

--- a/image/v1/zz_generated.swagger_doc_generated.go
+++ b/image/v1/zz_generated.swagger_doc_generated.go
@@ -25,7 +25,7 @@ func (DockerImageReference) SwaggerDoc() map[string]string {
 }
 
 var map_Image = map[string]string{
-	"":                             "Image is an immutable representation of a container image and metadata at a point in time.",
+	"":                             "Image is an immutable representation of a container image and metadata at a point in time. Images are named by taking a hash of their contents (metadata and content) and any change in format, content, or metadata results in a new name. The images resource is primarily for use by cluster administrators and integrations like the cluster image registry - end users instead access images via the imagestreamtags or imagestreamimages resources. While image metadata is stored in the API, any integration that implements the container image registry API must provide its own storage for the raw manifest data, image config, and layer contents.",
 	"dockerImageReference":         "DockerImageReference is the string that can be used to pull this image.",
 	"dockerImageMetadata":          "DockerImageMetadata contains metadata about this image",
 	"dockerImageMetadataVersion":   "DockerImageMetadataVersion conveys the version of the object, which if empty defaults to \"1.0\"",
@@ -132,7 +132,7 @@ func (ImageSignature) SwaggerDoc() map[string]string {
 }
 
 var map_ImageStream = map[string]string{
-	"":       "ImageStream stores a mapping of tags to images, metadata overrides that are applied when images are tagged in a stream, and an optional reference to a container image repository on a registry.",
+	"":       "An ImageStream stores a mapping of tags to images, metadata overrides that are applied when images are tagged in a stream, and an optional reference to a container image repository on a registry. Users typically update the spec.tags field to point to external images which are imported from container registries using credentials in your namespace with the pull secret type, or to existing image stream tags and images which are immediately accessible for tagging or pulling. The history of images applied to a tag is visible in the status.tags field and any user who can view an image stream is allowed to tag that image into their own image streams. Access to pull images from the integrated registry is granted by having the \"get imagestreams/layers\" permission on a given image stream. Users may remove a tag by deleting the imagestreamtag resource, which causes both spec and status for that tag to be removed. Image stream history is retained until an administrator runs the prune operation, which removes references that are no longer in use. To preserve a historical image, ensure there is a tag in spec pointing to that image by its digest.",
 	"spec":   "Spec describes the desired state of this stream",
 	"status": "Status describes the current state of this stream",
 }
@@ -142,7 +142,7 @@ func (ImageStream) SwaggerDoc() map[string]string {
 }
 
 var map_ImageStreamImage = map[string]string{
-	"":      "ImageStreamImage represents an Image that is retrieved by image name from an ImageStream.",
+	"":      "ImageStreamImage represents an Image that is retrieved by image name from an ImageStream. User interfaces and regular users can use this resource to access the metadata details of a tagged image in the image stream history for viewing, since Image resources are not directly accessible to end users. A not found error will be returned if no such image is referenced by a tag within the ImageStream. Images are created when spec tags are set on an image stream that represent an image in an external registry, when pushing to the integrated registry, or when tagging an existing image from one image stream to another. The name of an image stream image is in the form \"<STREAM>@<DIGEST>\", where the digest is the content addressible identifier for the image (sha256:xxxxx...). You can use ImageStreamImages as the from.kind of an image stream spec tag to reference an image exactly. The only operations supported on the imagestreamimage endpoint are retrieving the image.",
 	"image": "Image associated with the ImageStream and image name.",
 }
 
@@ -202,7 +202,7 @@ func (ImageStreamList) SwaggerDoc() map[string]string {
 }
 
 var map_ImageStreamMapping = map[string]string{
-	"":      "ImageStreamMapping represents a mapping from a single tag to a container image as well as the reference to the container image stream the image came from.",
+	"":      "ImageStreamMapping represents a mapping from a single image stream tag to a container image as well as the reference to the container image stream the image came from. This resource is used by privileged integrators to create an image resource and to associate it with an image stream in the status tags field. Creating an ImageStreamMapping will allow any user who can view the image stream to tag or pull that image, so only create mappings where the user has proven they have access to the image contents directly. The only operation supported for this resource is create and the metadata name and namespace should be set to the image stream containing the tag that should be updated.",
 	"image": "Image is a container image.",
 	"tag":   "Tag is a string value this image can be located with inside the stream.",
 }
@@ -234,7 +234,7 @@ func (ImageStreamStatus) SwaggerDoc() map[string]string {
 }
 
 var map_ImageStreamTag = map[string]string{
-	"":             "ImageStreamTag represents an Image that is retrieved by tag name from an ImageStream.",
+	"":             "ImageStreamTag represents an Image that is retrieved by tag name from an ImageStream. Use this resource to interact with the tags and images in an image stream by tag, or to see the image details for a particular tag. The image associated with this resource is the most recently successfully tagged, imported, or pushed image (as described in the image stream status.tags.items list for this tag). If an import is in progress or has failed the previous image will be shown. Deleting an image stream tag clears both the status and spec fields of an image stream. If no image can be retrieved for a given tag, a not found error will be returned.",
 	"tag":          "tag is the spec tag associated with this image stream tag, and it may be null if only pushes have occurred to this image stream.",
 	"generation":   "generation is the current generation of the tagged image - if tag is provided and this value is not equal to the tag generation, a user has requested an import that has not completed, or conditions will be filled out indicating any error.",
 	"lookupPolicy": "lookupPolicy indicates whether this tag will handle image references in this namespace.",


### PR DESCRIPTION
End users should have a bit more info about the core image types.
Describe behavior, intended use, target audience, and some details
of API interactions.