### PR TITLE
Provide a shortname to imagecontentsourcepolicy

### DIFF
--- a/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
+++ b/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
@@ -11,6 +11,7 @@ spec:
     singular: imagecontentsourcepolicy
     plural: imagecontentsourcepolicies
     listKind: ImageContentSourcePolicyList
+    short: icsp
   versions:
   - name: v1alpha1
     served: true


### PR DESCRIPTION
Save people from typing 20 letters x N times makes me happy.
Not sure this is as easy as adding this single line,

Please if you could back-port that to any release downward to 4.3.

fixes #622