### PR TITLE
Bug 1950270: Use "kubernetes.io/os" in the dns/ingress node selector description

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -667,7 +667,7 @@ spec:
                 properties:
                   nodeSelector:
                     description: "nodeSelector is the node selector applied to ingress
-                      controller deployments. \n If unset, the default is: \n   beta.kubernetes.io/os:
+                      controller deployments. \n If unset, the default is: \n   kubernetes.io/os:
                       linux   node-role.kubernetes.io/worker: '' \n If set, the specified
                       selector is used and replaces the default."
                     properties:

--- a/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
+++ b/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
@@ -63,7 +63,7 @@ spec:
                   nodeSelector:
                     description: "nodeSelector is the node selector applied to DNS
                       pods. \n If empty, the default is used, which is currently the
-                      following: \n   beta.kubernetes.io/os: linux \n This default
+                      following: \n   kubernetes.io/os: linux \n This default
                       is subject to change. \n If set, the specified selector is used
                       and replaces the default."
                     type: object

--- a/operator/v1/types_dns.go
+++ b/operator/v1/types_dns.go
@@ -99,7 +99,7 @@ type DNSNodePlacement struct {
 	//
 	// If empty, the default is used, which is currently the following:
 	//
-	//   beta.kubernetes.io/os: linux
+	//   kubernetes.io/os: linux
 	//
 	// This default is subject to change.
 	//

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -217,7 +217,7 @@ type NodePlacement struct {
 	//
 	// If unset, the default is:
 	//
-	//   beta.kubernetes.io/os: linux
+	//   kubernetes.io/os: linux
 	//   node-role.kubernetes.io/worker: ''
 	//
 	// If set, the specified selector is used and replaces the default.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -375,7 +375,7 @@ func (DNSList) SwaggerDoc() map[string]string {
 
 var map_DNSNodePlacement = map[string]string{
 	"":             "DNSNodePlacement describes the node scheduling configuration for DNS pods.",
-	"nodeSelector": "nodeSelector is the node selector applied to DNS pods.\n\nIf empty, the default is used, which is currently the following:\n\n  beta.kubernetes.io/os: linux\n\nThis default is subject to change.\n\nIf set, the specified selector is used and replaces the default.",
+	"nodeSelector": "nodeSelector is the node selector applied to DNS pods.\n\nIf empty, the default is used, which is currently the following:\n\n  kubernetes.io/os: linux\n\nThis default is subject to change.\n\nIf set, the specified selector is used and replaces the default.",
 	"tolerations":  "tolerations is a list of tolerations applied to DNS pods.\n\nThe default is an empty list.  This default is subject to change.\n\nSee https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
 }
 
@@ -678,7 +678,7 @@ func (LoggingDestination) SwaggerDoc() map[string]string {
 
 var map_NodePlacement = map[string]string{
 	"":             "NodePlacement describes node scheduling configuration for an ingress controller.",
-	"nodeSelector": "nodeSelector is the node selector applied to ingress controller deployments.\n\nIf unset, the default is:\n\n  beta.kubernetes.io/os: linux\n  node-role.kubernetes.io/worker: ''\n\nIf set, the specified selector is used and replaces the default.",
+	"nodeSelector": "nodeSelector is the node selector applied to ingress controller deployments.\n\nIf unset, the default is:\n\n  kubernetes.io/os: linux\n  node-role.kubernetes.io/worker: ''\n\nIf set, the specified selector is used and replaces the default.",
 	"tolerations":  "tolerations is a list of tolerations applied to ingress controller deployments.\n\nThe default is an empty list.\n\nSee https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/",
 }
 


### PR DESCRIPTION
Replace "beta.kuberneta.io/os" with "kubernetes.io/os" in the dns/ingress node selector description.

follow-up to  https://github.com/openshift/api/pull/870

@Miciah  Could you please take a look? thanks.