### PR TITLE
hack: fix protobuf validation

### DIFF
--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -4,7 +4,7 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 
-if [[ "$(protoc --version)" != "libprotoc 3.0."* ]]; then
+if [[ "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.x. Please download and
 install the platform appropriate Protobuf package for your OS:
 


### PR DESCRIPTION
We have higher versions of protobuf available.
This patch avoids build issue with higher versions like 3.11.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>