### PR TITLE
prevent mismatched featuregates

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -97,44 +97,98 @@ type FeatureGateEnabledDisabled struct {
 //
 // If you put an item in either of these lists, put your area and name on it so we can find owners.
 var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
-	Default: {
-		Enabled: []string{
-			"RotateKubeletServerCertificate", // sig-pod, sjenning
-			"SupportPodPidsLimit",            // sig-pod, sjenning
-			"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
-			"ServiceNodeExclusion",           // sig-scheduling, ccoleman
-			"SCTPSupport",                    // sig-network, ccallend
-		},
-		Disabled: []string{
-			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
-		},
-	},
+	Default: defaultFeatures,
 	CustomNoUpgrade: {
 		Enabled:  []string{},
 		Disabled: []string{},
 	},
-	TechPreviewNoUpgrade: {
-		Enabled: []string{
-			"RotateKubeletServerCertificate", // sig-pod, sjenning
-			"SupportPodPidsLimit",            // sig-pod, sjenning
-			"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
-			"ServiceNodeExclusion",           // sig-scheduling, ccoleman
-		},
-		Disabled: []string{
-			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
-		},
+	TechPreviewNoUpgrade: newDefaultFeatures().toFeatures(),
+	LatencySensitive: newDefaultFeatures().
+		with(
+			"TopologyManager", // sig-pod, sjenning
+		).
+		toFeatures(),
+}
+
+var defaultFeatures = &FeatureGateEnabledDisabled{
+	Enabled: []string{
+		"RotateKubeletServerCertificate", // sig-pod, sjenning
+		"SupportPodPidsLimit",            // sig-pod, sjenning
+		"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
+		"ServiceNodeExclusion",           // sig-scheduling, ccoleman
+		"SCTPSupport",                    // sig-network, ccallend
 	},
-	LatencySensitive: {
-		Enabled: []string{
-			"RotateKubeletServerCertificate", // sig-pod, sjenning
-			"SupportPodPidsLimit",            // sig-pod, sjenning
-			"TopologyManager",                // sig-pod, sjenning
-			"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
-			"ServiceNodeExclusion",           // sig-scheduling, ccoleman
-			"SCTPSupport",                    // sig-network, ccallend
-		},
-		Disabled: []string{
-			"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
-		},
+	Disabled: []string{
+		"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
 	},
+}
+
+type featureSetBuilder struct {
+	forceOn  []string
+	forceOff []string
+}
+
+func newDefaultFeatures() *featureSetBuilder {
+	return &featureSetBuilder{}
+}
+
+func (f *featureSetBuilder) with(forceOn ...string) *featureSetBuilder {
+	f.forceOn = append(f.forceOn, forceOn...)
+	return f
+}
+
+func (f *featureSetBuilder) without(forceOff ...string) *featureSetBuilder {
+	f.forceOff = append(f.forceOff, forceOff...)
+	return f
+}
+
+func (f *featureSetBuilder) isForcedOff(needle string) bool {
+	for _, forcedOff := range f.forceOff {
+		if needle == forcedOff {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *featureSetBuilder) isForcedOn(needle string) bool {
+	for _, forceOn := range f.forceOn {
+		if needle == forceOn {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *featureSetBuilder) toFeatures() *FeatureGateEnabledDisabled {
+	finalOn := []string{}
+	finalOff := []string{}
+
+	// only add the default enabled features if they haven't been explicitly set off
+	for _, defaultOn := range defaultFeatures.Enabled {
+		if !f.isForcedOff(defaultOn) {
+			finalOn = append(finalOn, defaultOn)
+		}
+	}
+	for _, currOn := range f.forceOn {
+		if f.isForcedOff(currOn) {
+			panic("coding error, you can't have features both on and off")
+		}
+		finalOn = append(finalOn, currOn)
+	}
+
+	// only add the default disabled features if they haven't been explicitly set on
+	for _, defaultOff := range defaultFeatures.Disabled {
+		if !f.isForcedOn(defaultOff) {
+			finalOff = append(finalOff, defaultOff)
+		}
+	}
+	for _, currOff := range f.forceOff {
+		finalOff = append(finalOff, currOff)
+	}
+
+	return &FeatureGateEnabledDisabled{
+		Enabled:  finalOn,
+		Disabled: finalOff,
+	}
 }

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -1,0 +1,92 @@
+package v1
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFeatureBuilder(t *testing.T) {
+	tests := []struct {
+		name     string
+		actual   *FeatureGateEnabledDisabled
+		expected *FeatureGateEnabledDisabled
+	}{
+		{
+			name:     "nothing",
+			actual:   newDefaultFeatures().toFeatures(),
+			expected: defaultFeatures,
+		},
+		{
+			name:   "disable-existing",
+			actual: newDefaultFeatures().without("SCTPSupport").toFeatures(),
+			expected: &FeatureGateEnabledDisabled{
+				Enabled: []string{
+					"RotateKubeletServerCertificate",
+					"SupportPodPidsLimit",
+					"NodeDisruptionExclusion",
+					"ServiceNodeExclusion",
+				},
+				Disabled: []string{
+					"LegacyNodeRoleBehavior",
+					"SCTPSupport",
+				},
+			},
+		},
+		{
+			name:   "enable-existing",
+			actual: newDefaultFeatures().with("LegacyNodeRoleBehavior").toFeatures(),
+			expected: &FeatureGateEnabledDisabled{
+				Enabled: []string{
+					"RotateKubeletServerCertificate",
+					"SupportPodPidsLimit",
+					"NodeDisruptionExclusion",
+					"ServiceNodeExclusion",
+					"SCTPSupport",
+					"LegacyNodeRoleBehavior",
+				},
+				Disabled: []string{},
+			},
+		},
+		{
+			name:   "disable-more",
+			actual: newDefaultFeatures().without("SCTPSupport", "other").toFeatures(),
+			expected: &FeatureGateEnabledDisabled{
+				Enabled: []string{
+					"RotateKubeletServerCertificate",
+					"SupportPodPidsLimit",
+					"NodeDisruptionExclusion",
+					"ServiceNodeExclusion",
+				},
+				Disabled: []string{
+					"LegacyNodeRoleBehavior",
+					"SCTPSupport",
+					"other",
+				},
+			},
+		},
+		{
+			name:   "enable-more",
+			actual: newDefaultFeatures().with("LegacyNodeRoleBehavior", "other").toFeatures(),
+			expected: &FeatureGateEnabledDisabled{
+				Enabled: []string{
+					"RotateKubeletServerCertificate",
+					"SupportPodPidsLimit",
+					"NodeDisruptionExclusion",
+					"ServiceNodeExclusion",
+					"SCTPSupport",
+					"LegacyNodeRoleBehavior",
+					"other",
+				},
+				Disabled: []string{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tc.expected, tc.actual) {
+				t.Error(tc.actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
featuregates were vulnerable to mismatches where an intent to include features on top of default required a fully copy that runs out of date. This allows someone to describe their deltas from the default which is much easier to get right.