### PR TITLE
bug 1871890: add current profile annotations to CVO manifests

### DIFF
--- a/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
+++ b/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null
   name: podnetworkconnectivitychecks.controlplane.operator.openshift.io
 spec:


### PR DESCRIPTION
This is matches https://github.com/openshift/enhancements/pull/414 and doesn't change existing behavior


tagging based on previous one.