### PR TITLE
add ibmcloud satellite upi provider enum

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -180,6 +180,10 @@ const (
 
 	// VPC means that the IBM Cloud cluster is using VPC infrastructure
 	IBMCloudProviderTypeVPC IBMCloudProviderType = "VPC"
+
+	// IBMCloudProviderTypeUPI means that the IBM Cloud cluster is using user provided infrastructure.
+	// This is utilized in IBM Cloud Satellite environments.
+	IBMCloudProviderTypeUPI IBMCloudProviderType = "UPI"
 )
 
 // PlatformSpec holds the desired state specific to the underlying infrastructure provider


### PR DESCRIPTION
This allows downstream operators to recognize they are in a UPI IBM Cloud Satellite environment and make config adjustments when applicable.