### PR TITLE
[wip] operator/v1: add lastFilteredRevision to NodeStatus

### DIFF
--- a/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
+++ b/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
@@ -168,6 +168,10 @@ spec:
                       lastFallbackCount:
                         description: lastFallbackCount is how often a fallback to a previous revision happened.
                         type: integer
+                      lastFilteredRevision:
+                        description: lastFilteredRevision is the last revision which was filtered for this node.
+                        type: integer
+                        format: int32
                       nodeName:
                         description: nodeName is the name of the node
                         type: string

--- a/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
+++ b/operator/v1/0000_20_kube-apiserver-operator_01_config.crd.yaml
@@ -209,6 +209,11 @@ spec:
                       description: lastFallbackCount is how often a fallback to a
                         previous revision happened.
                       type: integer
+                    lastFilteredRevision:
+                      description: lastFilteredRevision is the last revision which
+                        was filtered for this node.
+                      format: int32
+                      type: integer
                     nodeName:
                       description: nodeName is the name of the node
                       type: string

--- a/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-controller-manager-operator_01_config.crd.yaml
@@ -221,6 +221,11 @@ spec:
                       description: lastFallbackCount is how often a fallback to a
                         previous revision happened.
                       type: integer
+                    lastFilteredRevision:
+                      description: lastFilteredRevision is the last revision which
+                        was filtered for this node.
+                      format: int32
+                      type: integer
                     nodeName:
                       description: nodeName is the name of the node
                       type: string

--- a/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
+++ b/operator/v1/0000_25_kube-scheduler-operator_01_config.crd.yaml
@@ -211,6 +211,11 @@ spec:
                       description: lastFallbackCount is how often a fallback to a
                         previous revision happened.
                       type: integer
+                    lastFilteredRevision:
+                      description: lastFilteredRevision is the last revision which
+                        was filtered for this node.
+                      format: int32
+                      type: integer
                     nodeName:
                       description: nodeName is the name of the node
                       type: string

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -221,6 +221,8 @@ type NodeStatus struct {
 
 	// lastFailedRevision is the generation of the deployment we tried and failed to deploy.
 	LastFailedRevision int32 `json:"lastFailedRevision,omitempty"`
+	// lastFilteredRevision is the last revision which was filtered for this node.
+	LastFilteredRevision int32 `json:"lastFilteredRevision,omitempty"`
 	// lastFailedTime is the time the last failed revision failed the last time.
 	LastFailedTime *metav1.Time `json:"lastFailedTime,omitempty"`
 	// lastFailedReason is a machine readable failure reason string.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -39,6 +39,7 @@ var map_NodeStatus = map[string]string{
 	"currentRevision":          "currentRevision is the generation of the most recently successful deployment",
 	"targetRevision":           "targetRevision is the generation of the deployment we're trying to apply",
 	"lastFailedRevision":       "lastFailedRevision is the generation of the deployment we tried and failed to deploy.",
+	"lastFilteredRevision":     "lastFilteredRevision is the last revision which was filtered for this node.",
 	"lastFailedTime":           "lastFailedTime is the time the last failed revision failed the last time.",
 	"lastFailedReason":         "lastFailedReason is a machine readable failure reason string.",
 	"lastFailedCount":          "lastFailedCount is how often the installer pod of the last failed revision failed.",


### PR DESCRIPTION
This PR is in conjunction with https://github.com/openshift/library-go/pull/1231 the usage would look something like below for a filtered revision node status.

new node filtered revision 5
```
NodeStatus {
    NodeName: "ip-10-0-128-70.us-west-1.compute.internal",
    CurrentRevision: 0,
    TargetRevision: 0,
    LastFilteredRevision: 5,
}
```

existing node filtered revisions 4, 5.
```
NodeStatus {
    NodeName: "ip-10-0-128-70.us-west-1.compute.internal",
    CurrentRevision: 3,
    TargetRevision: 3,
    LastFilteredRevision: 5,
}
```


Signed-off-by: Sam Batschelet <sbatsche@redhat.com>