### PR TITLE
BUILD-159: add projected share resource csi driver operator to the list managed by the CSO

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -46,6 +46,7 @@ spec:
                 - manila.csi.openstack.org
                 - csi.ovirt.org
                 - csi.kubevirt.io
+                - csi.shared-resources.openshift.io
                 type: string
             type: object
           spec:

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
@@ -13,3 +13,4 @@
       - manila.csi.openstack.org
       - csi.ovirt.org
       - csi.kubevirt.io
+      - csi.shared-resources.openshift.io

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -37,18 +37,18 @@ type ClusterCSIDriver struct {
 // CSIDriverName is the name of the CSI driver
 type CSIDriverName string
 
-// If you are adding a new driver name here, ensure that kubebuilder:validation:Enum is updated above
-// and 0000_90_cluster_csi_driver_01_config.crd.yaml-merge-patch file is also updated with new driver name.
+// If you are adding a new driver name here, ensure that 0000_90_cluster_csi_driver_01_config.crd.yaml-merge-patch file is also updated with new driver name.
 const (
-	AWSEBSCSIDriver    CSIDriverName = "ebs.csi.aws.com"
-	AWSEFSCSIDriver    CSIDriverName = "efs.csi.aws.com"
-	AzureDiskCSIDriver CSIDriverName = "disk.csi.azure.com"
-	GCPPDCSIDriver     CSIDriverName = "pd.csi.storage.gke.io"
-	CinderCSIDriver    CSIDriverName = "cinder.csi.openstack.org"
-	VSphereCSIDriver   CSIDriverName = "csi.vsphere.vmware.com"
-	ManilaCSIDriver    CSIDriverName = "manila.csi.openstack.org"
-	OvirtCSIDriver     CSIDriverName = "csi.ovirt.org"
-	KubevirtCSIDriver  CSIDriverName = "csi.kubevirt.io"
+	AWSEBSCSIDriver          CSIDriverName = "ebs.csi.aws.com"
+	AWSEFSCSIDriver          CSIDriverName = "efs.csi.aws.com"
+	AzureDiskCSIDriver       CSIDriverName = "disk.csi.azure.com"
+	GCPPDCSIDriver           CSIDriverName = "pd.csi.storage.gke.io"
+	CinderCSIDriver          CSIDriverName = "cinder.csi.openstack.org"
+	VSphereCSIDriver         CSIDriverName = "csi.vsphere.vmware.com"
+	ManilaCSIDriver          CSIDriverName = "manila.csi.openstack.org"
+	OvirtCSIDriver           CSIDriverName = "csi.ovirt.org"
+	KubevirtCSIDriver        CSIDriverName = "csi.kubevirt.io"
+	SharedResourcesCSIDriver CSIDriverName = "csi.shared-resources.openshift.io"
 )
 
 // ClusterCSIDriverSpec is the desired behavior of CSI driver operator


### PR DESCRIPTION
`make update` etc. is behaving weird for me today ... I think my upgrading controller-gen for v0.5 for tekton has introduced formatting differences.

initially submitting with WIP and with any `make update` changes to see exactly how the verify job fails, and then see if I can split the difference

or I may have to maintain 2 versions of controller-gen