### PR TITLE
Bug 1908068: Enable DownwardAPIHugePages feature gate

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -125,6 +125,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		"SupportPodPidsLimit",            // sig-pod, sjenning
 		"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
 		"ServiceNodeExclusion",           // sig-scheduling, ccoleman
+		"DownwardAPIHugePages",           // sig-node, rphillips
 	},
 	Disabled: []string{
 		"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -25,6 +25,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"RotateKubeletServerCertificate",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
+					"DownwardAPIHugePages",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
@@ -42,6 +43,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
+					"DownwardAPIHugePages",
 					"LegacyNodeRoleBehavior",
 				},
 				Disabled: []string{},
@@ -56,6 +58,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"RotateKubeletServerCertificate",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
+					"DownwardAPIHugePages",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
@@ -74,6 +77,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"SupportPodPidsLimit",
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
+					"DownwardAPIHugePages",
 					"LegacyNodeRoleBehavior",
 					"other",
 				},


### PR DESCRIPTION
This adds the DownwardAPIHugePages to the enabled-by-default feature gate flags.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>