### PR TITLE
operator/ingress: Fix route admission godoc typos

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-custom-resource-definition.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-custom-resource-definition.yaml
@@ -290,7 +290,7 @@ spec:
             routeAdmission:
               description: "routeAdmission defines a policy for handling new route
                 claims (for example, to allow or deny claims across namespaces). \n
-                The empty, defaults will be applied. See specific routeAdmission fields
+                If empty, defaults will be applied. See specific routeAdmission fields
                 for details about their defaults."
               type: object
               properties:
@@ -298,7 +298,7 @@ spec:
                   description: "namespaceOwnership describes how host name claims
                     across namespaces should be handled. \n Value must be one of:
                     \n - Strict: Do not allow routes in different namespaces to claim
-                    the same host. \n - InterNamespaceAllowed: allow routes to claim
+                    the same host. \n - InterNamespaceAllowed: Allow routes to claim
                     different paths of the same   host name across namespaces. \n
                     If empty, the default is Strict."
                   type: string

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -149,7 +149,7 @@ type IngressControllerSpec struct {
 	// routeAdmission defines a policy for handling new route claims (for example,
 	// to allow or deny claims across namespaces).
 	//
-	// The empty, defaults will be applied. See specific routeAdmission fields
+	// If empty, defaults will be applied. See specific routeAdmission fields
 	// for details about their defaults.
 	//
 	// +optional
@@ -326,7 +326,7 @@ type RouteAdmissionPolicy struct {
 	//
 	// - Strict: Do not allow routes in different namespaces to claim the same host.
 	//
-	// - InterNamespaceAllowed: allow routes to claim different paths of the same
+	// - InterNamespaceAllowed: Allow routes to claim different paths of the same
 	//   host name across namespaces.
 	//
 	// If empty, the default is Strict.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -331,7 +331,7 @@ var map_IngressControllerSpec = map[string]string{
 	"routeSelector":              "routeSelector is used to filter the set of Routes serviced by the ingress controller. This is useful for implementing shards.\n\nIf unset, the default is no filtering.",
 	"nodePlacement":              "nodePlacement enables explicit control over the scheduling of the ingress controller.\n\nIf unset, defaults are used. See NodePlacement for more details.",
 	"tlsSecurityProfile":         "tlsSecurityProfile specifies settings for TLS connections for ingresscontrollers.\n\nIf unset, the default is based on the apiservers.config.openshift.io/cluster resource.\n\nNote that when using the Old, Intermediate, and Modern profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied to the ingress controller, resulting in a rollout.\n\nNote that the minimum TLS version for ingress controllers is 1.1, and the maximum TLS version is 1.2.  An implication of this restriction is that the Modern TLS profile type cannot be used because it requires TLS 1.3.",
-	"routeAdmission":             "routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces).\n\nThe empty, defaults will be applied. See specific routeAdmission fields for details about their defaults.",
+	"routeAdmission":             "routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces).\n\nIf empty, defaults will be applied. See specific routeAdmission fields for details about their defaults.",
 }
 
 func (IngressControllerSpec) SwaggerDoc() map[string]string {
@@ -390,7 +390,7 @@ func (PrivateStrategy) SwaggerDoc() map[string]string {
 
 var map_RouteAdmissionPolicy = map[string]string{
 	"":                   "RouteAdmissionPolicy is an admission policy for allowing new route claims.",
-	"namespaceOwnership": "namespaceOwnership describes how host name claims across namespaces should be handled.\n\nValue must be one of:\n\n- Strict: Do not allow routes in different namespaces to claim the same host.\n\n- InterNamespaceAllowed: allow routes to claim different paths of the same\n  host name across namespaces.\n\nIf empty, the default is Strict.",
+	"namespaceOwnership": "namespaceOwnership describes how host name claims across namespaces should be handled.\n\nValue must be one of:\n\n- Strict: Do not allow routes in different namespaces to claim the same host.\n\n- InterNamespaceAllowed: Allow routes to claim different paths of the same\n  host name across namespaces.\n\nIf empty, the default is Strict.",
 }
 
 func (RouteAdmissionPolicy) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Follow-up to #559.

* `operator/v1/types_ingress.go` (`IngressControllerSpec`): Change "The empty" to "If empty".
(`RouteAdmissionPolicy`): Capitalize the first word of the description for "InterNamespaceAllowed".
* `operator/v1/0000_50_ingress-operator_00-custom-resource-definition.yaml`:
* `operator/v1/zz_generated.swagger_doc_generated.go`: Regenerate.