### PR TITLE
config/network: Add a service node port range parameter to the network spec

### DIFF
--- a/config/v1/0000_10_config-operator_01_network.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network.crd.yaml
@@ -106,6 +106,14 @@ spec:
               type: array
               items:
                 type: string
+            serviceNodePortRange:
+              description: The port range allowed for Services of type NodePort. If
+                not specified, the default of 30000-32767 will be used. Such Services
+                without a NodePort specified will have one automatically allocated
+                from this range. This parameter can be updated after the cluster is
+                installed.
+              type: string
+              pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
         status:
           description: status holds observed values from the cluster. They may not
             be overridden.

--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -51,6 +51,15 @@ type NetworkSpec struct {
 	// not allowed to be set.
 	// +optional
 	ExternalIP *ExternalIPConfig `json:"externalIP,omitempty"`
+
+	// The port range allowed for Services of type NodePort.
+	// If not specified, the default of 30000-32767 will be used.
+	// Such Services without a NodePort specified will have one
+	// automatically allocated from this range.
+	// This parameter can be updated after the cluster is
+	// installed.
+	// +kubebuilder:validation:Pattern=`^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$`
+	ServiceNodePortRange string `json:"serviceNodePortRange,omitempty"`
 }
 
 // NetworkStatus is the current network configuration.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -976,11 +976,12 @@ func (Network) SwaggerDoc() map[string]string {
 }
 
 var map_NetworkSpec = map[string]string{
-	"":               "NetworkSpec is the desired network configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.",
-	"clusterNetwork": "IP address pool to use for pod IPs. This field is immutable after installation.",
-	"serviceNetwork": "IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.",
-	"networkType":    "NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.",
-	"externalIP":     "externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.",
+	"":                     "NetworkSpec is the desired network configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.",
+	"clusterNetwork":       "IP address pool to use for pod IPs. This field is immutable after installation.",
+	"serviceNetwork":       "IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.",
+	"networkType":          "NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.",
+	"externalIP":           "externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.",
+	"serviceNodePortRange": "The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.",
 }
 
 func (NetworkSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This enables the specification and configuration of a custom
service node port range for a cluster.