### PR TITLE
Bug 1948311: APIRequestCountStatus.Conditions makes sure that tags and comments align

### DIFF
--- a/apiserver/v1/types_apirequestcount.go
+++ b/apiserver/v1/types_apirequestcount.go
@@ -47,7 +47,7 @@ type APIRequestCountStatus struct {
 	// conditions contains details of the current status of this API Resource.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
-	Conditions []metav1.Condition `json:"conditions"`
+	Conditions []metav1.Condition `json:"conditions" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// removedInRelease is when the API will be removed.
 	// +kubebuilder:validation:Pattern=^[0-9][0-9]*\.[0-9][0-9]*$


### PR DESCRIPTION
otherwise genereting OpenAPI fails with: "Tags in comment and struct should match for member (Conditions) of (github.com/openshift/api/apiserver/v1.APIRequestCountStatus)"