### PR TITLE
Add IPv6DualStackOCP47 FeatureSet

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -40,6 +40,11 @@ var (
 
 	// IPv6DualStackNoUpgrade enables dual-stack. Turning this feature set on IS NOT SUPPORTED, CANNOT BE UNDONE, and PREVENTS UPGRADES.
 	IPv6DualStackNoUpgrade FeatureSet = "IPv6DualStackNoUpgrade"
+
+	// IPv6DualStackOCP47 enables dual-stack, pinned to the OCP 4.7 dual-stack API even if
+	// the upstream API changes in the future. Turning this feature set on IS NOT SUPPORTED
+	// without a support exception.
+	IPv6DualStackOCP47 FeatureSet = "IPv6DualStackOCP47"
 )
 
 type FeatureGateSpec struct {
@@ -112,6 +117,11 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		).
 		toFeatures(),
 	IPv6DualStackNoUpgrade: newDefaultFeatures().
+		with(
+			"IPv6DualStack", // sig-network, danwinship
+		).
+		toFeatures(),
+	IPv6DualStackOCP47: newDefaultFeatures().
 		with(
 			"IPv6DualStack", // sig-network, danwinship
 		).


### PR DESCRIPTION
This adds an `IPv6DualStackOCP47` FeatureSet, for use by important dual-stack customers™. At the moment, this is an exact duplicate of `IPv6DualStackNoUpgrade` other than the name and the description.

The plan is as follows:
- Customers for whom we are supporting dual-stack in OCP 4.7 will enable the `IPv6DualStackOCP47` FeatureSet, which will enable the `IPv6DualStack` feature gate.
- Assuming that all goes according to plan and the kube 1.20/OCP 4.7 dual-stack API goes to beta without any changes, then we will add the `IPv6DualStack` gate to the `Default` FeatureSet in 4.8 or 4.9, get the customers using `IPv6DualStackOCP47` to revert back to `Default` during that release cycle, and then delete the `IPv6DualStackOCP47` FeatureSet in the next release.
- If things go awry and the dual-stack API breaks again, then:
  1. We will add `<carry>` patches to `openshift/kubernetes` to add an `IPv6DualStackOCP47` feature gate and to provide the kube 1.20 dual-stack behavior when both `IPv6DualStack` and `IPv6DualStackOCP47` are enabled.
  2. We will update the `IPv6DualStackOCP47` FeatureSet in `openshift/api` to include the `IPv6DualStackOCP47` feature gate in addition to `IPv6DualStack`
  3. We will update the relevant operators with the updated version of `openshift/api`
- The result of the above should be that when updating from 4.7 to 4.8, as each kube-*-operator is updated, it will generate a new operand config with the 1.21+patches operand binary _and_ a configuration that includes `--feature-gates=IPv6DualStack=true,IPv6DualStackOCP47=true`, ensuring that each component switches from 1.20 to 1.21-but-still-using-the-1.20-API without any regressions

/assign @knobunc 