### PR TITLE
bug 1949306: make removedInRelease setable to empty string

### DIFF
--- a/apiserver/v1/apiserver.openshift.io_apirequestcount.yaml
+++ b/apiserver/v1/apiserver.openshift.io_apirequestcount.yaml
@@ -316,6 +316,7 @@ spec:
                 description: removedInRelease is when the API will be removed.
                 type: string
                 maxLength: 64
+                minLength: 0
                 pattern: ^[0-9][0-9]*\.[0-9][0-9]*$
               requestCount:
                 description: requestCount is a sum of all requestCounts across all

--- a/apiserver/v1/types_apirequestcount.go
+++ b/apiserver/v1/types_apirequestcount.go
@@ -50,10 +50,11 @@ type APIRequestCountStatus struct {
 	Conditions []metav1.Condition `json:"conditions"`
 
 	// removedInRelease is when the API will be removed.
+	// +kubebuilder:validation:MinLength=0
 	// +kubebuilder:validation:Pattern=^[0-9][0-9]*\.[0-9][0-9]*$
 	// +kubebuilder:validation:MaxLength=64
 	// +optional
-	RemovedInRelease string `json:"removedInRelease"`
+	RemovedInRelease string `json:"removedInRelease,omitempty"`
 
 	// requestCount is a sum of all requestCounts across all current hours, nodes, and users.
 	// +kubebuilder:validation:Minimum=0


### PR DESCRIPTION
trying to address

> 2021-04-19T13:13:50.448284583Z E0419 13:13:50.448191      18 apiaccess_count_controller.go:112] APIRequestCount.apiserver.openshift.io "apiservers.v1.config.openshift.io" is invalid: status.removedInRelease: Invalid value: "": status.removedInRelease in body should match '^[0-9][0-9]*\.[0-9][0-9]*$'