### PR TITLE
Define Hash field of GenerationStatus struct as optional

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -137,7 +137,8 @@ type GenerationStatus struct {
 	// lastGeneration is the last generation of the workload controller involved
 	LastGeneration int64 `json:"lastGeneration"`
 	// hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-	Hash string `json:"hash"`
+	// +optional
+	Hash string `json:"hash,omitempty"`
 }
 
 var (


### PR DESCRIPTION
In the comment, Hash field of GenerationStatus struct is [said to be an optional field](https://github.com/openshift/api/blob/master/operator/v1/types.go#L139) although the field is not defined to be optional. Due to bug in Go, mandatory fields weren't enforced properly and therefore this mistake was never discovered.

Signed-off-by: Itamar Holder <iholder@redhat.com>