### PR TITLE
Update docstrings for VSphereMachineProviderSpec

### DIFF
--- a/machine/v1beta1/types_vsphereprovider.go
+++ b/machine/v1beta1/types_vsphereprovider.go
@@ -48,6 +48,7 @@ type VSphereMachineProviderSpec struct {
 	// DiskGiB is the size of a virtual machine's disk, in GiB.
 	// Defaults to the analogue property value in the template from which this
 	// machine is cloned.
+	// This parameter will be ignored if 'LinkedClone' CloneMode is set.
 	// +optional
 	DiskGiB int32 `json:"diskGiB,omitempty"`
 	// Snapshot is the name of the snapshot from which the VM was cloned
@@ -59,8 +60,8 @@ type VSphereMachineProviderSpec struct {
 	// to FullClone.
 	// When LinkedClone mode is enabled the DiskGiB field is ignored as it is
 	// not possible to expand disks of linked clones.
-	// Defaults to LinkedClone, but fails gracefully to FullClone if the source
-	// of the clone operation has no snapshots.
+	// Defaults to FullClone.
+	// When using LinkedClone, if no snapshots exist for the source template, falls back to FullClone.
 	// +optional
 	CloneMode CloneMode `json:"cloneMode,omitempty"`
 }

--- a/machine/v1beta1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1beta1/zz_generated.swagger_doc_generated.go
@@ -663,9 +663,9 @@ var map_VSphereMachineProviderSpec = map[string]string{
 	"numCPUs":           "NumCPUs is the number of virtual processors in a virtual machine. Defaults to the analogue property value in the template from which this machine is cloned.",
 	"numCoresPerSocket": "NumCPUs is the number of cores among which to distribute CPUs in this virtual machine. Defaults to the analogue property value in the template from which this machine is cloned.",
 	"memoryMiB":         "MemoryMiB is the size of a virtual machine's memory, in MiB. Defaults to the analogue property value in the template from which this machine is cloned.",
-	"diskGiB":           "DiskGiB is the size of a virtual machine's disk, in GiB. Defaults to the analogue property value in the template from which this machine is cloned.",
+	"diskGiB":           "DiskGiB is the size of a virtual machine's disk, in GiB. Defaults to the analogue property value in the template from which this machine is cloned. This parameter will be ignored if 'LinkedClone' CloneMode is set.",
 	"snapshot":          "Snapshot is the name of the snapshot from which the VM was cloned",
-	"cloneMode":         "CloneMode specifies the type of clone operation. The LinkedClone mode is only support for templates that have at least one snapshot. If the template has no snapshots, then CloneMode defaults to FullClone. When LinkedClone mode is enabled the DiskGiB field is ignored as it is not possible to expand disks of linked clones. Defaults to LinkedClone, but fails gracefully to FullClone if the source of the clone operation has no snapshots.",
+	"cloneMode":         "CloneMode specifies the type of clone operation. The LinkedClone mode is only support for templates that have at least one snapshot. If the template has no snapshots, then CloneMode defaults to FullClone. When LinkedClone mode is enabled the DiskGiB field is ignored as it is not possible to expand disks of linked clones. Defaults to FullClone. When using LinkedClone, if no snapshots exist for the source template, falls back to FullClone.",
 }
 
 func (VSphereMachineProviderSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Due to potential default behaviour changes of `CloneMode` field docstrings should be updated.
vSphere Machine controller changes: https://github.com/openshift/machine-api-operator/pull/959
Related MAPI bug: https://bugzilla.redhat.com/show_bug.cgi?id=2001008

cc @JoelSpeed @elmiko 