### PR TITLE
Bug 1959696: Deprecate 'ConsoleConfigRoute' struct in console-operator config

### DIFF
--- a/operator/v1/0000_70_console-operator.crd.yaml
+++ b/operator/v1/0000_70_console-operator.crd.yaml
@@ -269,7 +269,7 @@ spec:
                   domain, manual DNS configurations steps are necessary. The default
                   console route will be maintained to reserve the default hostname
                   for console if the custom route is removed. If not specified, default
-                  route will be used.
+                  route will be used. DEPRECATED
                 type: object
                 properties:
                   hostname:

--- a/operator/v1/types_console.go
+++ b/operator/v1/types_console.go
@@ -40,6 +40,7 @@ type ConsoleSpec struct {
 	// The default console route will be maintained to reserve the default hostname
 	// for console if the custom route is removed.
 	// If not specified, default route will be used.
+	// DEPRECATED
 	// +optional
 	Route ConsoleConfigRoute `json:"route"`
 	// plugins defines a list of enabled console plugin names.
@@ -48,6 +49,7 @@ type ConsoleSpec struct {
 }
 
 // ConsoleConfigRoute holds information on external route access to console.
+// DEPRECATED
 type ConsoleConfigRoute struct {
 	// hostname is the desired custom domain under which console will be available.
 	Hostname string `json:"hostname"`

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -197,7 +197,7 @@ func (Console) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleConfigRoute = map[string]string{
-	"":         "ConsoleConfigRoute holds information on external route access to console.",
+	"":         "ConsoleConfigRoute holds information on external route access to console. DEPRECATED",
 	"hostname": "hostname is the desired custom domain under which console will be available.",
 	"secret":   "secret points to secret in the openshift-config namespace that contains custom certificate and key and needs to be created manually by the cluster admin. Referenced Secret is required to contain following key value pairs: - \"tls.crt\" - to specifies custom certificate - \"tls.key\" - to specifies private key of the custom certificate If the custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed.",
 }
@@ -235,7 +235,7 @@ var map_ConsoleSpec = map[string]string{
 	"":              "ConsoleSpec is the specification of the desired behavior of the Console.",
 	"customization": "customization is used to optionally provide a small set of customization options to the web console.",
 	"providers":     "providers contains configuration for using specific service providers.",
-	"route":         "route contains hostname and secret reference that contains the serving certificate. If a custom route is specified, a new route will be created with the provided hostname, under which console will be available. In case of custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed. In case of custom hostname points to an arbitrary domain, manual DNS configurations steps are necessary. The default console route will be maintained to reserve the default hostname for console if the custom route is removed. If not specified, default route will be used.",
+	"route":         "route contains hostname and secret reference that contains the serving certificate. If a custom route is specified, a new route will be created with the provided hostname, under which console will be available. In case of custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed. In case of custom hostname points to an arbitrary domain, manual DNS configurations steps are necessary. The default console route will be maintained to reserve the default hostname for console if the custom route is removed. If not specified, default route will be used. DEPRECATED",
 	"plugins":       "plugins defines a list of enabled console plugin names.",
 }
 


### PR DESCRIPTION
Adding `DEPRECATED: will be removed in 4.10`, although not 100% sure we want to set that expectation, or just add `DEPRECATED` string and remove the logic so when admin user sets the field nothing will happen, maybe just a log msg in the console-operator will appear notifying that the field is deprecated and that he needs to set the desired domain via ingress operator config. 

/assign @spadgett 