### PR TITLE
Bug 1952795: fix plural name for CloudPrivateIPConfig

### DIFF
--- a/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
+++ b/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
@@ -1,13 +1,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: cloudprivateipconfig.cloud.network.openshift.io
+  name: cloudprivateipconfigs.cloud.network.openshift.io
 spec:
   group: cloud.network.openshift.io
   names:
     kind: CloudPrivateIPConfig
     listKind: CloudPrivateIPConfigList
-    plural: cloudprivateipconfig
+    plural: cloudprivateipconfigs
     singular: cloudprivateipconfig
   scope: Cluster
   versions:

--- a/cloudnetwork/v1/generated.proto
+++ b/cloudnetwork/v1/generated.proto
@@ -28,7 +28,7 @@ option go_package = "v1";
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=cloudprivateipconfig,scope=Cluster
+// +kubebuilder:resource:path=cloudprivateipconfigs,scope=Cluster
 message CloudPrivateIPConfig {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 

--- a/cloudnetwork/v1/types.go
+++ b/cloudnetwork/v1/types.go
@@ -20,7 +20,7 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=cloudprivateipconfig,scope=Cluster
+// +kubebuilder:resource:path=cloudprivateipconfigs,scope=Cluster
 type CloudPrivateIPConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`


### PR DESCRIPTION
This fixes a minor issue with the CRD for cloud private IP configs. The CRD's `spec.names.plural` is currently incorrect and needs updating as the controller fails to find the resource as it currently stands.

/assign @danwinship @sttts 