### PR TITLE
Add CISInstanceCRN to IBMCloudPlatformStatus

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -396,6 +396,11 @@ spec:
                       infrastructure provider.
                     type: object
                     properties:
+                      cisInstanceCRN:
+                        description: CISInstanceCRN is the CRN of the Cloud Internet
+                          Services instance managing the DNS zone for the cluster's
+                          base domain
+                        type: string
                       location:
                         description: Location is where the cluster has been deployed
                         type: string

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -517,6 +517,10 @@ type IBMCloudPlatformStatus struct {
 
 	// ProviderType indicates the type of cluster that was created
 	ProviderType IBMCloudProviderType `json:"providerType,omitempty"`
+
+	// CISInstanceCRN is the CRN of the Cloud Internet Services instance managing
+	// the DNS zone for the cluster's base domain
+	CISInstanceCRN string `json:"cisInstanceCRN,omitempty"`
 }
 
 // KubevirtPlatformSpec holds the desired state of the kubevirt infrastructure provider.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -840,6 +840,7 @@ var map_IBMCloudPlatformStatus = map[string]string{
 	"location":          "Location is where the cluster has been deployed",
 	"resourceGroupName": "ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.",
 	"providerType":      "ProviderType indicates the type of cluster that was created",
+	"cisInstanceCRN":    "CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain",
 }
 
 func (IBMCloudPlatformStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
CISInstanceCRN is the Cloud Resource Name (CRN) referencing the instance of
IBM Cloud Internet Services that is setup to manage the DNS zone of the
cluster's base domain. This can be guaranteed in an IPI/UPI installation
since this configuration is a pre-requisite. Components like the Cluster
Ingress Operator will use this CRN in API calls to update DNS records.

This PR is required to implement IBMCloud IPI/UPI.
Enhancement doc: https://github.com/openshift/enhancements/pull/773
Relevant Installer PR: https://github.com/openshift/installer/pull/4923