### PR TITLE
operator/ingress: Fix up HTTP cookie capture API

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -361,19 +361,6 @@ spec:
                       items:
                         description: IngressControllerCaptureHTTPCookie describes
                           an HTTP cookie that should be captured.
-                        oneOf:
-                        - properties:
-                            matchType:
-                              enum:
-                              - Exact
-                          required:
-                          - name
-                        - properties:
-                            matchType:
-                              enum:
-                              - Prefix
-                          required:
-                          - namePrefix
                         properties:
                           matchType:
                             description: matchType specifies the type of match to
@@ -391,11 +378,13 @@ spec:
                             - Prefix
                             type: string
                           maxLength:
-                            description: maxLength specifies a maximum length for
-                              the cookie value.  If a cookie value exceeds this length,
-                              the value will be truncated in the log message.  Note
-                              that the ingress controller may impose a separate bound
-                              on the total length of HTTP headers in a request.
+                            description: maxLength specifies a maximum length of the
+                              string that will be logged, which includes the cookie
+                              name, cookie value, and one-character delimiter.  If
+                              the log entry exceeds this length, the value will be
+                              truncated in the log message.  Note that the ingress
+                              controller may impose a separate bound on the total
+                              length of HTTP headers in a request.
                             maximum: 1024
                             minimum: 1
                             type: integer
@@ -404,16 +393,16 @@ spec:
                               must be a valid HTTP cookie name as defined in RFC 6265
                               section 4.1.
                             maxLength: 1024
-                            minLength: 1
-                            pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
+                            minLength: 0
+                            pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]*$
                             type: string
                           namePrefix:
                             description: namePrefix specifies a cookie name prefix.  Its
                               value must be a valid HTTP cookie name as defined in
                               RFC 6265 section 4.1.
                             maxLength: 1024
-                            minLength: 1
-                            pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
+                            minLength: 0
+                            pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]*$
                             type: string
                         required:
                         - matchType

--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml-merge-patch
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml-merge-patch
@@ -18,14 +18,3 @@ spec:
                           - properties:
                               address:
                                 format: ipv6
-                    httpCaptureCookies:
-                      items:
-                        oneOf:
-                        - required: ["name"]
-                          properties:
-                            matchType:
-                              enum: ["Exact"]
-                        - required: ["namePrefix"]
-                          properties:
-                            matchType:
-                              enum: ["Prefix"]

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -672,8 +672,8 @@ type IngressControllerCaptureHTTPCookie struct {
 	// name specifies a cookie name.  Its value must be a valid HTTP cookie
 	// name as defined in RFC 6265 section 4.1.
 	//
-	// +kubebuilder:validation:Pattern="^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$"
-	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern="^[-!#$%&'*+.0-9A-Z^_`a-z|~]*$"
+	// +kubebuilder:validation:MinLength=0
 	// +kubebuilder:validation:MaxLength=1024
 	// +optional
 	Name string `json:"name"`
@@ -681,16 +681,18 @@ type IngressControllerCaptureHTTPCookie struct {
 	// namePrefix specifies a cookie name prefix.  Its value must be a valid
 	// HTTP cookie name as defined in RFC 6265 section 4.1.
 	//
-	// +kubebuilder:validation:Pattern="^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$"
-	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern="^[-!#$%&'*+.0-9A-Z^_`a-z|~]*$"
+	// +kubebuilder:validation:MinLength=0
 	// +kubebuilder:validation:MaxLength=1024
 	// +optional
 	NamePrefix string `json:"namePrefix"`
 
-	// maxLength specifies a maximum length for the cookie value.  If a
-	// cookie value exceeds this length, the value will be truncated in the
-	// log message.  Note that the ingress controller may impose a separate
-	// bound on the total length of HTTP headers in a request.
+	// maxLength specifies a maximum length of the string that will be
+	// logged, which includes the cookie name, cookie value, and
+	// one-character delimiter.  If the log entry exceeds this length, the
+	// value will be truncated in the log message.  Note that the ingress
+	// controller may impose a separate bound on the total length of HTTP
+	// headers in a request.
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=1

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -455,7 +455,7 @@ var map_IngressControllerCaptureHTTPCookie = map[string]string{
 	"matchType":  "matchType specifies the type of match to be performed on the cookie name.  Allowed values are \"Exact\" for an exact string match and \"Prefix\" for a string prefix match.  If \"Exact\" is specified, a name must be specified in the name field.  If \"Prefix\" is provided, a prefix must be specified in the namePrefix field.  For example, specifying matchType \"Prefix\" and namePrefix \"foo\" will capture a cookie named \"foo\" or \"foobar\" but not one named \"bar\".  The first matching cookie is captured.",
 	"name":       "name specifies a cookie name.  Its value must be a valid HTTP cookie name as defined in RFC 6265 section 4.1.",
 	"namePrefix": "namePrefix specifies a cookie name prefix.  Its value must be a valid HTTP cookie name as defined in RFC 6265 section 4.1.",
-	"maxLength":  "maxLength specifies a maximum length for the cookie value.  If a cookie value exceeds this length, the value will be truncated in the log message.  Note that the ingress controller may impose a separate bound on the total length of HTTP headers in a request.",
+	"maxLength":  "maxLength specifies a maximum length of the string that will be logged, which includes the cookie name, cookie value, and one-character delimiter.  If the log entry exceeds this length, the value will be truncated in the log message.  Note that the ingress controller may impose a separate bound on the total length of HTTP headers in a request.",
 }
 
 func (IngressControllerCaptureHTTPCookie) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Relax validation on `spec.logging.access.httpCaptureCookies` to allow the `name` and `namePrefix` subfields to be empty.

* `operator/v1/types_ingress.go` (`IngressControllerCaptureHTTPCookie`): Relax validation by allowing `Name` and `NamePrefix` to be empty.
* `operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml-merge-patch`: Delete validation added in #687.
* `operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml`:
* `operator/v1/zz_generated.swagger_doc_generated.go`: Regenerate.


----

Turns out what worked with `oc` commands does not work with client-go.  Specifying `matchType: Exact` and `name: foo` worked with `oc apply` but failed when updating using client-go:

    IngressController.operator.openshift.io "cookiecapture" is invalid: spec.logging.access.httpCaptureCookies.namePrefix: Invalid value: "": spec.logging.access.httpCaptureCookies.namePrefix in body should be at least 1 chars long