### PR TITLE
Bug 1809354: operatoringress/dnsrecord: Add observedGeneration

### DIFF
--- a/operatoringress/v1/0000_50_dns-record.yaml
+++ b/operatoringress/v1/0000_50_dns-record.yaml
@@ -69,6 +69,15 @@ spec:
           description: status is the most recently observed status of the dnsRecord.
           type: object
           properties:
+            observedGeneration:
+              description: observedGeneration is the most recently observed generation
+                of the DNSRecord.  When the DNSRecord is updated, the controller updates
+                the corresponding record in each managed zone.  If an update for a
+                particular zone fails, that failure is recorded in the status condition
+                for the zone so that the controller can determine that it needs to
+                retry the update for that specific zone.
+              type: integer
+              format: int64
             zones:
               description: zones are the status of the record in each zone.
               type: array

--- a/operatoringress/v1/types.go
+++ b/operatoringress/v1/types.go
@@ -56,6 +56,15 @@ type DNSRecordSpec struct {
 type DNSRecordStatus struct {
 	// zones are the status of the record in each zone.
 	Zones []DNSZoneStatus `json:"zones,omitempty"`
+
+	// observedGeneration is the most recently observed generation of the
+	// DNSRecord.  When the DNSRecord is updated, the controller updates the
+	// corresponding record in each managed zone.  If an update for a
+	// particular zone fails, that failure is recorded in the status
+	// condition for the zone so that the controller can determine that it
+	// needs to retry the update for that specific zone.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // DNSZoneStatus is the status of a record within a specific zone.

--- a/operatoringress/v1/zz_generated.swagger_doc_generated.go
+++ b/operatoringress/v1/zz_generated.swagger_doc_generated.go
@@ -42,8 +42,9 @@ func (DNSRecordSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DNSRecordStatus = map[string]string{
-	"":      "DNSRecordStatus is the most recently observed status of each record.",
-	"zones": "zones are the status of the record in each zone.",
+	"":                   "DNSRecordStatus is the most recently observed status of each record.",
+	"zones":              "zones are the status of the record in each zone.",
+	"observedGeneration": "observedGeneration is the most recently observed generation of the DNSRecord.  When the DNSRecord is updated, the controller updates the corresponding record in each managed zone.  If an update for a particular zone fails, that failure is recorded in the status condition for the zone so that the controller can determine that it needs to retry the update for that specific zone.",
 }
 
 func (DNSRecordStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
* `operatoringress/v1/types.go` (`DNSRecordStatus`): Add `ObservedGeneration` field.
* `operatoringress/v1/0000_50_dns-record.yaml`: Regenerate.