### PR TITLE
WIP config/v1: add PodSecurity feature gate to TechPreviewNoUpgrade

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -119,6 +119,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("CSIMigrationAzureDisk").      // sig-storage, fbertina, Kubernetes feature gate
 		with("ExternalCloudProvider").      // sig-cloud-provider, jspeed, OCP specific
 		with("InsightsOperatorPullingSCA"). // insights-operator/ccx, tremes, OCP specific
+		with("PodSecurity").                // sig-auth, s-urbaniak, Kubernetes feature gate
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(


### PR DESCRIPTION
This enables PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement) if TechPreviewNoUpgrade feature set is enabled.

This depends on admission configuration being merged first: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1217

This can be merged once 4.10 master opens, the earliest.

/hold