### PR TITLE
Include Azure Disk CSI in CSI Cluster Drivers

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -37,6 +37,7 @@ spec:
               name:
                 enum:
                 - ebs.csi.aws.com
+                - disk.csi.azure.com
                 - pd.csi.storage.gke.io
                 - cinder.csi.openstack.org
                 - manila.csi.openstack.org

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
@@ -5,6 +5,7 @@
       type: string
       enum:
       - ebs.csi.aws.com
+      - disk.csi.azure.com
       - pd.csi.storage.gke.io
       - cinder.csi.openstack.org
       - manila.csi.openstack.org

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -40,11 +40,12 @@ type CSIDriverName string
 // If you are adding a new driver name here, ensure that kubebuilder:validation:Enum is updated above
 // and 0000_90_cluster_csi_driver_01_config.crd.yaml-merge-patch file is also updated with new driver name.
 const (
-	AWSEBSCSIDriver CSIDriverName = "ebs.csi.aws.com"
-	GCPPDCSIDriver  CSIDriverName = "pd.csi.storage.gke.io"
-	CinderCSIDriver CSIDriverName = "cinder.csi.openstack.org"
-	ManilaCSIDriver CSIDriverName = "manila.csi.openstack.org"
-	OvirtCSIDriver  CSIDriverName = "csi.ovirt.org"
+	AWSEBSCSIDriver    CSIDriverName = "ebs.csi.aws.com"
+	AzureDiskCSIDriver CSIDriverName = "disk.csi.azure.com"
+	GCPPDCSIDriver     CSIDriverName = "pd.csi.storage.gke.io"
+	CinderCSIDriver    CSIDriverName = "cinder.csi.openstack.org"
+	ManilaCSIDriver    CSIDriverName = "manila.csi.openstack.org"
+	OvirtCSIDriver     CSIDriverName = "csi.ovirt.org"
 )
 
 // ClusterCSIDriverSpec is the desired behavior of CSI driver operator


### PR DESCRIPTION
This includes the Azure Disk CSI driver in the list of cluster drivers. It's needed to begin introducing the Azure Disk CSI Driver as tech preview.