### PR TITLE
Fix: cloud-network-config-controller with genclient marker for client-gen

### DIFF
--- a/cloudnetwork/v1/generated.proto
+++ b/cloudnetwork/v1/generated.proto
@@ -22,6 +22,8 @@ option go_package = "v1";
 // decides to edit it for some reason, their changes will be overwritten the
 // next time the network plugin reconciles the object. Note: the CR's name
 // must specify the requested private IP address (can be IPv4 or IPv6).
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true

--- a/cloudnetwork/v1/types.go
+++ b/cloudnetwork/v1/types.go
@@ -14,6 +14,8 @@ import (
 // decides to edit it for some reason, their changes will be overwritten the
 // next time the network plugin reconciles the object. Note: the CR's name
 // must specify the requested private IP address (can be IPv4 or IPv6).
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true


### PR DESCRIPTION
The fact that this marker was missing was leading to client-gen not generating any of its managed files, see PR: https://github.com/openshift/client-go/pull/181

I have tested this on a local version of https://github.com/openshift/client-go/pull/181 and it works now. 

/assign @sttts 