### PR TITLE
Bug 1833109: Adding ManagementState property to storage

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -819,6 +819,12 @@ spec:
                       description: region is the GCS location in which your bucket
                         exists. Optional, will be set based on the installed GCS Region.
                       type: string
+                managementState:
+                  description: managementState indicates if the operator manages the
+                    underlying storage unit. If Managed the operator will remove the
+                    storage when this operator gets Removed.
+                  type: string
+                  pattern: ^(Managed|Unmanaged)$
                 pvc:
                   description: pvc represents configuration that uses a PersistentVolumeClaim.
                   type: object
@@ -1097,6 +1103,12 @@ spec:
                       description: region is the GCS location in which your bucket
                         exists. Optional, will be set based on the installed GCS Region.
                       type: string
+                managementState:
+                  description: managementState indicates if the operator manages the
+                    underlying storage unit. If Managed the operator will remove the
+                    storage when this operator gets Removed.
+                  type: string
+                  pattern: ^(Managed|Unmanaged)$
                 pvc:
                   description: pvc represents configuration that uses a PersistentVolumeClaim.
                   type: object
@@ -1214,8 +1226,7 @@ spec:
                         registry.
                       type: string
             storageManaged:
-              description: storageManaged is a boolean which denotes whether or not
-                we created the registry storage medium (such as an S3 bucket).
+              description: storageManaged is deprecated, please refer to Storage.managementState
               type: boolean
             version:
               description: version is the level this availability applies to

--- a/imageregistry/v1/types.go
+++ b/imageregistry/v1/types.go
@@ -16,6 +16,14 @@ type ConfigList struct {
 	Items           []Config `json:"items"`
 }
 
+const (
+	// StorageManagementStateManaged indicates the operator is managing the underlying storage.
+	StorageManagementStateManaged = "Managed"
+	// StorageManagementStateUnmanaged indicates the operator is not managing the underlying
+	// storage.
+	StorageManagementStateUnmanaged = "Unmanaged"
+)
+
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -96,9 +104,7 @@ type ImageRegistrySpec struct {
 type ImageRegistryStatus struct {
 	operatorv1.OperatorStatus `json:",inline"`
 
-	// storageManaged is a boolean which denotes whether or not
-	// we created the registry storage medium (such as an
-	// S3 bucket).
+	// storageManaged is deprecated, please refer to Storage.managementState
 	StorageManaged bool `json:"storageManaged"`
 	// storage indicates the current applied storage configuration of the
 	// registry.
@@ -283,6 +289,12 @@ type ImageRegistryConfigStorage struct {
 	// azure represents configuration that uses Azure Blob Storage.
 	// +optional
 	Azure *ImageRegistryConfigStorageAzure `json:"azure,omitempty"`
+	// managementState indicates if the operator manages the underlying
+	// storage unit. If Managed the operator will remove the storage when
+	// this operator gets Removed.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^(Managed|Unmanaged)$`
+	ManagementState string `json:"managementState,omitempty"`
 }
 
 // ImageRegistryConfigRequests defines registry limits on requests read and write.

--- a/imageregistry/v1/zz_generated.swagger_doc_generated.go
+++ b/imageregistry/v1/zz_generated.swagger_doc_generated.go
@@ -71,13 +71,14 @@ func (ImageRegistryConfigRoute) SwaggerDoc() map[string]string {
 }
 
 var map_ImageRegistryConfigStorage = map[string]string{
-	"":         "ImageRegistryConfigStorage describes how the storage should be configured for the image registry.",
-	"emptyDir": "emptyDir represents ephemeral storage on the pod's host node. WARNING: this storage cannot be used with more than 1 replica and is not suitable for production use. When the pod is removed from a node for any reason, the data in the emptyDir is deleted forever.",
-	"s3":       "s3 represents configuration that uses Amazon Simple Storage Service.",
-	"gcs":      "gcs represents configuration that uses Google Cloud Storage.",
-	"swift":    "swift represents configuration that uses OpenStack Object Storage.",
-	"pvc":      "pvc represents configuration that uses a PersistentVolumeClaim.",
-	"azure":    "azure represents configuration that uses Azure Blob Storage.",
+	"":                "ImageRegistryConfigStorage describes how the storage should be configured for the image registry.",
+	"emptyDir":        "emptyDir represents ephemeral storage on the pod's host node. WARNING: this storage cannot be used with more than 1 replica and is not suitable for production use. When the pod is removed from a node for any reason, the data in the emptyDir is deleted forever.",
+	"s3":              "s3 represents configuration that uses Amazon Simple Storage Service.",
+	"gcs":             "gcs represents configuration that uses Google Cloud Storage.",
+	"swift":           "swift represents configuration that uses OpenStack Object Storage.",
+	"pvc":             "pvc represents configuration that uses a PersistentVolumeClaim.",
+	"azure":           "azure represents configuration that uses Azure Blob Storage.",
+	"managementState": "managementState indicates if the operator manages the underlying storage unit. If Managed the operator will remove the storage when this operator gets Removed.",
 }
 
 func (ImageRegistryConfigStorage) SwaggerDoc() map[string]string {
@@ -193,7 +194,7 @@ func (ImageRegistrySpec) SwaggerDoc() map[string]string {
 
 var map_ImageRegistryStatus = map[string]string{
 	"":               "ImageRegistryStatus reports image registry operational status.",
-	"storageManaged": "storageManaged is a boolean which denotes whether or not we created the registry storage medium (such as an S3 bucket).",
+	"storageManaged": "storageManaged is deprecated, please refer to Storage.managementState",
 	"storage":        "storage indicates the current applied storage configuration of the registry.",
 }
 


### PR DESCRIPTION
ManagementState indicates if the operartor should or not manage the underlying storage. If "Unmanaged" operator won't attempt to remove the storage when its state is set to "Removed".