### PR TITLE
enable priority and fairness for kube-apiserver

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -112,6 +112,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 
 var defaultFeatures = &FeatureGateEnabledDisabled{
 	Enabled: []string{
+		"APIPriorityAndFairness",         // sig-apimachinery, deads2k
 		"RotateKubeletServerCertificate", // sig-pod, sjenning
 		"SupportPodPidsLimit",            // sig-pod, sjenning
 		"NodeDisruptionExclusion",        // sig-scheduling, ccoleman

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -21,6 +21,7 @@ func TestFeatureBuilder(t *testing.T) {
 			actual: newDefaultFeatures().without("SCTPSupport").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
+					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
@@ -37,6 +38,7 @@ func TestFeatureBuilder(t *testing.T) {
 			actual: newDefaultFeatures().with("LegacyNodeRoleBehavior").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
+					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
@@ -52,6 +54,7 @@ func TestFeatureBuilder(t *testing.T) {
 			actual: newDefaultFeatures().without("SCTPSupport", "other").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
+					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
@@ -69,6 +72,7 @@ func TestFeatureBuilder(t *testing.T) {
 			actual: newDefaultFeatures().with("LegacyNodeRoleBehavior", "other").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
+					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",


### PR DESCRIPTION
This is a new feature for kube-apiserver.  We want soak time.  If it performs well, we may well keep this on.

/hold

holding for proof