### PR TITLE
[release-4.7] operator/ingress: Add unsupportedConfigOverrides

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -849,6 +849,12 @@ spec:
                     - Custom
                     type: string
                 type: object
+              unsupportedConfigOverrides:
+                description: unsupportedConfigOverrides allows specifying unsupported
+                  configuration options.  Its use is unsupported.
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
           status:
             description: status is the most recently observed status of the IngressController.

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -176,6 +177,14 @@ type IngressControllerSpec struct {
 	//
 	// +optional
 	HTTPHeaders *IngressControllerHTTPHeaders `json:"httpHeaders,omitempty"`
+
+	// unsupportedConfigOverrides allows specifying unsupported
+	// configuration options.  Its use is unsupported.
+	//
+	// +optional
+	// +nullable
+	// +kubebuilder:pruning:PreserveUnknownFields
+	UnsupportedConfigOverrides runtime.RawExtension `json:"unsupportedConfigOverrides"`
 }
 
 // NodePlacement describes node scheduling configuration for an ingress

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -1481,6 +1481,7 @@ func (in *IngressControllerSpec) DeepCopyInto(out *IngressControllerSpec) {
 		*out = new(IngressControllerHTTPHeaders)
 		(*in).DeepCopyInto(*out)
 	}
+	in.UnsupportedConfigOverrides.DeepCopyInto(&out.UnsupportedConfigOverrides)
 	return
 }
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -590,6 +590,7 @@ var map_IngressControllerSpec = map[string]string{
 	"routeAdmission":             "routeAdmission defines a policy for handling new route claims (for example, to allow or deny claims across namespaces).\n\nIf empty, defaults will be applied. See specific routeAdmission fields for details about their defaults.",
 	"logging":                    "logging defines parameters for what should be logged where.  If this field is empty, operational logs are enabled but access logs are disabled.",
 	"httpHeaders":                "httpHeaders defines policy for HTTP headers.\n\nIf this field is empty, the default values are used.",
+	"unsupportedConfigOverrides": "unsupportedConfigOverrides allows specifying unsupported configuration options.  Its use is unsupported.",
 }
 
 func (IngressControllerSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Add a spec.unsupportedConfigOverrides field to the IngressController API to
accommodate unsupported configuration overrides.

This commit resolves [NE-549](https://issues.redhat.com/browse/NE-549).

https://issues.redhat.com/browse/NE-549

* operator/v1/types_ingress.go (IngressControllerSpec): Add an
UnsupportedConfigOverrides field with type runtime.RawExtension.
* operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml:
* operator/v1/zz_generated.deepcopy.go:
* operator/v1/zz_generated.swagger_doc_generated.go: Regenerate.

-- 

This is the 4.7 backport of https://github.com/openshift/api/pull/878.
Related to https://github.com/openshift/cluster-ingress-operator/pull/619 (backport BZ Pending)