### PR TITLE
Adds LB provider constants to operator/ingress API

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -144,6 +144,7 @@ spec:
                           - GCP
                           - OpenStack
                           - VSphere
+                          - IBM
                           type: string
                       required:
                       - type
@@ -762,6 +763,7 @@ spec:
                           - GCP
                           - OpenStack
                           - VSphere
+                          - IBM
                           type: string
                       required:
                       - type

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -278,8 +278,18 @@ type ProviderLoadBalancerParameters struct {
 // load balancer. Allowed values are "AWS", "Azure", "BareMetal", "GCP",
 // "OpenStack", and "VSphere".
 //
-// +kubebuilder:validation:Enum=AWS;Azure;BareMetal;GCP;OpenStack;VSphere
+// +kubebuilder:validation:Enum=AWS;Azure;BareMetal;GCP;OpenStack;VSphere;IBM
 type LoadBalancerProviderType string
+
+const (
+	AWSLoadBalancerProvider       LoadBalancerProviderType = "AWS"
+	AzureLoadBalancerProvider     LoadBalancerProviderType = "Azure"
+	GCPLoadBalancerProvider       LoadBalancerProviderType = "GCP"
+	OpenStackLoadBalancerProvider LoadBalancerProviderType = "OpenStack"
+	VSphereLoadBalancerProvider   LoadBalancerProviderType = "VSphere"
+	IBMLoadBalancerProvider       LoadBalancerProviderType = "IBM"
+	BareMetalLoadBalancerProvider LoadBalancerProviderType = "BareMetal"
+)
 
 // AWSLoadBalancerParameters provides configuration settings that are
 // specific to AWS load balancers.


### PR DESCRIPTION
Adds constants for supported load balancer provider types.

In support of [NE-138](https://issues.redhat.com/browse/NE-138).

/assign @knobunc 
/cc @sttts @deads2k @frobware