### PR TITLE
Add omitempty tags to Route resources.

### DIFF
--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -34,7 +34,7 @@ type Route struct {
 	Spec RouteSpec `json:"spec" protobuf:"bytes,2,opt,name=spec"`
 	// status is the current state of the route
 	// +optional
-	Status RouteStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
+	Status RouteStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -69,7 +69,7 @@ type RouteSpec struct {
 	// chosen.
 	// Must follow DNS952 subdomain conventions.
 	// +optional
-	Host string `json:"host" protobuf:"bytes,1,opt,name=host"`
+	Host string `json:"host,omitempty" protobuf:"bytes,1,opt,name=host"`
 	// subdomain is a DNS subdomain that is requested within the ingress controller's
 	// domain (as a subdomain). If host is set this field is ignored. An ingress
 	// controller may choose to ignore this suggested name, in which case the controller
@@ -141,7 +141,7 @@ type RouteStatus struct {
 	// ingress describes the places where the route may be exposed. The list of
 	// ingress points may contain duplicate Host or RouterName values. Routes
 	// are considered live once they are `Ready`
-	Ingress []RouteIngress `json:"ingress" protobuf:"bytes,1,rep,name=ingress"`
+	Ingress []RouteIngress `json:"ingress,omitempty" protobuf:"bytes,1,rep,name=ingress"`
 }
 
 // RouteIngress holds information about the places where a route is exposed.


### PR DESCRIPTION
These are written out as "empty" values, which means that tools like ArgoCD
fail to synchronise the state of the resource because they're comparing fields against the GitOps resource.