### PR TITLE
removing conversion-gen=false for BuildVolumeSource.Type field

### DIFF
--- a/build/v1/generated.proto
+++ b/build/v1/generated.proto
@@ -629,7 +629,6 @@ message BuildVolumeSource {
   // type is the BuildVolumeSourceType for the volume source.
   // Type must match the populated volume source.
   // Valid types are: Secret, ConfigMap
-  // +k8s:conversion-gen=false
   optional string type = 1;
 
   // secret represents a Secret that should populate this volume.

--- a/build/v1/types.go
+++ b/build/v1/types.go
@@ -1385,7 +1385,6 @@ type BuildVolumeSource struct {
 	// type is the BuildVolumeSourceType for the volume source.
 	// Type must match the populated volume source.
 	// Valid types are: Secret, ConfigMap
-	// +k8s:conversion-gen=false
 	Type BuildVolumeSourceType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=BuildVolumeSourceType"`
 
 	// secret represents a Secret that should populate this volume.


### PR DESCRIPTION
Need to remove the `+k8s:conversion-gen=false` so that openshift/openshift-apiserver can auto-generate the conversions.
Tested this in the openshift/openshift-apiserver repo locally and it worked.