### PR TITLE
verify: add require api-approved.openshift.io annotation to all CRD's

### DIFF
--- a/apiserver/v1/apiserver.openshift.io_apirequestcount.yaml
+++ b/apiserver/v1/apiserver.openshift.io_apirequestcount.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/897
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   name: apirequestcounts.apiserver.openshift.io

--- a/authorization/v1/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
+++ b/authorization/v1/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
@@ -1,23 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: rolebindingrestrictions.authorization.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: rolebindingrestrictions.authorization.openshift.io
 spec:
   group: authorization.openshift.io
-  scope: Namespaced
   names:
     kind: RoleBindingRestriction
     listKind: RoleBindingRestrictionList
     plural: rolebindingrestrictions
     singular: rolebindingrestriction
+  scope: Namespaced
   versions:
   - name: v1
-    served: true
-    storage: true
     schema:
       openAPIV3Schema:
         description: RoleBindingRestriction is an object that can be matched against
@@ -208,3 +207,5 @@ spec:
                     items:
                       type: string
                 nullable: true
+    served: true
+    storage: true

--- a/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
+++ b/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/859
   name: cloudprivateipconfigs.cloud.network.openshift.io
 spec:
   group: cloud.network.openshift.io

--- a/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -1,47 +1,44 @@
-kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
 metadata:
-  name: clusteroperators.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/497
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: clusteroperators.config.openshift.io
 spec:
   group: config.openshift.io
   names:
     kind: ClusterOperator
     listKind: ClusterOperatorList
     plural: clusteroperators
-    singular: clusteroperator
     shortNames:
     - co
+    singular: clusteroperator
   scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    additionalPrinterColumns:
-    - jsonPath: .status.versions[?(@.name=="operator")].version
-      description: The version the operator is at.
+  - additionalPrinterColumns:
+    - description: The version the operator is at.
+      jsonPath: .status.versions[?(@.name=="operator")].version
       name: Version
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Available")].status
-      description: Whether the operator is running and stable.
+    - description: Whether the operator is running and stable.
+      jsonPath: .status.conditions[?(@.type=="Available")].status
       name: Available
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
-      description: Whether the operator is processing changes.
+    - description: Whether the operator is processing changes.
+      jsonPath: .status.conditions[?(@.type=="Progressing")].status
       name: Progressing
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Degraded")].status
-      description: Whether the operator is degraded.
+    - description: Whether the operator is degraded.
+      jsonPath: .status.conditions[?(@.type=="Degraded")].status
       name: Degraded
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Available")].lastTransitionTime
-      description: The time the operator's Available status last changed.
+    - description: The time the operator's Available status last changed.
+      jsonPath: .status.conditions[?(@.type=="Available")].lastTransitionTime
       name: Since
       type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: ClusterOperator is the Custom Resource object which holds the
@@ -162,3 +159,7 @@ spec:
                         the Available operand.  If 1.0.0 is Available, then this must
                         indicate 1.0.0 even if the operator is trying to rollout 1.1.0
                       type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -1,17 +1,36 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterversions.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/495
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: clusterversions.config.openshift.io
 spec:
   group: config.openshift.io
+  names:
+    kind: ClusterVersion
+    plural: clusterversions
+    singular: clusterversion
   scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
+  - additionalPrinterColumns:
+    - jsonPath: .status.history[?(@.state=="Completed")].version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].lastTransitionTime
+      name: Since
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].message
+      name: Status
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ClusterVersion is the configuration for the ClusterVersionOperator.
@@ -310,25 +329,7 @@ spec:
                   cluster will be updated with. It is used by the operator to avoid
                   unnecessary work and is for internal use only.
                 type: string
+    served: true
+    storage: true
     subresources:
       status: {}
-    additionalPrinterColumns:
-    - name: Version
-      type: string
-      jsonPath: .status.history[?(@.state=="Completed")].version
-    - name: Available
-      type: string
-      jsonPath: .status.conditions[?(@.type=="Available")].status
-    - name: Progressing
-      type: string
-      jsonPath: .status.conditions[?(@.type=="Progressing")].status
-    - name: Since
-      type: date
-      jsonPath: .status.conditions[?(@.type=="Progressing")].lastTransitionTime
-    - name: Status
-      type: string
-      jsonPath: .status.conditions[?(@.type=="Progressing")].message
-  names:
-    plural: clusterversions
-    singular: clusterversion
-    kind: ClusterVersion

--- a/config/v1/0000_03_config-operator_01_operatorhub.crd.yaml
+++ b/config/v1/0000_03_config-operator_01_operatorhub.crd.yaml
@@ -1,11 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: operatorhubs.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: operatorhubs.config.openshift.io
 spec:
   group: config.openshift.io
   names:
@@ -16,12 +17,8 @@ spec:
   scope: Cluster
   versions:
   - name: v1
-    subresources:
-      status: {}
-    served: true
-    storage: true
-    "schema":
-      "openAPIV3Schema":
+    schema:
+      openAPIV3Schema:
         description: OperatorHub is the Schema for the operatorhubs API. It can be
           used to change the state of the default hub sources for OperatorHub on the
           cluster from enabled to disabled and vice versa.
@@ -103,3 +100,7 @@ spec:
                       description: status indicates success or failure in applying
                         the configuration
                       type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_03_config-operator_01_proxy.crd.yaml
+++ b/config/v1/0000_03_config-operator_01_proxy.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: proxies.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: proxies.config.openshift.io
 spec:
   group: config.openshift.io
-  scope: Cluster
   names:
     kind: Proxy
     listKind: ProxyList
     plural: proxies
     singular: proxy
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Proxy holds cluster-wide information on how to configure default
@@ -101,3 +98,7 @@ spec:
                 description: noProxy is a comma-separated list of hostnames and/or
                   CIDRs for which the proxy should not be used.
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
@@ -1,27 +1,24 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: apiservers.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: apiservers.config.openshift.io
 spec:
   group: config.openshift.io
-  scope: Cluster
   names:
     kind: APIServer
-    singular: apiserver
-    plural: apiservers
     listKind: APIServerList
+    plural: apiservers
+    singular: apiserver
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
-      "openAPIV3Schema":
+      openAPIV3Schema:
         description: APIServer holds configuration (like serving certificates, client
           CA and CORS domains) shared by all API servers in the system, among them
           especially kube-apiserver and openshift-apiserver. The canonical name of
@@ -258,3 +255,7 @@ spec:
             description: status holds observed values from the cluster. They may not
               be overridden.
             type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_authentication.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: authentications.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: authentications.config.openshift.io
 spec:
   group: config.openshift.io
-  scope: Cluster
   names:
     kind: Authentication
     listKind: AuthenticationList
     plural: authentications
     singular: authentication
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Authentication specifies cluster-wide settings for authentication
@@ -159,3 +156,7 @@ spec:
                     description: name is the metadata.name of the referenced config
                       map
                     type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_build.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_build.crd.yaml
@@ -1,28 +1,25 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: builds.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: builds.config.openshift.io
 spec:
   group: config.openshift.io
-  scope: Cluster
-  preserveUnknownFields: false
   names:
     kind: Build
-    singular: build
-    plural: builds
     listKind: BuildList
+    plural: builds
+    singular: build
+  preserveUnknownFields: false
+  scope: Cluster
   versions:
   - name: v1
-    subresources:
-      status: {}
-    served: true
-    storage: true
-    "schema":
-      "openAPIV3Schema":
+    schema:
+      openAPIV3Schema:
         description: "Build configures the behavior of OpenShift builds for the entire
           cluster. This includes default settings that can be overridden in BuildConfig
           objects, and overrides which are applied to all builds. \n The canonical
@@ -398,3 +395,7 @@ spec:
                             to. If the operator is Exists, the value should be empty,
                             otherwise just a regular string.
                           type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_console.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_console.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: consoles.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: consoles.config.openshift.io
 spec:
-  scope: Cluster
   group: config.openshift.io
   names:
     kind: Console
     listKind: ConsoleList
     plural: consoles
     singular: console
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Console holds cluster-wide configuration for the web console,
@@ -71,3 +68,7 @@ spec:
                 description: The URL for the console. This will be derived from the
                   host for the route that is created for the console.
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_dns.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_dns.crd.yaml
@@ -1,11 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: dnses.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: dnses.config.openshift.io
 spec:
   group: config.openshift.io
   names:
@@ -16,12 +17,8 @@ spec:
   scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    "schema":
-      "openAPIV3Schema":
+    schema:
+      openAPIV3Schema:
         description: DNS holds cluster-wide information about DNS. The canonical name
           is `cluster`
         type: object
@@ -101,3 +98,7 @@ spec:
             description: status holds observed values from the cluster. They may not
               be overridden.
             type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_featuregate.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_featuregate.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: featuregates.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: featuregates.config.openshift.io
 spec:
   group: config.openshift.io
-  scope: Cluster
   names:
     kind: FeatureGate
     listKind: FeatureGateList
     plural: featuregates
     singular: featuregate
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Feature holds cluster-wide information about feature gates.  The
@@ -76,3 +73,7 @@ spec:
             description: status holds observed values from the cluster. They may not
               be overridden.
             type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_image.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_image.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: images.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: images.config.openshift.io
 spec:
   group: config.openshift.io
-  scope: Cluster
   names:
     kind: Image
-    singular: image
-    plural: images
     listKind: ImageList
+    plural: images
+    singular: image
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Image governs policies related to imagestream imports and runtime
@@ -159,3 +156,7 @@ spec:
                   can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but
                   this setting overrides the environment variable.
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -1,11 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: infrastructures.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io
   names:
@@ -16,10 +17,6 @@ spec:
   scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Infrastructure holds cluster-wide information about Infrastructure.  The
@@ -539,3 +536,7 @@ spec:
                           DNS, a DNS service is hosted as a static pod to serve those
                           hostnames to the nodes in the cluster.
                         type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -1,11 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: ingresses.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: ingresses.config.openshift.io
 spec:
   group: config.openshift.io
   names:
@@ -16,12 +17,8 @@ spec:
   scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    "schema":
-      "openAPIV3Schema":
+    schema:
+      openAPIV3Schema:
         description: Ingress holds cluster-wide information about ingress, including
           the default ingress domain used for routes. The canonical name is `cluster`.
         type: object
@@ -297,3 +294,7 @@ spec:
                           resource:
                             description: resource of the referent.
                             type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_network.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network.crd.yaml
@@ -1,11 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: networks.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: networks.config.openshift.io
 spec:
   group: config.openshift.io
   names:
@@ -13,14 +14,12 @@ spec:
     listKind: NetworkList
     plural: networks
     singular: network
-  scope: Cluster
   preserveUnknownFields: false
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    "schema":
-      "openAPIV3Schema":
+    schema:
+      openAPIV3Schema:
         description: 'Network holds cluster-wide information about Network. The canonical
           name is `cluster`. It is used to configure the desired network configuration,
           such as: IP address pools for services/pod IPs, network plugin, etc. Please
@@ -170,3 +169,5 @@ spec:
                 type: array
                 items:
                   type: string
+    served: true
+    storage: true

--- a/config/v1/0000_10_config-operator_01_oauth.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_oauth.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: oauths.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: oauths.config.openshift.io
 spec:
   group: config.openshift.io
-  scope: Cluster
   names:
     kind: OAuth
     listKind: OAuthList
     plural: oauths
     singular: oauth
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: OAuth holds cluster-wide information about OAuth.  The canonical
@@ -674,3 +671,7 @@ spec:
             description: status holds observed values from the cluster. They may not
               be overridden.
             type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_project.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_project.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: projects.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: projects.config.openshift.io
 spec:
   group: config.openshift.io
-  scope: Cluster
   names:
     kind: Project
     listKind: ProjectList
     plural: projects
     singular: project
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Project holds cluster-wide information about Project.  The canonical
@@ -64,3 +61,7 @@ spec:
             description: status holds observed values from the cluster. They may not
               be overridden.
             type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_scheduler.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_scheduler.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: schedulers.config.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: schedulers.config.openshift.io
 spec:
   group: config.openshift.io
-  scope: Cluster
   names:
     kind: Scheduler
-    singular: scheduler
-    plural: schedulers
     listKind: SchedulerList
+    plural: schedulers
+    singular: scheduler
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Scheduler holds cluster-wide config information to run the Kubernetes
@@ -104,3 +101,7 @@ spec:
             description: status holds observed values from the cluster. They may not
               be overridden.
             type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consoleclidownload.crd.yaml
+++ b/console/v1/0000_10_consoleclidownload.crd.yaml
@@ -1,35 +1,32 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: consoleclidownloads.console.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/481
     description: Extension for configuring openshift web console command line interface
       (CLI) downloads.
     displayName: ConsoleCLIDownload
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: consoleclidownloads.console.openshift.io
 spec:
-  scope: Cluster
   group: console.openshift.io
   names:
-    plural: consoleclidownloads
-    singular: consoleclidownload
     kind: ConsoleCLIDownload
     listKind: ConsoleCLIDownloadList
+    plural: consoleclidownloads
+    singular: consoleclidownload
+  scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
-    additionalPrinterColumns:
-    - name: Display name
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display name
       type: string
-      jsonPath: .spec.displayName
-    - name: Age
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
       type: string
-      jsonPath: .metadata.creationTimestamp
-    subresources:
-      status: {}
+    name: v1
     schema:
       openAPIV3Schema:
         description: ConsoleCLIDownload is an extension for configuring openshift
@@ -82,3 +79,7 @@ spec:
                     text:
                       description: text is the display text for the link
                       type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consoleexternalloglink.crd.yaml
+++ b/console/v1/0000_10_consoleexternalloglink.crd.yaml
@@ -1,38 +1,35 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: consoleexternalloglinks.console.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/481
     description: ConsoleExternalLogLink is an extension for customizing OpenShift
       web console log links.
     displayName: ConsoleExternalLogLinks
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: consoleexternalloglinks.console.openshift.io
 spec:
-  scope: Cluster
+  group: console.openshift.io
   names:
-    plural: consoleexternalloglinks
-    singular: consoleexternalloglink
     kind: ConsoleExternalLogLink
     listKind: ConsoleExternalLogLinkList
-  group: console.openshift.io
+    plural: consoleexternalloglinks
+    singular: consoleexternalloglink
+  scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
-    additionalPrinterColumns:
-    - name: Text
+  - additionalPrinterColumns:
+    - jsonPath: .spec.text
+      name: Text
       type: string
-      jsonPath: .spec.text
-    - name: HrefTemplate
+    - jsonPath: .spec.hrefTemplate
+      name: HrefTemplate
       type: string
-      jsonPath: .spec.hrefTemplate
-    - name: Age
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
       type: date
-      jsonPath: .metadata.creationTimestamp
-    subresources:
-      status: {}
+    name: v1
     schema:
       openAPIV3Schema:
         description: ConsoleExternalLogLink is an extension for customizing OpenShift
@@ -87,3 +84,7 @@ spec:
               text:
                 description: text is the display text for the link
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consolelink.crd.yaml
+++ b/console/v1/0000_10_consolelink.crd.yaml
@@ -1,40 +1,37 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: consolelinks.console.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/481
     description: Extension for customizing OpenShift web console links
     displayName: ConsoleLinks
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: consolelinks.console.openshift.io
 spec:
-  scope: Cluster
   group: console.openshift.io
   names:
-    plural: consolelinks
-    singular: consolelink
     kind: ConsoleLink
     listKind: ConsoleLinkList
+    plural: consolelinks
+    singular: consolelink
+  scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
-    additionalPrinterColumns:
-    - name: Text
+  - additionalPrinterColumns:
+    - jsonPath: .spec.text
+      name: Text
       type: string
-      jsonPath: .spec.text
-    - name: URL
+    - jsonPath: .spec.href
+      name: URL
       type: string
-      jsonPath: .spec.href
-    - name: Menu
+    - jsonPath: .spec.menu
+      name: Menu
       type: string
-      jsonPath: .spec.menu
-    - name: Age
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
       type: date
-      jsonPath: .metadata.creationTimestamp
-    subresources:
-      status: {}
+    name: v1
     schema:
       openAPIV3Schema:
         description: ConsoleLink is an extension for customizing OpenShift web console
@@ -156,3 +153,7 @@ spec:
               text:
                 description: text is the display text for the link
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consolenotification.crd.yaml
+++ b/console/v1/0000_10_consolenotification.crd.yaml
@@ -1,37 +1,34 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: consolenotifications.console.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/481
     description: Extension for configuring openshift web console notifications.
     displayName: ConsoleNotification
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: consolenotifications.console.openshift.io
 spec:
-  scope: Cluster
   group: console.openshift.io
   names:
-    plural: consolenotifications
-    singular: consolenotification
     kind: ConsoleNotification
     listKind: ConsoleNotificationList
+    plural: consolenotifications
+    singular: consolenotification
+  scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
-    additionalPrinterColumns:
-    - name: Text
+  - additionalPrinterColumns:
+    - jsonPath: .spec.text
+      name: Text
       type: string
-      jsonPath: .spec.text
-    - name: Location
+    - jsonPath: .spec.location
+      name: Location
       type: string
-      jsonPath: .spec.location
-    - name: Age
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
       type: date
-      jsonPath: .metadata.creationTimestamp
-    subresources:
-      status: {}
+    name: v1
     schema:
       openAPIV3Schema:
         description: ConsoleNotification is the extension for configuring openshift
@@ -90,3 +87,7 @@ spec:
               text:
                 description: text is the visible text of the notification.
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consolequickstart.crd.yaml
+++ b/console/v1/0000_10_consolequickstart.crd.yaml
@@ -1,26 +1,25 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: consolequickstarts.console.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/750
     description: Extension for guiding user through various workflows in the OpenShift
       web console.
     displayName: ConsoleQuickStart
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: consolequickstarts.console.openshift.io
 spec:
-  scope: Cluster
   group: console.openshift.io
   names:
-    plural: consolequickstarts
-    singular: consolequickstart
     kind: ConsoleQuickStart
     listKind: ConsoleQuickStartList
+    plural: consolequickstarts
+    singular: consolequickstart
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
     schema:
       openAPIV3Schema:
         description: ConsoleQuickStart is an extension for guiding user through various
@@ -201,3 +200,5 @@ spec:
                         step heading.
                       type: string
                       minLength: 1
+    served: true
+    storage: true

--- a/console/v1/0000_10_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_consoleyamlsample.crd.yaml
@@ -1,25 +1,24 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: consoleyamlsamples.console.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/481
     description: Extension for configuring openshift web console YAML samples.
     displayName: ConsoleYAMLSample
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: consoleyamlsamples.console.openshift.io
 spec:
-  scope: Cluster
   group: console.openshift.io
   names:
-    plural: consoleyamlsamples
-    singular: consoleyamlsample
     kind: ConsoleYAMLSample
     listKind: ConsoleYAMLSampleList
+    plural: consoleyamlsamples
+    singular: consoleyamlsample
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
     schema:
       openAPIV3Schema:
         description: ConsoleYAMLSample is an extension for customizing OpenShift web
@@ -86,3 +85,5 @@ spec:
                 description: yaml is the YAML sample to display.
                 type: string
                 pattern: ^(.|\s)*\S(.|\s)*$
+    served: true
+    storage: true

--- a/console/v1alpha1/0000_10_consoleplugin.crd.yaml
+++ b/console/v1alpha1/0000_10_consoleplugin.crd.yaml
@@ -1,23 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: consoleplugins.console.openshift.io
   annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-    displayName: ConsolePlugin
+    api-approved.openshift.io: https://github.com/openshift/api/pull/764
     description: Extension for configuring openshift web console plugins.
+    displayName: ConsolePlugin
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: consoleplugins.console.openshift.io
 spec:
-  scope: Cluster
   group: console.openshift.io
   names:
-    plural: consoleplugins
-    singular: consoleplugin
     kind: ConsolePlugin
     listKind: ConsolePluginList
+    plural: consoleplugins
+    singular: consoleplugin
+  scope: Cluster
   versions:
   - name: v1alpha1
-    served: true
-    storage: true
     schema:
       openAPIV3Schema:
         description: ConsolePlugin is an extension for customizing OpenShift web console
@@ -78,3 +77,5 @@ spec:
                       is listening to.
                     type: integer
                     format: int32
+    served: true
+    storage: true

--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -4,6 +4,8 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 
+[[ -n "${PROTO_OPTIONAL:-}" ]] && exit 0
+
 if [[ "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.x. Please download and
 install the platform appropriate Protobuf package for your OS:

--- a/hack/verify-crds-version-upgrade.sh
+++ b/hack/verify-crds-version-upgrade.sh
@@ -47,8 +47,9 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 LAST_COMMIT=$(git rev-parse HEAD~1)
 # Switch to master branch and apply all the existing v1beta1 crds
 git checkout $LAST_COMMIT
-for f in `find . -name "*crd.yaml" -type f`
-do
+for f in $(find . -name "*.yaml" -type f); do
+    grep -qre "kind:\(.*\)CustomResourceDefinition" || continue
+    grep -qre "name:\(.*\).openshift.io"  || continue
     if [[ $(./_output/tools/bin/yq r $f apiVersion) == "apiextensions.k8s.io/v1beta1" ]]; then
         v1beta1CRDName=$(./_output/tools/bin/yq r $f metadata.name)
         v1beta1CRDNames=("${v1beta1CRDNames[*]}" $v1beta1CRDName)
@@ -61,8 +62,9 @@ done
 # Switch to current branch and apply the crd with v1 version
 FALSE=false
 git checkout $CURRENT_BRANCH
-for f in `find . -name "*crd.yaml" -type f`
-do
+for f in $(find . -name "*.yaml" -type f); do
+    grep -qre "kind:\(.*\)CustomResourceDefinition" || continue
+    grep -qre "name:\(.*\).openshift.io"  || continue
     if [[ $(./_output/tools/bin/yq r $f apiVersion) == "apiextensions.k8s.io/v1" ]]; then
         v1CRDName=$(./_output/tools/bin/yq r $f metadata.name)
         $KUBECTL apply -f $f || FALSE=true

--- a/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
+++ b/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: helmchartrepositories.helm.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/598
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: helmchartrepositories.helm.openshift.io
 spec:
-  scope: Cluster
   group: helm.openshift.io
   names:
     kind: HelmChartRepository
     listKind: HelmChartRepositoryList
     plural: helmchartrepositories
     singular: helmchartrepository
+  scope: Cluster
   versions:
   - name: v1beta1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: HelmChartRepository holds cluster-wide configuration for proxied
@@ -171,3 +168,7 @@ spec:
                       type: string
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/imageregistry/v1/00-crd.yaml
+++ b/imageregistry/v1/00-crd.yaml
@@ -1,22 +1,24 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: configs.imageregistry.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/519
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: configs.imageregistry.operator.openshift.io
 spec:
   group: imageregistry.operator.openshift.io
+  names:
+    kind: Config
+    listKind: ConfigList
+    plural: configs
+    singular: config
   scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    "schema":
-      "openAPIV3Schema":
+    schema:
+      openAPIV3Schema:
         description: Config is the configuration object for a registry instance managed
           by the registry operator
         type: object
@@ -1535,8 +1537,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
-  names:
-    kind: Config
-    listKind: ConfigList
-    plural: configs
-    singular: config
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/imageregistry/v1/01-crd.yaml
+++ b/imageregistry/v1/01-crd.yaml
@@ -1,22 +1,24 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: imagepruners.imageregistry.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/555
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: imagepruners.imageregistry.operator.openshift.io
 spec:
   group: imageregistry.operator.openshift.io
+  names:
+    kind: ImagePruner
+    listKind: ImagePrunerList
+    plural: imagepruners
+    singular: imagepruner
   scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
-    "schema":
-      "openAPIV3Schema":
+    schema:
+      openAPIV3Schema:
         description: ImagePruner is the configuration object for an image registry
           pruner managed by the registry operator.
         type: object
@@ -1021,8 +1023,7 @@ spec:
                   has been applied.
                 type: integer
                 format: int64
-  names:
-    kind: ImagePruner
-    listKind: ImagePrunerList
-    plural: imagepruners
-    singular: imagepruner
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/network/v1/001-clusternetwork-crd.yaml
+++ b/network/v1/001-clusternetwork-crd.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/527
   name: clusternetworks.network.openshift.io
 spec:
   group: network.openshift.io
@@ -11,22 +13,20 @@ spec:
     singular: clusternetwork
   scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
-    additionalPrinterColumns:
-    - name: Cluster Network
-      type: string
-      description: The primary cluster network CIDR
+  - additionalPrinterColumns:
+    - description: The primary cluster network CIDR
       jsonPath: .network
-    - name: Service Network
+      name: Cluster Network
       type: string
-      description: The service network CIDR
+    - description: The service network CIDR
       jsonPath: .serviceNetwork
-    - name: Plugin Name
+      name: Service Network
       type: string
-      description: The OpenShift SDN network plug-in in use
+    - description: The OpenShift SDN network plug-in in use
       jsonPath: .pluginName
+      name: Plugin Name
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: ClusterNetwork describes the cluster network. There is normally
@@ -118,6 +118,8 @@ spec:
             format: int32
             maximum: 65535
             minimum: 1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/network/v1/002-hostsubnet-crd.yaml
+++ b/network/v1/002-hostsubnet-crd.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/527
   name: hostsubnets.network.openshift.io
 spec:
   group: network.openshift.io
@@ -11,32 +13,30 @@ spec:
     singular: hostsubnet
   scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
-    additionalPrinterColumns:
-    - name: Host
-      type: string
-      description: The name of the node
+  - additionalPrinterColumns:
+    - description: The name of the node
       jsonPath: .host
-    - name: Host IP
+      name: Host
       type: string
-      description: The IP address to be used as a VTEP by other nodes in the overlay
+    - description: The IP address to be used as a VTEP by other nodes in the overlay
         network
       jsonPath: .hostIP
-    - name: Subnet
+      name: Host IP
       type: string
-      description: The CIDR range of the overlay network assigned to the node for
+    - description: The CIDR range of the overlay network assigned to the node for
         its pods
       jsonPath: .subnet
-    - name: Egress CIDRs
+      name: Subnet
       type: string
-      description: The network egress CIDRs
+    - description: The network egress CIDRs
       jsonPath: .egressCIDRs
-    - name: Egress IPs
+      name: Egress CIDRs
       type: string
-      description: The network egress IP addresses
+    - description: The network egress IP addresses
       jsonPath: .egressIPs
+      name: Egress IPs
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: HostSubnet describes the container subnet network on a node.
@@ -96,6 +96,8 @@ spec:
               to the node for its pods
             type: string
             pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|[12][0-9]|3[0-2])$
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/network/v1/003-netnamespace-crd.yaml
+++ b/network/v1/003-netnamespace-crd.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/527
   name: netnamespaces.network.openshift.io
 spec:
   group: network.openshift.io
@@ -11,18 +13,16 @@ spec:
     singular: netnamespace
   scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
-    additionalPrinterColumns:
-    - name: NetID
-      type: integer
-      description: The network identifier of the network namespace
+  - additionalPrinterColumns:
+    - description: The network identifier of the network namespace
       jsonPath: .netid
-    - name: Egress IPs
-      type: string
-      description: The network egress IP addresses
+      name: NetID
+      type: integer
+    - description: The network egress IP addresses
       jsonPath: .egressIPs
+      name: Egress IPs
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: NetNamespace describes a single isolated network. When using
@@ -70,6 +70,8 @@ spec:
               same as the object's name, but both fields must be set.)
             type: string
             pattern: ^[a-z0-9.-]+$
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/network/v1/004-egressnetworkpolicy-crd.yaml
+++ b/network/v1/004-egressnetworkpolicy-crd.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/527
   name: egressnetworkpolicies.network.openshift.io
 spec:
   group: network.openshift.io
@@ -12,10 +14,8 @@ spec:
   scope: Namespaced
   versions:
   - name: v1
-    served: true
-    storage: true
-    "schema":
-      "openAPIV3Schema":
+    schema:
+      openAPIV3Schema:
         description: EgressNetworkPolicy describes the current egress network policy
           for a Namespace. When using the 'redhat/openshift-ovs-multitenant' network
           plugin, traffic from a pod to an IP address outside the cluster will be
@@ -78,6 +78,8 @@ spec:
                       description: type marks this as an "Allow" or "Deny" rule
                       type: string
                       pattern: ^Allow|Deny$
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/networkoperator/v1/001-egressrouter.crd.yaml
+++ b/networkoperator/v1/001-egressrouter.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/851
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   creationTimestamp: null

--- a/operator/v1/0000_10_config-operator_01_config.crd.yaml
+++ b/operator/v1/0000_10_config-operator_01_config.crd.yaml
@@ -1,26 +1,23 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: configs.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/612
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: configs.operator.openshift.io
 spec:
-  scope: Cluster
   group: operator.openshift.io
   names:
+    categories:
+    - coreoperators
     kind: Config
     plural: configs
     singular: config
-    categories:
-    - coreoperators
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Config provides information to configure the config operator.
@@ -162,3 +159,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
+++ b/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
@@ -1,26 +1,23 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: etcds.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/752
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: etcds.operator.openshift.io
 spec:
-  scope: Cluster
   group: operator.openshift.io
   names:
+    categories:
+    - coreoperators
     kind: Etcd
     plural: etcds
     singular: etcd
-    categories:
-    - coreoperators
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Etcd provides information to configure an operator to manage
@@ -228,3 +225,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
+++ b/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/operator/v1/0000_30_openshift-apiserver-operator_01_config.crd.yaml
+++ b/operator/v1/0000_30_openshift-apiserver-operator_01_config.crd.yaml
@@ -1,26 +1,23 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: openshiftapiservers.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: openshiftapiservers.operator.openshift.io
 spec:
-  scope: Cluster
   group: operator.openshift.io
   names:
+    categories:
+    - coreoperators
     kind: OpenShiftAPIServer
     plural: openshiftapiservers
     singular: openshiftapiserver
-    categories:
-    - coreoperators
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: OpenShiftAPIServer provides information to configure an operator
@@ -168,3 +165,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
+++ b/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
@@ -1,24 +1,21 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: cloudcredentials.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/692
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: cloudcredentials.operator.openshift.io
 spec:
-  scope: Cluster
   group: operator.openshift.io
   names:
     kind: CloudCredential
     listKind: CloudCredentialList
     plural: cloudcredentials
     singular: cloudcredential
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: CloudCredential provides a means to configure an operator to
@@ -176,3 +173,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_40_kube-storage-version-migrator-operator_00_config.crd.yaml
+++ b/operator/v1/0000_40_kube-storage-version-migrator-operator_00_config.crd.yaml
@@ -1,11 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: kubestorageversionmigrators.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/503
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: kubestorageversionmigrators.operator.openshift.io
 spec:
   group: operator.openshift.io
   names:
@@ -16,12 +17,8 @@ spec:
   scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
-      "openAPIV3Schema":
+      openAPIV3Schema:
         description: KubeStorageVersionMigrator provides information to configure
           an operator to manage kube-storage-version-migrator.
         type: object
@@ -157,3 +154,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_50_cluster-authentication-operator_01_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-authentication-operator_01_config.crd.yaml
@@ -1,23 +1,20 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: authentications.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: authentications.operator.openshift.io
 spec:
-  scope: Cluster
   group: operator.openshift.io
   names:
     kind: Authentication
     plural: authentications
     singular: authentication
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Authentication provides information to configure an operator
@@ -166,3 +163,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
@@ -1,26 +1,23 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: openshiftcontrollermanagers.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: openshiftcontrollermanagers.operator.openshift.io
 spec:
-  scope: Cluster
   group: operator.openshift.io
   names:
+    categories:
+    - coreoperators
     kind: OpenShiftControllerManager
     plural: openshiftcontrollermanagers
     singular: openshiftcontrollermanager
-    categories:
-    - coreoperators
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: OpenShiftControllerManager provides information to configure
@@ -158,3 +155,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
+++ b/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
@@ -1,11 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: storages.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/670
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: storages.operator.openshift.io
 spec:
   group: operator.openshift.io
   names:
@@ -15,10 +16,6 @@ spec:
   scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Storage provides a means to configure an operator to manage the
@@ -159,3 +156,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/616
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/operator/v1/0000_50_service-ca-operator_02_crd.yaml
+++ b/operator/v1/0000_50_service-ca-operator_02_crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: servicecas.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: servicecas.operator.openshift.io
 spec:
-  scope: Cluster
   group: operator.openshift.io
   names:
     kind: ServiceCA
     listKind: ServiceCAList
     plural: servicecas
     singular: serviceca
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: ServiceCA provides information to configure an operator to manage
@@ -160,3 +157,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -1,10 +1,11 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: networks.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: networks.operator.openshift.io
 spec:
   group: operator.openshift.io
   names:
@@ -15,8 +16,6 @@ spec:
   scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
     schema:
       openAPIV3Schema:
         description: Network describes the cluster's desired network configuration.
@@ -623,3 +622,5 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true

--- a/operator/v1/0000_70_console-operator.crd.yaml
+++ b/operator/v1/0000_70_console-operator.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: consoles.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/486
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: consoles.operator.openshift.io
 spec:
-  scope: Cluster
   group: operator.openshift.io
   names:
     kind: Console
     listKind: ConsoleList
     plural: consoles
     singular: console
+  scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: Console provides a means to configure an operator to manage the
@@ -367,3 +364,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
+++ b/operator/v1/0000_70_dns-operator_00-custom-resource-definition.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: dnses.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/operator/v1/0000_80_csi_snapshot_controller_operator_01_crd.yaml
+++ b/operator/v1/0000_80_csi_snapshot_controller_operator_01_crd.yaml
@@ -1,11 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: csisnapshotcontrollers.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/562
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: csisnapshotcontrollers.operator.openshift.io
 spec:
   group: operator.openshift.io
   names:
@@ -15,10 +16,6 @@ spec:
   scope: Cluster
   versions:
   - name: v1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: CSISnapshotController provides a means to configure an operator
@@ -159,3 +156,7 @@ spec:
               version:
                 description: version is the level this availability applies to
                 type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/701
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
+++ b/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
@@ -1,25 +1,22 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: imagecontentsourcepolicies.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: imagecontentsourcepolicies.operator.openshift.io
 spec:
   group: operator.openshift.io
-  scope: Cluster
   names:
     kind: ImageContentSourcePolicy
-    singular: imagecontentsourcepolicy
-    plural: imagecontentsourcepolicies
     listKind: ImageContentSourcePolicyList
+    plural: imagecontentsourcepolicies
+    singular: imagecontentsourcepolicy
+  scope: Cluster
   versions:
   - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: ImageContentSourcePolicy holds cluster-wide information about
@@ -91,3 +88,7 @@ spec:
                       description: source is the repository that users refer to, e.g.
                         in image pull specifications.
                       type: string
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
+++ b/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/639
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   name: podnetworkconnectivitychecks.controlplane.operator.openshift.io
@@ -15,10 +16,6 @@ spec:
   scope: Namespaced
   versions:
   - name: v1alpha1
-    served: true
-    storage: true
-    subresources:
-      status: {}
     schema:
       openAPIV3Schema:
         description: PodNetworkConnectivityCheck
@@ -257,3 +254,7 @@ spec:
                       type: string
                       format: date-time
                       nullable: true
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operatoringress/v1/0000_50_dns-record.yaml
+++ b/operatoringress/v1/0000_50_dns-record.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: dnsrecords.ingress.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/584
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/quota/v1/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
+++ b/quota/v1/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/samples/v1/0000_10_samplesconfig.crd.yaml
+++ b/samples/v1/0000_10_samplesconfig.crd.yaml
@@ -1,25 +1,27 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: configs.samples.operator.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/513
     description: Extension for configuring openshif samples operator.
     displayName: ConfigsSamples
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: configs.samples.operator.openshift.io
 spec:
-  scope: Cluster
-  preserveUnknownFields: false
   group: samples.operator.openshift.io
+  names:
+    kind: Config
+    listKind: ConfigList
+    plural: configs
+    singular: config
+  preserveUnknownFields: false
+  scope: Cluster
   versions:
   - name: v1
-    subresources:
-      status: {}
-    served: true
-    storage: true
-    "schema":
-      "openAPIV3Schema":
+    schema:
+      openAPIV3Schema:
         description: Config contains the configuration and detailed condition status
           for the Samples Operator.
         type: object
@@ -171,8 +173,7 @@ spec:
                 description: version is the value of the operator's payload based
                   version indicator when it was last successfully processed
                 type: string
-  names:
-    plural: configs
-    singular: config
-    kind: Config
-    listKind: ConfigList
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/security/v1/0000_03_security-openshift_01_scc.crd.yaml
+++ b/security/v1/0000_03_security-openshift_01_scc.crd.yaml
@@ -1,61 +1,60 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: securitycontextconstraints.security.openshift.io
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+  name: securitycontextconstraints.security.openshift.io
 spec:
   group: security.openshift.io
-  scope: Cluster
   names:
     kind: SecurityContextConstraints
     listKind: SecurityContextConstraintsList
     plural: securitycontextconstraints
     singular: securitycontextconstraints
+  scope: Cluster
   versions:
-  - name: v1
-    served: true
-    storage: true
-    additionalPrinterColumns:
-    - name: Priv
-      type: string
+  - additionalPrinterColumns:
+    - description: Determines if a container can request to be run as privileged
       jsonPath: .allowPrivilegedContainer
-      description: Determines if a container can request to be run as privileged
-    - name: Caps
+      name: Priv
       type: string
+    - description: A list of capabilities that can be requested to add to the container
       jsonPath: .allowedCapabilities
-      description: A list of capabilities that can be requested to add to the container
-    - name: SELinux
+      name: Caps
       type: string
+    - description: Strategy that will dictate what labels will be set in the SecurityContext
       jsonPath: .seLinuxContext.type
-      description: Strategy that will dictate what labels will be set in the SecurityContext
-    - name: RunAsUser
+      name: SELinux
       type: string
+    - description: Strategy that will dictate what RunAsUser is used in the SecurityContext
       jsonPath: .runAsUser.type
-      description: Strategy that will dictate what RunAsUser is used in the SecurityContext
-    - name: FSGroup
+      name: RunAsUser
       type: string
+    - description: Strategy that will dictate what fs group is used by the SecurityContext
       jsonPath: .fsGroup.type
-      description: Strategy that will dictate what fs group is used by the SecurityContext
-    - name: SupGroup
+      name: FSGroup
       type: string
-      jsonPath: .supplementalGroups.type
-      description: Strategy that will dictate what supplemental groups are used by
+    - description: Strategy that will dictate what supplemental groups are used by
         the SecurityContext
-    - name: Priority
+      jsonPath: .supplementalGroups.type
+      name: SupGroup
       type: string
+    - description: Sort order of SCCs
       jsonPath: .priority
-      description: Sort order of SCCs
-    - name: ReadOnlyRootFS
+      name: Priority
       type: string
+    - description: Force containers to run with a read only root file system
       jsonPath: .readOnlyRootFilesystem
-      description: Force containers to run with a read only root file system
-    - name: Volumes
+      name: ReadOnlyRootFS
       type: string
+    - description: White list of allowed volume plugins
       jsonPath: .volumes
-      description: White list of allowed volume plugins
+      name: Volumes
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: SecurityContextConstraints governs the ability to make requests
@@ -360,3 +359,5 @@ spec:
                 are used by volumes.
               type: string
             nullable: true
+    served: true
+    storage: true

--- a/securityinternal/v1/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
+++ b/securityinternal/v1/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/751
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
From now on, every CRD included in this repository will require to have the `api-approved.openshift.io` annotation that is set to a pull request URL where that CRD was introduced.

This follows upstream pattern of https://github.com/kubernetes/enhancements/blob/0e4d5df19d396511fe41ed0860b0ab9b96f46a2d/keps/sig-api-machinery/2337-k8s.io-group-protection/README.md

This is to make sure that every `*.openshift.io` CRD in OCP is coming from this repository.
As a follow-up to this, there will be an e2e test that makes sure every `openshift.io` CRD in the cluster has this annotation set.

NOTE: The normalization of existing CRD's is a consequence of `oc annotate` bug where in addition to annotation the YAML file is normalized as well. These are just reshuffles and should cause no harm to CRD's. 