### PR TITLE
BUG 1992599: feature: Enable the CPUManagerPolicyOptions by default

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -115,7 +115,8 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(
-			"TopologyManager", // sig-pod, sjenning
+			"CPUManagerPolicyOptions", // sig-node, fromanirh
+			"TopologyManager",         // sig-pod, sjenning
 		).
 		toFeatures(),
 	IPv6DualStackNoUpgrade: newDefaultFeatures().


### PR DESCRIPTION
This feature gate will make the kubelet to actually accept
the policy options; until some agent configures them
in the kubelet config file, no change of behaviour will
happen at all.

Signed-off-by: Francesco Romani <fromani@redhat.com>