### PR TITLE
Update patch merge tags in struct to match those in the comment

### DIFF
--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -331,7 +331,7 @@ type ConditionalUpdate struct {
 	// +listType=map
 	// +listMapKey=name
 	// +required
-	Risks []ConditionalUpdateRisk `json:"risks"`
+	Risks []ConditionalUpdateRisk `json:"risks" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// conditions represents the observations of the conditional update's
 	// current status. Known types are:

--- a/sharedresource/v1alpha1/types_shared_configmap.go
+++ b/sharedresource/v1alpha1/types_shared_configmap.go
@@ -84,5 +84,5 @@ type SharedConfigMapStatus struct {
 	// conditions represents any observations made on this particular shared resource by the underlying CSI driver or Share controller.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
-	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }

--- a/sharedresource/v1alpha1/types_shared_secret.go
+++ b/sharedresource/v1alpha1/types_shared_secret.go
@@ -82,5 +82,5 @@ type SharedSecretStatus struct {
 	// conditions represents any observations made on this particular shared resource by the underlying CSI driver or Share controller.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
-	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }


### PR DESCRIPTION
These tags have to be added for the `make update` in openshift-apiserver to succeed when updating to k8s 0.22.1.