### PR TITLE
Bug 1907373: bring selflinks back for 4.7, they will be removed in 4.8

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -129,6 +129,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 	},
 	Disabled: []string{
 		"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
+		"RemoveSelfLink",         // kuryr needs updating, deads2k will personally remove in 4.8
 	},
 }
 

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -29,6 +29,7 @@ func TestFeatureBuilder(t *testing.T) {
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
+					"RemoveSelfLink",
 					"SCTPSupport",
 				},
 			},
@@ -46,7 +47,9 @@ func TestFeatureBuilder(t *testing.T) {
 					"SCTPSupport",
 					"LegacyNodeRoleBehavior",
 				},
-				Disabled: []string{},
+				Disabled: []string{
+					"RemoveSelfLink",
+				},
 			},
 		},
 		{
@@ -62,6 +65,7 @@ func TestFeatureBuilder(t *testing.T) {
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
+					"RemoveSelfLink",
 					"SCTPSupport",
 					"other",
 				},
@@ -81,7 +85,9 @@ func TestFeatureBuilder(t *testing.T) {
 					"LegacyNodeRoleBehavior",
 					"other",
 				},
-				Disabled: []string{},
+				Disabled: []string{
+					"RemoveSelfLink",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This will allow our kube-apiserver to supply selflinks for one extra release in 4.7.  We will merge https://github.com/openshift/api/pull/826 that reverts this change as soon as master opens for 4.8.  We must re-align to upstream because the upstream code will be gone and not available to turn back on.