### PR TITLE
Add rolloutStategy parameter to ImageRegistrySpec

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -154,6 +154,11 @@ spec:
                   type: object
                   additionalProperties:
                     type: string
+            rolloutStrategy:
+              description: rolloutStrategy defines rollout strategy for the image
+                registry deployment. Valid values are RollingUpdate (default) and Recreate.
+              type: string
+              pattern: ^(RollingUpdate|Recreate)$
             routes:
               description: routes defines additional external facing routes which
                 should be created for the registry.

--- a/imageregistry/v1/types.go
+++ b/imageregistry/v1/types.go
@@ -82,6 +82,11 @@ type ImageRegistrySpec struct {
 	// tolerations defines the tolerations for the registry pod.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty" protobuf:"bytes,14,rep,name=tolerations"`
+	// rolloutStrategy defines rollout strategy for the image registry
+	// deployment.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^(RollingUpdate|Recreate)$`
+	RolloutStrategy string `json:"rolloutStrategy" protobuf:"bytes,15,opt,name=rolloutStrategy"`
 }
 
 // ImageRegistryStatus reports image registry operational status.

--- a/imageregistry/v1/zz_generated.swagger_doc_generated.go
+++ b/imageregistry/v1/zz_generated.swagger_doc_generated.go
@@ -181,6 +181,7 @@ var map_ImageRegistrySpec = map[string]string{
 	"resources":       "resources defines the resource requests+limits for the registry pod.",
 	"nodeSelector":    "nodeSelector defines the node selection constraints for the registry pod.",
 	"tolerations":     "tolerations defines the tolerations for the registry pod.",
+	"rolloutStrategy": "rolloutStrategy defines rollout strategy for the image registry deployment.",
 }
 
 func (ImageRegistrySpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
To allow us to define a rollout strategy for the image registry deployment, we create an additional parameter in ImageRegistrySpec.