### PR TITLE
Add Disabled status for Cluster Operator

### DIFF
--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -173,6 +173,9 @@ const (
 	// of what the administrator should do to allow the operator to successfully update.  A missing condition, True,
 	// and Unknown are all treated by the CVO as allowing an upgrade.
 	OperatorUpgradeable ClusterStatusConditionType = "Upgradeable"
+
+	// Disabled indicates that the operator is disabled.
+	OperatorDisabled ClusterStatusConditionType = "Disabled"
 )
 
 // ClusterOperatorList is a list of OperatorStatus resources.


### PR DESCRIPTION
It is used by insights and baremetal operators.

https://github.com/openshift/cluster-baremetal-operator/blob/master/controllers/clusteroperator.go#L23
https://github.com/openshift/insights-operator/blob/master/pkg/controller/status/status.go#L440

---

Previously it was only insights but now that with baremetal operator using it, I guess it's a good idea to put it in common. 
It might be also a good idea to use it in the CCO - https://github.com/openshift/cloud-credential-operator/blob/master/pkg/operator/utils/utils.go#L33