### PR TITLE
Bug 1873043: bring back service-ca crd names

### DIFF
--- a/operator/v1/0000_50_service-ca-operator_02_crd.yaml
+++ b/operator/v1/0000_50_service-ca-operator_02_crd.yaml
@@ -7,6 +7,11 @@ metadata:
 spec:
   scope: Cluster
   group: operator.openshift.io
+  names:
+    kind: ServiceCA
+    listKind: ServiceCAList
+    plural: servicecas
+    singular: serviceca
   versions:
   - name: v1
     served: true

--- a/operator/v1/0000_50_service-ca-operator_02_crd.yaml
+++ b/operator/v1/0000_50_service-ca-operator_02_crd.yaml
@@ -43,11 +43,13 @@ spec:
             type: object
             properties:
               logLevel:
-                description: logLevel is an intent based logging for an overall component.  It
-                  does not give fine grained control, but it is a simple way to manage
-                  coarse grained logging choices that operators have to interpret
-                  for their operands.
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                 type: string
+                default: Normal
               managementState:
                 description: managementState indicates whether and how the operator
                   should manage the component


### PR DESCRIPTION
these got accidentally removed back in https://github.com/openshift/api/commit/fdbff4bcb56c5263cc7b8a740a3684ca9f4ba116

(+ adding listKind which was not present previoously)