### PR TITLE
route: Define the ingress-to-route controller name

### DIFF
--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -303,3 +303,11 @@ const (
 	// needs to use routes with invalid hosts.
 	AllowNonDNSCompliantHostAnnotation = "route.openshift.io/allow-non-dns-compliant-host"
 )
+
+// Ingress-to-route controller
+const (
+	// IngressToRouteIngressClassControllerName is the name of the
+	// controller that translates ingresses into routes.  This value is
+	// intended to be used for the spec.controller field of ingressclasses.
+	IngressToRouteIngressClassControllerName = "openshift.io/ingress-to-route"
+)


### PR DESCRIPTION
This PR implements [NE-574](https://issues.redhat.com/browse/NE-574).

* `route/v1/types.go` (`IngressToRouteIngressClassControllerName`): New const. Define the name of the ingress-to-route controller.  This name can be used for the `spec.controller` field of ingressclasses.