### PR TITLE
Add optional AppsDomain to Ingress CR

### DIFF
--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -43,6 +43,14 @@ spec:
           description: spec holds user settable values for configuration
           type: object
           properties:
+            appsDomain:
+              description: appsDomain is an optional domain to use instead of the
+                one specified in the domain field when a Route is created without
+                specifying an explicit host. If appsDomain is nonempty, this value
+                is used to generate default host values for Route. Unlike domain,
+                appsDomain may be modified after installation. This assumes a new
+                ingresscontroller has been setup with a wildcard certificate.
+              type: string
             domain:
               description: "domain is used to generate a default host name for a route
                 when the route's host name is empty. The generated host name will

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -31,6 +31,16 @@ type IngressSpec struct {
 	//
 	// Once set, changing domain is not currently supported.
 	Domain string `json:"domain"`
+
+	// appsDomain is an optional domain to use instead of the one specified
+	// in the domain field when a Route is created without specifying an explicit
+	// host. If appsDomain is nonempty, this value is used to generate default
+	// host values for Route. Unlike domain, appsDomain may be modified after
+	// installation.
+	// This assumes a new ingresscontroller has been setup with a wildcard
+	// certificate.
+	// +optional
+	AppsDomain string `json:"appsDomain,omitempty"`
 }
 
 type IngressStatus struct {

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -980,7 +980,8 @@ func (Ingress) SwaggerDoc() map[string]string {
 }
 
 var map_IngressSpec = map[string]string{
-	"domain": "domain is used to generate a default host name for a route when the route's host name is empty. The generated host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\".\n\nIt is also used as the default wildcard domain suffix for ingress. The default ingresscontroller domain will follow this pattern: \"*.<domain>\".\n\nOnce set, changing domain is not currently supported.",
+	"domain":     "domain is used to generate a default host name for a route when the route's host name is empty. The generated host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\".\n\nIt is also used as the default wildcard domain suffix for ingress. The default ingresscontroller domain will follow this pattern: \"*.<domain>\".\n\nOnce set, changing domain is not currently supported.",
+	"appsDomain": "appsDomain is an optional domain to use instead of the one specified in the domain field when a Route is created without specifying an explicit host. If appsDomain is nonempty, this value is used to generate default host values for Route. Unlike domain, appsDomain may be modified after installation. This assumes a new ingresscontroller has been setup with a wildcard certificate.",
 }
 
 func (IngressSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This relates to https://github.com/openshift/enhancements/pull/432 and [RFE-952](https://issues.redhat.com/browse/RFE-952)

This adds an optional AppsDomain to the Ingress CR to support setting a custom domain (post install) for routes where the Host field is not specified. 