### PR TITLE
baremetal: Remove nodeDNSIP from platform status

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -128,15 +128,6 @@ spec:
                         default ingress controller. The IP is a suitable target of
                         a wildcard DNS record used to resolve default route host names.
                       type: string
-                    nodeDNSIP:
-                      description: nodeDNSIP is the IP address for the internal DNS
-                        used by the nodes. Unlike the one managed by the DNS operator,
-                        `NodeDNSIP` provides name resolution for the nodes themselves.
-                        There is no DNS-as-a-service for BareMetal deployments. In
-                        order to minimize necessary changes to the datacenter DNS,
-                        a DNS service is hosted as a static pod to serve those hostnames
-                        to the nodes in the cluster.
-                      type: string
                 gcp:
                   description: GCP contains settings specific to the Google Cloud
                     Platform infrastructure provider.

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -196,14 +196,6 @@ type BareMetalPlatformStatus struct {
 	// ingressIP is an external IP which routes to the default ingress controller.
 	// The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
 	IngressIP string `json:"ingressIP,omitempty"`
-
-	// nodeDNSIP is the IP address for the internal DNS used by the
-	// nodes. Unlike the one managed by the DNS operator, `NodeDNSIP`
-	// provides name resolution for the nodes themselves. There is no DNS-as-a-service for
-	// BareMetal deployments. In order to minimize necessary changes to the
-	// datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames
-	// to the nodes in the cluster.
-	NodeDNSIP string `json:"nodeDNSIP,omitempty"`
 }
 
 // OpenStackPlatformStatus holds the current status of the OpenStack infrastructure provider.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -700,7 +700,6 @@ var map_BareMetalPlatformStatus = map[string]string{
 	"":                    "BareMetalPlatformStatus holds the current status of the BareMetal infrastructure provider. For more information about the network architecture used with the BareMetal platform type, see: https://github.com/openshift/installer/blob/master/docs/design/baremetal/networking-infrastructure.md",
 	"apiServerInternalIP": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.",
 	"ingressIP":           "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.",
-	"nodeDNSIP":           "nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for BareMetal deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.",
 }
 
 func (BareMetalPlatformStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Use of this field is being removed in [0] and [1]. Once those two
PRs have merged there will no longer be any use for it.

0: https://github.com/openshift/machine-config-operator/pull/1569
1: https://github.com/openshift/installer/pull/3304