### PR TITLE
vsphere ipi: align with baremetal and remove nodednsip

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -384,12 +384,3 @@ spec:
                         default ingress controller. The IP is a suitable target of
                         a wildcard DNS record used to resolve default route host names.
                       type: string
-                    nodeDNSIP:
-                      description: nodeDNSIP is the IP address for the internal DNS
-                        used by the nodes. Unlike the one managed by the DNS operator,
-                        `NodeDNSIP` provides name resolution for the nodes themselves.
-                        There is no DNS-as-a-service for vSphere deployments. In order
-                        to minimize necessary changes to the datacenter DNS, a DNS
-                        service is hosted as a static pod to serve those hostnames
-                        to the nodes in the cluster.
-                      type: string

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -378,14 +378,6 @@ type VSpherePlatformStatus struct {
 	// ingressIP is an external IP which routes to the default ingress controller.
 	// The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
 	IngressIP string `json:"ingressIP,omitempty"`
-
-	// nodeDNSIP is the IP address for the internal DNS used by the
-	// nodes. Unlike the one managed by the DNS operator, `NodeDNSIP`
-	// provides name resolution for the nodes themselves. There is no DNS-as-a-service for
-	// vSphere deployments. In order to minimize necessary changes to the
-	// datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames
-	// to the nodes in the cluster.
-	NodeDNSIP string `json:"nodeDNSIP,omitempty"`
 }
 
 // IBMCloudPlatformSpec holds the desired state of the IBMCloud infrastructure provider.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -907,7 +907,6 @@ var map_VSpherePlatformStatus = map[string]string{
 	"":                    "VSpherePlatformStatus holds the current status of the vSphere infrastructure provider.",
 	"apiServerInternalIP": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.",
 	"ingressIP":           "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.",
-	"nodeDNSIP":           "nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for vSphere deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.",
 }
 
 func (VSpherePlatformStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Removing `nodeDNSIP` from vSphere platform status to align with baremetal.  vSphere IPI is scheduled for v4.5

See:
https://github.com/openshift/api/pull/600

Pending changes:
https://github.com/openshift/installer/pull/3470
https://github.com/openshift/machine-config-operator/pull/1657
And an additional MCO change