### PR TITLE
Bug 1879592: Add logLevel to imagepruners.imageregistry.operator.openshift.io

### DIFF
--- a/imageregistry/v1/01-crd.yaml
+++ b/imageregistry/v1/01-crd.yaml
@@ -656,6 +656,12 @@ spec:
                   pruning. Defaults to 60m (60 minutes).
                 type: string
                 format: duration
+              logLevel:
+                description: "logLevel sets the level of log output for the pruner
+                  job. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\".
+                  Defaults to \"Normal\"."
+                type: string
+                default: Normal
               nodeSelector:
                 description: nodeSelector defines the node selection constraints for
                   the image pruner pod.

--- a/imageregistry/v1/types_imagepruner.go
+++ b/imageregistry/v1/types_imagepruner.go
@@ -80,6 +80,13 @@ type ImagePrunerSpec struct {
 	// errors while parsing image references.
 	// +optional
 	IgnoreInvalidImageReferences bool `json:"ignoreInvalidImageReferences,omitempty"`
+	// logLevel sets the level of log output for the pruner job.
+	//
+	// Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+	// Defaults to "Normal".
+	// +optional
+	// +kubebuilder:default=Normal
+	LogLevel operatorv1.LogLevel `json:"logLevel,omitempty"`
 }
 
 // ImagePrunerStatus reports image pruner operational status.

--- a/imageregistry/v1/zz_generated.swagger_doc_generated.go
+++ b/imageregistry/v1/zz_generated.swagger_doc_generated.go
@@ -232,6 +232,7 @@ var map_ImagePrunerSpec = map[string]string{
 	"successfulJobsHistoryLimit":   "successfulJobsHistoryLimit specifies how many successful image pruner jobs to retain. Defaults to 3 if not set.",
 	"failedJobsHistoryLimit":       "failedJobsHistoryLimit specifies how many failed image pruner jobs to retain. Defaults to 3 if not set.",
 	"ignoreInvalidImageReferences": "ignoreInvalidImageReferences indicates whether the pruner can ignore errors while parsing image references.",
+	"logLevel":                     "logLevel sets the level of log output for the pruner job.\n\nValid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
 }
 
 func (ImagePrunerSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Today there is no way to change the log level of the pruner. It makes it harder to investigate the pruner problems.