### PR TITLE
SCTP is GA, so no longer feature-gated

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -125,7 +125,6 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		"SupportPodPidsLimit",            // sig-pod, sjenning
 		"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
 		"ServiceNodeExclusion",           // sig-scheduling, ccoleman
-		"SCTPSupport",                    // sig-network, ccallend
 	},
 	Disabled: []string{
 		"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -18,18 +18,17 @@ func TestFeatureBuilder(t *testing.T) {
 		},
 		{
 			name:   "disable-existing",
-			actual: newDefaultFeatures().without("SCTPSupport").toFeatures(),
+			actual: newDefaultFeatures().without("SupportPodPidsLimit").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
 					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
-					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
-					"SCTPSupport",
+					"SupportPodPidsLimit",
 				},
 			},
 		},
@@ -43,7 +42,6 @@ func TestFeatureBuilder(t *testing.T) {
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
-					"SCTPSupport",
 					"LegacyNodeRoleBehavior",
 				},
 				Disabled: []string{},
@@ -51,18 +49,17 @@ func TestFeatureBuilder(t *testing.T) {
 		},
 		{
 			name:   "disable-more",
-			actual: newDefaultFeatures().without("SCTPSupport", "other").toFeatures(),
+			actual: newDefaultFeatures().without("SupportPodPidsLimit", "other").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
 					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
-					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
-					"SCTPSupport",
+					"SupportPodPidsLimit",
 					"other",
 				},
 			},
@@ -77,7 +74,6 @@ func TestFeatureBuilder(t *testing.T) {
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
-					"SCTPSupport",
 					"LegacyNodeRoleBehavior",
 					"other",
 				},


### PR DESCRIPTION
SCTP is GA in 1.20 and the feature gate is now a no-op.
(FWIW it doesn't matter if this merges before the 1.20 rebase since it was already enabled-by-default in 1.19 anyway.)

/assign @knobunc 