### PR TITLE
podnetworkconnectivitychecks: add description, remove success flag

### DIFF
--- a/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
+++ b/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
@@ -39,6 +39,9 @@ spec:
           - sourcePod
           - targetEndpoint
           properties:
+            description:
+              description: Description of target endpoint in a human readable format.
+              type: string
             sourcePod:
               description: SourcePod names the pod from which the condition will be
                 checked
@@ -94,7 +97,6 @@ spec:
                 description: LogEntry records events
                 type: object
                 required:
-                - success
                 - time
                 properties:
                   latency:
@@ -108,10 +110,6 @@ spec:
                   reason:
                     description: Reason for status in a machine readable format.
                     type: string
-                  success:
-                    description: Success indicates if the log entry indicates a success
-                      or failure.
-                    type: boolean
                   time:
                     description: Start time of check action.
                     type: string
@@ -143,7 +141,6 @@ spec:
                 description: LogEntry records events
                 type: object
                 required:
-                - success
                 - time
                 properties:
                   latency:
@@ -157,10 +154,6 @@ spec:
                   reason:
                     description: Reason for status in a machine readable format.
                     type: string
-                  success:
-                    description: Success indicates if the log entry indicates a success
-                      or failure.
-                    type: boolean
                   time:
                     description: Start time of check action.
                     type: string

--- a/operatorcontrolplane/v1alpha1/types_conditioncheck.go
+++ b/operatorcontrolplane/v1alpha1/types_conditioncheck.go
@@ -25,6 +25,7 @@ type PodNetworkConnectivityCheck struct {
 }
 
 type PodNetworkConnectivityCheckSpec struct {
+
 	// SourcePod names the pod from which the condition will be checked
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
@@ -38,6 +39,10 @@ type PodNetworkConnectivityCheckSpec struct {
 	// +kubebuilder:validation:Pattern=`^\S+:\d*$`
 	// +required
 	TargetEndpoint string `json:"targetEndpoint"`
+
+	// Description of target endpoint in a human readable format.
+	// +optional
+	Description string `json:"description,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true
@@ -68,11 +73,6 @@ type LogEntry struct {
 	// +required
 	// +nullable
 	Start metav1.Time `json:"time"`
-
-	// Success indicates if the log entry indicates a success or failure.
-	// +kubebuilder:validation:Required
-	// +required
-	Success bool `json:"success"`
 
 	// Reason for status in a machine readable format.
 	// +optional

--- a/operatorcontrolplane/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/operatorcontrolplane/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -14,7 +14,6 @@ package v1alpha1
 var map_LogEntry = map[string]string{
 	"":        "LogEntry records events",
 	"time":    "Start time of check action.",
-	"success": "Success indicates if the log entry indicates a success or failure.",
 	"reason":  "Reason for status in a machine readable format.",
 	"message": "Message explaining status in a human readable format.",
 	"latency": "Latency records how long the action mentioned in the entry took.",
@@ -69,6 +68,7 @@ func (PodNetworkConnectivityCheckList) SwaggerDoc() map[string]string {
 var map_PodNetworkConnectivityCheckSpec = map[string]string{
 	"sourcePod":      "SourcePod names the pod from which the condition will be checked",
 	"targetEndpoint": "EndpointAddress to check. A TCP address of the form host:port. Note that if host is a DNS name, then the check would fail if the DNS name cannot be resolved. Specify an IP address for host to bypass DNS name lookup.",
+	"description":    "Description of target endpoint in a human readable format.",
 }
 
 func (PodNetworkConnectivityCheckSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
* Add **Description** to spec to help users identify what exactly the target endpoint refers to.
* Remove the unnecessary `LogEntry.Success` field.