### PR TITLE
config/v1: Add NodeSwap to TechPreviewNoUpgrade

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -124,6 +124,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("InsightsOperatorPullingSCA").  // insights-operator/ccx, tremes, OCP specific
 		with("CSIDriverSharedResource").     // sig-build, adkaplan, OCP specific
 		with("BuildCSIVolumes").             // sig-build, adkaplan, OCP specific
+		with("NodeSwap").                    // sig-node, ehashman, Kubernetes feature gate
 		with("MachineAPIProviderOpenStack"). // openstack, egarcia (#forum-openstack), OCP specific
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().


### PR DESCRIPTION
See https://github.com/openshift/enhancements/pull/902 for OpenShift enhancement details (not yet merged+implementable).

Should be all the implementation currently needed for [OCPNODE-618](https://issues.redhat.com/browse/OCPNODE-618). Enabling swap within a cluster doesn't require any other code changes; configs are detailed in the enhancement above. I was able to get swap working on a cluster-bot cluster using a `CustomNoUpgrade` feature gate config.