### PR TITLE
Add missing optional for BuildSourceType, BuildStrategyType and Identities

### DIFF
--- a/apps/v1/generated.proto
+++ b/apps/v1/generated.proto
@@ -283,6 +283,7 @@ message DeploymentRequest {
 // DeploymentStrategy describes how to perform a deployment.
 message DeploymentStrategy {
   // Type is the name of a deployment strategy.
+  // +optional
   optional string type = 1;
 
   // CustomParams are the input to the Custom deployment strategy, and may also

--- a/apps/v1/types.go
+++ b/apps/v1/types.go
@@ -83,6 +83,7 @@ type DeploymentConfigSpec struct {
 // DeploymentStrategy describes how to perform a deployment.
 type DeploymentStrategy struct {
 	// Type is the name of a deployment strategy.
+	// +optional
 	Type DeploymentStrategyType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=DeploymentStrategyType"`
 
 	// CustomParams are the input to the Custom deployment strategy, and may also

--- a/build/v1/generated.proto
+++ b/build/v1/generated.proto
@@ -362,6 +362,7 @@ message BuildRequest {
 message BuildSource {
   // type of build input to accept
   // +k8s:conversion-gen=false
+  // +optional
   optional string type = 1;
 
   // binary builds accept a binary as their input. The binary is generally assumed to be a tar,
@@ -496,6 +497,7 @@ message BuildStatusOutputTo {
 message BuildStrategy {
   // type is the kind of build strategy.
   // +k8s:conversion-gen=false
+  // +optional
   optional string type = 1;
 
   // dockerStrategy holds the parameters to the container image build strategy.

--- a/build/v1/types.go
+++ b/build/v1/types.go
@@ -400,7 +400,8 @@ const (
 type BuildSource struct {
 	// type of build input to accept
 	// +k8s:conversion-gen=false
-	Type BuildSourceType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=BuildSourceType"`
+	// +optional
+	Type BuildSourceType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=BuildSourceType"`
 
 	// binary builds accept a binary as their input. The binary is generally assumed to be a tar,
 	// gzipped tar, or zip file depending on the strategy. For container image builds, this is the build
@@ -603,7 +604,8 @@ type SourceControlUser struct {
 type BuildStrategy struct {
 	// type is the kind of build strategy.
 	// +k8s:conversion-gen=false
-	Type BuildStrategyType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=BuildStrategyType"`
+	// +optional
+	Type BuildStrategyType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=BuildStrategyType"`
 
 	// dockerStrategy holds the parameters to the container image build strategy.
 	DockerStrategy *DockerBuildStrategy `json:"dockerStrategy,omitempty" protobuf:"bytes,2,opt,name=dockerStrategy"`

--- a/user/v1/generated.proto
+++ b/user/v1/generated.proto
@@ -79,6 +79,7 @@ message User {
   optional string fullName = 2;
 
   // Identities are the identities associated with this user
+  // +optional
   repeated string identities = 3;
 
   // Groups specifies group names this user is a member of.

--- a/user/v1/types.go
+++ b/user/v1/types.go
@@ -24,7 +24,8 @@ type User struct {
 	FullName string `json:"fullName,omitempty" protobuf:"bytes,2,opt,name=fullName"`
 
 	// Identities are the identities associated with this user
-	Identities []string `json:"identities" protobuf:"bytes,3,rep,name=identities"`
+	// +optional
+	Identities []string `json:"identities,omitempty" protobuf:"bytes,3,rep,name=identities"`
 
 	// Groups specifies group names this user is a member of.
 	// This field is deprecated and will be removed in a future release.


### PR DESCRIPTION
Based on our apiserver we don't require any of these field being set and we correctly try to read the type from other fields, namely:
- `BuildSource` validation (https://github.com/openshift/openshift-apiserver/blob/5ea157ecf46924ff6aa52d0aa6a025c2f57d97fc/pkg/build/apis/build/validation/validation.go#L175-L239) and partial defaulting (https://github.com/openshift/openshift-apiserver/blob/5ea157ecf46924ff6aa52d0aa6a025c2f57d97fc/pkg/build/apis/build/v1/defaults.go#L11-L15)
- `BuildStrategy` validation (https://github.com/openshift/openshift-apiserver/blob/5ea157ecf46924ff6aa52d0aa6a025c2f57d97fc/pkg/build/apis/build/validation/validation.go#L483-L517) and partial defaulting (https://github.com/openshift/openshift-apiserver/blob/5ea157ecf46924ff6aa52d0aa6a025c2f57d97fc/pkg/build/apis/build/v1/defaults.go#L17-L39)
- `Identities` validation (https://github.com/openshift/openshift-apiserver/blob/5ea157ecf46924ff6aa52d0aa6a025c2f57d97fc/pkg/user/apis/user/validation/validation.go#L101-L117) 

This PR ensures the above is also reflected in the API through `optional` marker.

/assign @sttts @adambkaplan 