### PR TITLE
Remove description line about namespaced ClusterRoleBinding

### DIFF
--- a/authorization/v1/types.go
+++ b/authorization/v1/types.go
@@ -379,7 +379,6 @@ type ClusterRole struct {
 
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference any ClusterRole in the same namespace or in the global namespace.
 // It adds who information via (Users and Groups) OR Subjects and namespace information by which namespace it exists in.
-// ClusterRoleBindings in a given namespace only have effect in that namespace (excepting the master namespace which has power in all namespaces).
 type ClusterRoleBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`


### PR DESCRIPTION
It is incorrect. clusterrolse are always cluster global.

Looks like this was automatically copied from RoleBinding (which can be namespaced)

this should resolve the generated part of the documentation, currently showing errornous info

Signed-off-by: Yuval Kashtan <yuvalkashtan@gmail.com>