### PR TITLE
Bug 1832144: Adding missing Azure container name validation.

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -193,6 +193,9 @@ spec:
                       description: container defines Azure's container to be used
                         by registry.
                       type: string
+                      maxLength: 63
+                      minLength: 3
+                      pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
                 emptyDir:
                   description: 'emptyDir represents ephemeral storage on the pod''s
                     host node. WARNING: this storage cannot be used with more than
@@ -457,6 +460,9 @@ spec:
                       description: container defines Azure's container to be used
                         by registry.
                       type: string
+                      maxLength: 63
+                      minLength: 3
+                      pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
                 emptyDir:
                   description: 'emptyDir represents ephemeral storage on the pod''s
                     host node. WARNING: this storage cannot be used with more than

--- a/imageregistry/v1/types.go
+++ b/imageregistry/v1/types.go
@@ -234,6 +234,9 @@ type ImageRegistryConfigStorageAzure struct {
 	AccountName string `json:"accountName" protobuf:"bytes,1,opt,name=accountName"`
 	// container defines Azure's container to be used by registry.
 	// +optional
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:MinLength=3
+	// +kubebuilder:validation:Pattern=`^[0-9a-z]+(-[0-9a-z]+)*$`
 	Container string `json:"container" protobuf:"bytes,2,opt,name=container"`
 }
 


### PR DESCRIPTION
This patch adds validation to the Azure's container name as already done
by the type and crd on image registry operator.

Cherry pick of 6bf0e230a43a8faf00df09e04e1d9acfaf5a5187