### PR TITLE
AUTH-8: config,oauth: add groups to retrievable OpenIDClaims 

### DIFF
--- a/config/v1/0000_10_config-operator_01_oauth.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_oauth.crd.yaml
@@ -295,16 +295,27 @@ spec:
                                 type: array
                                 items:
                                   type: string
+                                x-kubernetes-list-type: atomic
+                              groups:
+                                description: groups is the list of claims value of which should be used to synchronize groups from the OIDC provider to OpenShift for the user. If multiple claims are specified, the first one with a non-empty value is used.
+                                type: array
+                                items:
+                                  description: OpenIDClaim represents a claim retrieved from an OpenID provider's tokens or userInfo responses
+                                  type: string
+                                  minLength: 1
+                                x-kubernetes-list-type: atomic
                               name:
                                 description: name is the list of claims whose values should be used as the display name. Optional. If unspecified, no display name is set for the identity
                                 type: array
                                 items:
                                   type: string
+                                x-kubernetes-list-type: atomic
                               preferredUsername:
                                 description: preferredUsername is the list of claims whose values should be used as the preferred username. If unspecified, the preferred username is determined from the value of the sub claim
                                 type: array
                                 items:
                                   type: string
+                                x-kubernetes-list-type: atomic
                           clientID:
                             description: clientID is the oauth client ID
                             type: string

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -539,6 +539,11 @@ type OpenIDIdentityProvider struct {
 //   iss Claim and the sub Claim."
 const UserIDClaim = "sub"
 
+// OpenIDClaim represents a claim retrieved from an OpenID provider's tokens or userInfo
+// responses
+// +kubebuilder:validation:MinLength=1
+type OpenIDClaim string
+
 // OpenIDClaims contains a list of OpenID claims to use when authenticating with an OpenID identity provider
 type OpenIDClaims struct {
 	// preferredUsername is the list of claims whose values should be used as the preferred username.
@@ -555,6 +560,13 @@ type OpenIDClaims struct {
 	// If unspecified, no email is set for the identity
 	// +optional
 	Email []string `json:"email,omitempty"`
+
+	// groups is the list of claims value of which should be used to synchronize groups
+	// from the OIDC provider to OpenShift for the user.
+	// If multiple claims are specified, the first one with a non-empty value is used.
+	// +listType=atomic
+	// +optional
+	Groups []OpenIDClaim `json:"groups,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -548,16 +548,19 @@ type OpenIDClaim string
 type OpenIDClaims struct {
 	// preferredUsername is the list of claims whose values should be used as the preferred username.
 	// If unspecified, the preferred username is determined from the value of the sub claim
+	// +listType=atomic
 	// +optional
 	PreferredUsername []string `json:"preferredUsername,omitempty"`
 
 	// name is the list of claims whose values should be used as the display name. Optional.
 	// If unspecified, no display name is set for the identity
+	// +listType=atomic
 	// +optional
 	Name []string `json:"name,omitempty"`
 
 	// email is the list of claims whose values should be used as the email address. Optional.
 	// If unspecified, no email is set for the identity
+	// +listType=atomic
 	// +optional
 	Email []string `json:"email,omitempty"`
 

--- a/config/v1/zz_generated.deepcopy.go
+++ b/config/v1/zz_generated.deepcopy.go
@@ -2959,6 +2959,11 @@ func (in *OpenIDClaims) DeepCopyInto(out *OpenIDClaims) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Groups != nil {
+		in, out := &in.Groups, &out.Groups
+		*out = make([]OpenIDClaim, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1486,6 +1486,7 @@ var map_OpenIDClaims = map[string]string{
 	"preferredUsername": "preferredUsername is the list of claims whose values should be used as the preferred username. If unspecified, the preferred username is determined from the value of the sub claim",
 	"name":              "name is the list of claims whose values should be used as the display name. Optional. If unspecified, no display name is set for the identity",
 	"email":             "email is the list of claims whose values should be used as the email address. Optional. If unspecified, no email is set for the identity",
+	"groups":            "groups is the list of claims value of which should be used to synchronize groups from the OIDC provider to OpenShift for the user. If multiple claims are specified, the first one with a non-empty value is used.",
 }
 
 func (OpenIDClaims) SwaggerDoc() map[string]string {

--- a/osin/v1/types.go
+++ b/osin/v1/types.go
@@ -397,6 +397,9 @@ type OpenIDClaims struct {
 	// email is the list of claims whose values should be used as the email address. Optional.
 	// If unspecified, no email is set for the identity
 	Email []string `json:"email"`
+	// groups is the list of claims value of which should be used to synchronize groups
+	// from the OIDC provider to OpenShift for the user
+	Groups []string `json:"groups"`
 }
 
 // GrantConfig holds the necessary configuration options for grant handlers

--- a/osin/v1/zz_generated.deepcopy.go
+++ b/osin/v1/zz_generated.deepcopy.go
@@ -404,6 +404,11 @@ func (in *OpenIDClaims) DeepCopyInto(out *OpenIDClaims) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Groups != nil {
+		in, out := &in.Groups, &out.Groups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
This PR adds API to specify which OpenID claims should be used to retrieve the group information

@openshift/openshift-team-auth-maintainers 