### PR TITLE
Bug 1808118: Making logging parameter optional

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -39,7 +39,6 @@ spec:
           description: ImageRegistrySpec defines the specs for the running registry.
           type: object
           required:
-          - logging
           - managementState
           - replicas
           properties:

--- a/imageregistry/v1/types.go
+++ b/imageregistry/v1/types.go
@@ -81,6 +81,7 @@ type ImageRegistrySpec struct {
 	// replicas determines the number of registry instances to run.
 	Replicas int32 `json:"replicas"`
 	// logging is deprecated, use logLevel instead.
+	// +optional
 	Logging int64 `json:"logging"`
 	// resources defines the resource requests+limits for the registry pod.
 	// +optional


### PR DESCRIPTION
Logging has been deprecated in favour of LogLevel, therefore this field
is now optional and should so be updated on api accordingly.