### PR TITLE
Add a default flag for ConsoleYamlSample

### DIFF
--- a/console/v1/0000_10_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_consoleyamlsample.crd.yaml
@@ -44,6 +44,9 @@ spec:
                 - title
                 - yaml
               properties:
+                default:
+                  description: default indicates that the YAML sample should be used as the default sample when creating new resources. The console YALM editor will be pre-populated with the sample marked as default.
+                  type: boolean
                 description:
                   description: description of the YAML sample.
                   type: string

--- a/console/v1/types_console_yaml_sample.go
+++ b/console/v1/types_console_yaml_sample.go
@@ -32,6 +32,11 @@ type ConsoleYAMLSampleSpec struct {
 	// YAML document at the user's cursor.
 	// +optional
 	Snippet bool `json:"snippet"`
+	// default indicates that the YAML sample should be used as the default
+	// sample when creating new resources. The console YALM editor will be
+	// pre-populated with the sample marked as default.
+	// +optional
+	Default bool `json:"default"`
 }
 
 // ConsoleYAMLSampleTitle of the YAML sample.


### PR DESCRIPTION
Suggested API change here. The operator framework is planning a move to using embedded YAML CRs instead of a CSV and this would remove the need for the alm-examples annotation on CSVs. Once this is in the API, I would plan to make a PR to the console that would use this flag to populate the initial YAML editor when creating new CRs via the UI.

This is partly me working out how this api is updated - I would expect to write a proposal to be discussed somewhere before actually PRing the API repo, but didn't see any contributor guidance, so please feel free to point me at a proper process!

The alternative to this could be to annotate a ConsoleYamlSample to say it is the default, in the same style as annotating a cluster default storage class.