### PR TITLE
ovirt: add a comment about DNS VIP field

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -353,13 +353,8 @@ spec:
                         a wildcard DNS record used to resolve default route host names.
                       type: string
                     nodeDNSIP:
-                      description: nodeDNSIP is the IP address for the internal DNS
-                        used by the nodes. Unlike the one managed by the DNS operator,
-                        `NodeDNSIP` provides name resolution for the nodes themselves.
-                        There is no DNS-as-a-service for oVirt deployments. In order
-                        to minimize necessary changes to the datacenter DNS, a DNS
-                        service is hosted as a static pod to serve those hostnames
-                        to the nodes in the cluster.
+                      description: 'deprecated: as of 4.6, this field is no longer
+                        set or honored.  It will be removed in a future release.'
                       type: string
                 type:
                   description: "type is the underlying infrastructure provider for

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -388,12 +388,7 @@ type OvirtPlatformStatus struct {
 	// The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
 	IngressIP string `json:"ingressIP,omitempty"`
 
-	// nodeDNSIP is the IP address for the internal DNS used by the
-	// nodes. Unlike the one managed by the DNS operator, `NodeDNSIP`
-	// provides name resolution for the nodes themselves. There is no DNS-as-a-service for
-	// oVirt deployments. In order to minimize necessary changes to the
-	// datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames
-	// to the nodes in the cluster.
+	// deprecated: as of 4.6, this field is no longer set or honored.  It will be removed in a future release.
 	NodeDNSIP string `json:"nodeDNSIP,omitempty"`
 }
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -868,7 +868,7 @@ var map_OvirtPlatformStatus = map[string]string{
 	"":                    "OvirtPlatformStatus holds the current status of the  oVirt infrastructure provider.",
 	"apiServerInternalIP": "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.",
 	"ingressIP":           "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.",
-	"nodeDNSIP":           "nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for oVirt deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.",
+	"nodeDNSIP":           "deprecated: as of 4.6, this field is no longer set or honored.  It will be removed in a future release.",
 }
 
 func (OvirtPlatformStatus) SwaggerDoc() map[string]string {

--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -307,6 +307,12 @@ spec:
                                 type: integer
                                 format: int32
                                 minimum: 0
+                        hybridOverlayVXLANPort:
+                          description: HybridOverlayVXLANPort defines the VXLAN port
+                            number to be used by the additional overlay network. Default
+                            is 4789
+                          type: integer
+                          format: int32
                     mtu:
                       description: mtu is the MTU to use for the tunnel interface.
                         This must be 100 bytes smaller than the uplink mtu. Default


### PR DESCRIPTION
In 4.6, this field is no longer set or honored.

See also:
https://github.com/openshift/machine-config-operator/commit/c4bf4e43ca809c3bc346d9bb490ccf33567b18fb

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1846330
Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>