### PR TITLE
FeatureGate: Add ingress Power of Two Random Choices Gate

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -127,7 +127,8 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		"ServiceNodeExclusion",           // sig-scheduling, ccoleman
 	},
 	Disabled: []string{
-		"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman
+		"LegacyNodeRoleBehavior",           // sig-scheduling, ccoleman
+		"PowerOfTwoRandomChoicesBalancing", // sig-network-edge, mmasters
 	},
 }
 

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -28,6 +28,7 @@ func TestFeatureBuilder(t *testing.T) {
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
+					"PowerOfTwoRandomChoicesBalancing",
 					"SupportPodPidsLimit",
 				},
 			},
@@ -44,7 +45,9 @@ func TestFeatureBuilder(t *testing.T) {
 					"ServiceNodeExclusion",
 					"LegacyNodeRoleBehavior",
 				},
-				Disabled: []string{},
+				Disabled: []string{
+					"PowerOfTwoRandomChoicesBalancing",
+				},
 			},
 		},
 		{
@@ -59,6 +62,7 @@ func TestFeatureBuilder(t *testing.T) {
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
+					"PowerOfTwoRandomChoicesBalancing",
 					"SupportPodPidsLimit",
 					"other",
 				},
@@ -77,7 +81,9 @@ func TestFeatureBuilder(t *testing.T) {
 					"LegacyNodeRoleBehavior",
 					"other",
 				},
-				Disabled: []string{},
+				Disabled: []string{
+					"PowerOfTwoRandomChoicesBalancing",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Add a new feature gate, `PowerOfTwoRandomChoicesBalancing`, that is
disabled by default. Enabling this feature gate will tell the
OpenShift Router (HAProxy) to use the "Power of Two Random Choices"
balancing algorithm by default, in place of the current `leastconn`
default balancing algorithm.

See https://www.haproxy.com/blog/power-of-two-load-balancing/
as well as https://github.com/openshift/enhancements/pull/665
for more context.

This is in support of https://issues.redhat.com/browse/NE-549. The current plan is to enable this feature gate in OCP 4.9.


/cc @Miciah 