### PR TITLE
config/v1/types_cluster_operator: Document newline inclusion

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -92,7 +92,9 @@ spec:
                     format: date-time
                   message:
                     description: message provides additional information about the
-                      current condition. This is only to be consumed by humans.
+                      current condition. This is only to be consumed by humans.  It
+                      may contain Line Feed characters (U+000A), which should be rendered
+                      as new lines.
                     type: string
                   reason:
                     description: reason is the CamelCase reason for the condition's

--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -218,7 +218,9 @@ spec:
                     format: date-time
                   message:
                     description: message provides additional information about the
-                      current condition. This is only to be consumed by humans.
+                      current condition. This is only to be consumed by humans.  It
+                      may contain Line Feed characters (U+000A), which should be rendered
+                      as new lines.
                     type: string
                   reason:
                     description: reason is the CamelCase reason for the condition's

--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -130,7 +130,8 @@ type ClusterOperatorStatusCondition struct {
 	Reason string `json:"reason,omitempty"`
 
 	// message provides additional information about the current condition.
-	// This is only to be consumed by humans.
+	// This is only to be consumed by humans.  It may contain Line Feed
+	// characters (U+000A), which should be rendered as new lines.
 	// +optional
 	Message string `json:"message,omitempty"`
 }

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -443,7 +443,7 @@ var map_ClusterOperatorStatusCondition = map[string]string{
 	"status":             "status of the condition, one of True, False, Unknown.",
 	"lastTransitionTime": "lastTransitionTime is the time of the last update to the current status property.",
 	"reason":             "reason is the CamelCase reason for the condition's current status.",
-	"message":            "message provides additional information about the current condition. This is only to be consumed by humans.",
+	"message":            "message provides additional information about the current condition. This is only to be consumed by humans.  It may contain Line Feed characters (U+000A), which should be rendered as new lines.",
 }
 
 func (ClusterOperatorStatusCondition) SwaggerDoc() map[string]string {


### PR DESCRIPTION
@deads2k  has been making the rounds asking for newline rendering, e.g. in openshift/installer#4242.  Regardless of how that particular effort works out, make it clear to both ClusterOperator readers and writers that LF characters may be part of the message string (for example, HTML renderings should replace them with `<br/>`).

I'd personally prefer leaning on an existing markup language like "message strings are Markdown", although this LF rule will exclude Markdown going forward, because [the Markdown spec has][2]:

> A paragraph is simply one or more consecutive lines of text, separated by one or more blank lines. (A blank line is any line that looks like a blank line — a line containing nothing but spaces or tabs is considered blank.) Normal paragraphs should not be indented with spaces or tabs.
>
> The implication of the “one or more consecutive lines of text” rule is that Markdown supports “hard-wrapped” text paragraphs. This differs significantly from most other text-to-HTML formatters (including Movable Type’s “Convert Line Breaks” option) which translate every line break character in a paragraph into a `<br />` tag.

Generated with:

```console
$ emacs		config/v1/types_cluster_operator.go  # twiddle the docstring
$ hack/update-swagger-docs.sh
$ go fmt ./...
$ make update-codegen-crds
$ git add -p # exclude some anyOf -> string changes, dunno what that's about
```

/assign @deads2k 

[2]: https://daringfireball.net/projects/markdown/syntax#p