### PR TITLE
Bug 1950590: Cap netflow/sflow/ipfix collectors to 10

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -417,8 +417,9 @@ spec:
                     properties:
                       collectors:
                         description: ipfixCollectors is list of strings formatted
-                          as ip:port
+                          as ip:port with a maximum of ten items
                         type: array
+                        maxItems: 10
                         minItems: 1
                         items:
                           type: string
@@ -430,8 +431,9 @@ spec:
                       collectors:
                         description: netFlow defines the NetFlow collectors that will
                           consume the flow data exported from OVS. It is a list of
-                          strings formatted as ip:port
+                          strings formatted as ip:port with a maximum of ten items
                         type: array
+                        maxItems: 10
                         minItems: 1
                         items:
                           type: string
@@ -442,8 +444,9 @@ spec:
                     properties:
                       collectors:
                         description: sFlowCollectors is list of strings formatted
-                          as ip:port
+                          as ip:port with a maximum of ten items
                         type: array
+                        maxItems: 10
                         minItems: 1
                         items:
                           type: string

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -395,20 +395,23 @@ type ExportNetworkFlows struct {
 
 type NetFlowConfig struct {
 	// netFlow defines the NetFlow collectors that will consume the flow data exported from OVS.
-	// It is a list of strings formatted as ip:port
+	// It is a list of strings formatted as ip:port with a maximum of ten items
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=10
 	Collectors []IPPort `json:"collectors,omitempty"`
 }
 
 type SFlowConfig struct {
-	// sFlowCollectors is list of strings formatted as ip:port
+	// sFlowCollectors is list of strings formatted as ip:port with a maximum of ten items
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=10
 	Collectors []IPPort `json:"collectors,omitempty"`
 }
 
 type IPFIXConfig struct {
-	// ipfixCollectors is list of strings formatted as ip:port
+	// ipfixCollectors is list of strings formatted as ip:port with a maximum of ten items
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=10
 	Collectors []IPPort `json:"collectors,omitempty"`
 }
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -863,7 +863,7 @@ func (IPAMConfig) SwaggerDoc() map[string]string {
 }
 
 var map_IPFIXConfig = map[string]string{
-	"collectors": "ipfixCollectors is list of strings formatted as ip:port",
+	"collectors": "ipfixCollectors is list of strings formatted as ip:port with a maximum of ten items",
 }
 
 func (IPFIXConfig) SwaggerDoc() map[string]string {
@@ -887,7 +887,7 @@ func (KuryrConfig) SwaggerDoc() map[string]string {
 }
 
 var map_NetFlowConfig = map[string]string{
-	"collectors": "netFlow defines the NetFlow collectors that will consume the flow data exported from OVS. It is a list of strings formatted as ip:port",
+	"collectors": "netFlow defines the NetFlow collectors that will consume the flow data exported from OVS. It is a list of strings formatted as ip:port with a maximum of ten items",
 }
 
 func (NetFlowConfig) SwaggerDoc() map[string]string {
@@ -995,7 +995,7 @@ func (ProxyConfig) SwaggerDoc() map[string]string {
 }
 
 var map_SFlowConfig = map[string]string{
-	"collectors": "sFlowCollectors is list of strings formatted as ip:port",
+	"collectors": "sFlowCollectors is list of strings formatted as ip:port with a maximum of ten items",
 }
 
 func (SFlowConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
It is unrealistic to expect customers to have more than 10, typically
they should have a LB in to distribute the load anyways.