### PR TITLE
Bug 1852112: Make hostPrefix optional for the sake of non-(sdn/ovn) plugins

### DIFF
--- a/config/v1/0000_10_config-operator_01_network.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network.crd.yaml
@@ -60,6 +60,7 @@ spec:
                     type: string
                   hostPrefix:
                     description: The size (prefix) of block to allocate to each node.
+                      If this field is not used by the plugin, it can be left unset.
                     type: integer
                     format: int32
                     minimum: 0
@@ -132,6 +133,7 @@ spec:
                     type: string
                   hostPrefix:
                     description: The size (prefix) of block to allocate to each node.
+                      If this field is not used by the plugin, it can be left unset.
                     type: integer
                     format: int32
                     minimum: 0

--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -84,9 +84,11 @@ type ClusterNetworkEntry struct {
 	// The complete block for pod IPs.
 	CIDR string `json:"cidr"`
 
-	// The size (prefix) of block to allocate to each node.
+	// The size (prefix) of block to allocate to each node. If this
+	// field is not used by the plugin, it can be left unset.
 	// +kubebuilder:validation:Minimum=0
-	HostPrefix uint32 `json:"hostPrefix"`
+	// +optional
+	HostPrefix uint32 `json:"hostPrefix,omitempty"`
 }
 
 // ExternalIPConfig specifies some IP blocks relevant for the ExternalIP field

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -949,7 +949,7 @@ func (IngressSpec) SwaggerDoc() map[string]string {
 var map_ClusterNetworkEntry = map[string]string{
 	"":           "ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.",
 	"cidr":       "The complete block for pod IPs.",
-	"hostPrefix": "The size (prefix) of block to allocate to each node.",
+	"hostPrefix": "The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.",
 }
 
 func (ClusterNetworkEntry) SwaggerDoc() map[string]string {

--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -163,7 +163,8 @@ spec:
               items:
                 description: ClusterNetworkEntry is a subnet from which to allocate
                   PodIPs. A network of size HostPrefix (in CIDR notation) will be
-                  allocated when nodes join the cluster. Not all network providers
+                  allocated when nodes join the cluster. If the HostPrefix field is
+                  not used by the plugin, it can be left unset. Not all network providers
                   support multiple ClusterNetworks
                 type: object
                 properties:
@@ -297,8 +298,9 @@ spec:
                             description: ClusterNetworkEntry is a subnet from which
                               to allocate PodIPs. A network of size HostPrefix (in
                               CIDR notation) will be allocated when nodes join the
-                              cluster. Not all network providers support multiple
-                              ClusterNetworks
+                              cluster. If the HostPrefix field is not used by the
+                              plugin, it can be left unset. Not all network providers
+                              support multiple ClusterNetworks
                             type: object
                             properties:
                               cidr:

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -79,12 +79,14 @@ type NetworkSpec struct {
 }
 
 // ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size
-// HostPrefix (in CIDR notation) will be allocated when nodes join the cluster.
+// HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If
+// the HostPrefix field is not used by the plugin, it can be left unset.
 // Not all network providers support multiple ClusterNetworks
 type ClusterNetworkEntry struct {
 	CIDR string `json:"cidr"`
 	// +kubebuilder:validation:Minimum=0
-	HostPrefix uint32 `json:"hostPrefix"`
+	// +optional
+	HostPrefix uint32 `json:"hostPrefix,omitempty"`
 }
 
 // DefaultNetworkDefinition represents a single network plugin's configuration.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -612,7 +612,7 @@ func (AdditionalNetworkDefinition) SwaggerDoc() map[string]string {
 }
 
 var map_ClusterNetworkEntry = map[string]string{
-	"": "ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. Not all network providers support multiple ClusterNetworks",
+	"": "ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks",
 }
 
 func (ClusterNetworkEntry) SwaggerDoc() map[string]string {


### PR DESCRIPTION
For plugins like which don't use the hostPrefix for anything, it does not
make sense to force customers to set specific values just to pass validation.
These plugins should be able to unset (0) the hostPrefix and not have to worry
about it. This patch makes hostPrefix optional. However note that if the
hostPrefix is set, the validation will happen and for the plugins like
OpenShiftSDN and OVNKubernetes which require hostPrefix, the validation
will happen irrespective of whether it is set or not.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>