### PR TITLE
adding HybridOverlayVXLANPort to HybridOverlayConfig stuct

### DIFF
--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -320,6 +320,10 @@ type OVNKubernetesConfig struct {
 type HybridOverlayConfig struct {
 	// HybridClusterNetwork defines a network space given to nodes on an additional overlay network.
 	HybridClusterNetwork []ClusterNetworkEntry `json:"hybridClusterNetwork"`
+	// HybridOverlayVXLANPort defines the VXLAN port number to be used by the additional overlay network.
+	// Default is 4789
+	// +optional
+	HybridOverlayVXLANPort *uint32 `json:"hybridOverlayVXLANPort,omitempty"`
 }
 
 // NetworkType describes the network plugin type to configure

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -850,6 +850,11 @@ func (in *HybridOverlayConfig) DeepCopyInto(out *HybridOverlayConfig) {
 		*out = make([]ClusterNetworkEntry, len(*in))
 		copy(*out, *in)
 	}
+	if in.HybridOverlayVXLANPort != nil {
+		in, out := &in.HybridOverlayVXLANPort, &out.HybridOverlayVXLANPort
+		*out = new(uint32)
+		**out = **in
+	}
 	return
 }
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -584,7 +584,8 @@ func (DefaultNetworkDefinition) SwaggerDoc() map[string]string {
 }
 
 var map_HybridOverlayConfig = map[string]string{
-	"hybridClusterNetwork": "HybridClusterNetwork defines a network space given to nodes on an additional overlay network.",
+	"hybridClusterNetwork":   "HybridClusterNetwork defines a network space given to nodes on an additional overlay network.",
+	"hybridOverlayVXLANPort": "HybridOverlayVXLANPort defines the VXLAN port number to be used by the additional overlay network. Default is 4789",
 }
 
 func (HybridOverlayConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
the vxlan port that was used when we started working on the windows/linux hybrid
networking solution (4789) is required to be left open by some of our supported
platforms. Make the VXLAN port configurable so that it can be set and will no longer
interfere with enabling cloud platforms