### PR TITLE
operatoringress: Fix typo in DNSRecord CRD.

### DIFF
--- a/operatoringress/v1/0000_50_dns-record.yaml
+++ b/operatoringress/v1/0000_50_dns-record.yaml
@@ -35,7 +35,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: spec is the specification of the desired behavior of the dnsecord.
+              description: spec is the specification of the desired behavior of the dnsRecord.
               type: object
               required:
                 - dnsName

--- a/operatoringress/v1/types.go
+++ b/operatoringress/v1/types.go
@@ -20,7 +20,7 @@ type DNSRecord struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// spec is the specification of the desired behavior of the dnsecord.
+	// spec is the specification of the desired behavior of the dnsRecord.
 	Spec DNSRecordSpec `json:"spec"`
 	// status is the most recently observed status of the dnsRecord.
 	Status DNSRecordStatus `json:"status"`

--- a/operatoringress/v1/zz_generated.swagger_doc_generated.go
+++ b/operatoringress/v1/zz_generated.swagger_doc_generated.go
@@ -13,7 +13,7 @@ package v1
 // AUTO-GENERATED FUNCTIONS START HERE
 var map_DNSRecord = map[string]string{
 	"":       "DNSRecord is a DNS record managed in the zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone.\n\nCluster admin manipulation of this resource is not supported. This resource is only for internal communication of OpenShift operators.",
-	"spec":   "spec is the specification of the desired behavior of the dnsecord.",
+	"spec":   "spec is the specification of the desired behavior of the dnsRecord.",
 	"status": "status is the most recently observed status of the dnsRecord.",
 }
 


### PR DESCRIPTION
operatoringress/v1/types.go:

Fix `dnsecord` -> `dnsRecord` in `spec` godoc.

operatoringress/v1/0000_50_dns-record.yaml,
operatoringress/v1/zz_generated.swagger_doc_generated.go:

Regenerate.