### PR TITLE
config/v1: add status subresource for infrstrastructure

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -11,6 +11,8 @@ spec:
     singular: infrastructure
   scope: Cluster
   preserveUnknownFields: false
+  subresources:
+    status: {}
   versions:
   - name: v1
     served: true

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -5,6 +5,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:subresource:status
 
 // Infrastructure holds cluster-wide information about Infrastructure.  The canonical name is `cluster`
 type Infrastructure struct {


### PR DESCRIPTION
There are various platform specific status fields for infrastructure. And all of these not not user modifyable.
These fields are setup at the install-time and never changed.
```
   aws:
     description: AWS contains settings specific to the Amazon Web Services
       infrastructure provider.
     type: object
     properties:
       region:
         description: region holds the default AWS region for new AWS
           resources created by the cluster.
         type: string
   azure:
     description: Azure contains settings specific to the Azure infrastructure
       provider.
     type: object
     properties:
       networkResourceGroupName:
         description: networkResourceGroupName is the Resource Group
           for network resources like the Virtual Network and Subnets
           used by the cluster. If empty, the value is same as ResourceGroupName.
         type: string
       resourceGroupName:
         description: resourceGroupName is the Resource Group for new
           Azure resources created for the cluster.
         type: string
   baremetal:
     description: BareMetal contains settings specific to the BareMetal
       platform.
     type: object
     properties:
       apiServerInternalIP:
         description: apiServerInternalIP is an IP address to contact
           the Kubernetes API server that can be used by components inside
           the cluster, like kubelets using the infrastructure rather
           than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI
           points to. It is the IP for a self-hosted load balancer in
           front of the API servers.
         type: string
       ingressIP:
         description: ingressIP is an external IP which routes to the
           default ingress controller. The IP is a suitable target of
           a wildcard DNS record used to resolve default route host names.
         type: string
       nodeDNSIP:
         description: nodeDNSIP is the IP address for the internal DNS
           used by the nodes. Unlike the one managed by the DNS operator,
           `NodeDNSIP` provides name resolution for the nodes themselves.
           There is no DNS-as-a-service for BareMetal deployments. In
           order to minimize necessary changes to the datacenter DNS,
           a DNS service is hosted as a static pod to serve those hostnames
           to the nodes in the cluster.
         type: string
   gcp:
     description: GCP contains settings specific to the Google Cloud
       Platform infrastructure provider.
     type: object
     properties:
       projectID:
         description: resourceGroupName is the Project ID for new GCP
           resources created for the cluster.
         type: string
       region:
         description: region holds the region for new GCP resources created
           for the cluster.
         type: string
   ibmcloud:
     description: IBMCloud contains settings specific to the IBMCloud
       infrastructure provider.
     type: object
     properties:
       location:
         description: Location is where the cluster has been deployed
         type: string
       providerType:
         description: ProviderType indicates the type of cluster that
           was created
         type: string
       resourceGroupName:
         description: ResourceGroupName is the Resource Group for new
           IBMCloud resources created for the cluster.
         type: string
   openstack:
     description: OpenStack contains settings specific to the OpenStack
       infrastructure provider.
     type: object
     properties:
       apiServerInternalIP:
         description: <>
         type: string
       cloudName:
         description: cloudName is the name of the desired OpenStack
           cloud in the client configuration file (`clouds.yaml`).
         type: string
       ingressIP:
         description: <>
         type: string
       nodeDNSIP:
         description: <>
         type: string
   ovirt:
     description: Ovirt contains settings specific to the oVirt infrastructure
       provider.
     type: object
     properties:
       apiServerInternalIP:
         description: <>
         type: string
       ingressIP:
         description: <>
         type: string
       nodeDNSIP:
         description: <>
         type: string
   vsphere:
     description: VSphere contains settings specific to the VSphere infrastructure
       provider.
     type: object
     properties:
       apiServerInternalIP:
         description: <>
         type: string
       ingressIP:
         description: <>
         type: string
       nodeDNSIP:
         description: <>
         type: string
```

To make sure there are no modifiers of the object, I skimmed through the audit logs of various CI runs to find if there was any client sending update or updating status of the infrastructure.

```
$ wget https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.4/2173/artifacts/e2e-aws/must-gather.tar
$ wget https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.4/1363/artifacts/e2e-openstack/must-gather.tar
$ wget https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.4/1467/artifacts/e2e-gcp/must-gather.tar
$ wget https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.4/1476/artifacts/e2e-azure/must-gather.tar

$ cat 0/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-f663341a354710612436078149ddf989d302e193faabd3896b16544a1a78e6b6/audit_logs/kube-apiserver/*.log > audit.log
$ cat 1/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-f663341a354710612436078149ddf989d302e193faabd3896b16544a1a78e6b6/audit_logs/kube-apiserver/*.log > audit.1.log
$ cat 2/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-f663341a354710612436078149ddf989d302e193faabd3896b16544a1a78e6b6/audit_logs/kube-apiserver/*.log > audit.2.log
$ cat 3/quay-io-openshift-release-dev-ocp-v4-0-art-dev-sha256-f663341a354710612436078149ddf989d302e193faabd3896b16544a1a78e6b6/audit_logs/kube-apiserver/*.log > audit.3.log

$ rg '"requestURI":"/apis/config.openshift.io/v1/infrastructures/cluster"' audit.1.log audit.2.log audit.3.log audit.log  | wc -l
363
$ rg '"requestURI":"/apis/config.openshift.io/v1/infrastructures/cluster","verb":"get"' audit.1.log audit.2.log audit.3.log audit.log  | wc -l
363
$ rg '"requestURI":"/apis/config.openshift.io/v1/infrastructures/cluster","verb":"update"' audit.1.log audit.2.log audit.3.log audit.log  | wc -l
0
```

And that shows that there are no update calls for infrastructure status..

Not having a subresource status for infrastructure makes controllers fragile as they have to send Update that can mutate the spec, so UpdateStatus is very useful.

/cc @deads2k 