### PR TITLE
operator/ingress: Add unsupportedConfigOverrides

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -974,6 +974,12 @@ spec:
                     minimum: 1
                     type: integer
                 type: object
+              unsupportedConfigOverrides:
+                description: unsupportedConfigOverrides allows specifying unsupported
+                  configuration options.  Its use is unsupported.
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
           status:
             description: status is the most recently observed status of the IngressController.

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -187,6 +188,14 @@ type IngressControllerSpec struct {
 	//
 	// +optional
 	TuningOptions IngressControllerTuningOptions `json:"tuningOptions,omitempty"`
+
+	// unsupportedConfigOverrides allows specifying unsupported
+	// configuration options.  Its use is unsupported.
+	//
+	// +optional
+	// +nullable
+	// +kubebuilder:pruning:PreserveUnknownFields
+	UnsupportedConfigOverrides runtime.RawExtension `json:"unsupportedConfigOverrides"`
 }
 
 // NodePlacement describes node scheduling configuration for an ingress

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -1582,6 +1582,7 @@ func (in *IngressControllerSpec) DeepCopyInto(out *IngressControllerSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.TuningOptions = in.TuningOptions
+	in.UnsupportedConfigOverrides.DeepCopyInto(&out.UnsupportedConfigOverrides)
 	return
 }
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -621,6 +621,7 @@ var map_IngressControllerSpec = map[string]string{
 	"logging":                    "logging defines parameters for what should be logged where.  If this field is empty, operational logs are enabled but access logs are disabled.",
 	"httpHeaders":                "httpHeaders defines policy for HTTP headers.\n\nIf this field is empty, the default values are used.",
 	"tuningOptions":              "tuningOptions defines parameters for adjusting the performance of ingress controller pods. All fields are optional and will use their respective defaults if not set. See specific tuningOptions fields for more details.\n\nSetting fields within tuningOptions is generally not recommended. The default values are suitable for most configurations.",
+	"unsupportedConfigOverrides": "unsupportedConfigOverrides allows specifying unsupported configuration options.  Its use is unsupported.",
 }
 
 func (IngressControllerSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Add a `spec.unsupportedConfigOverrides` field to the IngressController API to accommodate unsupported configuration overrides.

This PR resolves [NE-549](https://issues.redhat.com/browse/NE-549).

* `operator/v1/types_ingress.go` (`IngressControllerSpec`): Add an `UnsupportedConfigOverrides` field with type `runtime.RawExtension`.
* `operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml`:
* `operator/v1/zz_generated.deepcopy.go`:
* `operator/v1/zz_generated.swagger_doc_generated.go`: Regenerate.

---

This new API field supersedes the feature gate that https://github.com/openshift/api/pull/872 proposed, based on discussion with @deads2k, @derekwaynecarr, and @sgreene570.