### PR TITLE
Bug 1951853: operator/dns: Describe default toleration

### DIFF
--- a/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
+++ b/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
@@ -71,8 +71,13 @@ spec:
                       type: string
                   tolerations:
                     description: "tolerations is a list of tolerations applied to
-                      DNS pods. \n The default is an empty list.  This default is
-                      subject to change. \n See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/"
+                      DNS pods. \n If empty, the operator sets a toleration for the
+                      \"node-role.kubernetes.io/master\" taint.  This default is subject
+                      to change.  Specifying tolerations without including a toleration
+                      for the \"node-role.kubernetes.io/master\" taint may be risky
+                      as it could lead to an outage if all worker nodes become unavailable.
+                      \n Note that the daemon controller adds some tolerations as
+                      well.  See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/"
                     type: array
                     items:
                       description: The pod this Toleration is attached to tolerates

--- a/operator/v1/types_dns.go
+++ b/operator/v1/types_dns.go
@@ -110,9 +110,14 @@ type DNSNodePlacement struct {
 
 	// tolerations is a list of tolerations applied to DNS pods.
 	//
-	// The default is an empty list.  This default is subject to change.
+	// If empty, the DNS operator sets a toleration for the
+	// "node-role.kubernetes.io/master" taint.  This default is subject to
+	// change.  Specifying tolerations without including a toleration for
+	// the "node-role.kubernetes.io/master" taint may be risky as it could
+	// lead to an outage if all worker nodes become unavailable.
 	//
-	// See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+	// Note that the daemon controller adds some tolerations as well.  See
+	// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 	//
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -386,7 +386,7 @@ func (DNSList) SwaggerDoc() map[string]string {
 var map_DNSNodePlacement = map[string]string{
 	"":             "DNSNodePlacement describes the node scheduling configuration for DNS pods.",
 	"nodeSelector": "nodeSelector is the node selector applied to DNS pods.\n\nIf empty, the default is used, which is currently the following:\n\n  kubernetes.io/os: linux\n\nThis default is subject to change.\n\nIf set, the specified selector is used and replaces the default.",
-	"tolerations":  "tolerations is a list of tolerations applied to DNS pods.\n\nThe default is an empty list.  This default is subject to change.\n\nSee https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+	"tolerations":  "tolerations is a list of tolerations applied to DNS pods.\n\nIf empty, the DNS operator sets a toleration for the \"node-role.kubernetes.io/master\" taint.  This default is subject to change.  Specifying tolerations without including a toleration for the \"node-role.kubernetes.io/master\" taint may be risky as it could lead to an outage if all worker nodes become unavailable.\n\nNote that the daemon controller adds some tolerations as well.  See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
 }
 
 func (DNSNodePlacement) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Update the godoc for the `dnses.operator.openshift.io` resource's `spec.nodePlacement.tolerations` field to state that the DNS operator adds a toleration for the `node-role.kubernetes.io/master` taint, that omitting the toleration would be risky, and that the daemon controller adds some additional tolerations.

* `operator/v1/types_dns.go` (`DNSNodePlacement`): Fix description of the `Tolerations` field.
* `operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml`:
* `operator/v1/zz_generated.swagger_doc_generated.go`: Regenerate.