### PR TITLE
add approvers to reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,17 @@
 reviewers:
   - adambkaplan
   - abhinavdahiya
+  - smarterclayton
+  - deads2k
+  - derekwaynecarr
+  - eparis
+  - jwforres
+  - knobunc
+  - sjenning
+  - mfojtik
+  - soltysh
+  - sttts
+  - bparees
 approvers:
   - smarterclayton
   - deads2k


### PR DESCRIPTION
Prow auto-assigns PR reviewers _only_ out of `reviewers`, not out of `approvers`. This means that if you don't redundantly list the `approvers` in the `reviewers` section, no approver will ever be assigned to do reviews, which was probably not the intent here...

Not sure who the right person to assign this to is so I'll let one of the reviewers figure it out. :slightly_smiling_face: 