### PR TITLE
config: add an IPv6DualStackNoUpgrade feature set

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -37,6 +37,9 @@ var (
 
 	// TopologyManager enables ToplogyManager support. Upgrades are enabled with this feature.
 	LatencySensitive FeatureSet = "LatencySensitive"
+
+	// IPv6DualStackNoUpgrade enables dual-stack. Turning this feature set on IS NOT SUPPORTED, CANNOT BE UNDONE, and PREVENTS UPGRADES.
+	IPv6DualStackNoUpgrade FeatureSet = "IPv6DualStackNoUpgrade"
 )
 
 type FeatureGateSpec struct {
@@ -106,6 +109,11 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	LatencySensitive: newDefaultFeatures().
 		with(
 			"TopologyManager", // sig-pod, sjenning
+		).
+		toFeatures(),
+	IPv6DualStackNoUpgrade: newDefaultFeatures().
+		with(
+			"IPv6DualStack", // sig-network, danwinship
 		).
 		toFeatures(),
 }


### PR DESCRIPTION
We cannot yet enable the `IPv6DualStack` feature gate because it's still broken upstream but we'll need it for dual-stack development/testing. This would be expected to go away in 4.6 when we enable the feature gate by default.

I just copied the "CANNOT BE UNDONE, and PREVENTS UPGRADES" text from one of the other unsupported feature sets; AFAICT that it not actually implemented for other unsupported feature sets either.