### PR TITLE
Bug 1881636: Switch networking CRDs to apiextensions/v1

### DIFF
--- a/network/v1/001-clusternetwork-crd.yaml
+++ b/network/v1/001-clusternetwork-crd.yaml
@@ -1,7 +1,6 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: clusternetworks.network.openshift.io
 spec:
   group: network.openshift.io

--- a/network/v1/001-clusternetwork-crd.yaml
+++ b/network/v1/001-clusternetwork-crd.yaml
@@ -10,103 +10,6 @@ spec:
     plural: clusternetworks
     singular: clusternetwork
   scope: Cluster
-  validation:
-    # As compared to ValidateClusterNetwork, this does not validate that:
-    #   - the hostSubnetLengths are valid for their CIDRs
-    #   - the cluster/service networks do not overlap
-    #   - .network and .hostsubnetlength are set if name == 'default'
-    #   - .network and .hostsubnetlength are either unset, or equal to
-    #     .clusterNetworks[0].CIDR and .clusterNetworks[0].hostSubnetLength
-    openAPIV3Schema:
-      description: ClusterNetwork describes the cluster network. There is normally
-        only one object of this type, named "default", which is created by the SDN
-        network plugin based on the master configuration when the cluster is brought
-        up for the first time.
-      type: object
-      required:
-      - clusterNetworks
-      - serviceNetwork
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        clusterNetworks:
-          description: ClusterNetworks is a list of ClusterNetwork objects that defines
-            the global overlay network's L3 space by specifying a set of CIDR and
-            netmasks that the SDN can allocate addresses from.
-          type: array
-          items:
-            description: ClusterNetworkEntry defines an individual cluster network.
-              The CIDRs cannot overlap with other cluster network CIDRs, CIDRs reserved
-              for external ips, CIDRs reserved for service networks, and CIDRs reserved
-              for ingress ips.
-            type: object
-            required:
-            - CIDR
-            - hostSubnetLength
-            properties:
-              CIDR:
-                description: CIDR defines the total range of a cluster networks address
-                  space.
-                type: string
-                pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
-              hostSubnetLength:
-                description: HostSubnetLength is the number of bits of the accompanying
-                  CIDR address to allocate to each node. eg, 8 would mean that each
-                  node would have a /24 slice of the overlay network for its pods.
-                type: integer
-                format: int32
-                maximum: 30
-                minimum: 2
-        hostsubnetlength:
-          description: HostSubnetLength is the number of bits of network to allocate
-            to each node. eg, 8 would mean that each node would have a /24 slice of
-            the overlay network for its pods
-          type: integer
-          format: int32
-          maximum: 30
-          minimum: 2
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        mtu:
-          description: MTU is the MTU for the overlay network. This should be 50 less
-            than the MTU of the network connecting the nodes. It is normally autodetected
-            by the cluster network operator.
-          type: integer
-          format: int32
-          maximum: 65536
-          minimum: 576
-        network:
-          description: Network is a CIDR string specifying the global overlay network's
-            L3 space
-          type: string
-          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
-        pluginName:
-          description: PluginName is the name of the network plugin being used
-          type: string
-        serviceNetwork:
-          description: ServiceNetwork is the CIDR range that Service IP addresses
-            are allocated from
-          type: string
-          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
-        vxlanPort:
-          description: VXLANPort sets the VXLAN destination port used by the cluster.
-            It is set by the master configuration file on startup and cannot be edited
-            manually. Valid values for VXLANPort are integers 1-65535 inclusive and
-            if unset defaults to 4789. Changing VXLANPort allows users to resolve
-            issues between openshift SDN and other software trying to use the same
-            VXLAN destination port.
-          type: integer
-          format: int32
-          maximum: 65535
-          minimum: 1
   additionalPrinterColumns:
   - name: Cluster Network
     type: string
@@ -125,6 +28,97 @@ spec:
   - name: v1
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: ClusterNetwork describes the cluster network. There is normally
+          only one object of this type, named "default", which is created by the SDN
+          network plugin based on the master configuration when the cluster is brought
+          up for the first time.
+        type: object
+        required:
+        - clusterNetworks
+        - serviceNetwork
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          clusterNetworks:
+            description: ClusterNetworks is a list of ClusterNetwork objects that
+              defines the global overlay network's L3 space by specifying a set of
+              CIDR and netmasks that the SDN can allocate addresses from.
+            type: array
+            items:
+              description: ClusterNetworkEntry defines an individual cluster network.
+                The CIDRs cannot overlap with other cluster network CIDRs, CIDRs reserved
+                for external ips, CIDRs reserved for service networks, and CIDRs reserved
+                for ingress ips.
+              type: object
+              required:
+              - CIDR
+              - hostSubnetLength
+              properties:
+                CIDR:
+                  description: CIDR defines the total range of a cluster networks
+                    address space.
+                  type: string
+                  pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
+                hostSubnetLength:
+                  description: HostSubnetLength is the number of bits of the accompanying
+                    CIDR address to allocate to each node. eg, 8 would mean that each
+                    node would have a /24 slice of the overlay network for its pods.
+                  type: integer
+                  format: int32
+                  maximum: 30
+                  minimum: 2
+          hostsubnetlength:
+            description: HostSubnetLength is the number of bits of network to allocate
+              to each node. eg, 8 would mean that each node would have a /24 slice
+              of the overlay network for its pods
+            type: integer
+            format: int32
+            maximum: 30
+            minimum: 2
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          mtu:
+            description: MTU is the MTU for the overlay network. This should be 50
+              less than the MTU of the network connecting the nodes. It is normally
+              autodetected by the cluster network operator.
+            type: integer
+            format: int32
+            maximum: 65536
+            minimum: 576
+          network:
+            description: Network is a CIDR string specifying the global overlay network's
+              L3 space
+            type: string
+            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
+          pluginName:
+            description: PluginName is the name of the network plugin being used
+            type: string
+          serviceNetwork:
+            description: ServiceNetwork is the CIDR range that Service IP addresses
+              are allocated from
+            type: string
+            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
+          vxlanPort:
+            description: VXLANPort sets the VXLAN destination port used by the cluster.
+              It is set by the master configuration file on startup and cannot be
+              edited manually. Valid values for VXLANPort are integers 1-65535 inclusive
+              and if unset defaults to 4789. Changing VXLANPort allows users to resolve
+              issues between openshift SDN and other software trying to use the same
+              VXLAN destination port.
+            type: integer
+            format: int32
+            maximum: 65535
+            minimum: 1
 status:
   acceptedNames:
     kind: ""

--- a/network/v1/002-hostsubnet-crd.yaml
+++ b/network/v1/002-hostsubnet-crd.yaml
@@ -10,70 +10,6 @@ spec:
     plural: hostsubnets
     singular: hostsubnet
   scope: Cluster
-  validation:
-    # As compared to ValidateHostSubnet, this does not validate that:
-    #   - .host == .name
-    #   - either .subnet is set or the assign-subnet annotation is present
-    # As compared to ValidateHostSubnetUpdate, this does not validate that:
-    #   - .subnet is not changed on an existing object
-    openAPIV3Schema:
-      description: HostSubnet describes the container subnet network on a node. The
-        HostSubnet object must have the same name as the Node object it corresponds
-        to.
-      type: object
-      required:
-      - host
-      - hostIP
-      - subnet
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        egressCIDRs:
-          description: EgressCIDRs is the list of CIDR ranges available for automatically
-            assigning egress IPs to this node from. If this field is set then EgressIPs
-            should be treated as read-only.
-          type: array
-          items:
-            description: HostSubnetEgressCIDR represents one egress CIDR from which
-              to assign IP addresses for this node represented by the HostSubnet
-            type: string
-            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
-        egressIPs:
-          description: EgressIPs is the list of automatic egress IP addresses currently
-            hosted by this node. If EgressCIDRs is empty, this can be set by hand;
-            if EgressCIDRs is set then the master will overwrite the value here with
-            its own allocation of egress IPs.
-          type: array
-          items:
-            description: HostSubnetEgressIP represents one egress IP address currently
-              hosted on the node represented by HostSubnet
-            type: string
-            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$
-        host:
-          description: Host is the name of the node. (This is the same as the object's
-            name, but both fields must be set.)
-          type: string
-          pattern: ^[a-z0-9.-]+$
-        hostIP:
-          description: HostIP is the IP address to be used as a VTEP by other nodes
-            in the overlay network
-          type: string
-          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        subnet:
-          description: Subnet is the CIDR range of the overlay network assigned to
-            the node for its pods
-          type: string
-          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
   additionalPrinterColumns:
   - name: Host
     type: string
@@ -102,6 +38,65 @@ spec:
   - name: v1
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: HostSubnet describes the container subnet network on a node.
+          The HostSubnet object must have the same name as the Node object it corresponds
+          to.
+        type: object
+        required:
+        - host
+        - hostIP
+        - subnet
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          egressCIDRs:
+            description: EgressCIDRs is the list of CIDR ranges available for automatically
+              assigning egress IPs to this node from. If this field is set then EgressIPs
+              should be treated as read-only.
+            type: array
+            items:
+              description: HostSubnetEgressCIDR represents one egress CIDR from which
+                to assign IP addresses for this node represented by the HostSubnet
+              type: string
+              pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
+          egressIPs:
+            description: EgressIPs is the list of automatic egress IP addresses currently
+              hosted by this node. If EgressCIDRs is empty, this can be set by hand;
+              if EgressCIDRs is set then the master will overwrite the value here
+              with its own allocation of egress IPs.
+            type: array
+            items:
+              description: HostSubnetEgressIP represents one egress IP address currently
+                hosted on the node represented by HostSubnet
+              type: string
+              pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$
+          host:
+            description: Host is the name of the node. (This is the same as the object's
+              name, but both fields must be set.)
+            type: string
+            pattern: ^[a-z0-9.-]+$
+          hostIP:
+            description: HostIP is the IP address to be used as a VTEP by other nodes
+              in the overlay network
+            type: string
+            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          subnet:
+            description: Subnet is the CIDR range of the overlay network assigned
+              to the node for its pods
+            type: string
+            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
 status:
   acceptedNames:
     kind: ""

--- a/network/v1/002-hostsubnet-crd.yaml
+++ b/network/v1/002-hostsubnet-crd.yaml
@@ -1,7 +1,6 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: hostsubnets.network.openshift.io
 spec:
   group: network.openshift.io

--- a/network/v1/003-netnamespace-crd.yaml
+++ b/network/v1/003-netnamespace-crd.yaml
@@ -10,56 +10,6 @@ spec:
     plural: netnamespaces
     singular: netnamespace
   scope: Cluster
-  validation:
-    # As compared to ValidateNetNamespace, this does not validate that:
-    #   - .netname == .name
-    #   - .netid is not 1-9
-    openAPIV3Schema:
-      description: NetNamespace describes a single isolated network. When using the
-        redhat/openshift-ovs-multitenant plugin, every Namespace will have a corresponding
-        NetNamespace object with the same name. (When using redhat/openshift-ovs-subnet,
-        NetNamespaces are not used.)
-      type: object
-      required:
-      - netid
-      - netname
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        egressIPs:
-          description: EgressIPs is a list of reserved IPs that will be used as the
-            source for external traffic coming from pods in this namespace. (If empty,
-            external traffic will be masqueraded to Node IPs.)
-          type: array
-          items:
-            description: NetNamespaceEgressIP is a single egress IP out of a list
-              of reserved IPs used as source of external traffic coming from pods
-              in this namespace
-            type: string
-            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        netid:
-          description: NetID is the network identifier of the network namespace assigned
-            to each overlay network packet. This can be manipulated with the "oc adm
-            pod-network" commands.
-          type: integer
-          format: int32
-          maximum: 16777215
-          minimum: 0
-        netname:
-          description: NetName is the name of the network namespace. (This is the
-            same as the object's name, but both fields must be set.)
-          type: string
-          pattern: ^[a-z0-9.-]+$
   additionalPrinterColumns:
   - name: NetID
     type: integer
@@ -74,6 +24,53 @@ spec:
   - name: v1
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: NetNamespace describes a single isolated network. When using
+          the redhat/openshift-ovs-multitenant plugin, every Namespace will have a
+          corresponding NetNamespace object with the same name. (When using redhat/openshift-ovs-subnet,
+          NetNamespaces are not used.)
+        type: object
+        required:
+        - netid
+        - netname
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          egressIPs:
+            description: EgressIPs is a list of reserved IPs that will be used as
+              the source for external traffic coming from pods in this namespace.
+              (If empty, external traffic will be masqueraded to Node IPs.)
+            type: array
+            items:
+              description: NetNamespaceEgressIP is a single egress IP out of a list
+                of reserved IPs used as source of external traffic coming from pods
+                in this namespace
+              type: string
+              pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          netid:
+            description: NetID is the network identifier of the network namespace
+              assigned to each overlay network packet. This can be manipulated with
+              the "oc adm pod-network" commands.
+            type: integer
+            format: int32
+            maximum: 16777215
+            minimum: 0
+          netname:
+            description: NetName is the name of the network namespace. (This is the
+              same as the object's name, but both fields must be set.)
+            type: string
+            pattern: ^[a-z0-9.-]+$
 status:
   acceptedNames:
     kind: ""

--- a/network/v1/003-netnamespace-crd.yaml
+++ b/network/v1/003-netnamespace-crd.yaml
@@ -1,7 +1,6 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: netnamespaces.network.openshift.io
 spec:
   group: network.openshift.io

--- a/network/v1/004-egressnetworkpolicy-crd.yaml
+++ b/network/v1/004-egressnetworkpolicy-crd.yaml
@@ -1,7 +1,6 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: egressnetworkpolicies.network.openshift.io
 spec:
   group: network.openshift.io

--- a/network/v1/004-egressnetworkpolicy-crd.yaml
+++ b/network/v1/004-egressnetworkpolicy-crd.yaml
@@ -10,75 +10,75 @@ spec:
     plural: egressnetworkpolicies
     singular: egressnetworkpolicy
   scope: Namespaced
-  validation:
-    # This should be mostly equivalent to ValidateEgressNetworkPolicy
-    openAPIV3Schema:
-      description: EgressNetworkPolicy describes the current egress network policy
-        for a Namespace. When using the 'redhat/openshift-ovs-multitenant' network
-        plugin, traffic from a pod to an IP address outside the cluster will be checked
-        against each EgressNetworkPolicyRule in the pod's namespace's EgressNetworkPolicy,
-        in order. If no rule matches (or no EgressNetworkPolicy is present) then the
-        traffic will be allowed by default.
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: spec is the specification of the current egress network policy
-          type: object
-          required:
-          - egress
-          properties:
-            egress:
-              description: egress contains the list of egress policy rules
-              type: array
-              items:
-                description: EgressNetworkPolicyRule contains a single egress network
-                  policy rule
-                type: object
-                required:
-                - to
-                - type
-                properties:
-                  to:
-                    description: to is the target that traffic is allowed/denied to
-                    type: object
-                    properties:
-                      cidrSelector:
-                        description: CIDRSelector is the CIDR range to allow/deny
-                          traffic to. If this is set, dnsName must be unset Ideally
-                          we would have liked to use the cidr openapi format for this
-                          property. But openshift-sdn only supports v4 while specifying
-                          the cidr format allows both v4 and v6 cidrs We are therefore
-                          using a regex pattern to validate instead.
-                        type: string
-                        pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
-                      dnsName:
-                        description: DNSName is the domain name to allow/deny traffic
-                          to. If this is set, cidrSelector must be unset
-                        type: string
-                        pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
-                  type:
-                    description: type marks this as an "Allow" or "Deny" rule
-                    type: string
-                    pattern: ^Allow|Deny$
   version: v1
   versions:
   - name: v1
     served: true
     storage: true
+    "schema":
+      "openAPIV3Schema":
+        description: EgressNetworkPolicy describes the current egress network policy
+          for a Namespace. When using the 'redhat/openshift-ovs-multitenant' network
+          plugin, traffic from a pod to an IP address outside the cluster will be
+          checked against each EgressNetworkPolicyRule in the pod's namespace's EgressNetworkPolicy,
+          in order. If no rule matches (or no EgressNetworkPolicy is present) then
+          the traffic will be allowed by default.
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the current egress network policy
+            type: object
+            required:
+            - egress
+            properties:
+              egress:
+                description: egress contains the list of egress policy rules
+                type: array
+                items:
+                  description: EgressNetworkPolicyRule contains a single egress network
+                    policy rule
+                  type: object
+                  required:
+                  - to
+                  - type
+                  properties:
+                    to:
+                      description: to is the target that traffic is allowed/denied
+                        to
+                      type: object
+                      properties:
+                        cidrSelector:
+                          description: CIDRSelector is the CIDR range to allow/deny
+                            traffic to. If this is set, dnsName must be unset Ideally
+                            we would have liked to use the cidr openapi format for
+                            this property. But openshift-sdn only supports v4 while
+                            specifying the cidr format allows both v4 and v6 cidrs
+                            We are therefore using a regex pattern to validate instead.
+                          type: string
+                          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
+                        dnsName:
+                          description: DNSName is the domain name to allow/deny traffic
+                            to. If this is set, cidrSelector must be unset
+                          type: string
+                          pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                    type:
+                      description: type marks this as an "Allow" or "Deny" rule
+                      type: string
+                      pattern: ^Allow|Deny$
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
When running CRD validation against all CRDs (https://github.com/openshift/api/pull/743), these 4 fail due to not having a structural schema with pruning enabled. This switch to v1 will be required by k8s 1.22