### PR TITLE
operator/ingress: Add PROXY protocol API

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -93,6 +93,30 @@ spec:
                   hostNetwork:
                     description: hostNetwork holds parameters for the HostNetwork
                       endpoint publishing strategy. Present only if type is HostNetwork.
+                    properties:
+                      protocol:
+                        description: "protocol specifies whether the IngressController
+                          expects incoming connections to use plain TCP or whether
+                          the IngressController expects PROXY protocol. \n PROXY protocol
+                          can be used with load balancers that support it to communicate
+                          the source addresses of client connections when forwarding
+                          those connections to the IngressController.  Using PROXY
+                          protocol enables the IngressController to report those source
+                          addresses instead of reporting the load balancer's address
+                          in HTTP headers and logs.  Note that enabling PROXY protocol
+                          on the IngressController will cause connections to fail
+                          if you are not using a load balancer that uses PROXY protocol
+                          to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt
+                          for information about PROXY protocol. \n The following values
+                          are valid for this field: \n * The empty string. * \"TCP\".
+                          * \"PROXY\". \n The empty string specifies the default,
+                          which is TCP without PROXY protocol.  Note that the default
+                          is subject to change."
+                        enum:
+                        - ""
+                        - TCP
+                        - PROXY
+                        type: string
                     type: object
                   loadBalancer:
                     description: loadBalancer holds parameters for the load balancer.
@@ -189,6 +213,30 @@ spec:
                   nodePort:
                     description: nodePort holds parameters for the NodePortService
                       endpoint publishing strategy. Present only if type is NodePortService.
+                    properties:
+                      protocol:
+                        description: "protocol specifies whether the IngressController
+                          expects incoming connections to use plain TCP or whether
+                          the IngressController expects PROXY protocol. \n PROXY protocol
+                          can be used with load balancers that support it to communicate
+                          the source addresses of client connections when forwarding
+                          those connections to the IngressController.  Using PROXY
+                          protocol enables the IngressController to report those source
+                          addresses instead of reporting the load balancer's address
+                          in HTTP headers and logs.  Note that enabling PROXY protocol
+                          on the IngressController will cause connections to fail
+                          if you are not using a load balancer that uses PROXY protocol
+                          to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt
+                          for information about PROXY protocol. \n The following values
+                          are valid for this field: \n * The empty string. * \"TCP\".
+                          * \"PROXY\". \n The empty string specifies the default,
+                          which is TCP without PROXY protocol.  Note that the default
+                          is subject to change."
+                        enum:
+                        - ""
+                        - TCP
+                        - PROXY
+                        type: string
                     type: object
                   private:
                     description: private holds parameters for the Private endpoint
@@ -958,6 +1006,30 @@ spec:
                   hostNetwork:
                     description: hostNetwork holds parameters for the HostNetwork
                       endpoint publishing strategy. Present only if type is HostNetwork.
+                    properties:
+                      protocol:
+                        description: "protocol specifies whether the IngressController
+                          expects incoming connections to use plain TCP or whether
+                          the IngressController expects PROXY protocol. \n PROXY protocol
+                          can be used with load balancers that support it to communicate
+                          the source addresses of client connections when forwarding
+                          those connections to the IngressController.  Using PROXY
+                          protocol enables the IngressController to report those source
+                          addresses instead of reporting the load balancer's address
+                          in HTTP headers and logs.  Note that enabling PROXY protocol
+                          on the IngressController will cause connections to fail
+                          if you are not using a load balancer that uses PROXY protocol
+                          to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt
+                          for information about PROXY protocol. \n The following values
+                          are valid for this field: \n * The empty string. * \"TCP\".
+                          * \"PROXY\". \n The empty string specifies the default,
+                          which is TCP without PROXY protocol.  Note that the default
+                          is subject to change."
+                        enum:
+                        - ""
+                        - TCP
+                        - PROXY
+                        type: string
                     type: object
                   loadBalancer:
                     description: loadBalancer holds parameters for the load balancer.
@@ -1054,6 +1126,30 @@ spec:
                   nodePort:
                     description: nodePort holds parameters for the NodePortService
                       endpoint publishing strategy. Present only if type is NodePortService.
+                    properties:
+                      protocol:
+                        description: "protocol specifies whether the IngressController
+                          expects incoming connections to use plain TCP or whether
+                          the IngressController expects PROXY protocol. \n PROXY protocol
+                          can be used with load balancers that support it to communicate
+                          the source addresses of client connections when forwarding
+                          those connections to the IngressController.  Using PROXY
+                          protocol enables the IngressController to report those source
+                          addresses instead of reporting the load balancer's address
+                          in HTTP headers and logs.  Note that enabling PROXY protocol
+                          on the IngressController will cause connections to fail
+                          if you are not using a load balancer that uses PROXY protocol
+                          to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt
+                          for information about PROXY protocol. \n The following values
+                          are valid for this field: \n * The empty string. * \"TCP\".
+                          * \"PROXY\". \n The empty string specifies the default,
+                          which is TCP without PROXY protocol.  Note that the default
+                          is subject to change."
+                        enum:
+                        - ""
+                        - TCP
+                        - PROXY
+                        type: string
                     type: object
                   private:
                     description: private holds parameters for the Private endpoint

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -410,6 +410,34 @@ type AWSNetworkLoadBalancerParameters struct {
 // HostNetworkStrategy holds parameters for the HostNetwork endpoint publishing
 // strategy.
 type HostNetworkStrategy struct {
+	// protocol specifies whether the IngressController expects incoming
+	// connections to use plain TCP or whether the IngressController expects
+	// PROXY protocol.
+	//
+	// PROXY protocol can be used with load balancers that support it to
+	// communicate the source addresses of client connections when
+	// forwarding those connections to the IngressController.  Using PROXY
+	// protocol enables the IngressController to report those source
+	// addresses instead of reporting the load balancer's address in HTTP
+	// headers and logs.  Note that enabling PROXY protocol on the
+	// IngressController will cause connections to fail if you are not using
+	// a load balancer that uses PROXY protocol to forward connections to
+	// the IngressController.  See
+	// http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for
+	// information about PROXY protocol.
+	//
+	// The following values are valid for this field:
+	//
+	// * The empty string.
+	// * "TCP".
+	// * "PROXY".
+	//
+	// The empty string specifies the default, which is TCP without PROXY
+	// protocol.  Note that the default is subject to change.
+	//
+	// +kubebuilder:validation:Optional
+	// +optional
+	Protocol IngressControllerProtocol `json:"protocol,omitempty"`
 }
 
 // PrivateStrategy holds parameters for the Private endpoint publishing
@@ -419,7 +447,45 @@ type PrivateStrategy struct {
 
 // NodePortStrategy holds parameters for the NodePortService endpoint publishing strategy.
 type NodePortStrategy struct {
+	// protocol specifies whether the IngressController expects incoming
+	// connections to use plain TCP or whether the IngressController expects
+	// PROXY protocol.
+	//
+	// PROXY protocol can be used with load balancers that support it to
+	// communicate the source addresses of client connections when
+	// forwarding those connections to the IngressController.  Using PROXY
+	// protocol enables the IngressController to report those source
+	// addresses instead of reporting the load balancer's address in HTTP
+	// headers and logs.  Note that enabling PROXY protocol on the
+	// IngressController will cause connections to fail if you are not using
+	// a load balancer that uses PROXY protocol to forward connections to
+	// the IngressController.  See
+	// http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for
+	// information about PROXY protocol.
+	//
+	// The following values are valid for this field:
+	//
+	// * The empty string.
+	// * "TCP".
+	// * "PROXY".
+	//
+	// The empty string specifies the default, which is TCP without PROXY
+	// protocol.  Note that the default is subject to change.
+	//
+	// +kubebuilder:validation:Optional
+	// +optional
+	Protocol IngressControllerProtocol `json:"protocol,omitempty"`
 }
+
+// IngressControllerProtocol specifies whether PROXY protocol is enabled or not.
+// +kubebuilder:validation:Enum="";TCP;PROXY
+type IngressControllerProtocol string
+
+const (
+	DefaultProtocol IngressControllerProtocol = ""
+	TCPProtocol     IngressControllerProtocol = "TCP"
+	ProxyProtocol   IngressControllerProtocol = "PROXY"
+)
 
 // EndpointPublishingStrategy is a way to publish the endpoints of an
 // IngressController, and represents the type and any additional configuration

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -490,7 +490,8 @@ func (GCPLoadBalancerParameters) SwaggerDoc() map[string]string {
 }
 
 var map_HostNetworkStrategy = map[string]string{
-	"": "HostNetworkStrategy holds parameters for the HostNetwork endpoint publishing strategy.",
+	"":         "HostNetworkStrategy holds parameters for the HostNetwork endpoint publishing strategy.",
+	"protocol": "protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.\n\nPROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.\n\nThe following values are valid for this field:\n\n* The empty string. * \"TCP\". * \"PROXY\".\n\nThe empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.",
 }
 
 func (HostNetworkStrategy) SwaggerDoc() map[string]string {
@@ -662,7 +663,8 @@ func (NodePlacement) SwaggerDoc() map[string]string {
 }
 
 var map_NodePortStrategy = map[string]string{
-	"": "NodePortStrategy holds parameters for the NodePortService endpoint publishing strategy.",
+	"":         "NodePortStrategy holds parameters for the NodePortService endpoint publishing strategy.",
+	"protocol": "protocol specifies whether the IngressController expects incoming connections to use plain TCP or whether the IngressController expects PROXY protocol.\n\nPROXY protocol can be used with load balancers that support it to communicate the source addresses of client connections when forwarding those connections to the IngressController.  Using PROXY protocol enables the IngressController to report those source addresses instead of reporting the load balancer's address in HTTP headers and logs.  Note that enabling PROXY protocol on the IngressController will cause connections to fail if you are not using a load balancer that uses PROXY protocol to forward connections to the IngressController.  See http://www.haproxy.org/download/2.2/doc/proxy-protocol.txt for information about PROXY protocol.\n\nThe following values are valid for this field:\n\n* The empty string. * \"TCP\". * \"PROXY\".\n\nThe empty string specifies the default, which is TCP without PROXY protocol.  Note that the default is subject to change.",
 }
 
 func (NodePortStrategy) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This PR implements [NE-573](https://issues.redhat.com/browse/NE-573).

* `operator/v1/types_ingress.go` (`HostNetworkStrategy`, `NodePortStrategy`): Add `Protocol` fields with type `IngressControllerProtocol`.
(`IngressControllerProtocol`): New type.  Specify whether PROXY protocol is enabled or not.
* `operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml`:
* `operator/v1/zz_generated.swagger_doc_generated.go`: Regenerate.