### PR TITLE
network.operator: add back missing validation

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -49,6 +49,9 @@ spec:
                     request them by name. type must be specified, along with exactly
                     one "Config" that matches the type.
                   type: object
+                  required:
+                  - name
+                  - type
                   properties:
                     name:
                       description: name is the name of the network. This will be populated
@@ -170,6 +173,8 @@ spec:
                     is not used by the plugin, it can be left unset. Not all network
                     providers support multiple ClusterNetworks
                   type: object
+                  required:
+                  - cidr
                   properties:
                     cidr:
                       type: string
@@ -181,6 +186,8 @@ spec:
                 description: defaultNetwork is the "default" network that all pods
                   will receive
                 type: object
+                required:
+                - type
                 properties:
                   kuryrConfig:
                     description: KuryrConfig configures the kuryr plugin
@@ -307,6 +314,8 @@ spec:
                                 plugin, it can be left unset. Not all network providers
                                 support multiple ClusterNetworks
                               type: object
+                              required:
+                              - cidr
                               properties:
                                 cidr:
                                   type: string
@@ -320,6 +329,7 @@ spec:
                               Default is 4789
                             type: integer
                             format: int32
+                            minimum: 0
                       ipsecConfig:
                         description: ipsecConfig enables and configures IPsec for
                           pods on the pod network within the cluster.

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -87,6 +87,8 @@ type NetworkSpec struct {
 // the HostPrefix field is not used by the plugin, it can be left unset.
 // Not all network providers support multiple ClusterNetworks
 type ClusterNetworkEntry struct {
+	// +required
+	// +kubebuilder:validation:Required
 	CIDR string `json:"cidr"`
 	// +kubebuilder:validation:Minimum=0
 	// +optional
@@ -98,6 +100,8 @@ type ClusterNetworkEntry struct {
 type DefaultNetworkDefinition struct {
 	// type is the type of network
 	// All NetworkTypes are supported except for NetworkTypeRaw
+	// +required
+	// +kubebuilder:validation:Required
 	Type NetworkType `json:"type"`
 
 	// openShiftSDNConfig configures the openshift-sdn plugin
@@ -199,10 +203,14 @@ type IPAMConfig struct {
 type AdditionalNetworkDefinition struct {
 	// type is the type of network
 	// The supported values are NetworkTypeRaw, NetworkTypeSimpleMacvlan
+	// +required
+	// +kubebuilder:validation:Required
 	Type NetworkType `json:"type"`
 
 	// name is the name of the network. This will be populated in the resulting CRD
 	// This must be unique.
+	// +required
+	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
 	// namespace is the namespace of the network. This will be populated in the resulting CRD
@@ -332,6 +340,7 @@ type HybridOverlayConfig struct {
 	HybridClusterNetwork []ClusterNetworkEntry `json:"hybridClusterNetwork"`
 	// HybridOverlayVXLANPort defines the VXLAN port number to be used by the additional overlay network.
 	// Default is 4789
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	HybridOverlayVXLANPort *uint32 `json:"hybridOverlayVXLANPort,omitempty"`
 }


### PR DESCRIPTION
Previously, we had manually edited the CRD. Now we generate it automatically.

This PR only adds back the validation that was missing; it isn't a full audit of every possibly missing property.

/cc @rcarrillocruz 