### PR TITLE
Bug 1986129: Add missing 'include.release.openshift.io/single-node-developer' annotation to the ConsolePlugin CRD

### DIFF
--- a/console/v1alpha1/0000_10_consoleplugin.crd.yaml
+++ b/console/v1alpha1/0000_10_consoleplugin.crd.yaml
@@ -7,6 +7,7 @@ metadata:
     displayName: ConsolePlugin
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: consoleplugins.console.openshift.io
 spec:
   group: console.openshift.io


### PR DESCRIPTION
/assign @spadgett 