### PR TITLE
config/v1/types_cluster_version: Make Update properties omitempty

### DIFF
--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -236,14 +236,14 @@ type Update struct {
 	// field is part of spec, version is optional if image is specified.
 	//
 	// +optional
-	Version string `json:"version"`
+	Version string `json:"version,omitempty"`
 
 	// image is a container image location that contains the update. When this
 	// field is part of spec, image is optional if version is specified and the
 	// availableUpdates field contains a matching version.
 	//
 	// +optional
-	Image string `json:"image"`
+	Image string `json:"image,omitempty"`
 
 	// force allows an administrator to update to an image that has failed
 	// verification or upgradeable checks. This option should only
@@ -253,7 +253,7 @@ type Update struct {
 	// or potentially malicious sources.
 	//
 	// +optional
-	Force bool `json:"force"`
+	Force bool `json:"force,omitempty"`
 }
 
 // Release represents an OpenShift release image and associated metadata.


### PR DESCRIPTION
This type used to be used for both the admin-provided `spec.desiredUpdate` and the operator-provided `status.desired`.  That changed in 575f8d2f0d (#521, 4.6), when `status.desired` moved to a new `Release` type, so now `Update` is only used for `spec.desiredUpdate`.

The properties have been `+optional` since they landed in 898d7e3b7c (#127) and ab4ff93d20 (#293).

I'm adding `omitempty`, because if the admin doesn't have a particular `version` or `image` in mind, returning explicit empty strings is distracting noise.  With this commit, it will be easier to focus on the `version` or `image` property that did get set, and you need at least one of them to be set to be a usable update request.

The `force` property is a bit more wiggly, since there may be some benefit to explicitly pointing out that the admin is not forcing the update.  But forcing is supposed to be an exceptional-situation safety valve, so I'm adding `omitempty` there too, because the benefit of de-emphasizing the property's presence (and reducing the chance that an admin says "hey, let's see what `force: true` does" without reading associated docs) outweighs the benefit of explicitly pointing out `force: false` cases.