### PR TITLE
Tech Preview Shared Resource CSI Driver

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -119,6 +119,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("CSIMigrationAzureDisk").      // sig-storage, fbertina, Kubernetes feature gate
 		with("ExternalCloudProvider").      // sig-cloud-provider, jspeed, OCP specific
 		with("InsightsOperatorPullingSCA"). // insights-operator/ccx, tremes, OCP specific
+		with("CSIDriverSharedResource").    // sig-build, adkaplan, OCP specific
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(


### PR DESCRIPTION
Add the `CSIDriverSharedResource` feature gate to the tech preview set.
The CSI driver allows Secrets and ConfigMaps to be shared across
namespaces. This driver should only be installed on clusters that opt
into tech preview features.