### PR TITLE
Bug 1878040: Validations for LogLevel fields

### DIFF
--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -651,6 +651,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               logging:
                 description: logging is deprecated, use logLevel instead.
                 type: integer
@@ -674,11 +679,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               proxy:
                 description: proxy defines the proxy to be used when calling master
                   api, upstream registries, etc.

--- a/imageregistry/v1/01-crd.yaml
+++ b/imageregistry/v1/01-crd.yaml
@@ -662,6 +662,11 @@ spec:
                   Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               nodeSelector:
                 description: nodeSelector defines the node selection constraints for
                   the image pruner pod.

--- a/operator/v1/0000_10_config-operator_01_config.crd.yaml
+++ b/operator/v1/0000_10_config-operator_01_config.crd.yaml
@@ -51,6 +51,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -64,11 +69,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that
                   will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_20_etcd-operator_01.crd.yaml
+++ b/operator/v1/0000_20_etcd-operator_01.crd.yaml
@@ -63,6 +63,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -76,11 +81,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               succeededRevisionLimit:
                 description: succeededRevisionLimit is the number of successful static
                   pod installer revisions to keep on disk and in the api -1 = unlimited,

--- a/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
+++ b/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
@@ -54,6 +54,11 @@ spec:
                   to manage coarse grained logging choices that operators have to
                   interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
                 type: string
               managementState:
                 description: managementState indicates whether and how the operator
@@ -68,10 +73,16 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
                 type: string
               succeededRevisionLimit:
                 description: succeededRevisionLimit is the number of successful static

--- a/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
@@ -56,6 +56,11 @@ spec:
                   to manage coarse grained logging choices that operators have to
                   interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
                 type: string
               managementState:
                 description: managementState indicates whether and how the operator
@@ -70,10 +75,16 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
                 type: string
               succeededRevisionLimit:
                 description: succeededRevisionLimit is the number of successful static

--- a/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
@@ -56,6 +56,11 @@ spec:
                   to manage coarse grained logging choices that operators have to
                   interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
                 type: string
               managementState:
                 description: managementState indicates whether and how the operator
@@ -70,10 +75,16 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
                 type: string
               succeededRevisionLimit:
                 description: succeededRevisionLimit is the number of successful static

--- a/operator/v1/0000_30_openshift-apiserver-operator_01_config.crd.yaml
+++ b/operator/v1/0000_30_openshift-apiserver-operator_01_config.crd.yaml
@@ -52,6 +52,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -65,11 +70,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that
                   will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
+++ b/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
@@ -62,6 +62,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -75,11 +80,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that
                   will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_40_kube-storage-version-migrator-operator_00_config.crd.yaml
+++ b/operator/v1/0000_40_kube-storage-version-migrator-operator_00_config.crd.yaml
@@ -49,6 +49,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -62,11 +67,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that
                   will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_50_cluster-authentication-operator_01_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-authentication-operator_01_config.crd.yaml
@@ -48,6 +48,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -61,11 +66,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that
                   will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
@@ -50,6 +50,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -63,11 +68,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that
                   will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
+++ b/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
@@ -49,6 +49,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -62,11 +67,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that
                   will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_50_service-ca-operator_02_crd.yaml
+++ b/operator/v1/0000_50_service-ca-operator_02_crd.yaml
@@ -50,6 +50,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -63,11 +68,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that
                   will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -372,6 +372,11 @@ spec:
                   affected by this setting. Please note that turning on extensive
                   logging may affect performance. The default value is "Normal".
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               serviceNetwork:
                 description: serviceNetwork is the ip address pool to use for Service
                   IPs Currently, all existing network providers only support a single

--- a/operator/v1/0000_70_console-operator.crd.yaml
+++ b/operator/v1/0000_70_console-operator.crd.yaml
@@ -95,6 +95,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -108,11 +113,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               providers:
                 description: providers contains configuration for using specific service
                   providers.

--- a/operator/v1/0000_80_csi_snapshot_controller_operator_01_crd.yaml
+++ b/operator/v1/0000_80_csi_snapshot_controller_operator_01_crd.yaml
@@ -49,6 +49,11 @@ spec:
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
                 default: Normal
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component
@@ -62,11 +67,17 @@ spec:
                 nullable: true
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
                 type: string
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that
                   will override any previously set options.  It only needs to be the

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -49,6 +49,11 @@ spec:
                   to manage coarse grained logging choices that operators have to
                   interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
                   \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
                 type: string
               managementState:
                 description: managementState indicates whether and how the operator
@@ -63,10 +68,16 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               operatorLogLevel:
-                description: operatorLogLevel is an intent based logging for the operator
-                  itself.  It does not give fine grained control, but it is a simple
-                  way to manage coarse grained logging choices that operators have
-                  to interpret for themselves.
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\"."
+                enum:
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
                 type: string
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -60,6 +60,8 @@ type OperatorSpec struct {
 
 	// operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a
 	// simple way to manage coarse grained logging choices that operators have to interpret for themselves.
+	//
+	// Valid values are: "Normal", "Debug", "Trace", "TraceAll".
 	// +optional
 	OperatorLogLevel LogLevel `json:"operatorLogLevel"`
 
@@ -81,6 +83,7 @@ type OperatorSpec struct {
 	ObservedConfig runtime.RawExtension `json:"observedConfig"`
 }
 
+// +kubebuilder:validation:Enum=Normal;Debug;Trace;TraceAll
 type LogLevel string
 
 var (

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -58,7 +58,7 @@ var map_OperatorSpec = map[string]string{
 	"":                           "OperatorSpec contains common fields operators need.  It is intended to be anonymous included inside of the Spec struct for your particular operator.",
 	"managementState":            "managementState indicates whether and how the operator should manage the component",
 	"logLevel":                   "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands.\n\nValid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
-	"operatorLogLevel":           "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves.",
+	"operatorLogLevel":           "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves.\n\nValid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\".",
 	"unsupportedConfigOverrides": "unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides",
 	"observedConfig":             "observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator",
 }


### PR DESCRIPTION
As it is stated on OperatorSpec.LogLevel documentation valid values for the type LogLevel are Normal, Debug, Trace and TraceAll. Adding pattern validation for the LogLevel type seems to make sense.

This affected multiple CRDs, not sure if we can simply enforce this here or what would be the right approach to make sure all other operators comply with them. Other than that I am not sure these validations were omitted on purpose due some unknown reason.