### PR TITLE
README.md: Add a reference for API conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # api
 The canonical location of the OpenShift API definition.  This repo holds the API type definitions and serialization code used by [openshift/client-go](https://github.com/openshift/client-go)
 
+## defining new APIs
+
+When defining a new API, please follow [the OpenShift API
+conventions](https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#api),
+and then follow the instructions below to regenerate CRDs (if necessary) and
+submit a pull request with your new API definitions and generated files.
+
 ## pull request process
 
 Pull requests that change API types in this repo that have corresponding "internal" API objects in the 


### PR DESCRIPTION
* `README.md`: Add a section on defining new APIs, with a reference to the API conventions section of the OpenShift `CONVENTIONS.md` document.

---

This PR will be more useful if https://github.com/openshift/enhancements/pull/951 is accepted.