### PR TITLE
config/v1/types_cluster_version: Update force and verified godocs

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -63,7 +63,7 @@ spec:
                   type: object
                   properties:
                     force:
-                      description: "force allows an administrator to update to an image that has failed verification, does not appear in the availableUpdates list, or otherwise would be blocked by normal protections on update. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources. \n This flag does not override other forms of consistency checking that are required before a new update is deployed."
+                      description: force allows an administrator to update to an image that has failed verification or upgradeable checks. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources.
                       type: boolean
                     image:
                       description: image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.
@@ -207,7 +207,7 @@ spec:
                         description: state reflects whether the update was fully applied. The Partial state indicates the update is not fully applied, while the Completed state indicates the update was successfully rolled out at least once (all parts of the update successfully applied).
                         type: string
                       verified:
-                        description: verified indicates whether the provided update was properly verified before it was installed. If this is false the cluster may not be trusted.
+                        description: verified indicates whether the provided update was properly verified before it was installed. If this is false the cluster may not be trusted. Verified does not cover upgradeable checks that depend on the cluster state at the time when the update target was accepted.
                         type: boolean
                       version:
                         description: version is a semantic versioning identifying the update version. If the requested image does not define a version, or if a failure occurs retrieving the image, this value may be empty.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -157,6 +157,7 @@ type UpdateHistory struct {
 	// +kubebuilder:validation:Required
 	// +required
 	StartedTime metav1.Time `json:"startedTime"`
+
 	// completionTime, if set, is when the update was fully applied. The update
 	// that is currently being applied will have a null completion time.
 	// Completion time will always be set for entries that are not the current
@@ -172,13 +173,17 @@ type UpdateHistory struct {
 	//
 	// +optional
 	Version string `json:"version"`
+
 	// image is a container image location that contains the update. This value
 	// is always populated.
 	// +kubebuilder:validation:Required
 	// +required
 	Image string `json:"image"`
+
 	// verified indicates whether the provided update was properly verified
 	// before it was installed. If this is false the cluster may not be trusted.
+	// Verified does not cover upgradeable checks that depend on the cluster
+	// state at the time when the update target was accepted.
 	// +kubebuilder:validation:Required
 	// +required
 	Verified bool `json:"verified"`
@@ -229,22 +234,20 @@ type Update struct {
 	//
 	// +optional
 	Version string `json:"version"`
+
 	// image is a container image location that contains the update. When this
 	// field is part of spec, image is optional if version is specified and the
 	// availableUpdates field contains a matching version.
 	//
 	// +optional
 	Image string `json:"image"`
+
 	// force allows an administrator to update to an image that has failed
-	// verification, does not appear in the availableUpdates list, or otherwise
-	// would be blocked by normal protections on update. This option should only
+	// verification or upgradeable checks. This option should only
 	// be used when the authenticity of the provided image has been verified out
 	// of band because the provided image will run with full administrative access
 	// to the cluster. Do not use this flag with images that comes from unknown
 	// or potentially malicious sources.
-	//
-	// This flag does not override other forms of consistency checking that are
-	// required before a new update is deployed.
 	//
 	// +optional
 	Force bool `json:"force"`

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -556,7 +556,7 @@ var map_Update = map[string]string{
 	"":        "Update represents an administrator update request.",
 	"version": "version is a semantic versioning identifying the update version. When this field is part of spec, version is optional if image is specified.",
 	"image":   "image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.",
-	"force":   "force allows an administrator to update to an image that has failed verification, does not appear in the availableUpdates list, or otherwise would be blocked by normal protections on update. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources.\n\nThis flag does not override other forms of consistency checking that are required before a new update is deployed.",
+	"force":   "force allows an administrator to update to an image that has failed verification or upgradeable checks. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources.",
 }
 
 func (Update) SwaggerDoc() map[string]string {
@@ -570,7 +570,7 @@ var map_UpdateHistory = map[string]string{
 	"completionTime": "completionTime, if set, is when the update was fully applied. The update that is currently being applied will have a null completion time. Completion time will always be set for entries that are not the current update (usually to the started time of the next update).",
 	"version":        "version is a semantic versioning identifying the update version. If the requested image does not define a version, or if a failure occurs retrieving the image, this value may be empty.",
 	"image":          "image is a container image location that contains the update. This value is always populated.",
-	"verified":       "verified indicates whether the provided update was properly verified before it was installed. If this is false the cluster may not be trusted.",
+	"verified":       "verified indicates whether the provided update was properly verified before it was installed. If this is false the cluster may not be trusted. Verified does not cover upgradeable checks that depend on the cluster state at the time when the update target was accepted.",
 }
 
 func (UpdateHistory) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Addressing some of the ambiguities raised in [rhbz#1825396](https://bugzilla.redhat.com/show_bug.cgi?id=1825396).

These docs have not been adjusted since the properties landed in ab4ff93d20 (#293).  The initial cluster-version operator implementation only used them for signature checks, openshift/cluster-version-operator@f8eff25191 (openshift/cluster-version-operator#170).  At that time, `RetrievePayload` would always attempt to verify the proposed release image, including both signature validation and "does this look like a real release image?" checks.  If that verification succeeded, it would set `verified: true`.  If that verification failed, it would look at `force`, and if `force` was true, it would set `verified: false` and proceed with the update, while if `force` was false, it would reject the update.

Despite the API docs, `availableUpdates` never came into this in the CVO code.  The only `availableUpdates` guards are client-side in `oc`, and the API docs are discussion the ClusterVersion API, not `oc adm upgrade`'s `--force` API.  In openshift/oc@0501d04ff1 (openshift/oc#109), `oc`'s client-side guards split `--allow-explicit-upgrade` (for updating to something not in `availableUpdates`) and `--allow-upgrade-with-warnings` (for updating despite client-side guards against `Progressing` and `Degraded` ClusterVersion conditions) away from `--force`, but again, never part of the ClusterVersion force property's CVO-side handling.

Since then, the CVO grew precondition handlers in openshift/cluster-version-operator@aceb5bc66f (openshift/cluster-version-operator#243).  `syncOnce` ran all the precondition checks, which at that point was just the `Upgradeable` ClusterOperator and ClusterVersion condition check.  If that check failed, but `force` was true, it would proceed with the update, while if `force` was false, it would reject the update.  In neither case would `verified` be altered; it continued to only track the signature and "does this look like a real release image?" checks.  The idea at the time was that these would fall under the "normal protections" phrasing (overriden by `force`) and not the "other forms of consistency checking" phrasing (whatever those were supposed to be).

CC @smarterclayton