### PR TITLE
IR-119: Add IgnoreInvalidRefs for image pruner

### DIFF
--- a/imageregistry/v1/01-crd.yaml
+++ b/imageregistry/v1/01-crd.yaml
@@ -617,6 +617,10 @@ spec:
                 pruner jobs to retain. Defaults to 3 if not set.
               type: integer
               format: int32
+            ignoreInvalidImageReferences:
+              description: ignoreInvalidImageReferences indicates whether the pruner
+                can ignore errors while parsing image references.
+              type: boolean
             keepTagRevisions:
               description: keepTagRevisions specifies the number of image revisions
                 for a tag in an image stream that will be preserved. Defaults to 3.

--- a/imageregistry/v1/types_imagepruner.go
+++ b/imageregistry/v1/types_imagepruner.go
@@ -76,6 +76,10 @@ type ImagePrunerSpec struct {
 	// Defaults to 3 if not set.
 	// +optional
 	FailedJobsHistoryLimit *int32 `json:"failedJobsHistoryLimit,omitempty"`
+	// ignoreInvalidImageReferences indicates whether the pruner can ignore
+	// errors while parsing image references.
+	// +optional
+	IgnoreInvalidImageReferences bool `json:"ignoreInvalidImageReferences,omitempty"`
 }
 
 // ImagePrunerStatus reports image pruner operational status.

--- a/imageregistry/v1/zz_generated.swagger_doc_generated.go
+++ b/imageregistry/v1/zz_generated.swagger_doc_generated.go
@@ -218,18 +218,19 @@ func (ImagePrunerList) SwaggerDoc() map[string]string {
 }
 
 var map_ImagePrunerSpec = map[string]string{
-	"":                           "ImagePrunerSpec defines the specs for the running image pruner.",
-	"schedule":                   "schedule specifies when to execute the job using standard cronjob syntax: https://wikipedia.org/wiki/Cron. Defaults to `0 0 * * *`.",
-	"suspend":                    "suspend specifies whether or not to suspend subsequent executions of this cronjob. Defaults to false.",
-	"keepTagRevisions":           "keepTagRevisions specifies the number of image revisions for a tag in an image stream that will be preserved. Defaults to 3.",
-	"keepYoungerThan":            "keepYoungerThan specifies the minimum age in nanoseconds of an image and its referrers for it to be considered a candidate for pruning. DEPRECATED: This field is deprecated in favor of keepYoungerThanDuration. If both are set, this field is ignored and keepYoungerThanDuration takes precedence.",
-	"keepYoungerThanDuration":    "keepYoungerThanDuration specifies the minimum age of an image and its referrers for it to be considered a candidate for pruning. Defaults to 60m (60 minutes).",
-	"resources":                  "resources defines the resource requests and limits for the image pruner pod.",
-	"affinity":                   "affinity is a group of node affinity scheduling rules for the image pruner pod.",
-	"nodeSelector":               "nodeSelector defines the node selection constraints for the image pruner pod.",
-	"tolerations":                "tolerations defines the node tolerations for the image pruner pod.",
-	"successfulJobsHistoryLimit": "successfulJobsHistoryLimit specifies how many successful image pruner jobs to retain. Defaults to 3 if not set.",
-	"failedJobsHistoryLimit":     "failedJobsHistoryLimit specifies how many failed image pruner jobs to retain. Defaults to 3 if not set.",
+	"":                             "ImagePrunerSpec defines the specs for the running image pruner.",
+	"schedule":                     "schedule specifies when to execute the job using standard cronjob syntax: https://wikipedia.org/wiki/Cron. Defaults to `0 0 * * *`.",
+	"suspend":                      "suspend specifies whether or not to suspend subsequent executions of this cronjob. Defaults to false.",
+	"keepTagRevisions":             "keepTagRevisions specifies the number of image revisions for a tag in an image stream that will be preserved. Defaults to 3.",
+	"keepYoungerThan":              "keepYoungerThan specifies the minimum age in nanoseconds of an image and its referrers for it to be considered a candidate for pruning. DEPRECATED: This field is deprecated in favor of keepYoungerThanDuration. If both are set, this field is ignored and keepYoungerThanDuration takes precedence.",
+	"keepYoungerThanDuration":      "keepYoungerThanDuration specifies the minimum age of an image and its referrers for it to be considered a candidate for pruning. Defaults to 60m (60 minutes).",
+	"resources":                    "resources defines the resource requests and limits for the image pruner pod.",
+	"affinity":                     "affinity is a group of node affinity scheduling rules for the image pruner pod.",
+	"nodeSelector":                 "nodeSelector defines the node selection constraints for the image pruner pod.",
+	"tolerations":                  "tolerations defines the node tolerations for the image pruner pod.",
+	"successfulJobsHistoryLimit":   "successfulJobsHistoryLimit specifies how many successful image pruner jobs to retain. Defaults to 3 if not set.",
+	"failedJobsHistoryLimit":       "failedJobsHistoryLimit specifies how many failed image pruner jobs to retain. Defaults to 3 if not set.",
+	"ignoreInvalidImageReferences": "ignoreInvalidImageReferences indicates whether the pruner can ignore errors while parsing image references.",
 }
 
 func (ImagePrunerSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Invalid image references in pods/builds/etc cause the image pruner to abort its job. This is the safest approach because even if the pruner has bugs, it won't delete anything that is in use. But as there is no validation for image references, some clusters have invalid references because of their users mistakes and the pruner should ignore them.

The default value for `ignoreInvalidRefs` is `false` to maintain backward compatibility. But the operator will bootstrap the configuration object with `ignoreInvalidRefs: true`. So new clusters will have `ignoreInvalidRefs: true`, upgraded from 4.5 clusters will have `ignoreInvalidRefs: false`.