### PR TITLE
[WIP] adding new audit profile to APIServer

### DIFF
--- a/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
@@ -80,7 +80,7 @@ spec:
                     - Default
                     - WriteRequestBodies
                     - AllRequestBodies
-                    - UserRequests 
+                    - UserRequests
               clientCA:
                 description: 'clientCA references a ConfigMap containing a certificate
                   bundle for the signers that will be recognized for incoming client

--- a/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
@@ -71,7 +71,9 @@ spec:
                       like 'Default', but logs request and response HTTP payloads
                       for write requests (create, update, patch). - AllRequestBodies:
                       like 'WriteRequestBodies', but also logs request and response
-                      HTTP payloads for read requests (get, list). \n If unset, the
+                      HTTP payloads for read requests (get, list). - UserRequests:
+                      logs resources requested bu users in the `system:authenticated:oauth` group.
+                      \n If unset, the
                       'Default' profile is used as the default."
                     type: string
                     default: Default
@@ -79,6 +81,7 @@ spec:
                     - Default
                     - WriteRequestBodies
                     - AllRequestBodies
+                    - UserRequests
               clientCA:
                 description: 'clientCA references a ConfigMap containing a certificate
                   bundle for the signers that will be recognized for incoming client

--- a/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
@@ -72,9 +72,8 @@ spec:
                       for write requests (create, update, patch). - AllRequestBodies:
                       like 'WriteRequestBodies', but also logs request and response
                       HTTP payloads for read requests (get, list). - UserRequests:
-                      logs resources requested bu users in the `system:authenticated:oauth` group.
-                      \n If unset, the
-                      'Default' profile is used as the default."
+                      logs resource requests from system:authenticated:oauth users
+                      and oauthaccesstokens. \n If unset, the 'Default' profile is used as the default."
                     type: string
                     default: Default
                     enum:

--- a/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
@@ -73,14 +73,14 @@ spec:
                       like 'WriteRequestBodies', but also logs request and response
                       HTTP payloads for read requests (get, list). - UserRequests:
                       logs resource requests from system:authenticated:oauth users
-                      and oauthaccesstokens. \n If unset, the 'Default' profile is used as the default."
+                      \n If unset, the 'Default' profile is used as the default."
                     type: string
                     default: Default
                     enum:
                     - Default
                     - WriteRequestBodies
                     - AllRequestBodies
-                    - UserRequests
+                    - UserRequests 
               clientCA:
                 description: 'clientCA references a ConfigMap containing a certificate
                   bundle for the signers that will be recognized for incoming client

--- a/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
@@ -71,7 +71,7 @@ spec:
                       like 'Default', but logs request and response HTTP payloads
                       for write requests (create, update, patch). - AllRequestBodies:
                       like 'WriteRequestBodies', but also logs request and response
-                      HTTP payloads for read requests (get, list). - UserRequests:
+                      HTTP payloads for read requests (get, list). - UserRequestBodies:
                       logs resource requests from system:authenticated:oauth users
                       \n If unset, the 'Default' profile is used as the default."
                     type: string
@@ -80,7 +80,7 @@ spec:
                     - Default
                     - WriteRequestBodies
                     - AllRequestBodies
-                    - UserRequests
+                    - UserRequestBodies
               clientCA:
                 description: 'clientCA references a ConfigMap containing a certificate
                   bundle for the signers that will be recognized for incoming client

--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -59,7 +59,7 @@ type APIServerSpec struct {
 }
 
 // AuditProfileType defines the audit policy profile type.
-// +kubebuilder:validation:Enum=Default;WriteRequestBodies;AllRequestBodies
+// +kubebuilder:validation:Enum=Default;WriteRequestBodies;AllRequestBodies;UserRequests
 type AuditProfileType string
 
 const (

--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -74,8 +74,8 @@ const (
 	// and response HTTP payloads for read requests (get, list).
 	AllRequestBodiesAuditProfileType AuditProfileType = "AllRequestBodies"
 
-	// "UserRequests is a policy that filters logs on resource requests from
-	//  users in the system:authenticated:oauth user group
+	// "UserRequests" is a policy that filters logs on resource requests from
+	// users in the system:authenticated:oauth user group.
 	UserRequestsAuditProfileType AuditProfileType = "UserRequests"
 )
 

--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -59,7 +59,7 @@ type APIServerSpec struct {
 }
 
 // AuditProfileType defines the audit policy profile type.
-// +kubebuilder:validation:Enum=Default;WriteRequestBodies;AllRequestBodies;UserRequests
+// +kubebuilder:validation:Enum=Default;WriteRequestBodies;AllRequestBodies;UserRequestBodies
 type AuditProfileType string
 
 const (
@@ -76,7 +76,7 @@ const (
 
 	// "UserRequests" is a policy that filters logs on resource requests from
 	// users in the system:authenticated:oauth user group.
-	UserRequestsAuditProfileType AuditProfileType = "UserRequests"
+	UserRequestAuditProfileType AuditProfileType = "UserRequestBodies"
 )
 
 type Audit struct {
@@ -89,7 +89,7 @@ type Audit struct {
 	// write requests (create, update, patch).
 	// - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response
 	// HTTP payloads for read requests (get, list).
-	// - UserRequests: logs resource requests from system:authenticated:oauth users
+	// - UserRequestBodies: logs resource requests from system:authenticated:oauth users
 	//
 	// If unset, the 'Default' profile is used as the default.
 	// +kubebuilder:default=Default

--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -76,7 +76,7 @@ const (
 
 	// "UserRequests is a policy that filters logs on resource requests from
 	//  users in the system:authenticated:oauth user group
-	UserRequestsAuditProfileType = "UserRequests"
+	UserRequestsAuditProfileType AuditProfileType = "UserRequests"
 )
 
 type Audit struct {

--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -73,6 +73,10 @@ const (
 	// "AllRequestBodies" is similar to WriteRequestBodies, but also logs request
 	// and response HTTP payloads for read requests (get, list).
 	AllRequestBodiesAuditProfileType AuditProfileType = "AllRequestBodies"
+
+	// "UserRequests is a policy that filters logs on resource requests from
+	//  users in the system:authenticated:oauth user group
+	UserRequestsAuditProfileType = "UserRequests"
 )
 
 type Audit struct {
@@ -85,6 +89,7 @@ type Audit struct {
 	// write requests (create, update, patch).
 	// - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response
 	// HTTP payloads for read requests (get, list).
+	// - UserRequests: logs resource requests from system:authenticated:oauth users
 	//
 	// If unset, the 'Default' profile is used as the default.
 	// +kubebuilder:default=Default

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -293,7 +293,7 @@ func (APIServerSpec) SwaggerDoc() map[string]string {
 }
 
 var map_Audit = map[string]string{
-	"profile": "profile specifies the name of the desired audit policy configuration to be deployed to all OpenShift-provided API servers in the cluster.\n\nThe following profiles are provided: - Default: the existing default policy. - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - UserRequests: logs resource requests from system:authenticated:oauth users\n\nIf unset, the 'Default' profile is used as the default.",
+	"profile": "profile specifies the name of the desired audit policy configuration to be deployed to all OpenShift-provided API servers in the cluster.\n\nThe following profiles are provided: - Default: the existing default policy. - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - UserRequestBodies: logs resource requests from system:authenticated:oauth users\n\nIf unset, the 'Default' profile is used as the default.",
 }
 
 func (Audit) SwaggerDoc() map[string]string {

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -293,7 +293,7 @@ func (APIServerSpec) SwaggerDoc() map[string]string {
 }
 
 var map_Audit = map[string]string{
-	"profile": "profile specifies the name of the desired audit policy configuration to be deployed to all OpenShift-provided API servers in the cluster.\n\nThe following profiles are provided: - Default: the existing default policy. - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list).\n\nIf unset, the 'Default' profile is used as the default.",
+	"profile": "profile specifies the name of the desired audit policy configuration to be deployed to all OpenShift-provided API servers in the cluster.\n\nThe following profiles are provided: - Default: the existing default policy. - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - UserRequests: logs resource requests from system:authenticated:oauth users\n\nIf unset, the 'Default' profile is used as the default.",
 }
 
 func (Audit) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This adds the policy to the enum for the APIserver for the new userrequest audit policy. This policy will log userrequests on resources requested by system:authenticated:oauth users.