### PR TITLE
Bug 1816483: fix(codegen): add missing client tag to operatorhub config type

### DIFF
--- a/config/v1/types_operatorhub.go
+++ b/config/v1/types_operatorhub.go
@@ -37,6 +37,7 @@ type OperatorHubStatus struct {
 // the state of the default hub sources for OperatorHub on the cluster from
 // enabled to disabled and vice versa.
 // +kubebuilder:subresource:status
+// +genclient
 // +genclient:nonNamespaced
 type OperatorHub struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
The OperatorHub type definition is missing an additional `+genclient` marker comment required for Kubernetes client generation. As a result, the generated client is not available in `openshift/client-go`.