### PR TITLE
Add AWS EFS CSI driver

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -38,6 +38,7 @@ spec:
               name:
                 enum:
                 - ebs.csi.aws.com
+                - efs.csi.aws.com
                 - disk.csi.azure.com
                 - pd.csi.storage.gke.io
                 - cinder.csi.openstack.org

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
@@ -5,6 +5,7 @@
       type: string
       enum:
       - ebs.csi.aws.com
+      - efs.csi.aws.com
       - disk.csi.azure.com
       - pd.csi.storage.gke.io
       - cinder.csi.openstack.org

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -41,6 +41,7 @@ type CSIDriverName string
 // and 0000_90_cluster_csi_driver_01_config.crd.yaml-merge-patch file is also updated with new driver name.
 const (
 	AWSEBSCSIDriver    CSIDriverName = "ebs.csi.aws.com"
+	AWSEFSCSIDriver    CSIDriverName = "efs.csi.aws.com"
 	AzureDiskCSIDriver CSIDriverName = "disk.csi.azure.com"
 	GCPPDCSIDriver     CSIDriverName = "pd.csi.storage.gke.io"
 	CinderCSIDriver    CSIDriverName = "cinder.csi.openstack.org"


### PR DESCRIPTION
Add AWS EFS CSI driver to ClusterCSIDriver validation. It will be supported in 4.9.

KEP: https://github.com/openshift/enhancements/pull/687/
