### PR TITLE
Bug 1947800: config/v1: Switch Network Edge CRDs to CRD v1

### DIFF
--- a/config/v1/0000_10_config-operator_01_dns.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_dns.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dnses.config.openshift.io
@@ -14,91 +14,90 @@ spec:
     plural: dnses
     singular: dns
   scope: Cluster
-  preserveUnknownFields: false
   versions:
   - name: v1
     served: true
     storage: true
-  subresources:
-    status: {}
-  "validation":
-    "openAPIV3Schema":
-      description: DNS holds cluster-wide information about DNS. The canonical name
-        is `cluster`
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: spec holds user settable values for configuration
-          type: object
-          properties:
-            baseDomain:
-              description: "baseDomain is the base domain of the cluster. All managed
-                DNS records will be sub-domains of this base. \n For example, given
-                the base domain `openshift.example.com`, an API server DNS record
-                may be created for `cluster-api.openshift.example.com`. \n Once set,
-                this field cannot be changed."
-              type: string
-            privateZone:
-              description: "privateZone is the location where all the DNS records
-                that are only available internally to the cluster exist. \n If this
-                field is nil, no private records should be created. \n Once set, this
-                field cannot be changed."
-              type: object
-              properties:
-                id:
-                  description: "id is the identifier that can be used to find the
-                    DNS hosted zone. \n on AWS zone can be fetched using `ID` as id
-                    in [1] on Azure zone can be fetched using `ID` as a pre-determined
-                    name in [2], on GCP zone can be fetched using `ID` as a pre-determined
-                    name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
-                    [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
-                    [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
-                  type: string
-                tags:
-                  description: "tags can be used to query the DNS hosted zone. \n
-                    on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone
-                    using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
-                  type: object
-                  additionalProperties:
+    subresources:
+      status: {}
+    "schema":
+      "openAPIV3Schema":
+        description: DNS holds cluster-wide information about DNS. The canonical name
+          is `cluster`
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            type: object
+            properties:
+              baseDomain:
+                description: "baseDomain is the base domain of the cluster. All managed
+                  DNS records will be sub-domains of this base. \n For example, given
+                  the base domain `openshift.example.com`, an API server DNS record
+                  may be created for `cluster-api.openshift.example.com`. \n Once
+                  set, this field cannot be changed."
+                type: string
+              privateZone:
+                description: "privateZone is the location where all the DNS records
+                  that are only available internally to the cluster exist. \n If this
+                  field is nil, no private records should be created. \n Once set,
+                  this field cannot be changed."
+                type: object
+                properties:
+                  id:
+                    description: "id is the identifier that can be used to find the
+                      DNS hosted zone. \n on AWS zone can be fetched using `ID` as
+                      id in [1] on Azure zone can be fetched using `ID` as a pre-determined
+                      name in [2], on GCP zone can be fetched using `ID` as a pre-determined
+                      name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                      [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                      [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
                     type: string
-            publicZone:
-              description: "publicZone is the location where all the DNS records that
-                are publicly accessible to the internet exist. \n If this field is
-                nil, no public records should be created. \n Once set, this field
-                cannot be changed."
-              type: object
-              properties:
-                id:
-                  description: "id is the identifier that can be used to find the
-                    DNS hosted zone. \n on AWS zone can be fetched using `ID` as id
-                    in [1] on Azure zone can be fetched using `ID` as a pre-determined
-                    name in [2], on GCP zone can be fetched using `ID` as a pre-determined
-                    name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
-                    [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
-                    [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
-                  type: string
-                tags:
-                  description: "tags can be used to query the DNS hosted zone. \n
-                    on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone
-                    using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
-                  type: object
-                  additionalProperties:
+                  tags:
+                    description: "tags can be used to query the DNS hosted zone. \n
+                      on AWS, resourcegroupstaggingapi [1] can be used to fetch a
+                      zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                    type: object
+                    additionalProperties:
+                      type: string
+              publicZone:
+                description: "publicZone is the location where all the DNS records
+                  that are publicly accessible to the internet exist. \n If this field
+                  is nil, no public records should be created. \n Once set, this field
+                  cannot be changed."
+                type: object
+                properties:
+                  id:
+                    description: "id is the identifier that can be used to find the
+                      DNS hosted zone. \n on AWS zone can be fetched using `ID` as
+                      id in [1] on Azure zone can be fetched using `ID` as a pre-determined
+                      name in [2], on GCP zone can be fetched using `ID` as a pre-determined
+                      name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                      [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                      [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
                     type: string
-        status:
-          description: status holds observed values from the cluster. They may not
-            be overridden.
-          type: object
+                  tags:
+                    description: "tags can be used to query the DNS hosted zone. \n
+                      on AWS, resourcegroupstaggingapi [1] can be used to fetch a
+                      zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                    type: object
+                    additionalProperties:
+                      type: string
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object

--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingresses.config.openshift.io
@@ -14,283 +14,286 @@ spec:
     plural: ingresses
     singular: ingress
   scope: Cluster
-  preserveUnknownFields: false
   versions:
   - name: v1
     served: true
     storage: true
-  subresources:
-    status: {}
-  "validation":
-    "openAPIV3Schema":
-      description: Ingress holds cluster-wide information about ingress, including
-        the default ingress domain used for routes. The canonical name is `cluster`.
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: spec holds user settable values for configuration
-          type: object
-          properties:
-            appsDomain:
-              description: appsDomain is an optional domain to use instead of the
-                one specified in the domain field when a Route is created without
-                specifying an explicit host. If appsDomain is nonempty, this value
-                is used to generate default host values for Route. Unlike domain,
-                appsDomain may be modified after installation. This assumes a new
-                ingresscontroller has been setup with a wildcard certificate.
-              type: string
-            componentRoutes:
-              description: "componentRoutes is an optional list of routes that are
-                managed by OpenShift components that a cluster-admin is able to configure
-                the hostname and serving certificate for. The namespace and name of
-                each route in this list should match an existing entry in the status.componentRoutes
-                list. \n To determine the set of configurable Routes, look at namespace
-                and name of entries in the .status.componentRoutes list, where participating
-                operators write the status of configurable routes."
-              type: array
-              items:
-                description: ComponentRouteSpec allows for configuration of a route's
-                  hostname and serving certificate.
-                type: object
-                required:
-                - hostname
-                - name
-                - namespace
-                properties:
-                  hostname:
-                    description: hostname is the hostname that should be used by the
-                      route.
-                    type: string
-                    format: hostname
-                  name:
-                    description: "name is the logical name of the route to customize.
-                      \n The namespace and name of this componentRoute must match
-                      a corresponding entry in the list of status.componentRoutes
-                      if the route is to be customized."
-                    type: string
-                    maxLength: 256
-                    minLength: 1
-                  namespace:
-                    description: "namespace is the namespace of the route to customize.
-                      \n The namespace and name of this componentRoute must match
-                      a corresponding entry in the list of status.componentRoutes
-                      if the route is to be customized."
-                    type: string
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                  servingCertKeyPairSecret:
-                    description: servingCertKeyPairSecret is a reference to a secret
-                      of type `kubernetes.io/tls` in the openshift-config namespace.
-                      The serving cert/key pair must match and will be used by the
-                      operator to fulfill the intent of serving with this name. If
-                      the custom hostname uses the default routing suffix of the cluster,
-                      the Secret specification for a serving certificate will not
-                      be needed.
-                    type: object
-                    required:
-                    - name
-                    properties:
-                      name:
-                        description: name is the metadata.name of the referenced secret
-                        type: string
-            domain:
-              description: "domain is used to generate a default host name for a route
-                when the route's host name is empty. The generated host name will
-                follow this pattern: \"<route-name>.<route-namespace>.<domain>\".
-                \n It is also used as the default wildcard domain suffix for ingress.
-                The default ingresscontroller domain will follow this pattern: \"*.<domain>\".
-                \n Once set, changing domain is not currently supported."
-              type: string
-        status:
-          description: status holds observed values from the cluster. They may not
-            be overridden.
-          type: object
-          properties:
-            componentRoutes:
-              description: componentRoutes is where participating operators place
-                the current route status for routes whose hostnames and serving certificates
-                can be customized by the cluster-admin.
-              type: array
-              items:
-                description: ComponentRouteStatus contains information allowing configuration
-                  of a route's hostname and serving certificate.
-                type: object
-                required:
-                - defaultHostname
-                - name
-                - namespace
-                - relatedObjects
-                properties:
-                  conditions:
-                    description: "conditions are used to communicate the state of
-                      the componentRoutes entry. \n Supported conditions include Available,
-                      Degraded and Progressing. \n If available is true, the content
-                      served by the route can be accessed by users. This includes
-                      cases where a default may continue to serve content while the
-                      customized route specified by the cluster-admin is being configured.
-                      \n If Degraded is true, that means something has gone wrong
-                      trying to handle the componentRoutes entry. The currentHostnames
-                      field may or may not be in effect. \n If Progressing is true,
-                      that means the component is taking some action related to the
-                      componentRoutes entry."
-                    type: array
-                    items:
-                      description: "Condition contains details for one aspect of the
-                        current state of this API Resource. --- This struct is intended
-                        for direct use as an array at the field path .status.conditions.
-                        \ For example, type FooStatus struct{     // Represents the
-                        observations of a foo's current state.     // Known .status.conditions.type
-                        are: \"Available\", \"Progressing\", and \"Degraded\"     //
-                        +patchMergeKey=type     // +patchStrategy=merge     // +listType=map
-                        \    // +listMapKey=type     Conditions []metav1.Condition
-                        `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                        protobuf:\"bytes,1,rep,name=conditions\"` \n     // other
-                        fields }"
-                      type: object
-                      required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                      properties:
-                        lastTransitionTime:
-                          description: lastTransitionTime is the last time the condition
-                            transitioned from one status to another. This should be
-                            when the underlying condition changed.  If that is not
-                            known, then using the time when the API field changed
-                            is acceptable.
-                          type: string
-                          format: date-time
-                        message:
-                          description: message is a human readable message indicating
-                            details about the transition. This may be an empty string.
-                          type: string
-                          maxLength: 32768
-                        observedGeneration:
-                          description: observedGeneration represents the .metadata.generation
-                            that the condition was set based upon. For instance, if
-                            .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
-                            is 9, the condition is out of date with respect to the
-                            current state of the instance.
-                          type: integer
-                          format: int64
-                          minimum: 0
-                        reason:
-                          description: reason contains a programmatic identifier indicating
-                            the reason for the condition's last transition. Producers
-                            of specific condition types may define expected values
-                            and meanings for this field, and whether the values are
-                            considered a guaranteed API. The value should be a CamelCase
-                            string. This field may not be empty.
-                          type: string
-                          maxLength: 1024
-                          minLength: 1
-                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        status:
-                          description: status of the condition, one of True, False,
-                            Unknown.
-                          type: string
-                          enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type:
-                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            --- Many .condition.type values are consistent across
-                            resources like Available, but because arbitrary conditions
-                            can be useful (see .node.status.conditions), the ability
-                            to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                          type: string
-                          maxLength: 316
-                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                  consumingUsers:
-                    description: consumingUsers is a slice of ServiceAccounts that
-                      need to have read permission on the servingCertKeyPairSecret
-                      secret.
-                    type: array
-                    maxItems: 5
-                    items:
-                      description: ConsumingUser is an alias for string which we add
-                        validation to. Currently only service accounts are supported.
-                      type: string
-                      maxLength: 512
-                      minLength: 1
-                      pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                  currentHostnames:
-                    description: currentHostnames is the list of current names used
-                      by the route. Typically, this list should consist of a single
-                      hostname, but if multiple hostnames are supported by the route
-                      the operator may write multiple entries to this list.
-                    type: array
-                    minItems: 1
-                    items:
-                      description: Hostname is an alias for hostname string validation.
+    subresources:
+      status: {}
+    "schema":
+      "openAPIV3Schema":
+        description: Ingress holds cluster-wide information about ingress, including
+          the default ingress domain used for routes. The canonical name is `cluster`.
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            type: object
+            properties:
+              appsDomain:
+                description: appsDomain is an optional domain to use instead of the
+                  one specified in the domain field when a Route is created without
+                  specifying an explicit host. If appsDomain is nonempty, this value
+                  is used to generate default host values for Route. Unlike domain,
+                  appsDomain may be modified after installation. This assumes a new
+                  ingresscontroller has been setup with a wildcard certificate.
+                type: string
+              componentRoutes:
+                description: "componentRoutes is an optional list of routes that are
+                  managed by OpenShift components that a cluster-admin is able to
+                  configure the hostname and serving certificate for. The namespace
+                  and name of each route in this list should match an existing entry
+                  in the status.componentRoutes list. \n To determine the set of configurable
+                  Routes, look at namespace and name of entries in the .status.componentRoutes
+                  list, where participating operators write the status of configurable
+                  routes."
+                type: array
+                items:
+                  description: ComponentRouteSpec allows for configuration of a route's
+                    hostname and serving certificate.
+                  type: object
+                  required:
+                  - hostname
+                  - name
+                  - namespace
+                  properties:
+                    hostname:
+                      description: hostname is the hostname that should be used by
+                        the route.
                       type: string
                       format: hostname
-                  defaultHostname:
-                    description: defaultHostname is the hostname of this route prior
-                      to customization.
-                    type: string
-                    format: hostname
-                  name:
-                    description: "name is the logical name of the route to customize.
-                      It does not have to be the actual name of a route resource but
-                      it cannot be renamed. \n The namespace and name of this componentRoute
-                      must match a corresponding entry in the list of spec.componentRoutes
-                      if the route is to be customized."
-                    type: string
-                    maxLength: 256
-                    minLength: 1
-                  namespace:
-                    description: "namespace is the namespace of the route to customize.
-                      It must be a real namespace. Using an actual namespace ensures
-                      that no two components will conflict and the same component
-                      can be installed multiple times. \n The namespace and name of
-                      this componentRoute must match a corresponding entry in the
-                      list of spec.componentRoutes if the route is to be customized."
-                    type: string
-                    maxLength: 63
-                    minLength: 1
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                  relatedObjects:
-                    description: relatedObjects is a list of resources which are useful
-                      when debugging or inspecting how spec.componentRoutes is applied.
-                    type: array
-                    minItems: 1
-                    items:
-                      description: ObjectReference contains enough information to
-                        let you inspect or modify the referred object.
+                    name:
+                      description: "name is the logical name of the route to customize.
+                        \n The namespace and name of this componentRoute must match
+                        a corresponding entry in the list of status.componentRoutes
+                        if the route is to be customized."
+                      type: string
+                      maxLength: 256
+                      minLength: 1
+                    namespace:
+                      description: "namespace is the namespace of the route to customize.
+                        \n The namespace and name of this componentRoute must match
+                        a corresponding entry in the list of status.componentRoutes
+                        if the route is to be customized."
+                      type: string
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    servingCertKeyPairSecret:
+                      description: servingCertKeyPairSecret is a reference to a secret
+                        of type `kubernetes.io/tls` in the openshift-config namespace.
+                        The serving cert/key pair must match and will be used by the
+                        operator to fulfill the intent of serving with this name.
+                        If the custom hostname uses the default routing suffix of
+                        the cluster, the Secret specification for a serving certificate
+                        will not be needed.
                       type: object
                       required:
-                      - group
                       - name
-                      - resource
                       properties:
-                        group:
-                          description: group of the referent.
-                          type: string
                         name:
-                          description: name of the referent.
+                          description: name is the metadata.name of the referenced
+                            secret
                           type: string
-                        namespace:
-                          description: namespace of the referent.
-                          type: string
-                        resource:
-                          description: resource of the referent.
-                          type: string
+              domain:
+                description: "domain is used to generate a default host name for a
+                  route when the route's host name is empty. The generated host name
+                  will follow this pattern: \"<route-name>.<route-namespace>.<domain>\".
+                  \n It is also used as the default wildcard domain suffix for ingress.
+                  The default ingresscontroller domain will follow this pattern: \"*.<domain>\".
+                  \n Once set, changing domain is not currently supported."
+                type: string
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+            properties:
+              componentRoutes:
+                description: componentRoutes is where participating operators place
+                  the current route status for routes whose hostnames and serving
+                  certificates can be customized by the cluster-admin.
+                type: array
+                items:
+                  description: ComponentRouteStatus contains information allowing
+                    configuration of a route's hostname and serving certificate.
+                  type: object
+                  required:
+                  - defaultHostname
+                  - name
+                  - namespace
+                  - relatedObjects
+                  properties:
+                    conditions:
+                      description: "conditions are used to communicate the state of
+                        the componentRoutes entry. \n Supported conditions include
+                        Available, Degraded and Progressing. \n If available is true,
+                        the content served by the route can be accessed by users.
+                        This includes cases where a default may continue to serve
+                        content while the customized route specified by the cluster-admin
+                        is being configured. \n If Degraded is true, that means something
+                        has gone wrong trying to handle the componentRoutes entry.
+                        The currentHostnames field may or may not be in effect. \n
+                        If Progressing is true, that means the component is taking
+                        some action related to the componentRoutes entry."
+                      type: array
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, type FooStatus struct{
+                          \    // Represents the observations of a foo's current state.
+                          \    // Known .status.conditions.type are: \"Available\",
+                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                          \    // +patchStrategy=merge     // +listType=map     //
+                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                          \n     // other fields }"
+                        type: object
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            type: string
+                            format: date-time
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            type: string
+                            maxLength: 32768
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            type: integer
+                            format: int64
+                            minimum: 0
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            type: string
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            type: string
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            type: string
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    consumingUsers:
+                      description: consumingUsers is a slice of ServiceAccounts that
+                        need to have read permission on the servingCertKeyPairSecret
+                        secret.
+                      type: array
+                      maxItems: 5
+                      items:
+                        description: ConsumingUser is an alias for string which we
+                          add validation to. Currently only service accounts are supported.
+                        type: string
+                        maxLength: 512
+                        minLength: 1
+                        pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    currentHostnames:
+                      description: currentHostnames is the list of current names used
+                        by the route. Typically, this list should consist of a single
+                        hostname, but if multiple hostnames are supported by the route
+                        the operator may write multiple entries to this list.
+                      type: array
+                      minItems: 1
+                      items:
+                        description: Hostname is an alias for hostname string validation.
+                        type: string
+                        format: hostname
+                    defaultHostname:
+                      description: defaultHostname is the hostname of this route prior
+                        to customization.
+                      type: string
+                      format: hostname
+                    name:
+                      description: "name is the logical name of the route to customize.
+                        It does not have to be the actual name of a route resource
+                        but it cannot be renamed. \n The namespace and name of this
+                        componentRoute must match a corresponding entry in the list
+                        of spec.componentRoutes if the route is to be customized."
+                      type: string
+                      maxLength: 256
+                      minLength: 1
+                    namespace:
+                      description: "namespace is the namespace of the route to customize.
+                        It must be a real namespace. Using an actual namespace ensures
+                        that no two components will conflict and the same component
+                        can be installed multiple times. \n The namespace and name
+                        of this componentRoute must match a corresponding entry in
+                        the list of spec.componentRoutes if the route is to be customized."
+                      type: string
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    relatedObjects:
+                      description: relatedObjects is a list of resources which are
+                        useful when debugging or inspecting how spec.componentRoutes
+                        is applied.
+                      type: array
+                      minItems: 1
+                      items:
+                        description: ObjectReference contains enough information to
+                          let you inspect or modify the referred object.
+                        type: object
+                        required:
+                        - group
+                        - name
+                        - resource
+                        properties:
+                          group:
+                            description: group of the referent.
+                            type: string
+                          name:
+                            description: name of the referent.
+                            type: string
+                          namespace:
+                            description: namespace of the referent.
+                            type: string
+                          resource:
+                            description: resource of the referent.
+                            type: string


### PR DESCRIPTION
config/v1/0000_10_config-operator_01_ingress.crd.yaml:

Move the `ingresses.config.openshift.io` CRD to use
`apiextensions.k8s.io/v1` in place of `apiextensions.k8s.io/v1beta`.

config/v1/0000_10_config-operator_01_dns.crd.yaml:

Move the `dnses.config.openshift.io` CRD to use
`apiextensions.k8s.io/v1` in place of `apiextensions.k8s.io/v1beta`.

This commit resolves Bug 1947800.