### PR TITLE
Storage: register Cinder CSI driver

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -35,6 +35,7 @@ spec:
               name:
                 enum:
                 - ebs.csi.aws.com
+                - cinder.csi.openstack.org
                 - manila.csi.openstack.org
                 - csi.ovirt.org
                 type: string

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
@@ -5,5 +5,6 @@
       type: string
       enum:
       - ebs.csi.aws.com
+      - cinder.csi.openstack.org
       - manila.csi.openstack.org
       - csi.ovirt.org

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -41,6 +41,7 @@ type CSIDriverName string
 // and 0000_90_cluster_csi_driver_01_config.crd.yaml-merge-patch file is also updated with new driver name.
 const (
 	AWSEBSCSIDriver CSIDriverName = "ebs.csi.aws.com"
+	CinderCSIDriver CSIDriverName = "cinder.csi.openstack.org"
 	ManilaCSIDriver CSIDriverName = "manila.csi.openstack.org"
 	OvirtCSIDriver  CSIDriverName = "csi.ovirt.org"
 )


### PR DESCRIPTION
In OpenShift 4.7 we start using Cinder CSI driver, so we have to register the component along with the other CSI drivers.