### PR TITLE
config/v1/types_cluster_version: Drop availableUpdates from Force docs

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -85,16 +85,14 @@ spec:
               type: object
               properties:
                 force:
-                  description: "force allows an administrator to update to an image
-                    that has failed verification, does not appear in the availableUpdates
-                    list, or otherwise would be blocked by normal protections on update.
-                    This option should only be used when the authenticity of the provided
-                    image has been verified out of band because the provided image
-                    will run with full administrative access to the cluster. Do not
-                    use this flag with images that comes from unknown or potentially
-                    malicious sources. \n This flag does not override other forms
-                    of consistency checking that are required before a new update
-                    is deployed."
+                  description: force allows an administrator to update to an image
+                    that has failed verification, failed precondition checks, or would
+                    otherwise be blocked by normal protections on update. This option
+                    should only be used when the authenticity of the provided image
+                    has been verified out of band because the provided image will
+                    run with full administrative access to the cluster. Do not use
+                    this flag with images that comes from unknown or potentially malicious
+                    sources.
                   type: boolean
                 image:
                   description: image is a container image location that contains the
@@ -167,16 +165,14 @@ spec:
                 type: object
                 properties:
                   force:
-                    description: "force allows an administrator to update to an image
-                      that has failed verification, does not appear in the availableUpdates
-                      list, or otherwise would be blocked by normal protections on
-                      update. This option should only be used when the authenticity
-                      of the provided image has been verified out of band because
-                      the provided image will run with full administrative access
-                      to the cluster. Do not use this flag with images that comes
-                      from unknown or potentially malicious sources. \n This flag
-                      does not override other forms of consistency checking that are
-                      required before a new update is deployed."
+                    description: force allows an administrator to update to an image
+                      that has failed verification, failed precondition checks, or
+                      would otherwise be blocked by normal protections on update.
+                      This option should only be used when the authenticity of the
+                      provided image has been verified out of band because the provided
+                      image will run with full administrative access to the cluster.
+                      Do not use this flag with images that comes from unknown or
+                      potentially malicious sources.
                     type: boolean
                   image:
                     description: image is a container image location that contains
@@ -235,16 +231,14 @@ spec:
               type: object
               properties:
                 force:
-                  description: "force allows an administrator to update to an image
-                    that has failed verification, does not appear in the availableUpdates
-                    list, or otherwise would be blocked by normal protections on update.
-                    This option should only be used when the authenticity of the provided
-                    image has been verified out of band because the provided image
-                    will run with full administrative access to the cluster. Do not
-                    use this flag with images that comes from unknown or potentially
-                    malicious sources. \n This flag does not override other forms
-                    of consistency checking that are required before a new update
-                    is deployed."
+                  description: force allows an administrator to update to an image
+                    that has failed verification, failed precondition checks, or would
+                    otherwise be blocked by normal protections on update. This option
+                    should only be used when the authenticity of the provided image
+                    has been verified out of band because the provided image will
+                    run with full administrative access to the cluster. Do not use
+                    this flag with images that comes from unknown or potentially malicious
+                    sources.
                   type: boolean
                 image:
                   description: image is a container image location that contains the

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -236,16 +236,15 @@ type Update struct {
 	//
 	// +optional
 	Image string `json:"image"`
-	// force allows an administrator to update to an image that has failed
-	// verification, does not appear in the availableUpdates list, or otherwise
-	// would be blocked by normal protections on update. This option should only
-	// be used when the authenticity of the provided image has been verified out
-	// of band because the provided image will run with full administrative access
-	// to the cluster. Do not use this flag with images that comes from unknown
-	// or potentially malicious sources.
-	//
-	// This flag does not override other forms of consistency checking that are
-	// required before a new update is deployed.
+
+	// force allows an administrator to update to an image that has
+	// failed verification, failed precondition checks, or would
+	// otherwise be blocked by normal protections on update. This option
+	// should only be used when the authenticity of the provided image
+	// has been verified out of band because the provided image will run
+	// with full administrative access to the cluster. Do not use this
+	// flag with images that comes from unknown or potentially malicious
+	// sources.
 	//
 	// +optional
 	Force bool `json:"force"`

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -524,7 +524,7 @@ var map_Update = map[string]string{
 	"":        "Update represents a release of the ClusterVersionOperator, referenced by the Image member.",
 	"version": "version is a semantic versioning identifying the update version. When this field is part of spec, version is optional if image is specified.",
 	"image":   "image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.",
-	"force":   "force allows an administrator to update to an image that has failed verification, does not appear in the availableUpdates list, or otherwise would be blocked by normal protections on update. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources.\n\nThis flag does not override other forms of consistency checking that are required before a new update is deployed.",
+	"force":   "force allows an administrator to update to an image that has failed verification, failed precondition checks, or would otherwise be blocked by normal protections on update. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources.",
 }
 
 func (Update) SwaggerDoc() map[string]string {


### PR DESCRIPTION
The outgoing text is unchanged since the property landed ab4ff93d20 (#293).  Those docs fit on the `oc` client side until openshift/oc@0501d04ff1 (openshift/oc#109), but never applied to the cluster-version operator (CVO) side or the ClusterVersion type.  The CVO [uses `Force` to bypass verification failures][1] ([invalid pullspec][2], [lack of trusted signature][3], etc.) or [preconditions][4] ([ClusterVersion had `Upgradeable=False` for a requested minor bump][5]).  `availableUpdates` is orthogonal.

/assign @smarterclayton

[1]: https://github.com/openshift/cluster-version-operator/blob/28e4400eeb9ded7e09ff684e75780599cb25ec2c/pkg/cvo/updatepayload.go#L91-L102
[2]: https://github.com/openshift/cluster-version-operator/blob/28e4400eeb9ded7e09ff684e75780599cb25ec2c/pkg/verify/verify.go#L138
[3]: https://github.com/openshift/cluster-version-operator/blob/28e4400eeb9ded7e09ff684e75780599cb25ec2c/pkg/verify/verify.go#L182
[4]: https://github.com/openshift/cluster-version-operator/blob/28e4400eeb9ded7e09ff684e75780599cb25ec2c/pkg/cvo/sync_worker.go#L527-L529
[5]: https://github.com/openshift/cluster-version-operator/blob/28e4400eeb9ded7e09ff684e75780599cb25ec2c/pkg/payload/precondition/clusterversion/upgradeable.go#L74-L79