### PR TITLE
Add CSI migration to TechPreviewNoUpgrade

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -106,8 +106,10 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		Disabled: []string{},
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
-		with("CSIDriverAzureDisk"). // sig-storage, jsafrane
-		with("CSIDriverVSphere").   // sig-storage, jsafrane
+		with("CSIDriverAzureDisk").    // sig-storage, jsafrane, OCP specific
+		with("CSIDriverVSphere").      // sig-storage, jsafrane, OCP specific
+		with("CSIMigrationAWS").       // sig-storage, jsafrane, Kubernetes feature gate
+		with("CSIMigrationOpenStack"). // sig-storage, jsafrane, Kubernetes feature gate
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(


### PR DESCRIPTION
We want to have CSI migration for AWS and Cinder as tech preview in 4.8.

KEP: https://github.com/openshift/enhancements/pull/549/ 

cc @openshift/storage @Danil-Grigorev 