### PR TITLE
config/v1/types_infrastructure: Default ports for apiServerInternalURL too

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -152,9 +152,10 @@ spec:
           properties:
             apiServerInternalURI:
               description: apiServerInternalURL is a valid URI with scheme(http/https),
-                address and port.  apiServerInternalURL can be used by components
-                like kubelets, to contact the Kubernetes API server using the infrastructure
-                provider rather than Kubernetes networking.
+                address and optionally a port (defaulting to 80 for http and 443 for
+                https).  apiServerInternalURL can be used by components like kubelets,
+                to contact the Kubernetes API server using the infrastructure provider
+                rather than Kubernetes networking.
               type: string
             apiServerURL:
               description: apiServerURL is a valid URI with scheme(http/https), address

--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -151,17 +151,17 @@ spec:
           type: object
           properties:
             apiServerInternalURI:
-              description: apiServerInternalURL is a valid URI with scheme(http/https),
-                address and optionally a port (defaulting to 80 for http and 443 for
-                https).  apiServerInternalURL can be used by components like kubelets,
-                to contact the Kubernetes API server using the infrastructure provider
-                rather than Kubernetes networking.
+              description: apiServerInternalURL is a valid URI with scheme 'https',
+                address and optionally a port (defaulting to 443).  apiServerInternalURL
+                can be used by components like kubelets, to contact the Kubernetes
+                API server using the infrastructure provider rather than Kubernetes
+                networking.
               type: string
             apiServerURL:
-              description: apiServerURL is a valid URI with scheme(http/https), address
-                and optionally a port (defaulting to 80 for http and 443 for https).  apiServerURL
-                can be used by components like the web console to tell users where
-                to find the Kubernetes API.
+              description: apiServerURL is a valid URI with scheme 'https', address
+                and optionally a port (defaulting to 443).  apiServerURL can be used
+                by components like the web console to tell users where to find the
+                Kubernetes API.
               type: string
             etcdDiscoveryDomain:
               description: 'etcdDiscoveryDomain is the domain used to fetch the SRV

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -66,13 +66,13 @@ type InfrastructureStatus struct {
 	// For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
 	EtcdDiscoveryDomain string `json:"etcdDiscoveryDomain"`
 
-	// apiServerURL is a valid URI with scheme(http/https), address and
-	// optionally a port (defaulting to 80 for http and 443 for https).  apiServerURL can be used by components like the web console
+	// apiServerURL is a valid URI with scheme 'https', address and
+	// optionally a port (defaulting to 443).  apiServerURL can be used by components like the web console
 	// to tell users where to find the Kubernetes API.
 	APIServerURL string `json:"apiServerURL"`
 
-	// apiServerInternalURL is a valid URI with scheme(http/https),
-	// address and optionally a port (defaulting to 80 for http and 443 for https).  apiServerInternalURL can be used by components
+	// apiServerInternalURL is a valid URI with scheme 'https',
+	// address and optionally a port (defaulting to 443).  apiServerInternalURL can be used by components
 	// like kubelets, to contact the Kubernetes API server using the
 	// infrastructure provider rather than Kubernetes networking.
 	APIServerInternalURL string `json:"apiServerInternalURI"`

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -72,7 +72,7 @@ type InfrastructureStatus struct {
 	APIServerURL string `json:"apiServerURL"`
 
 	// apiServerInternalURL is a valid URI with scheme(http/https),
-	// address and port.  apiServerInternalURL can be used by components
+	// address and optionally a port (defaulting to 80 for http and 443 for https).  apiServerInternalURL can be used by components
 	// like kubelets, to contact the Kubernetes API server using the
 	// infrastructure provider rather than Kubernetes networking.
 	APIServerInternalURL string `json:"apiServerInternalURI"`

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -828,8 +828,8 @@ var map_InfrastructureStatus = map[string]string{
 	"platform":             "platform is the underlying infrastructure provider for the cluster.\n\nDeprecated: Use platformStatus.type instead.",
 	"platformStatus":       "platformStatus holds status information specific to the underlying infrastructure provider.",
 	"etcdDiscoveryDomain":  "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
-	"apiServerURL":         "apiServerURL is a valid URI with scheme(http/https), address and optionally a port (defaulting to 80 for http and 443 for https).  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.",
-	"apiServerInternalURI": "apiServerInternalURL is a valid URI with scheme(http/https), address and optionally a port (defaulting to 80 for http and 443 for https).  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.",
+	"apiServerURL":         "apiServerURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.",
+	"apiServerInternalURI": "apiServerInternalURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.",
 }
 
 func (InfrastructureStatus) SwaggerDoc() map[string]string {

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -829,7 +829,7 @@ var map_InfrastructureStatus = map[string]string{
 	"platformStatus":       "platformStatus holds status information specific to the underlying infrastructure provider.",
 	"etcdDiscoveryDomain":  "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
 	"apiServerURL":         "apiServerURL is a valid URI with scheme(http/https), address and optionally a port (defaulting to 80 for http and 443 for https).  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.",
-	"apiServerInternalURI": "apiServerInternalURL is a valid URI with scheme(http/https), address and port.  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.",
+	"apiServerInternalURI": "apiServerInternalURL is a valid URI with scheme(http/https), address and optionally a port (defaulting to 80 for http and 443 for https).  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.",
 }
 
 func (InfrastructureStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
We've declared the default ports for apiServerURL since afb690a81c (#646).  Echo that for `apiServerInternalURL`.  We don't have to call this out explicitly, since [the IANA URI scheme registry][1] links out to RFC 7230 for [http][2] and [https][3], which have:

> If the port subcomponent is empty or not given, TCP port 80 (the reserved port for WWW services) is the default.

and:

> All of the requirements listed above for the "http" scheme are also requirements for the "https" scheme, except that TCP port 443 is the default if the port subcomponent is empty or not given...

respectively.  But echoing those defaults locally doesn't hurt.

Autogenerated bumps via:

```console
$ hack/update-swagger-docs.sh
$ make update-codegen-crds
```

[1]: https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml
[2]: https://tools.ietf.org/html/rfc7230#section-2.7.1
[3]: https://tools.ietf.org/html/rfc7230#section-2.7.2