### PR TITLE
Bug 1894268: Add v4 and v6 join subnets to ovn-kubernetes config

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -331,6 +331,16 @@ spec:
                         type: integer
                         format: int32
                         minimum: 0
+                      v4JoinSubnet:
+                        description: v4JoinSubnet is the v4 join subnet to be used
+                          by ovn-kubernetes in case the default one is being already
+                          used by something else. Default is 100.64.0.0/16
+                        type: string
+                      v6JoinSubnet:
+                        description: v6JoinSubnet is the v6 join subnet to be used
+                          by ovn-kubernetes in case the default one is being already
+                          used by something else. Default is fd98::/48
+                        type: string
                   type:
                     description: type is the type of network All NetworkTypes are
                       supported except for NetworkTypeRaw

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -325,6 +325,16 @@ type OVNKubernetesConfig struct {
 	// cluster.
 	// +optional
 	IPsecConfig *IPsecConfig `json:"ipsecConfig,omitempty"`
+	// v4JoinSubnet is the v4 join subnet to be used by ovn-kubernetes in case the
+	// default one is being already used by something else.
+	// Default is 100.64.0.0/16
+	// +optional
+	V4JoinSubnet string `json:"v4JoinSubnet,omitempty"`
+	// v6JoinSubnet is the v6 join subnet to be used by ovn-kubernetes in case the
+	// default one is being already used by something else.
+	// Default is fd98::/48
+	// +optional
+	V6JoinSubnet string `json:"v6JoinSubnet,omitempty"`
 }
 
 type HybridOverlayConfig struct {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -854,6 +854,8 @@ var map_OVNKubernetesConfig = map[string]string{
 	"genevePort":          "geneve port is the UDP port to be used by geneve encapulation. Default is 6081",
 	"hybridOverlayConfig": "HybridOverlayConfig configures an additional overlay network for peers that are not using OVN.",
 	"ipsecConfig":         "ipsecConfig enables and configures IPsec for pods on the pod network within the cluster.",
+	"v4JoinSubnet":        "v4JoinSubnet is the v4 join subnet to be used by ovn-kubernetes in case the default one is being already used by something else. Default is 100.64.0.0/16",
+	"v6JoinSubnet":        "v6JoinSubnet is the v6 join subnet to be used by ovn-kubernetes in case the default one is being already used by something else. Default is fd98::/48",
 }
 
 func (OVNKubernetesConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Some users need to be able to specify the v4 and v6 join subnets
to use for ovn-k. In particular, they may be already using the
ones that ovn-k uses as default, and they need a way to be able to
specify a different set of subnets as join subnets. This PR
creates the config option for  the same. Eventually this will be
consumed by the CNO using rendered bootstrap data and passed 
to the ovn-k daemonsets.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>