### PR TITLE
Add ExternalCloudProvider to TechPreviewNoUpgrade FeatureSet

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -112,6 +112,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("CSIMigrationOpenStack"). // sig-storage, jsafrane, Kubernetes feature gate
 		with("CSIMigrationGCE").       // sig-storage, fbertina, Kubernetes feature gate
 		with("CSIMigrationAzureDisk"). // sig-storage, fbertina, Kubernetes feature gate
+		with("ExternalCloudProvider"). // sig-cloud-provider, jspeed, OCP specific
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(


### PR DESCRIPTION
This feature gate is required to enable extenal cloud providers, as we introduce this feature as tech preview in 4.9.