### PR TITLE
Introduce API change checklist PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+Thanks for submitting a change!
+Before opening this pull request, please fill out the following checklist:
+
+NOTE: If you tick an item with **API review required** please tag the @openshift/api-reviewers group and wait until member of this group review this pull request before merging.
+-->
+
+<!-- WRITE DESCRIPTION HERE -->
+
+---
+
+#### API change checklist
+
+- [ ] This change introduces a new API or changes an existing API in a way that is complaint with the [upstream API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md)  _(**API review required**)_
+- [ ] This change is deprecating an existing API and [deprecation guide](https://docs.openshift.com/container-platform/4.9/rest_api/understanding-api-support-tiers.html) was followed _(**API review required**)_
+- [ ] This change implements an [enhancement](https://github.com/openshift/enhancements) and the enhancement is linked in the PR description
+- [ ] This change modifies kubebuilder tags and it follows the [kubebuilder markers reference](https://book.kubebuilder.io/reference/markers/crd-validation.html)
+- [ ] This is a minor change to an existing API _(documentation, README change, etc.)
+- 


### PR DESCRIPTION
This PR introduces an API checklist as part of the new pull request template. PR authors will have to indicate that their changes are complaint with OpenShift/Kubernetes API conventions, they followed deprecations policy, their changes are backed up with enhancement or they understand the meaning of kubebuilder tags when changed.

This also makes it more obvious that @openshift/api-reviewers group should be tagged and asked for review/approval in some cases.