### PR TITLE
types_network: Change API that enables IPsec

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -323,13 +323,6 @@ spec:
                         description: ipsecConfig enables and configures IPsec for
                           pods on the pod network within the cluster.
                         type: object
-                        properties:
-                          enable:
-                            description: enable enables IPsec encryption for pod-to-pod
-                              traffic on the pod network within the cluster. Default
-                              is false.
-                            type: boolean
-                            default: false
                       mtu:
                         description: mtu is the MTU to use for the tunnel interface.
                           This must be 100 bytes smaller than the uplink mtu. Default

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -337,11 +337,6 @@ type HybridOverlayConfig struct {
 }
 
 type IPsecConfig struct {
-	// enable enables IPsec encryption for pod-to-pod traffic on the pod network
-	// within the cluster. Default is false.
-	// +optional
-	// +kubebuilder:default:=false
-	Enable bool `json:"enable"`
 }
 
 // NetworkType describes the network plugin type to configure

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -762,14 +762,6 @@ func (IPAMConfig) SwaggerDoc() map[string]string {
 	return map_IPAMConfig
 }
 
-var map_IPsecConfig = map[string]string{
-	"enable": "enable enables IPsec encryption for pod-to-pod traffic on the pod network within the cluster. Default is false.",
-}
-
-func (IPsecConfig) SwaggerDoc() map[string]string {
-	return map_IPsecConfig
-}
-
 var map_KuryrConfig = map[string]string{
 	"":                             "KuryrConfig configures the Kuryr-Kubernetes SDN",
 	"daemonProbesPort":             "The port kuryr-daemon will listen for readiness and liveness requests.",


### PR DESCRIPTION
Remove requirement to set "enable" flag.

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>