### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/authorization/v1/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
+++ b/authorization/v1/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: authorization.openshift.io
   scope: Namespaced

--- a/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.versions[?(@.name=="operator")].version

--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   versions:

--- a/config/v1/0000_03_config-operator_01_operatorhub.crd.yaml
+++ b/config/v1/0000_03_config-operator_01_operatorhub.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   names:

--- a/config/v1/0000_03_config-operator_01_proxy.crd.yaml
+++ b/config/v1/0000_03_config-operator_01_proxy.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   scope: Cluster

--- a/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   scope: Cluster

--- a/config/v1/0000_10_config-operator_01_authentication.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   scope: Cluster

--- a/config/v1/0000_10_config-operator_01_build.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_build.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   scope: Cluster

--- a/config/v1/0000_10_config-operator_01_console.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_console.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   preserveUnknownFields: false

--- a/config/v1/0000_10_config-operator_01_dns.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_dns.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   names:

--- a/config/v1/0000_10_config-operator_01_featuregate.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_featuregate.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   scope: Cluster

--- a/config/v1/0000_10_config-operator_01_image.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_image.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   scope: Cluster

--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   names:

--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   names:

--- a/config/v1/0000_10_config-operator_01_network.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   names:

--- a/config/v1/0000_10_config-operator_01_oauth.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_oauth.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   scope: Cluster

--- a/config/v1/0000_10_config-operator_01_project.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_project.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   scope: Cluster

--- a/config/v1/0000_10_config-operator_01_scheduler.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_scheduler.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: config.openshift.io
   scope: Cluster

--- a/console/v1/0000_10_consoleclidownload.crd.yaml
+++ b/console/v1/0000_10_consoleclidownload.crd.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   preserveUnknownFields: false

--- a/console/v1/0000_10_consoleexternalloglink.crd.yaml
+++ b/console/v1/0000_10_consoleexternalloglink.crd.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   preserveUnknownFields: false

--- a/console/v1/0000_10_consolelink.crd.yaml
+++ b/console/v1/0000_10_consolelink.crd.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   preserveUnknownFields: false

--- a/console/v1/0000_10_consolenotification.crd.yaml
+++ b/console/v1/0000_10_consolenotification.crd.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   preserveUnknownFields: false

--- a/console/v1/0000_10_consolequickstart.crd.yaml
+++ b/console/v1/0000_10_consolequickstart.crd.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: console.openshift.io

--- a/console/v1/0000_10_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_consoleyamlsample.crd.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: console.openshift.io

--- a/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
+++ b/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   preserveUnknownFields: false

--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: imageregistry.operator.openshift.io
   scope: Cluster

--- a/imageregistry/v1/01-crd.yaml
+++ b/imageregistry/v1/01-crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: imageregistry.operator.openshift.io
   scope: Cluster

--- a/operator/v1/0000_10_config-operator_01_config.crd.yaml
+++ b/operator/v1/0000_10_config-operator_01_config.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: operator.openshift.io

--- a/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
+++ b/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: operator.openshift.io

--- a/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
+++ b/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: kubeapiservers.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: kubecontrollermanagers.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: kubeschedulers.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/operator/v1/0000_30_openshift-apiserver-operator_01_config.crd.yaml
+++ b/operator/v1/0000_30_openshift-apiserver-operator_01_config.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: operator.openshift.io

--- a/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
+++ b/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: operator.openshift.io

--- a/operator/v1/0000_40_kube-storage-version-migrator-operator_00_config.crd.yaml
+++ b/operator/v1/0000_40_kube-storage-version-migrator-operator_00_config.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: operator.openshift.io
   names:

--- a/operator/v1/0000_50_cluster-authentication-operator_01_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-authentication-operator_01_config.crd.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: operator.openshift.io

--- a/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: operator.openshift.io

--- a/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
+++ b/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: operator.openshift.io
   names:

--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: ingresscontrollers.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/operator/v1/0000_50_service-ca-operator_02_crd.yaml
+++ b/operator/v1/0000_50_service-ca-operator_02_crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: operator.openshift.io

--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: operator.openshift.io
   names:

--- a/operator/v1/0000_70_console-operator.crd.yaml
+++ b/operator/v1/0000_70_console-operator.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   group: operator.openshift.io

--- a/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
+++ b/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: operator.openshift.io
   names:

--- a/operator/v1/0000_80_csi_snapshot_controller_operator_01_crd.yaml
+++ b/operator/v1/0000_80_csi_snapshot_controller_operator_01_crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: operator.openshift.io
   names:

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: clustercsidrivers.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
+++ b/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: operator.openshift.io
   scope: Cluster

--- a/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
+++ b/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: podnetworkconnectivitychecks.controlplane.operator.openshift.io
 spec:
   group: controlplane.operator.openshift.io

--- a/operatoringress/v1/0000_50_dns-record.yaml
+++ b/operatoringress/v1/0000_50_dns-record.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: ingress.operator.openshift.io
   names:

--- a/quota/v1/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
+++ b/quota/v1/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: clusterresourcequotas.quota.openshift.io
 spec:
   group: quota.openshift.io

--- a/samples/v1/0000_10_samplesconfig.crd.yaml
+++ b/samples/v1/0000_10_samplesconfig.crd.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   scope: Cluster
   subresources:

--- a/security/v1/0000_03_security-openshift_01_scc.crd.yaml
+++ b/security/v1/0000_03_security-openshift_01_scc.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   group: security.openshift.io
   scope: Cluster

--- a/securityinternal/v1/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
+++ b/securityinternal/v1/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: rangeallocations.security.internal.openshift.io
 spec:
   group: security.internal.openshift.io


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.