### PR TITLE
[WIP] [release 4.8] Bug 2022545: Atomic List Type 4.8 Backport

### DIFF
--- a/config/v1/0000_10_config-operator_01_oauth.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_oauth.crd.yaml
@@ -587,6 +587,7 @@ spec:
                       description: type identifies the identity provider type for
                         this entry.
                       type: string
+                x-kubernetes-list-type: atomic
               templates:
                 description: templates allow you to customize pages like the login
                   page.

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -28,6 +28,7 @@ type OAuthSpec struct {
 	// identityProviders is an ordered list of ways for a user to identify themselves.
 	// When this list is empty, no identities are provisioned for users.
 	// +optional
+	// +listType=atomic
 	IdentityProviders []IdentityProvider `json:"identityProviders,omitempty"`
 
 	// tokenConfig contains options for authorization and access tokens


### PR DESCRIPTION
While cherrypick worked to backport this bug to 4.9, with 4.8 the CRD changed a good deal. This is a manual change to backport atomic type.