### PR TITLE
Bug 1868536: Add validation to the 'networkType' field

### DIFF
--- a/config/v1/0000_10_config-operator_01_network.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network.crd.yaml
@@ -99,8 +99,13 @@ spec:
               description: 'NetworkType is the plugin that is to be deployed (e.g.
                 OpenShiftSDN). This should match a value that the cluster-network-operator
                 understands, or else no networking will be installed. Currently supported
-                values are: - OpenShiftSDN This field is immutable after installation.'
+                values are: - OpenShiftSDN, OVNKubernetes, Kuryr. This field is immutable
+                after installation.'
               type: string
+              enum:
+              - OpenShiftSDN
+              - OVNKubernetes
+              - Kuryr
             serviceNetwork:
               description: IP address pool for services. Currently, we only support
                 a single entry here. This field is immutable after installation.

--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -42,8 +42,9 @@ type NetworkSpec struct {
 	// This should match a value that the cluster-network-operator understands,
 	// or else no networking will be installed.
 	// Currently supported values are:
-	// - OpenShiftSDN
+	// - OpenShiftSDN, OVNKubernetes, Kuryr.
 	// This field is immutable after installation.
+	// +kubebuilder:validation:Enum=OpenShiftSDN;OVNKubernetes;Kuryr
 	NetworkType string `json:"networkType"`
 
 	// externalIP defines configuration for controllers that

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1011,7 +1011,7 @@ var map_NetworkSpec = map[string]string{
 	"":                     "NetworkSpec is the desired network configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.",
 	"clusterNetwork":       "IP address pool to use for pod IPs. This field is immutable after installation.",
 	"serviceNetwork":       "IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.",
-	"networkType":          "NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.",
+	"networkType":          "NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN, OVNKubernetes, Kuryr. This field is immutable after installation.",
 	"externalIP":           "externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.",
 	"serviceNodePortRange": "The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.",
 }

--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -326,6 +326,10 @@ spec:
                   description: type is the type of network All NetworkTypes are supported
                     except for NetworkTypeRaw
                   type: string
+                  enum:
+                  - OpenShiftSDN
+                  - OVNKubernetes
+                  - Kuryr
             deployKubeProxy:
               description: deployKubeProxy specifies whether or not a standalone kube-proxy
                 should be deployed by the operator. Some network providers include

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -94,6 +94,7 @@ type ClusterNetworkEntry struct {
 type DefaultNetworkDefinition struct {
 	// type is the type of network
 	// All NetworkTypes are supported except for NetworkTypeRaw
+	// +kubebuilder:validation:Enum=OpenShiftSDN;OVNKubernetes;Kuryr
 	Type NetworkType `json:"type"`
 
 	// openShiftSDNConfig configures the openshift-sdn plugin


### PR DESCRIPTION
Add validation to the 'networkType' field. Allowed values are
'OpenShiftSDN', 'OVNKubernetes' and 'Kuryr'.