### PR TITLE
add current profile annotations to CVO manifests

### DIFF
--- a/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
+++ b/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: cloudcredentials.operator.openshift.io
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   scope: Cluster
   group: operator.openshift.io


### PR DESCRIPTION
This is matches openshift/enhancements#414 and doesn't change existing behavior

---

It was missing in the original PR https://github.com/openshift/api/pull/722 and is required for https://github.com/openshift/cloud-credential-operator/pull/261