### PR TITLE
Bug 1928931: Set spec.scope for DNSRecord CRD

### DIFF
--- a/operatoringress/v1/0000_50_dns-record.yaml
+++ b/operatoringress/v1/0000_50_dns-record.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: DNSRecordList
     plural: dnsrecords
     singular: dnsrecord
-  scope: ""
+  scope: Namespaced
   versions:
   - name: v1
     served: true


### PR DESCRIPTION
spec.scope could be empty in CRD v1beta1 definitions, but it's required to be either `Cluster` or `Namespaced` in v1. This wasn't caught by CI in my earlier PR (#861) because the ingress operator keeps a copy of this CRD that needs to be manually updated before the changes actually take effect.

The companion PR for this in ingress operator can be found [here](https://github.com/openshift/cluster-ingress-operator/pull/575)