### PR TITLE
Fix replace for go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,3 @@ require (
 	k8s.io/code-generator v0.17.0
 	k8s.io/klog v1.0.0
 )
-
-replace (
-	k8s.io/api => k8s.io/api v0.17.0
-	k8s.io/apimachinery => k8s.io/apimachinery v0.17.0
-	k8s.io/code-generator => k8s.io/code-generator v0.17.0
-)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -116,7 +116,7 @@ gonum.org/v1/gonum/mat
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.4
 gopkg.in/yaml.v2
-# k8s.io/api v0.17.0 => k8s.io/api v0.17.0
+# k8s.io/api v0.17.0
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -147,7 +147,7 @@ k8s.io/api/settings/v1alpha1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apimachinery v0.17.0 => k8s.io/apimachinery v0.17.0
+# k8s.io/apimachinery v0.17.0
 k8s.io/apimachinery/pkg/api/apitesting
 k8s.io/apimachinery/pkg/api/apitesting/fuzzer
 k8s.io/apimachinery/pkg/api/apitesting/roundtrip
@@ -185,7 +185,7 @@ k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/code-generator v0.17.0 => k8s.io/code-generator v0.17.0
+# k8s.io/code-generator v0.17.0
 k8s.io/code-generator
 k8s.io/code-generator/cmd/client-gen
 k8s.io/code-generator/cmd/client-gen/args


### PR DESCRIPTION
replace stanzas prevent normal `go mod` vendor of require to match and that in turn impacts transitive dependency calculations downstream.