### PR TITLE
operator/ingress: Fix up Tunable Buffer Sizes API

### DIFF
--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -949,7 +949,7 @@ type IngressControllerHTTPHeaderBuffer struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=16384
 	// +optional
-	HeaderBufferBytes int32 `json:"headerBufferBytes"`
+	HeaderBufferBytes int32 `json:"headerBufferBytes,omitempty"`
 
 	// headerBufferMaxRewriteBytes describes how much memory should be reserved
 	// (in bytes) from headerBufferBytes for HTTP header rewriting
@@ -963,7 +963,7 @@ type IngressControllerHTTPHeaderBuffer struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=4096
 	// +optional
-	HeaderBufferMaxRewriteBytes int32 `json:"headerBufferMaxRewriteBytes"`
+	HeaderBufferMaxRewriteBytes int32 `json:"headerBufferMaxRewriteBytes,omitempty"`
 }
 
 var (


### PR DESCRIPTION
Add `omitempty` to the json options for `HeaderBufferBytes` and `HeaderBufferMaxRewriteBytes`. This is needed when calling the
IngressController's DeepCopy funcs to ensure that empty `HeaderBuffer*` values aren't defaulted to `0`, which violates the enforced minimum integer values (and thus breaks subsequent resource updates).