### PR TITLE
Bug 1880856: operator/network: update docs on iptablesSyncPeriod

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -353,7 +353,10 @@ spec:
                     description: The address to "bind" on Defaults to 0.0.0.0
                     type: string
                   iptablesSyncPeriod:
-                    description: 'The period that iptables rules are refreshed. Default:
+                    description: 'An internal kube-proxy parameter. In older releases
+                      of OCP, this sometimes needed to be adjusted in large clusters
+                      for performance reasons, but this is no longer necessary, and
+                      there is no reason to change this from the default value. Default:
                       30s'
                     type: string
                   proxyArguments:

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -337,7 +337,9 @@ type ProxyArgumentList []string
 // ProxyConfig defines the configuration knobs for kubeproxy
 // All of these are optional and have sensible defaults
 type ProxyConfig struct {
-	// The period that iptables rules are refreshed.
+	// An internal kube-proxy parameter. In older releases of OCP, this sometimes needed to be adjusted
+	// in large clusters for performance reasons, but this is no longer necessary, and there is no reason
+	// to change this from the default value.
 	// Default: 30s
 	IptablesSyncPeriod string `json:"iptablesSyncPeriod,omitempty"`
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -835,7 +835,7 @@ func (OpenShiftSDNConfig) SwaggerDoc() map[string]string {
 
 var map_ProxyConfig = map[string]string{
 	"":                   "ProxyConfig defines the configuration knobs for kubeproxy All of these are optional and have sensible defaults",
-	"iptablesSyncPeriod": "The period that iptables rules are refreshed. Default: 30s",
+	"iptablesSyncPeriod": "An internal kube-proxy parameter. In older releases of OCP, this sometimes needed to be adjusted in large clusters for performance reasons, but this is no longer necessary, and there is no reason to change this from the default value. Default: 30s",
 	"bindAddress":        "The address to \"bind\" on Defaults to 0.0.0.0",
 	"proxyArguments":     "Any additional arguments to pass to the kubeproxy process",
 }


### PR DESCRIPTION
In older releases, it was sometimes necessary for users to tweak kube-proxy's `iptablesSyncPeriod` to strike the right balance between "recovering from errors promptly" and "not causing errors constantly and totally breaking everything". With the rewrite of iptables monitoring in kube 1.18 this is no longer necessary, and modifying `iptablesSyncPeriod` is no longer particularly useful, so this updates the API docs to indicate that. (I've filed an openshift-docs PR too.)

In theory this could be backported as far as 4.3 but it's probably not worth bothering.

/cc @juanluisvaladas 
/assign @knobunc 