### PR TITLE
Bug 1920619: Remove default Profile for scheduler

### DIFF
--- a/config/v1/0000_10_config-operator_01_scheduler.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_scheduler.crd.yaml
@@ -95,7 +95,6 @@ spec:
                   values are \"LowNodeUtilization\", \"HighNodeUtilization\", \"NoScoring\"
                   Defaults to \"LowNodeUtilization\""
                 type: string
-                default: LowNodeUtilization
                 enum:
                 - ""
                 - LowNodeUtilization

--- a/config/v1/types_scheduling.go
+++ b/config/v1/types_scheduling.go
@@ -35,8 +35,7 @@ type SchedulerSpec struct {
 	// Valid values are "LowNodeUtilization", "HighNodeUtilization", "NoScoring"
 	// Defaults to "LowNodeUtilization"
 	// +optional
-	// +kubebuilder:default=LowNodeUtilization
-	Profile SchedulerProfile `json:"profile"`
+	Profile SchedulerProfile `json:"profile,omitempty"`
 	// defaultNodeSelector helps set the cluster-wide default node selector to
 	// restrict pod placement to specific nodes. This is applied to the pods
 	// created in all namespaces and creates an intersection with any existing


### PR DESCRIPTION
Since scheduler profiles are still Tech Preview, this shouldn't have a default yet