### PR TITLE
Fix typo in ProjectRequest

### DIFF
--- a/project/v1/generated.proto
+++ b/project/v1/generated.proto
@@ -43,7 +43,7 @@ message ProjectList {
   repeated Project items = 2;
 }
 
-// ProjecRequest is the set of options necessary to fully qualify a project request
+// ProjectRequest is the set of options necessary to fully qualify a project request
 message ProjectRequest {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 

--- a/project/v1/types.go
+++ b/project/v1/types.go
@@ -81,7 +81,7 @@ type Project struct {
 // +genclient:skipVerbs=get,list,create,update,patch,delete,deleteCollection,watch
 // +genclient:method=Create,verb=create,result=Project
 
-// ProjecRequest is the set of options necessary to fully qualify a project request
+// ProjectRequest is the set of options necessary to fully qualify a project request
 type ProjectRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

--- a/project/v1/zz_generated.swagger_doc_generated.go
+++ b/project/v1/zz_generated.swagger_doc_generated.go
@@ -31,7 +31,7 @@ func (ProjectList) SwaggerDoc() map[string]string {
 }
 
 var map_ProjectRequest = map[string]string{
-	"":            "ProjecRequest is the set of options necessary to fully qualify a project request",
+	"":            "ProjectRequest is the set of options necessary to fully qualify a project request",
 	"displayName": "DisplayName is the display name to apply to a project",
 	"description": "Description is the description to apply to a project",
 }


### PR DESCRIPTION
This fixes a typo in ProjectRequest.

So I think this updates fixes this here:

https://docs.openshift.com/container-platform/4.6/rest_api/project_apis/projectrequest-project-openshift-io-v1.html