### PR TITLE
config/v1/types_cluster_operator: Expand upgradeable inputs to cluster scope

### DIFF
--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -170,7 +170,7 @@ const (
 	// unexpected errors are handled as operators mature.
 	OperatorDegraded ClusterStatusConditionType = "Degraded"
 
-	// Upgradeable indicates whether the operator is in a state that is safe to upgrade. When status is `False`
+	// Upgradeable indicates whether the operator safe to upgrade based on the current cluster state. When status is `False`
 	// administrators should not upgrade their cluster and the message field should contain a human readable description
 	// of what the administrator should do to allow the operator to successfully update.  A missing condition, True,
 	// and Unknown are all treated by the CVO as allowing an upgrade.


### PR DESCRIPTION
Consider these cases:

a. Component A is in a state that allows updates, and nothing in the rest of the cluster would break if A updated.
b. Component A is in a state that allows updates, but component B (which is in-cluster, but not part of A) would break if A updated.
c. Component A would break if it updated.

Operator A should pretty clearly be `Upgradeable=True` for (a) and `Upgradeable=False` for (c).

Before this commit, a narrow reading of the comment would have operator A be `Upgradeable=True` for (b).  This commit moves it to `Upgradeable=False`, based on discussion in openshift/enhancements#762, where it becomes the job of the API-server to set `Upgradeable=False` if updating the API-server would break nodes running old kubelets.  The API-server can say "to unblock minor updates, update your kubelets".  The machine-config operator will simultaneously say "hey, your kubelets are old, and here's how to update: `$STEPS`", but it won't use `Upgradeable=False` to say that (because the machine-config operator would be _happy_ to have its component nodes updated).

As pointed out in discussion in openshift/enhancements#762, this is a bit of a bottomless pit.  For example, component A may be removing a deprecated feature on update, and there may be user workloads that occasionally depend on that feature but hardly ever use it.  Component A might reasonably think "nobody has used `$OUTGOING_FEATURE` in the last week, so I'm `Upgradeable=True`", and then post-update, the user-workload would go to hit the removed API and break.  And obviously in-cluster components will have even more limited access to any out-of-cluster components that depend on them.  So using `Upgradeable=False` to protect other components from breaking is going to be a best-effort sort of thing.  But this commit pivots so that it's more clear that we'll put that effort in when we can.

[1]: https://github.com/openshift/enhancements/pull/762