### PR TITLE
BUILD-353: Rename csi.shared-resources.openshift.io driver to csi.sharedresource.openshift.io

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -48,7 +48,7 @@ spec:
                 - manila.csi.openstack.org
                 - csi.ovirt.org
                 - csi.kubevirt.io
-                - csi.shared-resources.openshift.io
+                - csi.sharedresource.openshift.io
                 - diskplugin.csi.alibabacloud.com
                 - vpc.block.csi.ibm.io
                 type: string

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml-patch
@@ -14,6 +14,6 @@
       - manila.csi.openstack.org
       - csi.ovirt.org
       - csi.kubevirt.io
-      - csi.shared-resources.openshift.io
+      - csi.sharedresource.openshift.io
       - diskplugin.csi.alibabacloud.com
       - vpc.block.csi.ibm.io


### PR DESCRIPTION
Hopefully this is the last of the shared resources updates.
I think we got them all this time.