### PR TITLE
feature: Enable the IPv6DualStack feature gate by default

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -117,6 +117,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
 		"ServiceNodeExclusion",           // sig-scheduling, ccoleman
 		"SCTPSupport",                    // sig-network, ccallend
+		"IPv6DualStack",                  // sig-network, ccoleman
 	},
 	Disabled: []string{
 		"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -25,6 +25,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
+					"IPv6DualStack",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
@@ -42,6 +43,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 					"SCTPSupport",
+					"IPv6DualStack",
 					"LegacyNodeRoleBehavior",
 				},
 				Disabled: []string{},
@@ -56,6 +58,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
+					"IPv6DualStack",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
@@ -74,6 +77,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 					"SCTPSupport",
+					"IPv6DualStack",
 					"LegacyNodeRoleBehavior",
 					"other",
 				},


### PR DESCRIPTION
1.17 adds dual-stack support if you specify multiple flags for
the CIDR ranges. Since dual stack support requires config generation
enabling the feature gate does not change default behavior of the
platform.

Will enable further development and testing.