### PR TITLE
add a mechanism to register external repos with openshift.io APIs

### DIFF
--- a/known-apis.yaml
+++ b/known-apis.yaml
@@ -1,0 +1,21 @@
+apiVersion: apis.openshift.io/v1
+kind: KnownAPIList
+items:
+  metadata:
+    name: group.openshift.io
+  spec:
+    owner:
+      component: NameOfTheComponentOrProduct
+      # must have at least two contacts.  Please don't win the lottery at the same time.
+      contacts:
+        - firstcontact@redhat.com
+        - secondcontact@redhat.com
+      # this gives a clear primary location, with failover or historical locations.
+      repo: https://github.com/somewhere/over-the-rainbow
+      additionalRepos:
+        - https://github.com/somewhere/old-location-to-handle-moves
+    group: group.openshift.io
+    # kinds are conceptually the same across all versions, so if it is owned in one version, it is owned in all versions
+    kinds:
+      - kind: KindOne
+      - kind: KindTwo


### PR DESCRIPTION
This is a spot where we can at least be aware of what openshift APIs exist so that we don't accidentally collide across them.  Given this metadata file, we should create verify scripts that lint it and check for collisions as we add more.

This would also provide a basis for us to add restrictions on using openshift.io names similar to upstream k8s.io restrictions.

/assign @derekwaynecarr @smarterclayton @eparis 

holding for an enhancement if we agree this is a thing we should do.
/hold

We may want to consider a similar thing for openshift- prefixed namespaces.