### PR TITLE
Bug 1816991: Mark accessTokenInactivitiyTimeoutSecounds deprecated

### DIFF
--- a/config/v1/0000_10_config-operator_01_oauth.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_oauth.crd.yaml
@@ -637,17 +637,8 @@ spec:
               type: object
               properties:
                 accessTokenInactivityTimeoutSeconds:
-                  description: 'accessTokenInactivityTimeoutSeconds defines the default
-                    token inactivity timeout for tokens granted by any client. The
-                    value represents the maximum amount of time that can occur between
-                    consecutive uses of the token. Tokens become invalid if they are
-                    not used within this temporal window. The user will need to acquire
-                    a new token to regain access once a token times out. Valid values
-                    are integer values:   x < 0  Tokens time out is enabled but tokens
-                    never timeout unless configured per client (e.g. `-1`)   x = 0  Tokens
-                    time out is disabled (default)   x > 0  Tokens time out if there
-                    is no activity for x seconds The current minimum allowed value
-                    for X is 300 (5 minutes)'
+                  description: 'accessTokenInactivityTimeoutSeconds - DEPRECATED:
+                    setting this field has no effect.'
                   type: integer
                   format: int32
                 accessTokenMaxAgeSeconds:

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -47,17 +47,7 @@ type TokenConfig struct {
 	// accessTokenMaxAgeSeconds defines the maximum age of access tokens
 	AccessTokenMaxAgeSeconds int32 `json:"accessTokenMaxAgeSeconds"`
 
-	// accessTokenInactivityTimeoutSeconds defines the default token
-	// inactivity timeout for tokens granted by any client.
-	// The value represents the maximum amount of time that can occur between
-	// consecutive uses of the token. Tokens become invalid if they are not
-	// used within this temporal window. The user will need to acquire a new
-	// token to regain access once a token times out.
-	// Valid values are integer values:
-	//   x < 0  Tokens time out is enabled but tokens never timeout unless configured per client (e.g. `-1`)
-	//   x = 0  Tokens time out is disabled (default)
-	//   x > 0  Tokens time out if there is no activity for x seconds
-	// The current minimum allowed value for X is 300 (5 minutes)
+	// accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.
 	// +optional
 	AccessTokenInactivityTimeoutSeconds int32 `json:"accessTokenInactivityTimeoutSeconds,omitempty"`
 }

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1114,7 +1114,7 @@ func (RequestHeaderIdentityProvider) SwaggerDoc() map[string]string {
 var map_TokenConfig = map[string]string{
 	"":                                    "TokenConfig holds the necessary configuration options for authorization and access tokens",
 	"accessTokenMaxAgeSeconds":            "accessTokenMaxAgeSeconds defines the maximum age of access tokens",
-	"accessTokenInactivityTimeoutSeconds": "accessTokenInactivityTimeoutSeconds defines the default token inactivity timeout for tokens granted by any client. The value represents the maximum amount of time that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. The user will need to acquire a new token to regain access once a token times out. Valid values are integer values:\n  x < 0  Tokens time out is enabled but tokens never timeout unless configured per client (e.g. `-1`)\n  x = 0  Tokens time out is disabled (default)\n  x > 0  Tokens time out if there is no activity for x seconds\nThe current minimum allowed value for X is 300 (5 minutes)",
+	"accessTokenInactivityTimeoutSeconds": "accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.",
 }
 
 func (TokenConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Adding this field to the API while we were not ready to wire code support for it was a mistake.

/assign @marun 