### PR TITLE
Bug 1769008: Adding missing Azure container name validation.

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -192,6 +192,9 @@ spec:
                       description: container defines Azure's container to be used
                         by registry.
                       type: string
+                      maxLength: 63
+                      minLength: 3
+                      pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
                 emptyDir:
                   description: 'emptyDir represents ephemeral storage on the pod''s
                     host node. WARNING: this storage cannot be used with more than
@@ -456,6 +459,9 @@ spec:
                       description: container defines Azure's container to be used
                         by registry.
                       type: string
+                      maxLength: 63
+                      minLength: 3
+                      pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
                 emptyDir:
                   description: 'emptyDir represents ephemeral storage on the pod''s
                     host node. WARNING: this storage cannot be used with more than

--- a/imageregistry/v1/types.go
+++ b/imageregistry/v1/types.go
@@ -234,6 +234,9 @@ type ImageRegistryConfigStorageAzure struct {
 	AccountName string `json:"accountName" protobuf:"bytes,1,opt,name=accountName"`
 	// container defines Azure's container to be used by registry.
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MinLength=3
+	// +kubebuilder:validation:Pattern=`^[0-9a-z]+(-[0-9a-z]+)*$`
 	Container string `json:"container" protobuf:"bytes,2,opt,name=container"`
 }
 


### PR DESCRIPTION
This patch adds validation to the Azure's container name as already done by the type and crd on image registry operator.

I have missed these changes when I initially migrated `type` and `crd` from the operator.