### PR TITLE
Add ContainerRuntimeSearchRegistries under RegistrySources

### DIFF
--- a/config/v1/0000_10_config-operator_01_image.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_image.crd.yaml
@@ -116,6 +116,20 @@ spec:
                   type: array
                   items:
                     type: string
+                containerRuntimeSearchRegistries:
+                  description: 'containerRuntimeSearchRegistries are registries that
+                    will be searched when pulling images that do not have fully qualified
+                    domains in their pull specs. Registries will be searched in the
+                    order provided in the list. Note: this search list only works
+                    with the container runtime, i.e CRI-O. Will NOT work with builds
+                    or imagestream imports.'
+                  type: array
+                  format: hostname
+                  minItems: 1
+                  uniqueItems: true
+                  items:
+                    type: string
+                  x-kubernetes-list-type: set
                 insecureRegistries:
                   description: insecureRegistries are registries which do not have
                     a valid TLS certificates or only support HTTP connections.

--- a/config/v1/types_image.go
+++ b/config/v1/types_image.go
@@ -112,4 +112,13 @@ type RegistrySources struct {
 	// Only one of BlockedRegistries or AllowedRegistries may be set.
 	// +optional
 	AllowedRegistries []string `json:"allowedRegistries,omitempty"`
+	// containerRuntimeSearchRegistries are registries that will be searched when pulling images that do not have fully qualified
+	// domains in their pull specs. Registries will be searched in the order provided in the list.
+	// Note: this search list only works with the container runtime, i.e CRI-O. Will NOT work with builds or imagestream imports.
+	// +optional
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:UniqueItems=true
+	// +kubebuilder:validation:Format=hostname
+	// +listType=set
+	ContainerRuntimeSearchRegistries []string `json:"containerRuntimeSearchRegistries,omitempty"`
 }

--- a/config/v1/zz_generated.deepcopy.go
+++ b/config/v1/zz_generated.deepcopy.go
@@ -3287,6 +3287,11 @@ func (in *RegistrySources) DeepCopyInto(out *RegistrySources) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ContainerRuntimeSearchRegistries != nil {
+		in, out := &in.ContainerRuntimeSearchRegistries, &out.ContainerRuntimeSearchRegistries
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -701,10 +701,11 @@ func (RegistryLocation) SwaggerDoc() map[string]string {
 }
 
 var map_RegistrySources = map[string]string{
-	"":                   "RegistrySources holds cluster-wide information about how to handle the registries config.",
-	"insecureRegistries": "insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.",
-	"blockedRegistries":  "blockedRegistries cannot be used for image pull and push actions. All other registries are permitted.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
-	"allowedRegistries":  "allowedRegistries are the only registries permitted for image pull and push actions. All other registries are denied.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
+	"":                                 "RegistrySources holds cluster-wide information about how to handle the registries config.",
+	"insecureRegistries":               "insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.",
+	"blockedRegistries":                "blockedRegistries cannot be used for image pull and push actions. All other registries are permitted.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
+	"allowedRegistries":                "allowedRegistries are the only registries permitted for image pull and push actions. All other registries are denied.\n\nOnly one of BlockedRegistries or AllowedRegistries may be set.",
+	"containerRuntimeSearchRegistries": "containerRuntimeSearchRegistries are registries that will be searched when pulling images that do not have fully qualified domains in their pull specs. Registries will be searched in the order provided in the list. Note: this search list only works with the container runtime, i.e CRI-O. Will NOT work with builds or imagestream imports.",
 }
 
 func (RegistrySources) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Add the containerRuntimeSearchRegistries option to the
image.config.openshift.io CRD so that users can update
the list of registries to be searched when pulling using
short names.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>

edit: bparees
api implementation of https://github.com/openshift/enhancements/pull/378
RFE: https://issues.redhat.com/browse/IR-142
