### PR TITLE
Bug 1874613: operator/v1: fix scope of ingresscontrollers to be namespaced

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -11,7 +11,7 @@ spec:
     listKind: IngressControllerList
     plural: ingresscontrollers
     singular: ingresscontroller
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     schema:


### PR DESCRIPTION
This got broken while moving to v1.