### PR TITLE
Update useExternalOpenvswitch description

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -269,9 +269,10 @@ spec:
                         format: int32
                         minimum: 0
                       useExternalOpenvswitch:
-                        description: useExternalOpenvswitch tells the operator not
-                          to install openvswitch, because it will be provided separately.
-                          If set, you must provide it yourself.
+                        description: useExternalOpenvswitch is ignored. This used
+                          to control whether Open vSwitch was run as a system service
+                          or in a container, but as of OpenShift 4.7, OpenShift always
+                          runs it as a system service.
                         type: boolean
                       vxlanPort:
                         description: vxlanPort is the port to use for all vxlan packets.

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -234,8 +234,9 @@ type OpenShiftSDNConfig struct {
 	// +optional
 	MTU *uint32 `json:"mtu,omitempty"`
 
-	// useExternalOpenvswitch tells the operator not to install openvswitch, because
-	// it will be provided separately. If set, you must provide it yourself.
+	// useExternalOpenvswitch is ignored. This used to control whether Open vSwitch
+	// was run as a system service or in a container, but as of OpenShift 4.7,
+	// OpenShift always runs it as a system service.
 	// +optional
 	UseExternalOpenvswitch *bool `json:"useExternalOpenvswitch,omitempty"`
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -835,7 +835,7 @@ var map_OpenShiftSDNConfig = map[string]string{
 	"mode":                   "mode is one of \"Multitenant\", \"Subnet\", or \"NetworkPolicy\"",
 	"vxlanPort":              "vxlanPort is the port to use for all vxlan packets. The default is 4789.",
 	"mtu":                    "mtu is the mtu to use for the tunnel interface. Defaults to 1450 if unset. This must be 50 bytes smaller than the machine's uplink.",
-	"useExternalOpenvswitch": "useExternalOpenvswitch tells the operator not to install openvswitch, because it will be provided separately. If set, you must provide it yourself.",
+	"useExternalOpenvswitch": "useExternalOpenvswitch is ignored. This used to control whether Open vSwitch was run as a system service or in a container, but as of OpenShift 4.7, OpenShift always runs it as a system service.",
 	"enableUnidling":         "enableUnidling controls whether or not the service proxy will support idling and unidling of services. By default, unidling is enabled.",
 }
 


### PR DESCRIPTION
In prior releases this field was used to tell the CNO not to deploy the
opevswitch daemonset for development purposes. In 4.7 we don't deploy
openvswitch with the cluster network operator at all, so we're ignoring
the field, although we keep it to avoid breaking compatibility.

/assign @danwinship 