### PR TITLE
Bug 2023434: Add Purchase Plan Name to Azure Machine Provider Spec

### DIFF
--- a/machine/v1beta1/types_azureprovider.go
+++ b/machine/v1beta1/types_azureprovider.go
@@ -174,7 +174,27 @@ type Image struct {
 	Version string `json:"version"`
 	// ResourceID specifies an image to use by ID
 	ResourceID string `json:"resourceID"`
+	// Type identifies the source of the image and related information, such as purchase plans.
+	// Valid values are "ID", "MarketplaceWithPlan", "MarketplaceNoPlan", and omitted, which
+	// means no opinion and the platform chooses a good default which may change over time.
+	// Currently that default is "MarketplaceNoPlan" if publisher data is supplied, or "ID" if not.
+	// For more information about purchase plans, see:
+	// https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#check-the-purchase-plan-information
+	// +optional
+	Type AzureImageType `json:"type,omitempty"`
 }
+
+// AzureImageType provides an enumeration for the valid image types.
+type AzureImageType string
+
+const (
+	// AzureImageTypeID specifies that the image should be referenced by its resource ID.
+	AzureImageTypeID AzureImageType = "ID"
+	// AzureImageTypeMarketplaceNoPlan are images available from the marketplace that do not require a purchase plan.
+	AzureImageTypeMarketplaceNoPlan AzureImageType = "MarketplaceNoPlan"
+	// AzureImageTypeMarketplaceWithPlan require a purchase plan. Upstream these images are referred to as "ThirdParty."
+	AzureImageTypeMarketplaceWithPlan AzureImageType = "MarketplaceWithPlan"
+)
 
 type OSDisk struct {
 	// OSType is the operating system type of the OS disk. Possible values include "Linux" and "Windows".

--- a/machine/v1beta1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1beta1/zz_generated.swagger_doc_generated.go
@@ -225,6 +225,7 @@ var map_Image = map[string]string{
 	"sku":        "SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter",
 	"version":    "Version specifies the version of an image sku. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.",
 	"resourceID": "ResourceID specifies an image to use by ID",
+	"type":       "Type identifies the source of the image and related information, such as purchase plans. Valid values are \"ID\", \"MarketplaceWithPlan\", \"MarketplaceNoPlan\", and omitted, which means no opinion and the platform chooses a good default which may change over time. Currently that default is \"MarketplaceNoPlan\" if publisher data is supplied, or \"ID\" if not. For more information about purchase plans, see: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage#check-the-purchase-plan-information",
 }
 
 func (Image) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Edited: The original PR added support for both Marketplace and Shared Image Gallery images. I have decreased the scope to only Marketplace images, which means we just need a flag as to when to populate the purchase plan. To avoid a boolean, I have added a `string` field `PurchasePlanName` which when present should have the same value as the `SKU`, and would indicate we should create a plan. Using a string avoids using a boolean, and allows us space if there is ever drift in the Microsoft API where purchase plan name != SKU.  

Upstream types: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/d2b4e8ed2313adc270a0911d9d0c64e344f34cc4/api/v1beta1/types.go#L316-L398

The OpenShift cluster-api-provider-azure will need to implement logic based off the upstream (I will open a PR soon): https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/d2b4e8ed2313adc270a0911d9d0c64e344f34cc4/azure/services/virtualmachines/virtualmachines.go#L259-L287