### PR TITLE
 config/v1/types_infrastructure.go: add kube cloud config to status

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -40,11 +40,18 @@ spec:
           type: object
           properties:
             cloudConfig:
-              description: cloudConfig is a reference to a ConfigMap containing the
+              description: "cloudConfig is a reference to a ConfigMap containing the
                 cloud provider configuration file. This configuration file is used
                 to configure the Kubernetes cloud provider integration when using
                 the built-in cloud provider integration or the external cloud controller
-                manager. The namespace for this config map is openshift-config.
+                manager. The namespace for this config map is openshift-config. \n
+                cloudConfig should only be consumed by the kube_cloud_config controller.
+                The controller is responsible for using the user configuration in
+                the spec for various platforms and combining that with the user provided
+                ConfigMap in this field to create a stitched kube cloud config. The
+                controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed`
+                namespace with the kube cloud config is stored in `cloud.conf` key.
+                All the clients are expected to use the generated ConfigMap only."
               type: object
               properties:
                 key:

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -26,6 +26,15 @@ type InfrastructureSpec struct {
 	// This configuration file is used to configure the Kubernetes cloud provider integration
 	// when using the built-in cloud provider integration or the external cloud controller manager.
 	// The namespace for this config map is openshift-config.
+	//
+	// cloudConfig should only be consumed by the kube_cloud_config controller.
+	// The controller is responsible for using the user configuration in the spec
+	// for various platforms and combining that with the user provided ConfigMap in this field
+	// to create a stitched kube cloud config.
+	// The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace
+	// with the kube cloud config is stored in `cloud.conf` key.
+	// All the clients are expected to use the generated ConfigMap only.
+	//
 	// +optional
 	CloudConfig ConfigMapFileReference `json:"cloudConfig"`
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -800,7 +800,7 @@ func (InfrastructureList) SwaggerDoc() map[string]string {
 
 var map_InfrastructureSpec = map[string]string{
 	"":             "InfrastructureSpec contains settings that apply to the cluster infrastructure.",
-	"cloudConfig":  "cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config.",
+	"cloudConfig":  "cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config.\n\ncloudConfig should only be consumed by the kube_cloud_config controller. The controller is responsible for using the user configuration in the spec for various platforms and combining that with the user provided ConfigMap in this field to create a stitched kube cloud config. The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace with the kube cloud config is stored in `cloud.conf` key. All the clients are expected to use the generated ConfigMap only.",
 	"platformSpec": "platformSpec holds desired information specific to the underlying infrastructure provider.",
 }
 


### PR DESCRIPTION
depends on #599 please review that first.

The cloudConfig is generated by the stitching together the user specifed config and the other platform spec in the infrstructure object.

