### PR TITLE
Remove "InsightsOperatorPullingSCA" from tech preview featureset

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -121,7 +121,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("CSIMigrationAzureFile").       // sig-storage, fbertina, Kubernetes feature gate
 		with("CSIMigrationvSphere").         // sig-storage, fbertina, Kubernetes feature gate
 		with("ExternalCloudProvider").       // sig-cloud-provider, jspeed, OCP specific
-		with("InsightsOperatorPullingSCA").  // insights-operator/ccx, tremes, OCP specific
 		with("CSIDriverSharedResource").     // sig-build, adkaplan, OCP specific
 		with("BuildCSIVolumes").             // sig-build, adkaplan, OCP specific
 		with("NodeSwap").                    // sig-node, ehashman, Kubernetes feature gate


### PR DESCRIPTION
Moving [Insighst pulling SCA/entitlement certs functionality](https://github.com/openshift/enhancements/blob/master/enhancements/insights/pulling-sca-certs-from-ocm.md) from TP to GA. 