### PR TITLE
Bug 1801437: Add UnknownRevisionLimit to static pod operators

### DIFF
--- a/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
+++ b/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
@@ -76,6 +76,13 @@ spec:
                 0 or unset = 5 (default)
               format: int32
               type: integer
+            unknownRevisionLimit:
+              description: unknownRevisionLimit is the number of static pod installer
+                revisions in an unknown state (anything besides failed, succeeded,
+                or inprogress) to keep on disk and in the api. -1 = unlimited, 0 or
+                unset = 5 (default)
+              format: int32
+              type: integer
             unsupportedConfigOverrides:
               description: 'unsupportedConfigOverrides holds a sparse config that
                 will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
@@ -78,6 +78,13 @@ spec:
                 0 or unset = 5 (default)
               format: int32
               type: integer
+            unknownRevisionLimit:
+              description: unknownRevisionLimit is the number of static pod installer
+                revisions in an unknown state (anything besides failed, succeeded,
+                or inprogress) to keep on disk and in the api. -1 = unlimited, 0 or
+                unset = 5 (default)
+              format: int32
+              type: integer
             unsupportedConfigOverrides:
               description: 'unsupportedConfigOverrides holds a sparse config that
                 will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
@@ -78,6 +78,13 @@ spec:
                 0 or unset = 5 (default)
               format: int32
               type: integer
+            unknownRevisionLimit:
+              description: unknownRevisionLimit is the number of static pod installer
+                revisions in an unknown state (anything besides failed, succeeded,
+                or inprogress) to keep on disk and in the api. -1 = unlimited, 0 or
+                unset = 5 (default)
+              format: int32
+              type: integer
             unsupportedConfigOverrides:
               description: 'unsupportedConfigOverrides holds a sparse config that
                 will override any previously set options.  It only needs to be the

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -177,6 +177,10 @@ type StaticPodOperatorSpec struct {
 	// succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api
 	// -1 = unlimited, 0 or unset = 5 (default)
 	SucceededRevisionLimit int32 `json:"succeededRevisionLimit,omitempty"`
+	// unknownRevisionLimit is the number of static pod installer revisions in an unknown state (anything besides
+	// failed, succeeded, or inprogress) to keep on disk and in the api.
+	// -1 = unlimited, 0 or unset = 5 (default)
+	UnknownRevisionLimit int32 `json:"unknownRevisionLimit,omitempty"`
 }
 
 // StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -84,6 +84,7 @@ var map_StaticPodOperatorSpec = map[string]string{
 	"forceRedeploymentReason": "forceRedeploymentReason can be used to force the redeployment of the operand by providing a unique string. This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work this time instead of failing again on the same config.",
 	"failedRevisionLimit":     "failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
 	"succeededRevisionLimit":  "succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
+	"unknownRevisionLimit":    "unknownRevisionLimit is the number of static pod installer revisions in an unknown state (anything besides failed, succeeded, or inprogress) to keep on disk and in the api. -1 = unlimited, 0 or unset = 5 (default)",
 }
 
 func (StaticPodOperatorSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This adds an `unknownRevisionLimit` field to static pod operators so that revisions in an unknown state (ie, anything not succeeded, failed, or in progress) can be pruned similarly to how succeeded/failed revisions currently are.