### PR TITLE
Bug 1883701: operator/ingress: Restore scale subresource

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -1031,4 +1031,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.availableReplicas
       status: {}


### PR DESCRIPTION
Restore the IngressController CRD's "scale" subresource.

#720 inadvertently deleted the "scale" subresource.

* `operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml`: Add `spec.versions[].subresources.scale`.