### PR TITLE
Expose external ip on the status field of network config

### DIFF
--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -67,6 +67,10 @@ type NetworkStatus struct {
 
 	// ClusterNetworkMTU is the MTU for inter-pod networking.
 	ClusterNetworkMTU int `json:"clusterNetworkMTU,omitempty"`
+
+	// externalIP defines configuration for controllers that
+	// affect Service.ExternalIP.
+	ExternalIP *ExternalIPConfig `json:"externalIP,omitempty"`
 }
 
 // ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs


### PR DESCRIPTION
This commit adds the `ExternalIP` field to the `NetworkStatus` field of the network config. This mirrors the field in the `NetworkSpec` field and allows any operator which edits the network config to also be able to write configuration to the `ExternalIP` field in the status field as well as prevent it from stomping on any changes to that field.