### PR TITLE
Bug 1808118: Migrating imageregistry to extensions v1

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -1,11 +1,1287 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: configs.imageregistry.operator.openshift.io
 spec:
   group: imageregistry.operator.openshift.io
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: Config is the configuration object for a registry instance managed
+          by the registry operator
+        type: object
+        required:
+        - metadata
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageRegistrySpec defines the specs for the running registry.
+            type: object
+            required:
+            - logging
+            - managementState
+            - replicas
+            properties:
+              affinity:
+                description: affinity is a group of node affinity scheduling rules
+                  for the image registry pod(s).
+                type: object
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    type: object
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        type: array
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          type: object
+                          required:
+                          - preference
+                          - weight
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  type: array
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  type: array
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              type: integer
+                              format: int32
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        type: object
+                        required:
+                        - nodeSelectorTerms
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            type: array
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  type: array
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  type: array
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    type: object
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        type: array
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          type: object
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              type: object
+                              required:
+                              - topologyKey
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      type: array
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        type: object
+                                        required:
+                                        - key
+                                        - operator
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  type: array
+                                  items:
+                                    type: string
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              type: integer
+                              format: int32
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        type: array
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          type: object
+                          required:
+                          - topologyKey
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  type: array
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              type: array
+                              items:
+                                type: string
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    type: object
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        type: array
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          type: object
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              type: object
+                              required:
+                              - topologyKey
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      type: array
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        type: object
+                                        required:
+                                        - key
+                                        - operator
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  type: array
+                                  items:
+                                    type: string
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              type: integer
+                              format: int32
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        type: array
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          type: object
+                          required:
+                          - topologyKey
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  type: array
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              type: array
+                              items:
+                                type: string
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+              defaultRoute:
+                description: defaultRoute indicates whether an external facing route
+                  for the registry should be created using the default generated hostname.
+                type: boolean
+              disableRedirect:
+                description: disableRedirect controls whether to route all data through
+                  the Registry, rather than redirecting to the backend.
+                type: boolean
+              httpSecret:
+                description: httpSecret is the value needed by the registry to secure
+                  uploads, generated by default.
+                type: string
+              logLevel:
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                type: string
+                default: Normal
+              logging:
+                description: logging is deprecated, use logLevel instead.
+                type: integer
+                format: int64
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                type: string
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+              nodeSelector:
+                description: nodeSelector defines the node selection constraints for
+                  the registry pod.
+                type: object
+                additionalProperties:
+                  type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                type: object
+                nullable: true
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                description: operatorLogLevel is an intent based logging for the operator
+                  itself.  It does not give fine grained control, but it is a simple
+                  way to manage coarse grained logging choices that operators have
+                  to interpret for themselves.
+                type: string
+              proxy:
+                description: proxy defines the proxy to be used when calling master
+                  api, upstream registries, etc.
+                type: object
+                properties:
+                  http:
+                    description: http defines the proxy to be used by the image registry
+                      when accessing HTTP endpoints.
+                    type: string
+                  https:
+                    description: https defines the proxy to be used by the image registry
+                      when accessing HTTPS endpoints.
+                    type: string
+                  noProxy:
+                    description: noProxy defines a comma-separated list of host names
+                      that shouldn't go through any proxy.
+                    type: string
+              readOnly:
+                description: readOnly indicates whether the registry instance should
+                  reject attempts to push new images or delete existing ones.
+                type: boolean
+              replicas:
+                description: replicas determines the number of registry instances
+                  to run.
+                type: integer
+                format: int32
+              requests:
+                description: requests controls how many parallel requests a given
+                  registry instance will handle before queuing additional requests.
+                type: object
+                properties:
+                  read:
+                    description: read defines limits for image registry's reads.
+                    type: object
+                    properties:
+                      maxInQueue:
+                        description: maxInQueue sets the maximum queued api requests
+                          to the registry.
+                        type: integer
+                      maxRunning:
+                        description: maxRunning sets the maximum in flight api requests
+                          to the registry.
+                        type: integer
+                      maxWaitInQueue:
+                        description: maxWaitInQueue sets the maximum time a request
+                          can wait in the queue before being rejected.
+                        type: string
+                        format: duration
+                  write:
+                    description: write defines limits for image registry's writes.
+                    type: object
+                    properties:
+                      maxInQueue:
+                        description: maxInQueue sets the maximum queued api requests
+                          to the registry.
+                        type: integer
+                      maxRunning:
+                        description: maxRunning sets the maximum in flight api requests
+                          to the registry.
+                        type: integer
+                      maxWaitInQueue:
+                        description: maxWaitInQueue sets the maximum time a request
+                          can wait in the queue before being rejected.
+                        type: string
+                        format: duration
+              resources:
+                description: resources defines the resource requests+limits for the
+                  registry pod.
+                type: object
+                properties:
+                  limits:
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                    additionalProperties:
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                  requests:
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                    additionalProperties:
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+              rolloutStrategy:
+                description: rolloutStrategy defines rollout strategy for the image
+                  registry deployment.
+                type: string
+                pattern: ^(RollingUpdate|Recreate)$
+              routes:
+                description: routes defines additional external facing routes which
+                  should be created for the registry.
+                type: array
+                items:
+                  description: ImageRegistryConfigRoute holds information on external
+                    route access to image registry.
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    hostname:
+                      description: hostname for the route.
+                      type: string
+                    name:
+                      description: name of the route to be created.
+                      type: string
+                    secretName:
+                      description: secretName points to secret containing the certificates
+                        to be used by the route.
+                      type: string
+              storage:
+                description: storage details for configuring registry storage, e.g.
+                  S3 bucket coordinates.
+                type: object
+                properties:
+                  azure:
+                    description: azure represents configuration that uses Azure Blob
+                      Storage.
+                    type: object
+                    properties:
+                      accountName:
+                        description: accountName defines the account to be used by
+                          the registry.
+                        type: string
+                      cloudName:
+                        description: cloudName is the name of the Azure cloud environment
+                          to be used by the registry. If empty, the operator will
+                          set it based on the infrastructure object.
+                        type: string
+                      container:
+                        description: container defines Azure's container to be used
+                          by registry.
+                        type: string
+                        maxLength: 63
+                        minLength: 3
+                        pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
+                  emptyDir:
+                    description: 'emptyDir represents ephemeral storage on the pod''s
+                      host node. WARNING: this storage cannot be used with more than
+                      1 replica and is not suitable for production use. When the pod
+                      is removed from a node for any reason, the data in the emptyDir
+                      is deleted forever.'
+                    type: object
+                  gcs:
+                    description: gcs represents configuration that uses Google Cloud
+                      Storage.
+                    type: object
+                    properties:
+                      bucket:
+                        description: bucket is the bucket name in which you want to
+                          store the registry's data. Optional, will be generated if
+                          not provided.
+                        type: string
+                      keyID:
+                        description: keyID is the KMS key ID to use for encryption.
+                          Optional, buckets are encrypted by default on GCP. This
+                          allows for the use of a custom encryption key.
+                        type: string
+                      projectID:
+                        description: projectID is the Project ID of the GCP project
+                          that this bucket should be associated with.
+                        type: string
+                      region:
+                        description: region is the GCS location in which your bucket
+                          exists. Optional, will be set based on the installed GCS
+                          Region.
+                        type: string
+                  managementState:
+                    description: managementState indicates if the operator manages
+                      the underlying storage unit. If Managed the operator will remove
+                      the storage when this operator gets Removed.
+                    type: string
+                    pattern: ^(Managed|Unmanaged)$
+                  pvc:
+                    description: pvc represents configuration that uses a PersistentVolumeClaim.
+                    type: object
+                    properties:
+                      claim:
+                        description: claim defines the Persisent Volume Claim's name
+                          to be used.
+                        type: string
+                  s3:
+                    description: s3 represents configuration that uses Amazon Simple
+                      Storage Service.
+                    type: object
+                    properties:
+                      bucket:
+                        description: bucket is the bucket name in which you want to
+                          store the registry's data. Optional, will be generated if
+                          not provided.
+                        type: string
+                      cloudFront:
+                        description: cloudFront configures Amazon Cloudfront as the
+                          storage middleware in a registry.
+                        type: object
+                        required:
+                        - baseURL
+                        - keypairID
+                        - privateKey
+                        properties:
+                          baseURL:
+                            description: baseURL contains the SCHEME://HOST[/PATH]
+                              at which Cloudfront is served.
+                            type: string
+                          duration:
+                            description: duration is the duration of the Cloudfront
+                              session.
+                            type: string
+                            format: duration
+                          keypairID:
+                            description: keypairID is key pair ID provided by AWS.
+                            type: string
+                          privateKey:
+                            description: privateKey points to secret containing the
+                              private key, provided by AWS.
+                            type: object
+                            required:
+                            - key
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                      encrypt:
+                        description: encrypt specifies whether the registry stores
+                          the image in encrypted format or not. Optional, defaults
+                          to false.
+                        type: boolean
+                      keyID:
+                        description: keyID is the KMS key ID to use for encryption.
+                          Optional, Encrypt must be true, or this parameter is ignored.
+                        type: string
+                      region:
+                        description: region is the AWS region in which your bucket
+                          exists. Optional, will be set based on the installed AWS
+                          Region.
+                        type: string
+                      regionEndpoint:
+                        description: regionEndpoint is the endpoint for S3 compatible
+                          storage services. Optional, defaults based on the Region
+                          that is provided.
+                        type: string
+                      virtualHostedStyle:
+                        description: virtualHostedStyle enables using S3 virtual hosted
+                          style bucket paths with a custom RegionEndpoint Optional,
+                          defaults to false.
+                        type: boolean
+                  swift:
+                    description: swift represents configuration that uses OpenStack
+                      Object Storage.
+                    type: object
+                    properties:
+                      authURL:
+                        description: authURL defines the URL for obtaining an authentication
+                          token.
+                        type: string
+                      authVersion:
+                        description: authVersion specifies the OpenStack Auth's version.
+                        type: string
+                      container:
+                        description: container defines the name of Swift container
+                          where to store the registry's data.
+                        type: string
+                      domain:
+                        description: domain specifies Openstack's domain name for
+                          Identity v3 API.
+                        type: string
+                      domainID:
+                        description: domainID specifies Openstack's domain id for
+                          Identity v3 API.
+                        type: string
+                      regionName:
+                        description: regionName defines Openstack's region in which
+                          container exists.
+                        type: string
+                      tenant:
+                        description: tenant defines Openstack tenant name to be used
+                          by registry.
+                        type: string
+                      tenantID:
+                        description: tenant defines Openstack tenant id to be used
+                          by registry.
+                        type: string
+              tolerations:
+                description: tolerations defines the tolerations for the registry
+                  pod.
+                type: array
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  type: object
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      type: integer
+                      format: int64
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                type: object
+                nullable: true
+                x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: ImageRegistryStatus reports image registry operational status.
+            type: object
+            required:
+            - storage
+            - storageManaged
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                type: array
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  type: object
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                type: array
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  type: object
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      type: integer
+                      format: int64
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                type: integer
+                format: int64
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                type: integer
+                format: int32
+              storage:
+                description: storage indicates the current applied storage configuration
+                  of the registry.
+                type: object
+                properties:
+                  azure:
+                    description: azure represents configuration that uses Azure Blob
+                      Storage.
+                    type: object
+                    properties:
+                      accountName:
+                        description: accountName defines the account to be used by
+                          the registry.
+                        type: string
+                      cloudName:
+                        description: cloudName is the name of the Azure cloud environment
+                          to be used by the registry. If empty, the operator will
+                          set it based on the infrastructure object.
+                        type: string
+                      container:
+                        description: container defines Azure's container to be used
+                          by registry.
+                        type: string
+                        maxLength: 63
+                        minLength: 3
+                        pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
+                  emptyDir:
+                    description: 'emptyDir represents ephemeral storage on the pod''s
+                      host node. WARNING: this storage cannot be used with more than
+                      1 replica and is not suitable for production use. When the pod
+                      is removed from a node for any reason, the data in the emptyDir
+                      is deleted forever.'
+                    type: object
+                  gcs:
+                    description: gcs represents configuration that uses Google Cloud
+                      Storage.
+                    type: object
+                    properties:
+                      bucket:
+                        description: bucket is the bucket name in which you want to
+                          store the registry's data. Optional, will be generated if
+                          not provided.
+                        type: string
+                      keyID:
+                        description: keyID is the KMS key ID to use for encryption.
+                          Optional, buckets are encrypted by default on GCP. This
+                          allows for the use of a custom encryption key.
+                        type: string
+                      projectID:
+                        description: projectID is the Project ID of the GCP project
+                          that this bucket should be associated with.
+                        type: string
+                      region:
+                        description: region is the GCS location in which your bucket
+                          exists. Optional, will be set based on the installed GCS
+                          Region.
+                        type: string
+                  managementState:
+                    description: managementState indicates if the operator manages
+                      the underlying storage unit. If Managed the operator will remove
+                      the storage when this operator gets Removed.
+                    type: string
+                    pattern: ^(Managed|Unmanaged)$
+                  pvc:
+                    description: pvc represents configuration that uses a PersistentVolumeClaim.
+                    type: object
+                    properties:
+                      claim:
+                        description: claim defines the Persisent Volume Claim's name
+                          to be used.
+                        type: string
+                  s3:
+                    description: s3 represents configuration that uses Amazon Simple
+                      Storage Service.
+                    type: object
+                    properties:
+                      bucket:
+                        description: bucket is the bucket name in which you want to
+                          store the registry's data. Optional, will be generated if
+                          not provided.
+                        type: string
+                      cloudFront:
+                        description: cloudFront configures Amazon Cloudfront as the
+                          storage middleware in a registry.
+                        type: object
+                        required:
+                        - baseURL
+                        - keypairID
+                        - privateKey
+                        properties:
+                          baseURL:
+                            description: baseURL contains the SCHEME://HOST[/PATH]
+                              at which Cloudfront is served.
+                            type: string
+                          duration:
+                            description: duration is the duration of the Cloudfront
+                              session.
+                            type: string
+                            format: duration
+                          keypairID:
+                            description: keypairID is key pair ID provided by AWS.
+                            type: string
+                          privateKey:
+                            description: privateKey points to secret containing the
+                              private key, provided by AWS.
+                            type: object
+                            required:
+                            - key
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                      encrypt:
+                        description: encrypt specifies whether the registry stores
+                          the image in encrypted format or not. Optional, defaults
+                          to false.
+                        type: boolean
+                      keyID:
+                        description: keyID is the KMS key ID to use for encryption.
+                          Optional, Encrypt must be true, or this parameter is ignored.
+                        type: string
+                      region:
+                        description: region is the AWS region in which your bucket
+                          exists. Optional, will be set based on the installed AWS
+                          Region.
+                        type: string
+                      regionEndpoint:
+                        description: regionEndpoint is the endpoint for S3 compatible
+                          storage services. Optional, defaults based on the Region
+                          that is provided.
+                        type: string
+                      virtualHostedStyle:
+                        description: virtualHostedStyle enables using S3 virtual hosted
+                          style bucket paths with a custom RegionEndpoint Optional,
+                          defaults to false.
+                        type: boolean
+                  swift:
+                    description: swift represents configuration that uses OpenStack
+                      Object Storage.
+                    type: object
+                    properties:
+                      authURL:
+                        description: authURL defines the URL for obtaining an authentication
+                          token.
+                        type: string
+                      authVersion:
+                        description: authVersion specifies the OpenStack Auth's version.
+                        type: string
+                      container:
+                        description: container defines the name of Swift container
+                          where to store the registry's data.
+                        type: string
+                      domain:
+                        description: domain specifies Openstack's domain name for
+                          Identity v3 API.
+                        type: string
+                      domainID:
+                        description: domainID specifies Openstack's domain id for
+                          Identity v3 API.
+                        type: string
+                      regionName:
+                        description: regionName defines Openstack's region in which
+                          container exists.
+                        type: string
+                      tenant:
+                        description: tenant defines Openstack tenant name to be used
+                          by registry.
+                        type: string
+                      tenantID:
+                        description: tenant defines Openstack tenant id to be used
+                          by registry.
+                        type: string
+              storageManaged:
+                description: storageManaged is deprecated, please refer to Storage.managementState
+                type: boolean
+              version:
+                description: version is the level this availability applies to
+                type: string
   names:
     kind: Config
     listKind: ConfigList
@@ -14,1247 +1290,3 @@ spec:
   preserveUnknownFields: false
   subresources:
     status: {}
-  validation:
-    openAPIV3Schema:
-      description: Config is the configuration object for a registry instance managed
-        by the registry operator
-      type: object
-      required:
-      - metadata
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ImageRegistrySpec defines the specs for the running registry.
-          type: object
-          required:
-          - logging
-          - managementState
-          - replicas
-          properties:
-            affinity:
-              description: affinity is a group of node affinity scheduling rules for
-                the image registry pod(s).
-              type: object
-              properties:
-                nodeAffinity:
-                  description: Describes node affinity scheduling rules for the pod.
-                  type: object
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node matches the corresponding matchExpressions; the
-                        node(s) with the highest sum are the most preferred.
-                      type: array
-                      items:
-                        description: An empty preferred scheduling term matches all
-                          objects with implicit weight 0 (i.e. it's a no-op). A null
-                          preferred scheduling term matches no objects (i.e. is also
-                          a no-op).
-                        type: object
-                        required:
-                        - preference
-                        - weight
-                        properties:
-                          preference:
-                            description: A node selector term, associated with the
-                              corresponding weight.
-                            type: object
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                type: array
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                type: array
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                          weight:
-                            description: Weight associated with matching the corresponding
-                              nodeSelectorTerm, in the range 1-100.
-                            type: integer
-                            format: int32
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to an update), the system may or may not try to
-                        eventually evict the pod from its node.
-                      type: object
-                      required:
-                      - nodeSelectorTerms
-                      properties:
-                        nodeSelectorTerms:
-                          description: Required. A list of node selector terms. The
-                            terms are ORed.
-                          type: array
-                          items:
-                            description: A null or empty node selector term matches
-                              no objects. The requirements of them are ANDed. The
-                              TopologySelectorTerm type implements a subset of the
-                              NodeSelectorTerm.
-                            type: object
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                type: array
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                type: array
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                podAffinity:
-                  description: Describes pod affinity scheduling rules (e.g. co-locate
-                    this pod in the same node, zone, etc. as some other pod(s)).
-                  type: object
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      type: array
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        type: object
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            type: object
-                            required:
-                            - topologyKey
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    type: array
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                      - key
-                                      - operator
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchLabels:
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                type: array
-                                items:
-                                  type: string
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            type: integer
-                            format: int32
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      type: array
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        type: object
-                        required:
-                        - topologyKey
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            type: object
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                type: array
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                              matchLabels:
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                                additionalProperties:
-                                  type: string
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            type: array
-                            items:
-                              type: string
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                podAntiAffinity:
-                  description: Describes pod anti-affinity scheduling rules (e.g.
-                    avoid putting this pod in the same node, zone, etc. as some other
-                    pod(s)).
-                  type: object
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the anti-affinity expressions specified by this
-                        field, but it may choose a node that violates one or more
-                        of the expressions. The node that is most preferred is the
-                        one with the greatest sum of weights, i.e. for each node that
-                        meets all of the scheduling requirements (resource request,
-                        requiredDuringScheduling anti-affinity expressions, etc.),
-                        compute a sum by iterating through the elements of this field
-                        and adding "weight" to the sum if the node has pods which
-                        matches the corresponding podAffinityTerm; the node(s) with
-                        the highest sum are the most preferred.
-                      type: array
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        type: object
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            type: object
-                            required:
-                            - topologyKey
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    type: array
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                      - key
-                                      - operator
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchLabels:
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                type: array
-                                items:
-                                  type: string
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            type: integer
-                            format: int32
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the anti-affinity requirements specified by
-                        this field are not met at scheduling time, the pod will not
-                        be scheduled onto the node. If the anti-affinity requirements
-                        specified by this field cease to be met at some point during
-                        pod execution (e.g. due to a pod label update), the system
-                        may or may not try to eventually evict the pod from its node.
-                        When there are multiple elements, the lists of nodes corresponding
-                        to each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      type: array
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        type: object
-                        required:
-                        - topologyKey
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            type: object
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                type: array
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                              matchLabels:
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                                additionalProperties:
-                                  type: string
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            type: array
-                            items:
-                              type: string
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-            defaultRoute:
-              description: defaultRoute indicates whether an external facing route
-                for the registry should be created using the default generated hostname.
-              type: boolean
-            disableRedirect:
-              description: disableRedirect controls whether to route all data through
-                the Registry, rather than redirecting to the backend.
-              type: boolean
-            httpSecret:
-              description: httpSecret is the value needed by the registry to secure
-                uploads, generated by default.
-              type: string
-            logLevel:
-              description: "logLevel is an intent based logging for an overall component.
-                \ It does not give fine grained control, but it is a simple way to
-                manage coarse grained logging choices that operators have to interpret
-                for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\",
-                \"TraceAll\". Defaults to \"Normal\"."
-              type: string
-              default: Normal
-            logging:
-              description: logging is deprecated, use logLevel instead.
-              type: integer
-              format: int64
-            managementState:
-              description: managementState indicates whether and how the operator
-                should manage the component
-              type: string
-              pattern: ^(Managed|Unmanaged|Force|Removed)$
-            nodeSelector:
-              description: nodeSelector defines the node selection constraints for
-                the registry pod.
-              type: object
-              additionalProperties:
-                type: string
-            observedConfig:
-              description: observedConfig holds a sparse config that controller has
-                observed from the cluster state.  It exists in spec because it is
-                an input to the level for the operator
-              type: object
-              nullable: true
-              x-kubernetes-preserve-unknown-fields: true
-            operatorLogLevel:
-              description: operatorLogLevel is an intent based logging for the operator
-                itself.  It does not give fine grained control, but it is a simple
-                way to manage coarse grained logging choices that operators have to
-                interpret for themselves.
-              type: string
-            proxy:
-              description: proxy defines the proxy to be used when calling master
-                api, upstream registries, etc.
-              type: object
-              properties:
-                http:
-                  description: http defines the proxy to be used by the image registry
-                    when accessing HTTP endpoints.
-                  type: string
-                https:
-                  description: https defines the proxy to be used by the image registry
-                    when accessing HTTPS endpoints.
-                  type: string
-                noProxy:
-                  description: noProxy defines a comma-separated list of host names
-                    that shouldn't go through any proxy.
-                  type: string
-            readOnly:
-              description: readOnly indicates whether the registry instance should
-                reject attempts to push new images or delete existing ones.
-              type: boolean
-            replicas:
-              description: replicas determines the number of registry instances to
-                run.
-              type: integer
-              format: int32
-            requests:
-              description: requests controls how many parallel requests a given registry
-                instance will handle before queuing additional requests.
-              type: object
-              properties:
-                read:
-                  description: read defines limits for image registry's reads.
-                  type: object
-                  properties:
-                    maxInQueue:
-                      description: maxInQueue sets the maximum queued api requests
-                        to the registry.
-                      type: integer
-                    maxRunning:
-                      description: maxRunning sets the maximum in flight api requests
-                        to the registry.
-                      type: integer
-                    maxWaitInQueue:
-                      description: maxWaitInQueue sets the maximum time a request
-                        can wait in the queue before being rejected.
-                      type: string
-                      format: duration
-                write:
-                  description: write defines limits for image registry's writes.
-                  type: object
-                  properties:
-                    maxInQueue:
-                      description: maxInQueue sets the maximum queued api requests
-                        to the registry.
-                      type: integer
-                    maxRunning:
-                      description: maxRunning sets the maximum in flight api requests
-                        to the registry.
-                      type: integer
-                    maxWaitInQueue:
-                      description: maxWaitInQueue sets the maximum time a request
-                        can wait in the queue before being rejected.
-                      type: string
-                      format: duration
-            resources:
-              description: resources defines the resource requests+limits for the
-                registry pod.
-              type: object
-              properties:
-                limits:
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                  additionalProperties:
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    x-kubernetes-int-or-string: true
-                requests:
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                  additionalProperties:
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    x-kubernetes-int-or-string: true
-            rolloutStrategy:
-              description: rolloutStrategy defines rollout strategy for the image
-                registry deployment.
-              type: string
-              pattern: ^(RollingUpdate|Recreate)$
-            routes:
-              description: routes defines additional external facing routes which
-                should be created for the registry.
-              type: array
-              items:
-                description: ImageRegistryConfigRoute holds information on external
-                  route access to image registry.
-                type: object
-                required:
-                - name
-                properties:
-                  hostname:
-                    description: hostname for the route.
-                    type: string
-                  name:
-                    description: name of the route to be created.
-                    type: string
-                  secretName:
-                    description: secretName points to secret containing the certificates
-                      to be used by the route.
-                    type: string
-            storage:
-              description: storage details for configuring registry storage, e.g.
-                S3 bucket coordinates.
-              type: object
-              properties:
-                azure:
-                  description: azure represents configuration that uses Azure Blob
-                    Storage.
-                  type: object
-                  properties:
-                    accountName:
-                      description: accountName defines the account to be used by the
-                        registry.
-                      type: string
-                    cloudName:
-                      description: cloudName is the name of the Azure cloud environment
-                        to be used by the registry. If empty, the operator will set
-                        it based on the infrastructure object.
-                      type: string
-                    container:
-                      description: container defines Azure's container to be used
-                        by registry.
-                      type: string
-                      maxLength: 63
-                      minLength: 3
-                      pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
-                emptyDir:
-                  description: 'emptyDir represents ephemeral storage on the pod''s
-                    host node. WARNING: this storage cannot be used with more than
-                    1 replica and is not suitable for production use. When the pod
-                    is removed from a node for any reason, the data in the emptyDir
-                    is deleted forever.'
-                  type: object
-                gcs:
-                  description: gcs represents configuration that uses Google Cloud
-                    Storage.
-                  type: object
-                  properties:
-                    bucket:
-                      description: bucket is the bucket name in which you want to
-                        store the registry's data. Optional, will be generated if
-                        not provided.
-                      type: string
-                    keyID:
-                      description: keyID is the KMS key ID to use for encryption.
-                        Optional, buckets are encrypted by default on GCP. This allows
-                        for the use of a custom encryption key.
-                      type: string
-                    projectID:
-                      description: projectID is the Project ID of the GCP project
-                        that this bucket should be associated with.
-                      type: string
-                    region:
-                      description: region is the GCS location in which your bucket
-                        exists. Optional, will be set based on the installed GCS Region.
-                      type: string
-                managementState:
-                  description: managementState indicates if the operator manages the
-                    underlying storage unit. If Managed the operator will remove the
-                    storage when this operator gets Removed.
-                  type: string
-                  pattern: ^(Managed|Unmanaged)$
-                pvc:
-                  description: pvc represents configuration that uses a PersistentVolumeClaim.
-                  type: object
-                  properties:
-                    claim:
-                      description: claim defines the Persisent Volume Claim's name
-                        to be used.
-                      type: string
-                s3:
-                  description: s3 represents configuration that uses Amazon Simple
-                    Storage Service.
-                  type: object
-                  properties:
-                    bucket:
-                      description: bucket is the bucket name in which you want to
-                        store the registry's data. Optional, will be generated if
-                        not provided.
-                      type: string
-                    cloudFront:
-                      description: cloudFront configures Amazon Cloudfront as the
-                        storage middleware in a registry.
-                      type: object
-                      required:
-                      - baseURL
-                      - keypairID
-                      - privateKey
-                      properties:
-                        baseURL:
-                          description: baseURL contains the SCHEME://HOST[/PATH] at
-                            which Cloudfront is served.
-                          type: string
-                        duration:
-                          description: duration is the duration of the Cloudfront
-                            session.
-                          type: string
-                          format: duration
-                        keypairID:
-                          description: keypairID is key pair ID provided by AWS.
-                          type: string
-                        privateKey:
-                          description: privateKey points to secret containing the
-                            private key, provided by AWS.
-                          type: object
-                          required:
-                          - key
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                    encrypt:
-                      description: encrypt specifies whether the registry stores the
-                        image in encrypted format or not. Optional, defaults to false.
-                      type: boolean
-                    keyID:
-                      description: keyID is the KMS key ID to use for encryption.
-                        Optional, Encrypt must be true, or this parameter is ignored.
-                      type: string
-                    region:
-                      description: region is the AWS region in which your bucket exists.
-                        Optional, will be set based on the installed AWS Region.
-                      type: string
-                    regionEndpoint:
-                      description: regionEndpoint is the endpoint for S3 compatible
-                        storage services. Optional, defaults based on the Region that
-                        is provided.
-                      type: string
-                    virtualHostedStyle:
-                      description: virtualHostedStyle enables using S3 virtual hosted
-                        style bucket paths with a custom RegionEndpoint Optional,
-                        defaults to false.
-                      type: boolean
-                swift:
-                  description: swift represents configuration that uses OpenStack
-                    Object Storage.
-                  type: object
-                  properties:
-                    authURL:
-                      description: authURL defines the URL for obtaining an authentication
-                        token.
-                      type: string
-                    authVersion:
-                      description: authVersion specifies the OpenStack Auth's version.
-                      type: string
-                    container:
-                      description: container defines the name of Swift container where
-                        to store the registry's data.
-                      type: string
-                    domain:
-                      description: domain specifies Openstack's domain name for Identity
-                        v3 API.
-                      type: string
-                    domainID:
-                      description: domainID specifies Openstack's domain id for Identity
-                        v3 API.
-                      type: string
-                    regionName:
-                      description: regionName defines Openstack's region in which
-                        container exists.
-                      type: string
-                    tenant:
-                      description: tenant defines Openstack tenant name to be used
-                        by registry.
-                      type: string
-                    tenantID:
-                      description: tenant defines Openstack tenant id to be used by
-                        registry.
-                      type: string
-            tolerations:
-              description: tolerations defines the tolerations for the registry pod.
-              type: array
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                type: object
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    type: integer
-                    format: int64
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-            unsupportedConfigOverrides:
-              description: 'unsupportedConfigOverrides holds a sparse config that
-                will override any previously set options.  It only needs to be the
-                fields to override it will end up overlaying in the following order:
-                1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
-              type: object
-              nullable: true
-              x-kubernetes-preserve-unknown-fields: true
-        status:
-          description: ImageRegistryStatus reports image registry operational status.
-          type: object
-          required:
-          - storage
-          - storageManaged
-          properties:
-            conditions:
-              description: conditions is a list of conditions and their status
-              type: array
-              items:
-                description: OperatorCondition is just the standard condition fields.
-                type: object
-                properties:
-                  lastTransitionTime:
-                    type: string
-                    format: date-time
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-            generations:
-              description: generations are used to determine when an item needs to
-                be reconciled or has changed in a way that needs a reaction.
-              type: array
-              items:
-                description: GenerationStatus keeps track of the generation for a
-                  given resource so that decisions about forced updates can be made.
-                type: object
-                properties:
-                  group:
-                    description: group is the group of the thing you're tracking
-                    type: string
-                  hash:
-                    description: hash is an optional field set for resources without
-                      generation that are content sensitive like secrets and configmaps
-                    type: string
-                  lastGeneration:
-                    description: lastGeneration is the last generation of the workload
-                      controller involved
-                    type: integer
-                    format: int64
-                  name:
-                    description: name is the name of the thing you're tracking
-                    type: string
-                  namespace:
-                    description: namespace is where the thing you're tracking is
-                    type: string
-                  resource:
-                    description: resource is the resource type of the thing you're
-                      tracking
-                    type: string
-            observedGeneration:
-              description: observedGeneration is the last generation change you've
-                dealt with
-              type: integer
-              format: int64
-            readyReplicas:
-              description: readyReplicas indicates how many replicas are ready and
-                at the desired state
-              type: integer
-              format: int32
-            storage:
-              description: storage indicates the current applied storage configuration
-                of the registry.
-              type: object
-              properties:
-                azure:
-                  description: azure represents configuration that uses Azure Blob
-                    Storage.
-                  type: object
-                  properties:
-                    accountName:
-                      description: accountName defines the account to be used by the
-                        registry.
-                      type: string
-                    cloudName:
-                      description: cloudName is the name of the Azure cloud environment
-                        to be used by the registry. If empty, the operator will set
-                        it based on the infrastructure object.
-                      type: string
-                    container:
-                      description: container defines Azure's container to be used
-                        by registry.
-                      type: string
-                      maxLength: 63
-                      minLength: 3
-                      pattern: ^[0-9a-z]+(-[0-9a-z]+)*$
-                emptyDir:
-                  description: 'emptyDir represents ephemeral storage on the pod''s
-                    host node. WARNING: this storage cannot be used with more than
-                    1 replica and is not suitable for production use. When the pod
-                    is removed from a node for any reason, the data in the emptyDir
-                    is deleted forever.'
-                  type: object
-                gcs:
-                  description: gcs represents configuration that uses Google Cloud
-                    Storage.
-                  type: object
-                  properties:
-                    bucket:
-                      description: bucket is the bucket name in which you want to
-                        store the registry's data. Optional, will be generated if
-                        not provided.
-                      type: string
-                    keyID:
-                      description: keyID is the KMS key ID to use for encryption.
-                        Optional, buckets are encrypted by default on GCP. This allows
-                        for the use of a custom encryption key.
-                      type: string
-                    projectID:
-                      description: projectID is the Project ID of the GCP project
-                        that this bucket should be associated with.
-                      type: string
-                    region:
-                      description: region is the GCS location in which your bucket
-                        exists. Optional, will be set based on the installed GCS Region.
-                      type: string
-                managementState:
-                  description: managementState indicates if the operator manages the
-                    underlying storage unit. If Managed the operator will remove the
-                    storage when this operator gets Removed.
-                  type: string
-                  pattern: ^(Managed|Unmanaged)$
-                pvc:
-                  description: pvc represents configuration that uses a PersistentVolumeClaim.
-                  type: object
-                  properties:
-                    claim:
-                      description: claim defines the Persisent Volume Claim's name
-                        to be used.
-                      type: string
-                s3:
-                  description: s3 represents configuration that uses Amazon Simple
-                    Storage Service.
-                  type: object
-                  properties:
-                    bucket:
-                      description: bucket is the bucket name in which you want to
-                        store the registry's data. Optional, will be generated if
-                        not provided.
-                      type: string
-                    cloudFront:
-                      description: cloudFront configures Amazon Cloudfront as the
-                        storage middleware in a registry.
-                      type: object
-                      required:
-                      - baseURL
-                      - keypairID
-                      - privateKey
-                      properties:
-                        baseURL:
-                          description: baseURL contains the SCHEME://HOST[/PATH] at
-                            which Cloudfront is served.
-                          type: string
-                        duration:
-                          description: duration is the duration of the Cloudfront
-                            session.
-                          type: string
-                          format: duration
-                        keypairID:
-                          description: keypairID is key pair ID provided by AWS.
-                          type: string
-                        privateKey:
-                          description: privateKey points to secret containing the
-                            private key, provided by AWS.
-                          type: object
-                          required:
-                          - key
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                    encrypt:
-                      description: encrypt specifies whether the registry stores the
-                        image in encrypted format or not. Optional, defaults to false.
-                      type: boolean
-                    keyID:
-                      description: keyID is the KMS key ID to use for encryption.
-                        Optional, Encrypt must be true, or this parameter is ignored.
-                      type: string
-                    region:
-                      description: region is the AWS region in which your bucket exists.
-                        Optional, will be set based on the installed AWS Region.
-                      type: string
-                    regionEndpoint:
-                      description: regionEndpoint is the endpoint for S3 compatible
-                        storage services. Optional, defaults based on the Region that
-                        is provided.
-                      type: string
-                    virtualHostedStyle:
-                      description: virtualHostedStyle enables using S3 virtual hosted
-                        style bucket paths with a custom RegionEndpoint Optional,
-                        defaults to false.
-                      type: boolean
-                swift:
-                  description: swift represents configuration that uses OpenStack
-                    Object Storage.
-                  type: object
-                  properties:
-                    authURL:
-                      description: authURL defines the URL for obtaining an authentication
-                        token.
-                      type: string
-                    authVersion:
-                      description: authVersion specifies the OpenStack Auth's version.
-                      type: string
-                    container:
-                      description: container defines the name of Swift container where
-                        to store the registry's data.
-                      type: string
-                    domain:
-                      description: domain specifies Openstack's domain name for Identity
-                        v3 API.
-                      type: string
-                    domainID:
-                      description: domainID specifies Openstack's domain id for Identity
-                        v3 API.
-                      type: string
-                    regionName:
-                      description: regionName defines Openstack's region in which
-                        container exists.
-                      type: string
-                    tenant:
-                      description: tenant defines Openstack tenant name to be used
-                        by registry.
-                      type: string
-                    tenantID:
-                      description: tenant defines Openstack tenant id to be used by
-                        registry.
-                      type: string
-            storageManaged:
-              description: storageManaged is deprecated, please refer to Storage.managementState
-              type: boolean
-            version:
-              description: version is the level this availability applies to
-              type: string

--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -9,6 +9,8 @@ spec:
   - name: v1
     served: true
     storage: true
+    subresources:
+      status: {}
     "schema":
       "openAPIV3Schema":
         description: Config is the configuration object for a registry instance managed
@@ -1287,6 +1289,3 @@ spec:
     listKind: ConfigList
     plural: configs
     singular: config
-  preserveUnknownFields: false
-  subresources:
-    status: {}

--- a/imageregistry/v1/01-crd.yaml
+++ b/imageregistry/v1/01-crd.yaml
@@ -9,6 +9,8 @@ spec:
   - name: v1
     served: true
     storage: true
+    subresources:
+      status: {}
     "schema":
       "openAPIV3Schema":
         description: ImagePruner is the configuration object for an image registry
@@ -769,9 +771,6 @@ spec:
                   has been applied.
                 type: integer
                 format: int64
-  preserveUnknownFields: false
-  subresources:
-    status: {}
   names:
     kind: ImagePruner
     listKind: ImagePrunerList

--- a/imageregistry/v1/01-crd.yaml
+++ b/imageregistry/v1/01-crd.yaml
@@ -1,11 +1,774 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: imagepruners.imageregistry.operator.openshift.io
 spec:
   group: imageregistry.operator.openshift.io
   scope: Cluster
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: ImagePruner is the configuration object for an image registry
+          pruner managed by the registry operator.
+        type: object
+        required:
+        - metadata
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImagePrunerSpec defines the specs for the running image pruner.
+            type: object
+            properties:
+              affinity:
+                description: affinity is a group of node affinity scheduling rules
+                  for the image pruner pod.
+                type: object
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    type: object
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        type: array
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
+                          type: object
+                          required:
+                          - preference
+                          - weight
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  type: array
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  type: array
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              type: integer
+                              format: int32
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        type: object
+                        required:
+                        - nodeSelectorTerms
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            type: array
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  type: array
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  type: array
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    type: object
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        type: array
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          type: object
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              type: object
+                              required:
+                              - topologyKey
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      type: array
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        type: object
+                                        required:
+                                        - key
+                                        - operator
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  type: array
+                                  items:
+                                    type: string
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              type: integer
+                              format: int32
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        type: array
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          type: object
+                          required:
+                          - topologyKey
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  type: array
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              type: array
+                              items:
+                                type: string
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    type: object
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        type: array
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          type: object
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              type: object
+                              required:
+                              - topologyKey
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  type: object
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      type: array
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        type: object
+                                        required:
+                                        - key
+                                        - operator
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            type: array
+                                            items:
+                                              type: string
+                                    matchLabels:
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  type: array
+                                  items:
+                                    type: string
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              type: integer
+                              format: int32
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        type: array
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          type: object
+                          required:
+                          - topologyKey
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  type: array
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            namespaces:
+                              description: namespaces specifies which namespaces the
+                                labelSelector applies to (matches against); null or
+                                empty list means "this pod's namespace"
+                              type: array
+                              items:
+                                type: string
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+              failedJobsHistoryLimit:
+                description: failedJobsHistoryLimit specifies how many failed image
+                  pruner jobs to retain. Defaults to 3 if not set.
+                type: integer
+                format: int32
+              ignoreInvalidImageReferences:
+                description: ignoreInvalidImageReferences indicates whether the pruner
+                  can ignore errors while parsing image references.
+                type: boolean
+              keepTagRevisions:
+                description: keepTagRevisions specifies the number of image revisions
+                  for a tag in an image stream that will be preserved. Defaults to
+                  3.
+                type: integer
+              keepYoungerThan:
+                description: 'keepYoungerThan specifies the minimum age in nanoseconds
+                  of an image and its referrers for it to be considered a candidate
+                  for pruning. DEPRECATED: This field is deprecated in favor of keepYoungerThanDuration.
+                  If both are set, this field is ignored and keepYoungerThanDuration
+                  takes precedence.'
+                type: integer
+                format: int64
+              keepYoungerThanDuration:
+                description: keepYoungerThanDuration specifies the minimum age of
+                  an image and its referrers for it to be considered a candidate for
+                  pruning. Defaults to 60m (60 minutes).
+                type: string
+                format: duration
+              nodeSelector:
+                description: nodeSelector defines the node selection constraints for
+                  the image pruner pod.
+                type: object
+                additionalProperties:
+                  type: string
+              resources:
+                description: resources defines the resource requests and limits for
+                  the image pruner pod.
+                type: object
+                properties:
+                  limits:
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                    additionalProperties:
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                  requests:
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                    additionalProperties:
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+              schedule:
+                description: 'schedule specifies when to execute the job using standard
+                  cronjob syntax: https://wikipedia.org/wiki/Cron. Defaults to `0
+                  0 * * *`.'
+                type: string
+              successfulJobsHistoryLimit:
+                description: successfulJobsHistoryLimit specifies how many successful
+                  image pruner jobs to retain. Defaults to 3 if not set.
+                type: integer
+                format: int32
+              suspend:
+                description: suspend specifies whether or not to suspend subsequent
+                  executions of this cronjob. Defaults to false.
+                type: boolean
+              tolerations:
+                description: tolerations defines the node tolerations for the image
+                  pruner pod.
+                type: array
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  type: object
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      type: integer
+                      format: int64
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+          status:
+            description: ImagePrunerStatus reports image pruner operational status.
+            type: object
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status.
+                type: array
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  type: object
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                      format: date-time
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+              observedGeneration:
+                description: observedGeneration is the last generation change that
+                  has been applied.
+                type: integer
+                format: int64
   preserveUnknownFields: false
   subresources:
     status: {}
@@ -14,743 +777,3 @@ spec:
     listKind: ImagePrunerList
     plural: imagepruners
     singular: imagepruner
-  "validation":
-    "openAPIV3Schema":
-      description: ImagePruner is the configuration object for an image registry pruner
-        managed by the registry operator.
-      type: object
-      required:
-      - metadata
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ImagePrunerSpec defines the specs for the running image pruner.
-          type: object
-          properties:
-            affinity:
-              description: affinity is a group of node affinity scheduling rules for
-                the image pruner pod.
-              type: object
-              properties:
-                nodeAffinity:
-                  description: Describes node affinity scheduling rules for the pod.
-                  type: object
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node matches the corresponding matchExpressions; the
-                        node(s) with the highest sum are the most preferred.
-                      type: array
-                      items:
-                        description: An empty preferred scheduling term matches all
-                          objects with implicit weight 0 (i.e. it's a no-op). A null
-                          preferred scheduling term matches no objects (i.e. is also
-                          a no-op).
-                        type: object
-                        required:
-                        - preference
-                        - weight
-                        properties:
-                          preference:
-                            description: A node selector term, associated with the
-                              corresponding weight.
-                            type: object
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                type: array
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                type: array
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                          weight:
-                            description: Weight associated with matching the corresponding
-                              nodeSelectorTerm, in the range 1-100.
-                            type: integer
-                            format: int32
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to an update), the system may or may not try to
-                        eventually evict the pod from its node.
-                      type: object
-                      required:
-                      - nodeSelectorTerms
-                      properties:
-                        nodeSelectorTerms:
-                          description: Required. A list of node selector terms. The
-                            terms are ORed.
-                          type: array
-                          items:
-                            description: A null or empty node selector term matches
-                              no objects. The requirements of them are ANDed. The
-                              TopologySelectorTerm type implements a subset of the
-                              NodeSelectorTerm.
-                            type: object
-                            properties:
-                              matchExpressions:
-                                description: A list of node selector requirements
-                                  by node's labels.
-                                type: array
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                              matchFields:
-                                description: A list of node selector requirements
-                                  by node's fields.
-                                type: array
-                                items:
-                                  description: A node selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: The label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: Represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                      type: string
-                                    values:
-                                      description: An array of string values. If the
-                                        operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be
-                                        empty. If the operator is Gt or Lt, the values
-                                        array must have a single element, which will
-                                        be interpreted as an integer. This array is
-                                        replaced during a strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                podAffinity:
-                  description: Describes pod affinity scheduling rules (e.g. co-locate
-                    this pod in the same node, zone, etc. as some other pod(s)).
-                  type: object
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the affinity expressions specified by this field,
-                        but it may choose a node that violates one or more of the
-                        expressions. The node that is most preferred is the one with
-                        the greatest sum of weights, i.e. for each node that meets
-                        all of the scheduling requirements (resource request, requiredDuringScheduling
-                        affinity expressions, etc.), compute a sum by iterating through
-                        the elements of this field and adding "weight" to the sum
-                        if the node has pods which matches the corresponding podAffinityTerm;
-                        the node(s) with the highest sum are the most preferred.
-                      type: array
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        type: object
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            type: object
-                            required:
-                            - topologyKey
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    type: array
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                      - key
-                                      - operator
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchLabels:
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                type: array
-                                items:
-                                  type: string
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            type: integer
-                            format: int32
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the affinity requirements specified by this
-                        field are not met at scheduling time, the pod will not be
-                        scheduled onto the node. If the affinity requirements specified
-                        by this field cease to be met at some point during pod execution
-                        (e.g. due to a pod label update), the system may or may not
-                        try to eventually evict the pod from its node. When there
-                        are multiple elements, the lists of nodes corresponding to
-                        each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      type: array
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        type: object
-                        required:
-                        - topologyKey
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            type: object
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                type: array
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                              matchLabels:
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                                additionalProperties:
-                                  type: string
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            type: array
-                            items:
-                              type: string
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-                podAntiAffinity:
-                  description: Describes pod anti-affinity scheduling rules (e.g.
-                    avoid putting this pod in the same node, zone, etc. as some other
-                    pod(s)).
-                  type: object
-                  properties:
-                    preferredDuringSchedulingIgnoredDuringExecution:
-                      description: The scheduler will prefer to schedule pods to nodes
-                        that satisfy the anti-affinity expressions specified by this
-                        field, but it may choose a node that violates one or more
-                        of the expressions. The node that is most preferred is the
-                        one with the greatest sum of weights, i.e. for each node that
-                        meets all of the scheduling requirements (resource request,
-                        requiredDuringScheduling anti-affinity expressions, etc.),
-                        compute a sum by iterating through the elements of this field
-                        and adding "weight" to the sum if the node has pods which
-                        matches the corresponding podAffinityTerm; the node(s) with
-                        the highest sum are the most preferred.
-                      type: array
-                      items:
-                        description: The weights of all of the matched WeightedPodAffinityTerm
-                          fields are added per-node to find the most preferred node(s)
-                        type: object
-                        required:
-                        - podAffinityTerm
-                        - weight
-                        properties:
-                          podAffinityTerm:
-                            description: Required. A pod affinity term, associated
-                              with the corresponding weight.
-                            type: object
-                            required:
-                            - topologyKey
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    type: array
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                      - key
-                                      - operator
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchLabels:
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                type: array
-                                items:
-                                  type: string
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                          weight:
-                            description: weight associated with matching the corresponding
-                              podAffinityTerm, in the range 1-100.
-                            type: integer
-                            format: int32
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      description: If the anti-affinity requirements specified by
-                        this field are not met at scheduling time, the pod will not
-                        be scheduled onto the node. If the anti-affinity requirements
-                        specified by this field cease to be met at some point during
-                        pod execution (e.g. due to a pod label update), the system
-                        may or may not try to eventually evict the pod from its node.
-                        When there are multiple elements, the lists of nodes corresponding
-                        to each podAffinityTerm are intersected, i.e. all terms must
-                        be satisfied.
-                      type: array
-                      items:
-                        description: Defines a set of pods (namely those matching
-                          the labelSelector relative to the given namespace(s)) that
-                          this pod should be co-located (affinity) or not co-located
-                          (anti-affinity) with, where co-located is defined as running
-                          on a node whose value of the label with key <topologyKey>
-                          matches that of any node on which a pod of the set of pods
-                          is running
-                        type: object
-                        required:
-                        - topologyKey
-                        properties:
-                          labelSelector:
-                            description: A label query over a set of resources, in
-                              this case pods.
-                            type: object
-                            properties:
-                              matchExpressions:
-                                description: matchExpressions is a list of label selector
-                                  requirements. The requirements are ANDed.
-                                type: array
-                                items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
-                                    relates the key and values.
-                                  type: object
-                                  required:
-                                  - key
-                                  - operator
-                                  properties:
-                                    key:
-                                      description: key is the label key that the selector
-                                        applies to.
-                                      type: string
-                                    operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
-                                      type: string
-                                    values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
-                                      type: array
-                                      items:
-                                        type: string
-                              matchLabels:
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
-                                type: object
-                                additionalProperties:
-                                  type: string
-                          namespaces:
-                            description: namespaces specifies which namespaces the
-                              labelSelector applies to (matches against); null or
-                              empty list means "this pod's namespace"
-                            type: array
-                            items:
-                              type: string
-                          topologyKey:
-                            description: This pod should be co-located (affinity)
-                              or not co-located (anti-affinity) with the pods matching
-                              the labelSelector in the specified namespaces, where
-                              co-located is defined as running on a node whose value
-                              of the label with key topologyKey matches that of any
-                              node on which any of the selected pods is running. Empty
-                              topologyKey is not allowed.
-                            type: string
-            failedJobsHistoryLimit:
-              description: failedJobsHistoryLimit specifies how many failed image
-                pruner jobs to retain. Defaults to 3 if not set.
-              type: integer
-              format: int32
-            ignoreInvalidImageReferences:
-              description: ignoreInvalidImageReferences indicates whether the pruner
-                can ignore errors while parsing image references.
-              type: boolean
-            keepTagRevisions:
-              description: keepTagRevisions specifies the number of image revisions
-                for a tag in an image stream that will be preserved. Defaults to 3.
-              type: integer
-            keepYoungerThan:
-              description: 'keepYoungerThan specifies the minimum age in nanoseconds
-                of an image and its referrers for it to be considered a candidate
-                for pruning. DEPRECATED: This field is deprecated in favor of keepYoungerThanDuration.
-                If both are set, this field is ignored and keepYoungerThanDuration
-                takes precedence.'
-              type: integer
-              format: int64
-            keepYoungerThanDuration:
-              description: keepYoungerThanDuration specifies the minimum age of an
-                image and its referrers for it to be considered a candidate for pruning.
-                Defaults to 60m (60 minutes).
-              type: string
-              format: duration
-            nodeSelector:
-              description: nodeSelector defines the node selection constraints for
-                the image pruner pod.
-              type: object
-              additionalProperties:
-                type: string
-            resources:
-              description: resources defines the resource requests and limits for
-                the image pruner pod.
-              type: object
-              properties:
-                limits:
-                  description: 'Limits describes the maximum amount of compute resources
-                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                  additionalProperties:
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    x-kubernetes-int-or-string: true
-                requests:
-                  description: 'Requests describes the minimum amount of compute resources
-                    required. If Requests is omitted for a container, it defaults
-                    to Limits if that is explicitly specified, otherwise to an implementation-defined
-                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                  type: object
-                  additionalProperties:
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    x-kubernetes-int-or-string: true
-            schedule:
-              description: 'schedule specifies when to execute the job using standard
-                cronjob syntax: https://wikipedia.org/wiki/Cron. Defaults to `0 0
-                * * *`.'
-              type: string
-            successfulJobsHistoryLimit:
-              description: successfulJobsHistoryLimit specifies how many successful
-                image pruner jobs to retain. Defaults to 3 if not set.
-              type: integer
-              format: int32
-            suspend:
-              description: suspend specifies whether or not to suspend subsequent
-                executions of this cronjob. Defaults to false.
-              type: boolean
-            tolerations:
-              description: tolerations defines the node tolerations for the image
-                pruner pod.
-              type: array
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                type: object
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    type: integer
-                    format: int64
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-        status:
-          description: ImagePrunerStatus reports image pruner operational status.
-          type: object
-          properties:
-            conditions:
-              description: conditions is a list of conditions and their status.
-              type: array
-              items:
-                description: OperatorCondition is just the standard condition fields.
-                type: object
-                properties:
-                  lastTransitionTime:
-                    type: string
-                    format: date-time
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-            observedGeneration:
-              description: observedGeneration is the last generation change that has
-                been applied.
-              type: integer
-              format: int64


### PR DESCRIPTION
Some of our types now inherit the Default directive. This directive is incompatible with v1beta1. This PR migrates imageregistry CRDs to v1 instead. The error we are seeing without this migration:

`cannot set default values in apiextensions.k8s.io/v1beta1 CRDs, must use apiextensions.k8s.io/v1`

Default directive was introduced through https://github.com/openshift/api/commit/e9ece8d38ce61a4358550ade3ce33e6baf055f76