### PR TITLE
Remove uniqueItems validation from containerRuntimeSearchRegistries

### DIFF
--- a/config/v1/0000_10_config-operator_01_image.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_image.crd.yaml
@@ -128,7 +128,6 @@ spec:
                   type: array
                   format: hostname
                   minItems: 1
-                  uniqueItems: true
                   items:
                     type: string
                   x-kubernetes-list-type: set

--- a/config/v1/types_image.go
+++ b/config/v1/types_image.go
@@ -117,7 +117,6 @@ type RegistrySources struct {
 	// Note: this search list only works with the container runtime, i.e CRI-O. Will NOT work with builds or imagestream imports.
 	// +optional
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:UniqueItems=true
 	// +kubebuilder:validation:Format=hostname
 	// +listType=set
 	ContainerRuntimeSearchRegistries []string `json:"containerRuntimeSearchRegistries,omitempty"`


### PR DESCRIPTION
The uniqueItems validation is causing a failure when the cluster-config-operator
is rendering the CRD. So remove that validation.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>