### PR TITLE
config: add aws resourceTags to spec of infrastructure

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -76,6 +76,37 @@ spec:
                       Services infrastructure provider.
                     type: object
                     properties:
+                      resourceTags:
+                        description: resourceTags is a list of additional tags to
+                          apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                          for information on tagging AWS resources. AWS supports a
+                          maximum of 50 tags per resource. OpenShift reserves 25 tags
+                          for its use, leaving 25 tags available for the user.
+                        type: array
+                        maxItems: 25
+                        items:
+                          description: AWSResourceTag is a tag to apply to AWS resources
+                            created for the cluster.
+                          type: object
+                          required:
+                          - key
+                          - value
+                          properties:
+                            key:
+                              description: key is the key of the tag
+                              type: string
+                              maxLength: 128
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                            value:
+                              description: value is the value of the tag. Some AWS
+                                service do not support empty values. Since tags are
+                                added to resources in many services, the length of
+                                the tag value must meet the requirements of all services.
+                              type: string
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                       serviceEndpoints:
                         description: serviceEndpoints list contains custom endpoints
                           which will override default service endpoint of AWS Services.

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -301,6 +301,14 @@ type AWSPlatformSpec struct {
 	// There must be only one ServiceEndpoint for a service.
 	// +optional
 	ServiceEndpoints []AWSServiceEndpoint `json:"serviceEndpoints,omitempty"`
+
+	// resourceTags is a list of additional tags to apply to AWS resources created for the cluster.
+	// See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources.
+	// AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags
+	// available for the user.
+	// +kubebuilder:validation:MaxItems=25
+	// +optional
+	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
 }
 
 // AWSPlatformStatus holds the current status of the Amazon Web Services infrastructure provider.

--- a/config/v1/zz_generated.deepcopy.go
+++ b/config/v1/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *AWSPlatformSpec) DeepCopyInto(out *AWSPlatformSpec) {
 		*out = make([]AWSServiceEndpoint, len(*in))
 		copy(*out, *in)
 	}
+	if in.ResourceTags != nil {
+		in, out := &in.ResourceTags, &out.ResourceTags
+		*out = make([]AWSResourceTag, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -715,6 +715,7 @@ func (RegistrySources) SwaggerDoc() map[string]string {
 var map_AWSPlatformSpec = map[string]string{
 	"":                 "AWSPlatformSpec holds the desired state of the Amazon Web Services infrastructure provider. This only includes fields that can be modified in the cluster.",
 	"serviceEndpoints": "serviceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.",
+	"resourceTags":     "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.",
 }
 
 func (AWSPlatformSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Add the `spec.platformSpec.aws.resourceTags` field to the infrastructure.config.openshift.io CRD. This is the user-facing field for setting additional tags to be applied to AWS resources created for the cluster. There will be a controller in cluster-config-operator that syncs the field from the spec to the status.

/cc @deads2k 