### PR TITLE
Route: Document possible values for spec.tls.termination

### DIFF
--- a/route/v1/generated.proto
+++ b/route/v1/generated.proto
@@ -212,6 +212,10 @@ message RouterShard {
 // TLSConfig defines config used to secure a route and provide termination
 message TLSConfig {
   // termination indicates termination type.
+  //
+  // * edge - TLS termination is done by the router and http is used to communicate with the backend (default)
+  // * passthrough - Traffic is sent straight to the destination without the router providing TLS termination
+  // * reencrypt - TLS termination is done by the router and https is used to communicate with the backend
   optional string termination = 1;
 
   // certificate provides certificate contents

--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -212,6 +212,10 @@ type RouterShard struct {
 // TLSConfig defines config used to secure a route and provide termination
 type TLSConfig struct {
 	// termination indicates termination type.
+	//
+	// * edge - TLS termination is done by the router and http is used to communicate with the backend (default)
+	// * passthrough - Traffic is sent straight to the destination without the router providing TLS termination
+	// * reencrypt - TLS termination is done by the router and https is used to communicate with the backend
 	Termination TLSTerminationType `json:"termination" protobuf:"bytes,1,opt,name=termination,casttype=TLSTerminationType"`
 
 	// certificate provides certificate contents

--- a/route/v1/zz_generated.swagger_doc_generated.go
+++ b/route/v1/zz_generated.swagger_doc_generated.go
@@ -113,7 +113,7 @@ func (RouterShard) SwaggerDoc() map[string]string {
 
 var map_TLSConfig = map[string]string{
 	"":                              "TLSConfig defines config used to secure a route and provide termination",
-	"termination":                   "termination indicates termination type.",
+	"termination":                   "termination indicates termination type.\n\n* edge - TLS termination is done by the router and http is used to communicate with the backend (default) * passthrough - Traffic is sent straight to the destination without the router providing TLS termination * reencrypt - TLS termination is done by the router and https is used to communicate with the backend",
 	"certificate":                   "certificate provides certificate contents",
 	"key":                           "key provides key file contents",
 	"caCertificate":                 "caCertificate provides the cert authority certificate contents",


### PR DESCRIPTION
Without this PR, finding out the possible values requires to check on the docs:
```
$ k explain route.spec.tls.termination
KIND:     Route
VERSION:  route.openshift.io/v1

FIELD:    termination <string>

DESCRIPTION:
     termination indicates termination type.
```

After this PR, a list of possible values and a brief explanation will be in the `kubectl describe` output