### PR TITLE
Bug 1794376: config: disable IPv6DualStack feature flag

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -117,7 +117,6 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
 		"ServiceNodeExclusion",           // sig-scheduling, ccoleman
 		"SCTPSupport",                    // sig-network, ccallend
-		"IPv6DualStack",                  // sig-network, ccoleman
 	},
 	Disabled: []string{
 		"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -25,7 +25,6 @@ func TestFeatureBuilder(t *testing.T) {
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
-					"IPv6DualStack",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
@@ -43,7 +42,6 @@ func TestFeatureBuilder(t *testing.T) {
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 					"SCTPSupport",
-					"IPv6DualStack",
 					"LegacyNodeRoleBehavior",
 				},
 				Disabled: []string{},
@@ -58,7 +56,6 @@ func TestFeatureBuilder(t *testing.T) {
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
-					"IPv6DualStack",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
@@ -77,7 +74,6 @@ func TestFeatureBuilder(t *testing.T) {
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 					"SCTPSupport",
-					"IPv6DualStack",
 					"LegacyNodeRoleBehavior",
 					"other",
 				},


### PR DESCRIPTION
We are not going to ship dual stack support in 4.4 and enabling this flag bricks the clusters as the service object ip family field is being defaulted (operators with old clients are affected).

