### PR TITLE
Run verify-crds.sh against all CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ verify-scripts:
 	bash -x hack/verify-deepcopy.sh
 	bash -x hack/verify-protobuf.sh
 	bash -x hack/verify-swagger-docs.sh
-	bash -x hack/verify-crds.sh
+	hack/verify-crds.sh
 	bash -x hack/verify-types.sh
 .PHONY: verify-scripts
 verify: verify-scripts verify-codegen-crds

--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -6,20 +6,8 @@ if [ ! -f ./_output/tools/bin/yq ]; then
     chmod +x ./_output/tools/bin/yq
 fi
 
-FILES="authorization/v1/*.crd.yaml
-config/v1/*.crd.yaml
-helm/v1beta1/*.crd.yaml
-console/v1/*.crd.yaml
-imageregistry/v1/*crd.yaml
-operator/v1/*.crd.yaml
-operator/v1alpha1/*.crd.yaml
-quota/v1/*.crd.yaml
-samples/v1/*.crd.yaml
-security/v1/*.crd.yaml
-securityinternal/v1/*.crd.yaml
-"
 FAILS=false
-for f in $FILES
+for f in `find . -name "*crd.yaml" -type f`
 do
     if [[ $(./_output/tools/bin/yq r $f apiVersion) == "apiextensions.k8s.io/v1beta1" ]]; then
         if [[ $(./_output/tools/bin/yq r $f spec.validation.openAPIV3Schema.properties.metadata.description) != "null" ]]; then


### PR DESCRIPTION
As noticed in https://github.com/openshift/api/pull/741, we currently need to manually add new groups to this list or they'll miss verification. This checks against all CRDs in all directories