### PR TITLE
Bug 1833245: Validating duration fields on image registry types

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -692,6 +692,7 @@ spec:
                       description: maxWaitInQueue sets the maximum time a request
                         can wait in the queue before being rejected.
                       type: string
+                      format: duration
                 write:
                   description: write defines limits for image registry's writes.
                   type: object
@@ -708,6 +709,7 @@ spec:
                       description: maxWaitInQueue sets the maximum time a request
                         can wait in the queue before being rejected.
                       type: string
+                      format: duration
             resources:
               description: resources defines the resource requests+limits for the
                 registry pod.
@@ -839,6 +841,7 @@ spec:
                           description: duration is the duration of the Cloudfront
                             session.
                           type: string
+                          format: duration
                         keypairID:
                           description: keypairID is key pair ID provided by AWS.
                           type: string
@@ -1111,6 +1114,7 @@ spec:
                           description: duration is the duration of the Cloudfront
                             session.
                           type: string
+                          format: duration
                         keypairID:
                           description: keypairID is key pair ID provided by AWS.
                           type: string

--- a/imageregistry/v1/01-crd.yaml
+++ b/imageregistry/v1/01-crd.yaml
@@ -634,6 +634,7 @@ spec:
                 image and its referrers for it to be considered a candidate for pruning.
                 Defaults to 60m (60 minutes).
               type: string
+              format: duration
             nodeSelector:
               description: nodeSelector defines the node selection constraints for
                 the image pruner pod.

--- a/imageregistry/v1/types.go
+++ b/imageregistry/v1/types.go
@@ -133,6 +133,7 @@ type ImageRegistryConfigStorageS3CloudFront struct {
 	KeypairID string `json:"keypairID" protobuf:"bytes,3,opt,name=keypairID"`
 	// duration is the duration of the Cloudfront session.
 	// +optional
+	// +kubebuilder:validation:Format=duration
 	Duration metav1.Duration `json:"duration,omitempty" protobuf:"bytes,4,opt,name=duration"`
 }
 
@@ -301,6 +302,7 @@ type ImageRegistryConfigRequestsLimits struct {
 	// maxWaitInQueue sets the maximum time a request can wait in the queue
 	// before being rejected.
 	// +optional
+	// +kubebuilder:validation:Format=duration
 	MaxWaitInQueue metav1.Duration `json:"maxWaitInQueue,omitempty" protobuf:"bytes,3,opt,name=maxWaitInQueue"`
 }
 

--- a/imageregistry/v1/types_imagepruner.go
+++ b/imageregistry/v1/types_imagepruner.go
@@ -54,6 +54,7 @@ type ImagePrunerSpec struct {
 	// keepYoungerThanDuration specifies the minimum age of an image and its referrers for it to be considered a candidate for pruning.
 	// Defaults to 60m (60 minutes).
 	// +optional
+	// +kubebuilder:validation:Format=duration
 	KeepYoungerThanDuration *metav1.Duration `json:"keepYoungerThanDuration,omitempty"`
 	// resources defines the resource requests and limits for the image pruner pod.
 	// +optional


### PR DESCRIPTION
Adding a Format tag to validate "metav1.Duration" types on Image
Registry types.