### PR TITLE
Bug 1813894: Add flag to enable service ca injection into token secrets

### DIFF
--- a/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
@@ -35,6 +35,12 @@ spec:
           description: spec is the specification of the desired behavior of the Kubernetes
             Controller Manager
           properties:
+            enableDeprecatedAndRemovedServiceCAKeyUntilNextRelease_ThisMakesClusterImpossibleToUpgrade:
+              description: enableDeprecatedAndRemovedServiceCAKeyUntilNextRelease_ThisMakesClusterImpossibleToUpgrade
+                enables service ca injection into all legacy service account token
+                secrets. Defaults to false. If set to true, will make it impossible
+                to upgrade the cluster.
+              type: boolean
             failedRevisionLimit:
               description: failedRevisionLimit is the number of failed static pod
                 installer revisions to keep on disk and in the api -1 = unlimited,

--- a/operator/v1/types_kubecontrollermanager.go
+++ b/operator/v1/types_kubecontrollermanager.go
@@ -25,6 +25,12 @@ type KubeControllerManager struct {
 
 type KubeControllerManagerSpec struct {
 	StaticPodOperatorSpec `json:",inline"`
+
+	// enableDeprecatedAndRemovedServiceCAKeyUntilNextRelease_ThisMakesClusterImpossibleToUpgrade
+	// enables service ca injection into all legacy service account token secrets. Defaults to
+	// false. If set to true, will make it impossible to upgrade the cluster.
+	// +optional
+	EnableDeprecatedAndRemovedServiceCAKeyUntilNextRelease_ThisMakesClusterImpossibleToUpgrade bool `json:"enableDeprecatedAndRemovedServiceCAKeyUntilNextRelease_ThisMakesClusterImpossibleToUpgrade"`
 }
 
 type KubeControllerManagerStatus struct {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -533,6 +533,14 @@ func (KubeControllerManagerList) SwaggerDoc() map[string]string {
 	return map_KubeControllerManagerList
 }
 
+var map_KubeControllerManagerSpec = map[string]string{
+	"enableDeprecatedAndRemovedServiceCAKeyUntilNextRelease_ThisMakesClusterImpossibleToUpgrade": "enableDeprecatedAndRemovedServiceCAKeyUntilNextRelease_ThisMakesClusterImpossibleToUpgrade enables service ca injection into all legacy service account token secrets. Defaults to false. If set to true, will make it impossible to upgrade the cluster.",
+}
+
+func (KubeControllerManagerSpec) SwaggerDoc() map[string]string {
+	return map_KubeControllerManagerSpec
+}
+
 var map_KubeStorageVersionMigrator = map[string]string{
 	"": "KubeStorageVersionMigrator provides information to configure an operator to manage kube-storage-version-migrator.",
 }


### PR DESCRIPTION
Add a flag to enable the (deprecated) injection of the service ca certificate bundle into every service account token.

In support of [bz 1813894](https://bugzilla.redhat.com/show_bug.cgi?id=1813894)