### PR TITLE
Add feature gate to support multiple sizes huge pages

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -105,7 +105,8 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	TechPreviewNoUpgrade: newDefaultFeatures().toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(
-			"TopologyManager", // sig-pod, sjenning
+			"HugePageStorageMediumSize", // cnf, alukiano
+			"TopologyManager",           // sig-pod, sjenning
 		).
 		toFeatures(),
 }


### PR DESCRIPTION
As part of the telco effort, we should provide the possibility,
to use multiple sizes huge pages under the node.

Kubernetes supports this feature as alpha under the 1.18, to enable it
you should enable feature gate `HugePageStorageMediumSize`,
see https://github.com/kubernetes/kubernetes/pull/84051.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>