### PR TITLE
clarify that Progressing should be true when operators/operands react…

### DIFF
--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -149,7 +149,10 @@ const (
 	// Progressing indicates that the operator is actively rolling out new code,
 	// propagating config changes, or otherwise moving from one steady state to
 	// another.  Operators should not report progressing when they are reconciling
-	// a previously known state.
+	// (without action) a previously known state.  If the observed cluster state
+	// has changed and the operator/operand is reacting to it (scaling up for instance),
+	// Progressing should become true since it is moving from one steady state to
+	// another.
 	OperatorProgressing ClusterStatusConditionType = "Progressing"
 
 	// Degraded indicates that the operator's current state does not match its


### PR DESCRIPTION
… to changes in cluster state

Came up in a storage library-go change.

@wking @jsafrane @bertinatto 