### PR TITLE
config/v1: add PodSecurity to Default features

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -140,6 +140,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		"NodeDisruptionExclusion",        // sig-scheduling, ccoleman
 		"ServiceNodeExclusion",           // sig-scheduling, ccoleman
 		"DownwardAPIHugePages",           // sig-node, rphillips
+		"PodSecurity",                    // sig-auth, s-urbaniak
 	},
 	Disabled: []string{
 		"LegacyNodeRoleBehavior", // sig-scheduling, ccoleman

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -26,6 +26,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 					"DownwardAPIHugePages",
+					"PodSecurity",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
@@ -44,6 +45,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 					"DownwardAPIHugePages",
+					"PodSecurity",
 					"LegacyNodeRoleBehavior",
 				},
 				Disabled: []string{},
@@ -59,6 +61,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 					"DownwardAPIHugePages",
+					"PodSecurity",
 				},
 				Disabled: []string{
 					"LegacyNodeRoleBehavior",
@@ -78,6 +81,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"NodeDisruptionExclusion",
 					"ServiceNodeExclusion",
 					"DownwardAPIHugePages",
+					"PodSecurity",
 					"LegacyNodeRoleBehavior",
 					"other",
 				},


### PR DESCRIPTION
This enables PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement) by default.

This depends on admission configuration being merged first: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1217

This can be merged once 4.10 master opens, the earliest.

/hold