### PR TITLE
Add Kubevirt CSI Driver to ClusterCSIDriver's enum

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -42,6 +42,7 @@ spec:
                 - cinder.csi.openstack.org
                 - manila.csi.openstack.org
                 - csi.ovirt.org
+                - csi.kubevirt.io
                 type: string
             type: object
           spec:

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
@@ -10,3 +10,4 @@
       - cinder.csi.openstack.org
       - manila.csi.openstack.org
       - csi.ovirt.org
+      - csi.kubevirt.io

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -46,6 +46,7 @@ const (
 	CinderCSIDriver    CSIDriverName = "cinder.csi.openstack.org"
 	ManilaCSIDriver    CSIDriverName = "manila.csi.openstack.org"
 	OvirtCSIDriver     CSIDriverName = "csi.ovirt.org"
+	KubevirtCSIDriver  CSIDriverName = "csi.kubevirt.io"
 )
 
 // ClusterCSIDriverSpec is the desired behavior of CSI driver operator


### PR DESCRIPTION
This change is part of [CNV-9798](https://issues.redhat.com/browse/CNV-9798) - Update CSO to deploy Kubevirt CSI driver operator.
It is needed to enable tenant kubevirt clusters consume PVs from the infra OCP cluster