### PR TITLE
Fix CSI migration feature gate name for vSphere

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -119,7 +119,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("CSIMigrationGCE").            // sig-storage, fbertina, Kubernetes feature gate
 		with("CSIMigrationAzureDisk").      // sig-storage, fbertina, Kubernetes feature gate
 		with("CSIMigrationAzureFile").      // sig-storage, fbertina, Kubernetes feature gate
-		with("CSIMigrationVSphere").        // sig-storage, fbertina, Kubernetes feature gate
+		with("CSIMigrationvSphere").        // sig-storage, fbertina, Kubernetes feature gate
 		with("ExternalCloudProvider").      // sig-cloud-provider, jspeed, OCP specific
 		with("InsightsOperatorPullingSCA"). // insights-operator/ccx, tremes, OCP specific
 		with("CSIDriverSharedResource").    // sig-build, adkaplan, OCP specific


### PR DESCRIPTION
The correct name is `CSIMigrationvSphere`, with a lowercase `v`: https://github.com/kubernetes/kubernetes/blob/aa7c6338c6767a86a76abae819670145033497f6/pkg/features/kube_features.go#L305

CC @openshift/storage 