### PR TITLE
Bug 1880786: operatorcontrolplane: make structural

### DIFF
--- a/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
+++ b/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
@@ -1,9 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-  creationTimestamp: null
   name: podnetworkconnectivitychecks.controlplane.operator.openshift.io
 spec:
   group: controlplane.operator.openshift.io
@@ -13,254 +12,247 @@ spec:
     plural: podnetworkconnectivitychecks
     singular: podnetworkconnectivitycheck
   scope: ""
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: PodNetworkConnectivityCheck
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Spec defines the source and target of the connectivity check
-          type: object
-          required:
-          - sourcePod
-          - targetEndpoint
-          properties:
-            sourcePod:
-              description: SourcePod names the pod from which the condition will be
-                checked
-              type: string
-              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-            targetEndpoint:
-              description: EndpointAddress to check. A TCP address of the form host:port.
-                Note that if host is a DNS name, then the check would fail if the
-                DNS name cannot be resolved. Specify an IP address for host to bypass
-                DNS name lookup.
-              type: string
-              pattern: ^\S+:\d*$
-            tlsClientCert:
-              description: TLSClientCert, if specified, references a kubernetes.io/tls
-                type secret with 'tls.crt' and 'tls.key' entries containing an optional
-                TLS client certificate and key to be used when checking endpoints
-                that require a client certificate in order to gracefully preform the
-                scan without causing excessive logging in the endpoint process. The
-                secret must exist in the same namespace as this resource.
-              type: object
-              required:
-              - name
-              properties:
-                name:
-                  description: name is the metadata.name of the referenced secret
-                  type: string
-        status:
-          description: Status contains the observed status of the connectivity check
-          type: object
-          properties:
-            conditions:
-              description: Conditions summarize the status of the check
-              type: array
-              items:
-                description: PodNetworkConnectivityCheckCondition represents the overall
-                  status of the pod network connectivity.
-                type: object
-                required:
-                - lastTransitionTime
-                - status
-                - type
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    type: string
-                    format: date-time
-                    nullable: true
-                  message:
-                    description: Message indicating details about last transition
-                      in a human readable format.
-                    type: string
-                  reason:
-                    description: Reason for the condition's last status transition
-                      in a machine readable format.
-                    type: string
-                  status:
-                    description: Status of the condition
-                    type: string
-                  type:
-                    description: Type of the condition
-                    type: string
-            failures:
-              description: Failures contains logs of unsuccessful check actions
-              type: array
-              items:
-                description: LogEntry records events
-                type: object
-                required:
-                - success
-                - time
-                properties:
-                  latency:
-                    description: Latency records how long the action mentioned in
-                      the entry took.
-                    type: string
-                    nullable: true
-                  message:
-                    description: Message explaining status in a human readable format.
-                    type: string
-                  reason:
-                    description: Reason for status in a machine readable format.
-                    type: string
-                  success:
-                    description: Success indicates if the log entry indicates a success
-                      or failure.
-                    type: boolean
-                  time:
-                    description: Start time of check action.
-                    type: string
-                    format: date-time
-                    nullable: true
-            outages:
-              description: Outages contains logs of time periods of outages
-              type: array
-              items:
-                description: OutageEntry records time period of an outage
-                type: object
-                required:
-                - start
-                properties:
-                  end:
-                    description: End of outage detected
-                    type: string
-                    format: date-time
-                    nullable: true
-                  endLogs:
-                    description: EndLogs contains log entries related to the end of
-                      this outage. Should contain the success entry that resolved
-                      the outage and possibly a few of the failure log entries that
-                      preceded it.
-                    type: array
-                    items:
-                      description: LogEntry records events
-                      type: object
-                      required:
-                      - success
-                      - time
-                      properties:
-                        latency:
-                          description: Latency records how long the action mentioned
-                            in the entry took.
-                          type: string
-                          nullable: true
-                        message:
-                          description: Message explaining status in a human readable
-                            format.
-                          type: string
-                        reason:
-                          description: Reason for status in a machine readable format.
-                          type: string
-                        success:
-                          description: Success indicates if the log entry indicates
-                            a success or failure.
-                          type: boolean
-                        time:
-                          description: Start time of check action.
-                          type: string
-                          format: date-time
-                          nullable: true
-                  message:
-                    description: Message summarizes outage details in a human readable
-                      format.
-                    type: string
-                  start:
-                    description: Start of outage detected
-                    type: string
-                    format: date-time
-                    nullable: true
-                  startLogs:
-                    description: StartLogs contains log entries related to the start
-                      of this outage. Should contain the original failure, any entries
-                      where the failure mode changed.
-                    type: array
-                    items:
-                      description: LogEntry records events
-                      type: object
-                      required:
-                      - success
-                      - time
-                      properties:
-                        latency:
-                          description: Latency records how long the action mentioned
-                            in the entry took.
-                          type: string
-                          nullable: true
-                        message:
-                          description: Message explaining status in a human readable
-                            format.
-                          type: string
-                        reason:
-                          description: Reason for status in a machine readable format.
-                          type: string
-                        success:
-                          description: Success indicates if the log entry indicates
-                            a success or failure.
-                          type: boolean
-                        time:
-                          description: Start time of check action.
-                          type: string
-                          format: date-time
-                          nullable: true
-            successes:
-              description: Successes contains logs successful check actions
-              type: array
-              items:
-                description: LogEntry records events
-                type: object
-                required:
-                - success
-                - time
-                properties:
-                  latency:
-                    description: Latency records how long the action mentioned in
-                      the entry took.
-                    type: string
-                    nullable: true
-                  message:
-                    description: Message explaining status in a human readable format.
-                    type: string
-                  reason:
-                    description: Reason for status in a machine readable format.
-                    type: string
-                  success:
-                    description: Success indicates if the log entry indicates a success
-                      or failure.
-                    type: boolean
-                  time:
-                    description: Start time of check action.
-                    type: string
-                    format: date-time
-                    nullable: true
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: PodNetworkConnectivityCheck
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the source and target of the connectivity check
+            type: object
+            required:
+            - sourcePod
+            - targetEndpoint
+            properties:
+              sourcePod:
+                description: SourcePod names the pod from which the condition will
+                  be checked
+                type: string
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+              targetEndpoint:
+                description: EndpointAddress to check. A TCP address of the form host:port.
+                  Note that if host is a DNS name, then the check would fail if the
+                  DNS name cannot be resolved. Specify an IP address for host to bypass
+                  DNS name lookup.
+                type: string
+                pattern: ^\S+:\d*$
+              tlsClientCert:
+                description: TLSClientCert, if specified, references a kubernetes.io/tls
+                  type secret with 'tls.crt' and 'tls.key' entries containing an optional
+                  TLS client certificate and key to be used when checking endpoints
+                  that require a client certificate in order to gracefully preform
+                  the scan without causing excessive logging in the endpoint process.
+                  The secret must exist in the same namespace as this resource.
+                type: object
+                required:
+                - name
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced secret
+                    type: string
+          status:
+            description: Status contains the observed status of the connectivity check
+            type: object
+            properties:
+              conditions:
+                description: Conditions summarize the status of the check
+                type: array
+                items:
+                  description: PodNetworkConnectivityCheckCondition represents the
+                    overall status of the pod network connectivity.
+                  type: object
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                      format: date-time
+                      nullable: true
+                    message:
+                      description: Message indicating details about last transition
+                        in a human readable format.
+                      type: string
+                    reason:
+                      description: Reason for the condition's last status transition
+                        in a machine readable format.
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: Type of the condition
+                      type: string
+              failures:
+                description: Failures contains logs of unsuccessful check actions
+                type: array
+                items:
+                  description: LogEntry records events
+                  type: object
+                  required:
+                  - success
+                  - time
+                  properties:
+                    latency:
+                      description: Latency records how long the action mentioned in
+                        the entry took.
+                      type: string
+                      nullable: true
+                    message:
+                      description: Message explaining status in a human readable format.
+                      type: string
+                    reason:
+                      description: Reason for status in a machine readable format.
+                      type: string
+                    success:
+                      description: Success indicates if the log entry indicates a
+                        success or failure.
+                      type: boolean
+                    time:
+                      description: Start time of check action.
+                      type: string
+                      format: date-time
+                      nullable: true
+              outages:
+                description: Outages contains logs of time periods of outages
+                type: array
+                items:
+                  description: OutageEntry records time period of an outage
+                  type: object
+                  required:
+                  - start
+                  properties:
+                    end:
+                      description: End of outage detected
+                      type: string
+                      format: date-time
+                      nullable: true
+                    endLogs:
+                      description: EndLogs contains log entries related to the end
+                        of this outage. Should contain the success entry that resolved
+                        the outage and possibly a few of the failure log entries that
+                        preceded it.
+                      type: array
+                      items:
+                        description: LogEntry records events
+                        type: object
+                        required:
+                        - success
+                        - time
+                        properties:
+                          latency:
+                            description: Latency records how long the action mentioned
+                              in the entry took.
+                            type: string
+                            nullable: true
+                          message:
+                            description: Message explaining status in a human readable
+                              format.
+                            type: string
+                          reason:
+                            description: Reason for status in a machine readable format.
+                            type: string
+                          success:
+                            description: Success indicates if the log entry indicates
+                              a success or failure.
+                            type: boolean
+                          time:
+                            description: Start time of check action.
+                            type: string
+                            format: date-time
+                            nullable: true
+                    message:
+                      description: Message summarizes outage details in a human readable
+                        format.
+                      type: string
+                    start:
+                      description: Start of outage detected
+                      type: string
+                      format: date-time
+                      nullable: true
+                    startLogs:
+                      description: StartLogs contains log entries related to the start
+                        of this outage. Should contain the original failure, any entries
+                        where the failure mode changed.
+                      type: array
+                      items:
+                        description: LogEntry records events
+                        type: object
+                        required:
+                        - success
+                        - time
+                        properties:
+                          latency:
+                            description: Latency records how long the action mentioned
+                              in the entry took.
+                            type: string
+                            nullable: true
+                          message:
+                            description: Message explaining status in a human readable
+                              format.
+                            type: string
+                          reason:
+                            description: Reason for status in a machine readable format.
+                            type: string
+                          success:
+                            description: Success indicates if the log entry indicates
+                              a success or failure.
+                            type: boolean
+                          time:
+                            description: Start time of check action.
+                            type: string
+                            format: date-time
+                            nullable: true
+              successes:
+                description: Successes contains logs successful check actions
+                type: array
+                items:
+                  description: LogEntry records events
+                  type: object
+                  required:
+                  - success
+                  - time
+                  properties:
+                    latency:
+                      description: Latency records how long the action mentioned in
+                        the entry took.
+                      type: string
+                      nullable: true
+                    message:
+                      description: Message explaining status in a human readable format.
+                      type: string
+                    reason:
+                      description: Reason for status in a machine readable format.
+                      type: string
+                    success:
+                      description: Success indicates if the log entry indicates a
+                        success or failure.
+                      type: boolean
+                    time:
+                      description: Start time of check action.
+                      type: string
+                      format: date-time
+                      nullable: true


### PR DESCRIPTION
As v1beta1 CRD without `preserveUnknownFields: false` the CRD was not structural and hence `oc explain` did not work.