### PR TITLE
Add accessMode parameter to define PVC storage access mode

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -506,6 +506,11 @@ spec:
                       description: claim defines the Persisent Volume Claim's name
                         to be used.
                       type: string
+                    accessMode:
+                      description: accessMode defines the type of the PVC access mode.
+                        ReadWriteMany (default) and ReadWriteOnce modes are supported.
+                      type: string
+                      pattern: ^(ReadWriteMany|ReadWriteOnce)$
                 s3:
                   description: s3 represents configuration that uses Amazon Simple
                     Storage Service.

--- a/imageregistry/v1/types.go
+++ b/imageregistry/v1/types.go
@@ -229,6 +229,10 @@ type ImageRegistryConfigStoragePVC struct {
 	// claim defines the Persisent Volume Claim's name to be used.
 	// +optional
 	Claim string `json:"claim" protobuf:"bytes,1,opt,name=claim"`
+	// accessMode defines the type of the PVC access mode.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^(ReadWriteMany|ReadWriteOnce)$`
+	AccessMode string `json:"accessMode,omitempty" protobuf:"bytes,2,opt,name=accessMode"`
 }
 
 // ImageRegistryConfigStorageAzure holds the information to configure

--- a/imageregistry/v1/zz_generated.swagger_doc_generated.go
+++ b/imageregistry/v1/zz_generated.swagger_doc_generated.go
@@ -115,8 +115,9 @@ func (ImageRegistryConfigStorageGCS) SwaggerDoc() map[string]string {
 }
 
 var map_ImageRegistryConfigStoragePVC = map[string]string{
-	"":      "ImageRegistryConfigStoragePVC holds Persistent Volume Claims data to be used by the registry.",
-	"claim": "claim defines the Persisent Volume Claim's name to be used.",
+	"":           "ImageRegistryConfigStoragePVC holds Persistent Volume Claims data to be used by the registry.",
+	"claim":      "claim defines the Persisent Volume Claim's name to be used.",
+	"accessMode": "accessMode defines the type of the PVC access mode.",
 }
 
 func (ImageRegistryConfigStoragePVC) SwaggerDoc() map[string]string {


### PR DESCRIPTION
In the image registry we should allow to create volumes with RWO access mode 