### PR TITLE
Updating ForcePull in controlplane to be a pointer

### DIFF
--- a/openshiftcontrolplane/v1/types.go
+++ b/openshiftcontrolplane/v1/types.go
@@ -303,8 +303,12 @@ type SourceStrategyDefaultsConfig struct {
 type BuildOverridesConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// forcePull indicates whether the build strategy should always be set to ForcePull=true
-	ForcePull bool `json:"forcePull"`
+	// forcePull overrides, if set, the equivalent value in the builds,
+	// i.e. false disables force pull for all builds,
+	// true enables force pull for all builds,
+	// independently of what each build specifies itself
+	// +optional
+	ForcePull *bool `json:"forcePull,omitempty"`
 
 	// imageLabels is a list of labels that are applied to the resulting image.
 	// If user provided a label in their Build/BuildConfig with the same name as one in this

--- a/openshiftcontrolplane/v1/zz_generated.deepcopy.go
+++ b/openshiftcontrolplane/v1/zz_generated.deepcopy.go
@@ -119,6 +119,11 @@ func (in *BuildDefaultsConfig) DeepCopyObject() runtime.Object {
 func (in *BuildOverridesConfig) DeepCopyInto(out *BuildOverridesConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
+	if in.ForcePull != nil {
+		in, out := &in.ForcePull, &out.ForcePull
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ImageLabels != nil {
 		in, out := &in.ImageLabels, &out.ImageLabels
 		*out = make([]buildv1.ImageLabel, len(*in))

--- a/openshiftcontrolplane/v1/zz_generated.swagger_doc_generated.go
+++ b/openshiftcontrolplane/v1/zz_generated.swagger_doc_generated.go
@@ -38,7 +38,7 @@ func (BuildDefaultsConfig) SwaggerDoc() map[string]string {
 
 var map_BuildOverridesConfig = map[string]string{
 	"":             "BuildOverridesConfig controls override settings for builds",
-	"forcePull":    "forcePull indicates whether the build strategy should always be set to ForcePull=true",
+	"forcePull":    "forcePull overrides, if set, the equivalent value in the builds, i.e. false disables force pull for all builds, true enables force pull for all builds, independently of what each build specifies itself",
 	"imageLabels":  "imageLabels is a list of labels that are applied to the resulting image. If user provided a label in their Build/BuildConfig with the same name as one in this list, the user's label will be overwritten.",
 	"nodeSelector": "nodeSelector is a selector which must be true for the build pod to fit on a node",
 	"annotations":  "annotations are annotations that will be added to the build pod",


### PR DESCRIPTION
We need to update openshiftcontrolplane/v1/BuildOverridesConfig/ForcePull to be in line with  config/v1/BuildOverrides/ForcePull addition from https://github.com/openshift/api/pull/673 since it gets a copy of that value at https://github.com/openshift/openshift-controller-manager/blob/master/pkg/cmd/controller/build.go#L76 and we need to still be able to see if it was set by an administrator or not.

This seems to be leftover code from 3.x as having a node cache on 4.x is not currently supported, and it seems that the only place this code is used within OpenShift is in the openshift-controller-manager, so it should be pretty safe to update and not break everything.  

https://issues.redhat.com/browse/BUILD-96