### PR TITLE
Clarify that useExternalOpenvswitch is deprecated and ignored

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01_crd.yaml
@@ -278,9 +278,11 @@ spec:
                         format: int32
                         minimum: 0
                       useExternalOpenvswitch:
-                        description: useExternalOpenvswitch tells the operator not
-                          to install openvswitch, because it will be provided separately.
-                          If set, you must provide it yourself.
+                        description: 'useExternalOpenvswitch used to control whether
+                          the operator would deploy an OVS DaemonSet itself or expect
+                          someone else to start OVS. As of 4.6, OVS is always run
+                          as a system service, and this flag is ignored. DEPRECATED:
+                          non-functional as of 4.6'
                         type: boolean
                       vxlanPort:
                         description: vxlanPort is the port to use for all vxlan packets.

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -264,8 +264,10 @@ type OpenShiftSDNConfig struct {
 	// +optional
 	MTU *uint32 `json:"mtu,omitempty"`
 
-	// useExternalOpenvswitch tells the operator not to install openvswitch, because
-	// it will be provided separately. If set, you must provide it yourself.
+	// useExternalOpenvswitch used to control whether the operator would deploy an OVS
+	// DaemonSet itself or expect someone else to start OVS. As of 4.6, OVS is always
+	// run as a system service, and this flag is ignored.
+	// DEPRECATED: non-functional as of 4.6
 	// +optional
 	UseExternalOpenvswitch *bool `json:"useExternalOpenvswitch,omitempty"`
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -974,7 +974,7 @@ var map_OpenShiftSDNConfig = map[string]string{
 	"mode":                   "mode is one of \"Multitenant\", \"Subnet\", or \"NetworkPolicy\"",
 	"vxlanPort":              "vxlanPort is the port to use for all vxlan packets. The default is 4789.",
 	"mtu":                    "mtu is the mtu to use for the tunnel interface. Defaults to 1450 if unset. This must be 50 bytes smaller than the machine's uplink.",
-	"useExternalOpenvswitch": "useExternalOpenvswitch tells the operator not to install openvswitch, because it will be provided separately. If set, you must provide it yourself.",
+	"useExternalOpenvswitch": "useExternalOpenvswitch used to control whether the operator would deploy an OVS DaemonSet itself or expect someone else to start OVS. As of 4.6, OVS is always run as a system service, and this flag is ignored. DEPRECATED: non-functional as of 4.6",
 	"enableUnidling":         "enableUnidling controls whether or not the service proxy will support idling and unidling of services. By default, unidling is enabled.",
 }
 


### PR DESCRIPTION
This field is a no-op as of 4.6, but can't be removed for compatibility reasons.

(Replacement for #802)
