### PR TITLE
Specify case when ComponentRouteSpec's hostname contains the same hostname as the default route

### DIFF
--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -100,7 +100,9 @@ spec:
                         operator to fulfill the intent of serving with this name.
                         If the custom hostname uses the default routing suffix of
                         the cluster, the Secret specification for a serving certificate
-                        will not be needed.
+                        will not be needed. If the custom hostname uses the same hostname
+                        as customized route, the Secret specification will used on
+                        that route, without creating a custom route.
                       type: object
                       required:
                       - name

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -105,6 +105,8 @@ type ComponentRouteSpec struct {
 	// The serving cert/key pair must match and will be used by the operator to fulfill the intent of serving with this name.
 	// If the custom hostname uses the default routing suffix of the cluster,
 	// the Secret specification for a serving certificate will not be needed.
+	// If the custom hostname uses the same hostname as customized route,
+	// the Secret specification will used on that route, without creating a custom route.
 	// +optional
 	ServingCertKeyPairSecret SecretNameReference `json:"servingCertKeyPairSecret"`
 }

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1008,7 +1008,7 @@ var map_ComponentRouteSpec = map[string]string{
 	"namespace":                "namespace is the namespace of the route to customize.\n\nThe namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized.",
 	"name":                     "name is the logical name of the route to customize.\n\nThe namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized.",
 	"hostname":                 "hostname is the hostname that should be used by the route.",
-	"servingCertKeyPairSecret": "servingCertKeyPairSecret is a reference to a secret of type `kubernetes.io/tls` in the openshift-config namespace. The serving cert/key pair must match and will be used by the operator to fulfill the intent of serving with this name. If the custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed.",
+	"servingCertKeyPairSecret": "servingCertKeyPairSecret is a reference to a secret of type `kubernetes.io/tls` in the openshift-config namespace. The serving cert/key pair must match and will be used by the operator to fulfill the intent of serving with this name. If the custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed. If the custom hostname uses the same hostname as customized route, the Secret specification will used on that route, without creating a custom route.",
 }
 
 func (ComponentRouteSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Adding additional comment to clarify additional use-case when the `ComponentRouteSpec`'s specifies the same hostname as the default route.
Not really sure if we need BZ here since its just adding comment. 

/assign @sttts

cc'ing @awgreene per our discussion 👍 