### PR TITLE
Bug 1947798: Use CRD v1 for images.config and ICSPs

### DIFF
--- a/config/v1/0000_10_config-operator_01_image.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_image.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: images.config.openshift.io
@@ -9,7 +9,6 @@ metadata:
 spec:
   group: config.openshift.io
   scope: Cluster
-  preserveUnknownFields: false
   names:
     kind: Image
     singular: image
@@ -19,143 +18,144 @@ spec:
   - name: v1
     served: true
     storage: true
-  subresources:
-    status: {}
-  "validation":
-    "openAPIV3Schema":
-      description: Image governs policies related to imagestream imports and runtime
-        configuration for external registries. It allows cluster admins to configure
-        which registries OpenShift is allowed to import images from, extra CA trust
-        bundles for external registries, and policies to block or allow registry hostnames.
-        When exposing OpenShift's image registry to the public, this also lets cluster
-        admins specify the external hostname.
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: spec holds user settable values for configuration
-          type: object
-          properties:
-            additionalTrustedCA:
-              description: additionalTrustedCA is a reference to a ConfigMap containing
-                additional CAs that should be trusted during imagestream import, pod
-                image pull, build image pull, and imageregistry pullthrough. The namespace
-                for this config map is openshift-config.
-              type: object
-              required:
-              - name
-              properties:
-                name:
-                  description: name is the metadata.name of the referenced config
-                    map
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: Image governs policies related to imagestream imports and runtime
+          configuration for external registries. It allows cluster admins to configure
+          which registries OpenShift is allowed to import images from, extra CA trust
+          bundles for external registries, and policies to block or allow registry
+          hostnames. When exposing OpenShift's image registry to the public, this
+          also lets cluster admins specify the external hostname.
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            type: object
+            properties:
+              additionalTrustedCA:
+                description: additionalTrustedCA is a reference to a ConfigMap containing
+                  additional CAs that should be trusted during imagestream import,
+                  pod image pull, build image pull, and imageregistry pullthrough.
+                  The namespace for this config map is openshift-config.
+                type: object
+                required:
+                - name
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+              allowedRegistriesForImport:
+                description: allowedRegistriesForImport limits the container image
+                  registries that normal users may import images from. Set this list
+                  to the registries that you trust to contain valid Docker images
+                  and that you want applications to be able to import from. Users
+                  with permission to create Images or ImageStreamMappings via the
+                  API are not affected by this policy - typically only administrators
+                  or system integrations will have those permissions.
+                type: array
+                items:
+                  description: RegistryLocation contains a location of the registry
+                    specified by the registry domain name. The domain name might include
+                    wildcards, like '*' or '??'.
+                  type: object
+                  properties:
+                    domainName:
+                      description: domainName specifies a domain name for the registry
+                        In case the registry use non-standard (80 or 443) port, the
+                        port should be included in the domain name as well.
+                      type: string
+                    insecure:
+                      description: insecure indicates whether the registry is secure
+                        (https) or insecure (http) By default (if not specified) the
+                        registry is assumed as secure.
+                      type: boolean
+              externalRegistryHostnames:
+                description: externalRegistryHostnames provides the hostnames for
+                  the default external image registry. The external hostname should
+                  be set only when the image registry is exposed externally. The first
+                  value is used in 'publicDockerImageRepository' field in ImageStreams.
+                  The value must be in "hostname[:port]" format.
+                type: array
+                items:
                   type: string
-            allowedRegistriesForImport:
-              description: allowedRegistriesForImport limits the container image registries
-                that normal users may import images from. Set this list to the registries
-                that you trust to contain valid Docker images and that you want applications
-                to be able to import from. Users with permission to create Images
-                or ImageStreamMappings via the API are not affected by this policy
-                - typically only administrators or system integrations will have those
-                permissions.
-              type: array
-              items:
-                description: RegistryLocation contains a location of the registry
-                  specified by the registry domain name. The domain name might include
-                  wildcards, like '*' or '??'.
+              registrySources:
+                description: registrySources contains configuration that determines
+                  how the container runtime should treat individual registries when
+                  accessing images for builds+pods. (e.g. whether or not to allow
+                  insecure access).  It does not contain configuration for the internal
+                  cluster registry.
                 type: object
                 properties:
-                  domainName:
-                    description: domainName specifies a domain name for the registry
-                      In case the registry use non-standard (80 or 443) port, the
-                      port should be included in the domain name as well.
-                    type: string
-                  insecure:
-                    description: insecure indicates whether the registry is secure
-                      (https) or insecure (http) By default (if not specified) the
-                      registry is assumed as secure.
-                    type: boolean
-            externalRegistryHostnames:
-              description: externalRegistryHostnames provides the hostnames for the
-                default external image registry. The external hostname should be set
-                only when the image registry is exposed externally. The first value
-                is used in 'publicDockerImageRepository' field in ImageStreams. The
-                value must be in "hostname[:port]" format.
-              type: array
-              items:
+                  allowedRegistries:
+                    description: "allowedRegistries are the only registries permitted
+                      for image pull and push actions. All other registries are denied.
+                      \n Only one of BlockedRegistries or AllowedRegistries may be
+                      set."
+                    type: array
+                    items:
+                      type: string
+                  blockedRegistries:
+                    description: "blockedRegistries cannot be used for image pull
+                      and push actions. All other registries are permitted. \n Only
+                      one of BlockedRegistries or AllowedRegistries may be set."
+                    type: array
+                    items:
+                      type: string
+                  containerRuntimeSearchRegistries:
+                    description: 'containerRuntimeSearchRegistries are registries
+                      that will be searched when pulling images that do not have fully
+                      qualified domains in their pull specs. Registries will be searched
+                      in the order provided in the list. Note: this search list only
+                      works with the container runtime, i.e CRI-O. Will NOT work with
+                      builds or imagestream imports.'
+                    type: array
+                    format: hostname
+                    minItems: 1
+                    items:
+                      type: string
+                    x-kubernetes-list-type: set
+                  insecureRegistries:
+                    description: insecureRegistries are registries which do not have
+                      a valid TLS certificates or only support HTTP connections.
+                    type: array
+                    items:
+                      type: string
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+            properties:
+              externalRegistryHostnames:
+                description: externalRegistryHostnames provides the hostnames for
+                  the default external image registry. The external hostname should
+                  be set only when the image registry is exposed externally. The first
+                  value is used in 'publicDockerImageRepository' field in ImageStreams.
+                  The value must be in "hostname[:port]" format.
+                type: array
+                items:
+                  type: string
+              internalRegistryHostname:
+                description: internalRegistryHostname sets the hostname for the default
+                  internal image registry. The value must be in "hostname[:port]"
+                  format. This value is set by the image registry operator which controls
+                  the internal registry hostname. For backward compatibility, users
+                  can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but
+                  this setting overrides the environment variable.
                 type: string
-            registrySources:
-              description: registrySources contains configuration that determines
-                how the container runtime should treat individual registries when
-                accessing images for builds+pods. (e.g. whether or not to allow insecure
-                access).  It does not contain configuration for the internal cluster
-                registry.
-              type: object
-              properties:
-                allowedRegistries:
-                  description: "allowedRegistries are the only registries permitted
-                    for image pull and push actions. All other registries are denied.
-                    \n Only one of BlockedRegistries or AllowedRegistries may be set."
-                  type: array
-                  items:
-                    type: string
-                blockedRegistries:
-                  description: "blockedRegistries cannot be used for image pull and
-                    push actions. All other registries are permitted. \n Only one
-                    of BlockedRegistries or AllowedRegistries may be set."
-                  type: array
-                  items:
-                    type: string
-                containerRuntimeSearchRegistries:
-                  description: 'containerRuntimeSearchRegistries are registries that
-                    will be searched when pulling images that do not have fully qualified
-                    domains in their pull specs. Registries will be searched in the
-                    order provided in the list. Note: this search list only works
-                    with the container runtime, i.e CRI-O. Will NOT work with builds
-                    or imagestream imports.'
-                  type: array
-                  format: hostname
-                  minItems: 1
-                  items:
-                    type: string
-                  x-kubernetes-list-type: set
-                insecureRegistries:
-                  description: insecureRegistries are registries which do not have
-                    a valid TLS certificates or only support HTTP connections.
-                  type: array
-                  items:
-                    type: string
-        status:
-          description: status holds observed values from the cluster. They may not
-            be overridden.
-          type: object
-          properties:
-            externalRegistryHostnames:
-              description: externalRegistryHostnames provides the hostnames for the
-                default external image registry. The external hostname should be set
-                only when the image registry is exposed externally. The first value
-                is used in 'publicDockerImageRepository' field in ImageStreams. The
-                value must be in "hostname[:port]" format.
-              type: array
-              items:
-                type: string
-            internalRegistryHostname:
-              description: internalRegistryHostname sets the hostname for the default
-                internal image registry. The value must be in "hostname[:port]" format.
-                This value is set by the image registry operator which controls the
-                internal registry hostname. For backward compatibility, users can
-                still use OPENSHIFT_DEFAULT_REGISTRY environment variable but this
-                setting overrides the environment variable.
-              type: string

--- a/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
+++ b/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: imagecontentsourcepolicies.operator.openshift.io
@@ -9,7 +9,6 @@ metadata:
 spec:
   group: operator.openshift.io
   scope: Cluster
-  preserveUnknownFields: false
   names:
     kind: ImageContentSourcePolicy
     singular: imagecontentsourcepolicy
@@ -19,74 +18,76 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-  subresources:
-    status: {}
-  "validation":
-    "openAPIV3Schema":
-      description: ImageContentSourcePolicy holds cluster-wide information about how
-        to handle registry mirror rules. When multiple policies are defined, the outcome
-        of the behavior is defined on each field.
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: spec holds user settable values for configuration
-          type: object
-          properties:
-            repositoryDigestMirrors:
-              description: "repositoryDigestMirrors allows images referenced by image
-                digests in pods to be pulled from alternative mirrored repository
-                locations. The image pull specification provided to the pod will be
-                compared to the source locations described in RepositoryDigestMirrors
-                and the image may be pulled down from any of the mirrors in the list
-                instead of the specified repository allowing administrators to choose
-                a potentially faster mirror. Only image pull specifications that have
-                an image digest will have this behavior applied to them - tags will
-                continue to be pulled from the specified repository in the pull spec.
-                \n Each “source” repository is treated independently; configurations
-                for different “source” repositories don’t interact. \n When multiple
-                policies are defined for the same “source” repository, the sets of
-                defined mirrors will be merged together, preserving the relative order
-                of the mirrors, if possible. For example, if policy A has mirrors
-                `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be
-                used in the order `a, b, c, d, e`.  If the orders of mirror entries
-                conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected
-                but the resulting order is unspecified."
-              type: array
-              items:
-                description: 'RepositoryDigestMirrors holds cluster-wide information
-                  about how to handle mirros in the registries config. Note: the mirrors
-                  only work when pulling the images that are referenced by their digests.'
-                type: object
-                required:
-                - source
-                properties:
-                  mirrors:
-                    description: mirrors is one or more repositories that may also
-                      contain the same images. The order of mirrors in this list is
-                      treated as the user's desired priority, while source is by default
-                      considered lower priority than all mirrors. Other cluster configuration,
-                      including (but not limited to) other repositoryDigestMirrors
-                      objects, may impact the exact order mirrors are contacted in,
-                      or some mirrors may be contacted in parallel, so this should
-                      be considered a preference rather than a guarantee of ordering.
-                    type: array
-                    items:
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: ImageContentSourcePolicy holds cluster-wide information about
+          how to handle registry mirror rules. When multiple policies are defined,
+          the outcome of the behavior is defined on each field.
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            type: object
+            properties:
+              repositoryDigestMirrors:
+                description: "repositoryDigestMirrors allows images referenced by
+                  image digests in pods to be pulled from alternative mirrored repository
+                  locations. The image pull specification provided to the pod will
+                  be compared to the source locations described in RepositoryDigestMirrors
+                  and the image may be pulled down from any of the mirrors in the
+                  list instead of the specified repository allowing administrators
+                  to choose a potentially faster mirror. Only image pull specifications
+                  that have an image digest will have this behavior applied to them
+                  - tags will continue to be pulled from the specified repository
+                  in the pull spec. \n Each “source” repository is treated independently;
+                  configurations for different “source” repositories don’t interact.
+                  \n When multiple policies are defined for the same “source” repository,
+                  the sets of defined mirrors will be merged together, preserving
+                  the relative order of the mirrors, if possible. For example, if
+                  policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`,
+                  the mirrors will be used in the order `a, b, c, d, e`.  If the orders
+                  of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration
+                  is not rejected but the resulting order is unspecified."
+                type: array
+                items:
+                  description: 'RepositoryDigestMirrors holds cluster-wide information
+                    about how to handle mirros in the registries config. Note: the
+                    mirrors only work when pulling the images that are referenced
+                    by their digests.'
+                  type: object
+                  required:
+                  - source
+                  properties:
+                    mirrors:
+                      description: mirrors is one or more repositories that may also
+                        contain the same images. The order of mirrors in this list
+                        is treated as the user's desired priority, while source is
+                        by default considered lower priority than all mirrors. Other
+                        cluster configuration, including (but not limited to) other
+                        repositoryDigestMirrors objects, may impact the exact order
+                        mirrors are contacted in, or some mirrors may be contacted
+                        in parallel, so this should be considered a preference rather
+                        than a guarantee of ordering.
+                      type: array
+                      items:
+                        type: string
+                    source:
+                      description: source is the repository that users refer to, e.g.
+                        in image pull specifications.
                       type: string
-                  source:
-                    description: source is the repository that users refer to, e.g.
-                      in image pull specifications.
-                    type: string


### PR DESCRIPTION
CRD v1beta1 is going to be removed, so we need to migrate to v1.