### PR TITLE
Include vSphere CSI Driver in clustercsidrivers

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -40,6 +40,7 @@ spec:
                 - disk.csi.azure.com
                 - pd.csi.storage.gke.io
                 - cinder.csi.openstack.org
+                - csi.vsphere.vmware.com
                 - manila.csi.openstack.org
                 - csi.ovirt.org
                 - csi.kubevirt.io

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
@@ -8,6 +8,7 @@
       - disk.csi.azure.com
       - pd.csi.storage.gke.io
       - cinder.csi.openstack.org
+      - csi.vsphere.vmware.com
       - manila.csi.openstack.org
       - csi.ovirt.org
       - csi.kubevirt.io

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -44,6 +44,7 @@ const (
 	AzureDiskCSIDriver CSIDriverName = "disk.csi.azure.com"
 	GCPPDCSIDriver     CSIDriverName = "pd.csi.storage.gke.io"
 	CinderCSIDriver    CSIDriverName = "cinder.csi.openstack.org"
+	VSphereCSIDriver   CSIDriverName = "csi.vsphere.vmware.com"
 	ManilaCSIDriver    CSIDriverName = "manila.csi.openstack.org"
 	OvirtCSIDriver     CSIDriverName = "csi.ovirt.org"
 	KubevirtCSIDriver  CSIDriverName = "csi.kubevirt.io"


### PR DESCRIPTION
This is part of the work required to add a CSI driver operator for vSphere (Tech Preview) in OCP 4.8:

https:// issues.redhat.com/browse/STOR-434

CC @openshift/storage 