### PR TITLE
v1alpha1/podnetworkconnectivitychecks: add logs to outages

### DIFF
--- a/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
+++ b/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
@@ -145,11 +145,82 @@ spec:
                     type: string
                     format: date-time
                     nullable: true
+                  endLogs:
+                    description: EndLogs contains log entries related to the end of
+                      this outage. Should contain the success entry that resolved
+                      the outage and possibly a few of the failure log entries that
+                      preceded it.
+                    type: array
+                    items:
+                      description: LogEntry records events
+                      type: object
+                      required:
+                      - success
+                      - time
+                      properties:
+                        latency:
+                          description: Latency records how long the action mentioned
+                            in the entry took.
+                          type: string
+                          nullable: true
+                        message:
+                          description: Message explaining status in a human readable
+                            format.
+                          type: string
+                        reason:
+                          description: Reason for status in a machine readable format.
+                          type: string
+                        success:
+                          description: Success indicates if the log entry indicates
+                            a success or failure.
+                          type: boolean
+                        time:
+                          description: Start time of check action.
+                          type: string
+                          format: date-time
+                          nullable: true
+                  message:
+                    description: Message summarizes outage details in a human readable
+                      format.
+                    type: string
                   start:
                     description: Start of outage detected
                     type: string
                     format: date-time
                     nullable: true
+                  startLogs:
+                    description: StartLogs contains log entries related to the start
+                      of this outage. Should contain the original failure, any entries
+                      where the failure mode changed.
+                    type: array
+                    items:
+                      description: LogEntry records events
+                      type: object
+                      required:
+                      - success
+                      - time
+                      properties:
+                        latency:
+                          description: Latency records how long the action mentioned
+                            in the entry took.
+                          type: string
+                          nullable: true
+                        message:
+                          description: Message explaining status in a human readable
+                            format.
+                          type: string
+                        reason:
+                          description: Reason for status in a machine readable format.
+                          type: string
+                        success:
+                          description: Success indicates if the log entry indicates
+                            a success or failure.
+                          type: boolean
+                        time:
+                          description: Start time of check action.
+                          type: string
+                          format: date-time
+                          nullable: true
             successes:
               description: Successes contains logs successful check actions
               type: array

--- a/operatorcontrolplane/v1alpha1/types_conditioncheck.go
+++ b/operatorcontrolplane/v1alpha1/types_conditioncheck.go
@@ -110,6 +110,20 @@ type OutageEntry struct {
 	// +optional
 	// +nullable
 	End metav1.Time `json:"end,omitempty"`
+
+	// StartLogs contains log entries related to the start of this outage. Should contain
+	// the original failure, any entries where the failure mode changed.
+	// +optional
+	StartLogs []LogEntry `json:"startLogs,omitempty"`
+
+	// EndLogs contains log entries related to the end of this outage. Should contain the success
+	// entry that resolved the outage and possibly a few of the failure log entries that preceded it.
+	// +optional
+	EndLogs []LogEntry `json:"endLogs,omitempty"`
+
+	// Message summarizes outage details in a human readable format.
+	// +optional
+	Message string `json:"message,omitempty"`
 }
 
 // PodNetworkConnectivityCheckCondition represents the overall status of the pod network connectivity.

--- a/operatorcontrolplane/v1alpha1/zz_generated.deepcopy.go
+++ b/operatorcontrolplane/v1alpha1/zz_generated.deepcopy.go
@@ -31,6 +31,20 @@ func (in *OutageEntry) DeepCopyInto(out *OutageEntry) {
 	*out = *in
 	in.Start.DeepCopyInto(&out.Start)
 	in.End.DeepCopyInto(&out.End)
+	if in.StartLogs != nil {
+		in, out := &in.StartLogs, &out.StartLogs
+		*out = make([]LogEntry, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.EndLogs != nil {
+		in, out := &in.EndLogs, &out.EndLogs
+		*out = make([]LogEntry, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/operatorcontrolplane/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/operatorcontrolplane/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -25,9 +25,12 @@ func (LogEntry) SwaggerDoc() map[string]string {
 }
 
 var map_OutageEntry = map[string]string{
-	"":      "OutageEntry records time period of an outage",
-	"start": "Start of outage detected",
-	"end":   "End of outage detected",
+	"":          "OutageEntry records time period of an outage",
+	"start":     "Start of outage detected",
+	"end":       "End of outage detected",
+	"startLogs": "StartLogs contains log entries related to the start of this outage. Should contain the original failure, any entries where the failure mode changed.",
+	"endLogs":   "EndLogs contains log entries related to the end of this outage. Should contain the success entry that resolved the outage and possibly a few of the failure log entries that preceded it.",
+	"message":   "Message summarizes outage details in a human readable format.",
 }
 
 func (OutageEntry) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Keeps a list of important success/failure log entries related to an outage associated with the outage itself to provide context when reviewing the logs long after the original entries have been rotated out.

Example:
```yaml
status:
  outages:
  - end: "2020-07-14T02:12:40Z"
    start: "2020-07-14T01:23:03Z"
    logs:
      - latency: 113.463µs
        message: 'tcp connection to 10.128.0.38:8443 succeeded'
        reason: TCPConnect
        success: true
        time: "2020-07-14T02:12:40Z"
      - latency: 858.991937ms
        message: 'dial tcp 10.128.0.38:8443: connect: no route to host'
        reason: TCPConnectError
        success: false
        time: "2020-07-14T01:23:03Z"
```

