### PR TITLE
IBM cloud managed profile: add consoleplugin CRD

### DIFF
--- a/console/v1alpha1/0000_10_consoleplugin.crd.yaml
+++ b/console/v1alpha1/0000_10_consoleplugin.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/764
     description: Extension for configuring openshift web console plugins.
     displayName: ConsolePlugin
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consoleplugins.console.openshift.io
 spec:


### PR DESCRIPTION
Adds annotation to include the consoleplugin CRD in the `ibm-cloud-managed` profile