### PR TITLE
Bug 1877693 - dnsrecords specify recordTTL as 30 but the value is nul…

### DIFF
--- a/operatoringress/v1/0000_50_dns-record.yaml
+++ b/operatoringress/v1/0000_50_dns-record.yaml
@@ -50,7 +50,8 @@ spec:
               minLength: 1
             recordTTL:
               description: recordTTL is the record TTL in seconds. If zero, the default
-                is 30.
+                is 30. RecordTTL will not be used in AWS regions Alias targets, but
+                will be used in CNAME targets, per AWS API contract.
               type: integer
               format: int64
               minimum: 0

--- a/operatoringress/v1/types.go
+++ b/operatoringress/v1/types.go
@@ -45,6 +45,8 @@ type DNSRecordSpec struct {
 	// +required
 	RecordType DNSRecordType `json:"recordType"`
 	// recordTTL is the record TTL in seconds. If zero, the default is 30.
+	// RecordTTL will not be used in AWS regions Alias targets, but
+	// will be used in CNAME targets, per AWS API contract.
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Minimum=0
@@ -103,10 +105,10 @@ type DNSZoneCondition struct {
 type DNSRecordType string
 
 const (
-	// CNAME is an RFC 1035 CNAME record.
+	// CNAMERecordType is an RFC 1035 CNAME record.
 	CNAMERecordType DNSRecordType = "CNAME"
 
-	// CNAME is an RFC 1035 A record.
+	// ARecordType is an RFC 1035 A record.
 	ARecordType DNSRecordType = "A"
 )
 

--- a/operatoringress/v1/zz_generated.swagger_doc_generated.go
+++ b/operatoringress/v1/zz_generated.swagger_doc_generated.go
@@ -34,7 +34,7 @@ var map_DNSRecordSpec = map[string]string{
 	"dnsName":    "dnsName is the hostname of the DNS record",
 	"targets":    "targets are record targets.",
 	"recordType": "recordType is the DNS record type. For example, \"A\" or \"CNAME\".",
-	"recordTTL":  "recordTTL is the record TTL in seconds. If zero, the default is 30.",
+	"recordTTL":  "recordTTL is the record TTL in seconds. If zero, the default is 30. RecordTTL will not be used in AWS regions Alias targets, but will be used in CNAME targets, per AWS API contract.",
 }
 
 func (DNSRecordSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Bug 1877693 - dnsrecords specify recordTTL as 30 but the value is null in AWS Route 53.  Per AWS API contract, Alias targets may not contain TTL, only CNAME may contain TTL. See https://github.com/openshift/cluster-ingress-operator/pull/454#discussion_r483898974. Documenting this behavior.