### PR TITLE
Add go.mod to tls dir to avoid invalid char errors on vendoring

### DIFF
--- a/tls/go.mod
+++ b/tls/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift/api/tls
+
+go 1.16


### PR DESCRIPTION
Closes #944.