### PR TITLE
Fix image registry's rollout parameter

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -156,7 +156,7 @@ spec:
                     type: string
             rolloutStrategy:
               description: rolloutStrategy defines rollout strategy for the image
-                registry deployment. Valid values are RollingUpdate (default) and Recreate.
+                registry deployment.
               type: string
               pattern: ^(RollingUpdate|Recreate)$
             routes:

--- a/imageregistry/v1/types.go
+++ b/imageregistry/v1/types.go
@@ -86,7 +86,7 @@ type ImageRegistrySpec struct {
 	// deployment.
 	// +optional
 	// +kubebuilder:validation:Pattern=`^(RollingUpdate|Recreate)$`
-	RolloutStrategy string `json:"rolloutStrategy" protobuf:"bytes,15,opt,name=rolloutStrategy"`
+	RolloutStrategy string `json:"rolloutStrategy,omitempty" protobuf:"bytes,15,opt,name=rolloutStrategy"`
 }
 
 // ImageRegistryStatus reports image registry operational status.

--- a/operator/v1/0000_80_csi_snapshot_controller_operator_01_crd.yaml
+++ b/operator/v1/0000_80_csi_snapshot_controller_operator_01_crd.yaml
@@ -19,9 +19,11 @@ spec:
     storage: true
   validation:
     openAPIV3Schema:
-      description: CSISnapshotController provides information to configure an operator to
-        manage the CSISnapshotController.
+      description: CSISnapshotController provides a means to configure an operator
+        to manage the CSI snapshots. `cluster` is the canonical name.
       type: object
+      required:
+      - spec
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -36,8 +38,7 @@ spec:
         metadata:
           type: object
         spec:
-          description: CSISnapshotControllerSpec is the specification of the desired behavior of
-            the CSISnapshotController operator.
+          description: spec holds user settable values for configuration
           type: object
           properties:
             logLevel:
@@ -73,8 +74,8 @@ spec:
               nullable: true
               x-kubernetes-preserve-unknown-fields: true
         status:
-          description: CSISnapshotControllerStatus defines the observed status of 
-            the CSISnapshotController operator.
+          description: status holds observed values from the cluster. They may not
+            be overridden.
           type: object
           properties:
             conditions:


### PR DESCRIPTION
Add `omitempty` tag so empty values are not validated by the regex.