### PR TITLE
config: support for other Azure cloud environments

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -227,6 +227,17 @@ spec:
                     provider.
                   type: object
                   properties:
+                    cloudName:
+                      description: cloudName is the name of the Azure cloud environment
+                        which can be used to configure the Azure SDK with the appropriate
+                        Azure API endpoints. If empty, the value is equal to `AzurePublicCloud`.
+                      type: string
+                      enum:
+                      - ""
+                      - AzurePublicCloud
+                      - AzureUSGovernmentCloud
+                      - AzureChinaCloud
+                      - AzureGermanCloud
                     networkResourceGroupName:
                       description: networkResourceGroupName is the Resource Group
                         for network resources like the Virtual Network and Subnets

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -277,7 +277,31 @@ type AzurePlatformStatus struct {
 	// If empty, the value is same as ResourceGroupName.
 	// +optional
 	NetworkResourceGroupName string `json:"networkResourceGroupName,omitempty"`
+
+	// cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK
+	// with the appropriate Azure API endpoints.
+	// If empty, the value is equal to `AzurePublicCloud`.
+	// +optional
+	CloudName AzureCloudEnvironment `json:"cloudName,omitempty"`
 }
+
+// AzureCloudEnvironment is the name of the Azure cloud environment
+// +kubebuilder:validation:Enum="";AzurePublicCloud;AzureUSGovernmentCloud;AzureChinaCloud;AzureGermanCloud
+type AzureCloudEnvironment string
+
+const (
+	// AzurePublicCloud is the general-purpose, public Azure cloud environment.
+	AzurePublicCloud AzureCloudEnvironment = "AzurePublicCloud"
+
+	// AzureUSGovernmentCloud is the Azure cloud environment for the US government.
+	AzureUSGovernmentCloud AzureCloudEnvironment = "AzureUSGovernmentCloud"
+
+	// AzureChinaCloud is the Azure cloud environment used in China.
+	AzureChinaCloud AzureCloudEnvironment = "AzureChinaCloud"
+
+	// AzureGermanCloud is the Azure cloud environment used in Germany.
+	AzureGermanCloud AzureCloudEnvironment = "AzureGermanCloud"
+)
 
 // GCPPlatformSpec holds the desired state of the Google Cloud Platform infrastructure provider.
 // This only includes fields that can be modified in the cluster.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -720,6 +720,7 @@ var map_AzurePlatformStatus = map[string]string{
 	"":                         "AzurePlatformStatus holds the current status of the Azure infrastructure provider.",
 	"resourceGroupName":        "resourceGroupName is the Resource Group for new Azure resources created for the cluster.",
 	"networkResourceGroupName": "networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster. If empty, the value is same as ResourceGroupName.",
+	"cloudName":                "cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the value is equal to `AzurePublicCloud`.",
 }
 
 func (AzurePlatformStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Add the `.status.azure.cloudName` field to the Infrastructure type in config. This field informs in which Azure cloud environment the cluster is installed and consequently which Azure API endpoint should be used when communicating via the Azure SDK.

See https://github.com/openshift/enhancements/pull/321

https://issues.redhat.com/browse/CORS-1441