### PR TITLE
Bug 1964112: Fix for host name validator error

### DIFF
--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -288,7 +288,7 @@ const (
 	// AllowNonDNSCompliantHostAnnotation indicates that the host name in a route
 	// configuration is not required to follow strict DNS compliance.
 	// Unless the annotation is set to true, the route host name must have at least one label.
-	// Label's must have no more than 63 characters from the set of
+	// Labels must have no more than 63 characters from the set of
 	// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric
 	// character. A trailing dot is not allowed. The total host name length must be no more
 	// than 253 characters.

--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -287,10 +287,10 @@ const (
 const (
 	// AllowNonDNSCompliantHostAnnotation indicates that the host name in a route
 	// configuration is not required to follow strict DNS compliance.
-	// Unless the annotation is set to true, the route host name must have
-	// at least two labels, with each label no more than 63 characters from the set of
+	// Unless the annotation is set to true, the route host name must have at least one label.
+	// Label's must have no more than 63 characters from the set of
 	// alphanumeric characters, '-' or '.', and must start and end with an alphanumeric
-	// character. A trailing dot is allowed. The total host name length must be no more
+	// character. A trailing dot is not allowed. The total host name length must be no more
 	// than 253 characters.
 	//
 	// When the annotation is set to true, the host name must pass a smaller set of


### PR DESCRIPTION
This PR applies to the fix for https://github.com/openshift/openshift-apiserver/pull/228. 

It makes use of the annotation in route/v1/types.go.

This update aligns the comments to reflect the type of validation that will be enforced.