### PR TITLE
Add GCP PD CSI Driver to ClusterCSIDriver's enum

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -35,6 +35,7 @@ spec:
               name:
                 enum:
                 - ebs.csi.aws.com
+                - pd.csi.storage.gke.io
                 - cinder.csi.openstack.org
                 - manila.csi.openstack.org
                 - csi.ovirt.org

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
@@ -5,6 +5,7 @@
       type: string
       enum:
       - ebs.csi.aws.com
+      - pd.csi.storage.gke.io
       - cinder.csi.openstack.org
       - manila.csi.openstack.org
       - csi.ovirt.org

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -41,6 +41,7 @@ type CSIDriverName string
 // and 0000_90_cluster_csi_driver_01_config.crd.yaml-merge-patch file is also updated with new driver name.
 const (
 	AWSEBSCSIDriver CSIDriverName = "ebs.csi.aws.com"
+	GCPPDCSIDriver  CSIDriverName = "pd.csi.storage.gke.io"
 	CinderCSIDriver CSIDriverName = "cinder.csi.openstack.org"
 	ManilaCSIDriver CSIDriverName = "manila.csi.openstack.org"
 	OvirtCSIDriver  CSIDriverName = "csi.ovirt.org"


### PR DESCRIPTION
In OCP 4.7 we're going to deploy the GCP PD CSI Driver by default.

CC @openshift/storage 