### PR TITLE
Include MTU option for KuryrConfig

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -207,6 +207,16 @@ spec:
                           Kuryr keeps a number of ports ready to be attached to pods.
                           By default port prepopulation is disabled.
                         type: boolean
+                      mtu:
+                        description: mtu is the MTU that Kuryr should use when creating
+                          pod networks in Neutron. The value has to be lower or equal
+                          to the MTU of the nodes network and Neutron has to allow
+                          creation of tenant networks with such MTU. If unset Pod
+                          networks will be created with the same MTU as the nodes
+                          network has.
+                        type: integer
+                        format: int32
+                        minimum: 0
                       openStackServiceNetwork:
                         description: openStackServiceNetwork contains the CIDR of
                           network from which to allocate IPs for OpenStack Octavia's

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -318,6 +318,14 @@ type KuryrConfig struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	PoolBatchPorts *uint `json:"poolBatchPorts,omitempty"`
+
+	// mtu is the MTU that Kuryr should use when creating pod networks in Neutron.
+	// The value has to be lower or equal to the MTU of the nodes network and Neutron has
+	// to allow creation of tenant networks with such MTU. If unset Pod networks will be
+	// created with the same MTU as the nodes network has.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MTU *uint32 `json:"mtu,omitempty"`
 }
 
 // ovnKubernetesConfig contains the configuration parameters for networks

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -2041,6 +2041,11 @@ func (in *KuryrConfig) DeepCopyInto(out *KuryrConfig) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.MTU != nil {
+		in, out := &in.MTU, &out.MTU
+		*out = new(uint32)
+		**out = **in
+	}
 	return
 }
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -856,6 +856,7 @@ var map_KuryrConfig = map[string]string{
 	"poolMaxPorts":                 "poolMaxPorts sets a maximum number of free ports that are being kept in a port pool. If the number of ports exceeds this setting, free ports will get deleted. Setting 0 will disable this upper bound, effectively preventing pools from shrinking and this is the default value. For more information about port pools see enablePortPoolsPrepopulation setting.",
 	"poolMinPorts":                 "poolMinPorts sets a minimum number of free ports that should be kept in a port pool. If the number of ports is lower than this setting, new ports will get created and added to pool. The default is 1. For more information about port pools see enablePortPoolsPrepopulation setting.",
 	"poolBatchPorts":               "poolBatchPorts sets a number of ports that should be created in a single batch request to extend the port pool. The default is 3. For more information about port pools see enablePortPoolsPrepopulation setting.",
+	"mtu":                          "mtu is the MTU that Kuryr should use when creating pod networks in Neutron. The value has to be lower or equal to the MTU of the nodes network and Neutron has to allow creation of tenant networks with such MTU. If unset Pod networks will be created with the same MTU as the nodes network has.",
 }
 
 func (KuryrConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
When using a Provider Network for the Machines
the same MTU is attempted to be used for the
Tenant Networks of the Pods, which can be considered
too big by Neutron. A new option is being included
to allow the user to set the desired MTU for the Pods
Network to avoid such scenario.