### PR TITLE
Add `disabled` field to `HelmChartRepository`

### DIFF
--- a/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
+++ b/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
@@ -88,6 +88,9 @@ spec:
               type: string
               maxLength: 2048
               minLength: 1
+            disabled:
+              description: If set to true, disable the repo usage in the cluster
+              type: boolean
             name:
               description: Optional associated human readable repository name, it
                 can be used by UI for displaying purposes

--- a/helm/v1beta1/types_helm.go
+++ b/helm/v1beta1/types_helm.go
@@ -36,6 +36,10 @@ type HelmChartRepositoryList struct {
 // Helm chart repository exposed within the cluster
 type HelmChartRepositorySpec struct {
 
+	// If set to true, disable the repo usage in the cluster
+	// +optional
+	Disabled bool `json:"disabled,omitempty"`
+
 	// Optional associated human readable repository name, it can be used by UI for displaying purposes
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=100


### PR DESCRIPTION
The default Red Hat repo is delivered as a part of console operator payload:

https://github.com/openshift/console-operator/blob/master/manifests/01-helm.yaml

and since these resource are monitored by CVO, it is not possible to remove the default
configuration, and many customers are asking for exactly that.

In order to solve the customer request, `disabled` field is added to `HelmChartRepository`.
If set to true, that repo will be ignored/skipped in all relevant Helm operations.
At the same time, other cluster components (e.g. console UI) might use the new flag
to enable/disable some parts of UI.