### PR TITLE
Create a feature gate for MAPO tech preview

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -111,19 +111,20 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		Disabled: []string{},
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
-		with("CSIDriverAzureDisk").         // sig-storage, jsafrane, OCP specific
-		with("CSIDriverAzureFile").         // sig-storage, fbertina, OCP specific
-		with("CSIDriverVSphere").           // sig-storage, jsafrane, OCP specific
-		with("CSIMigrationAWS").            // sig-storage, jsafrane, Kubernetes feature gate
-		with("CSIMigrationOpenStack").      // sig-storage, jsafrane, Kubernetes feature gate
-		with("CSIMigrationGCE").            // sig-storage, fbertina, Kubernetes feature gate
-		with("CSIMigrationAzureDisk").      // sig-storage, fbertina, Kubernetes feature gate
-		with("CSIMigrationAzureFile").      // sig-storage, fbertina, Kubernetes feature gate
-		with("CSIMigrationvSphere").        // sig-storage, fbertina, Kubernetes feature gate
-		with("ExternalCloudProvider").      // sig-cloud-provider, jspeed, OCP specific
-		with("InsightsOperatorPullingSCA"). // insights-operator/ccx, tremes, OCP specific
-		with("CSIDriverSharedResource").    // sig-build, adkaplan, OCP specific
-		with("BuildCSIVolumes").            // sig-build, adkaplan, OCP specific
+		with("CSIDriverAzureDisk").          // sig-storage, jsafrane, OCP specific
+		with("CSIDriverAzureFile").          // sig-storage, fbertina, OCP specific
+		with("CSIDriverVSphere").            // sig-storage, jsafrane, OCP specific
+		with("CSIMigrationAWS").             // sig-storage, jsafrane, Kubernetes feature gate
+		with("CSIMigrationOpenStack").       // sig-storage, jsafrane, Kubernetes feature gate
+		with("CSIMigrationGCE").             // sig-storage, fbertina, Kubernetes feature gate
+		with("CSIMigrationAzureDisk").       // sig-storage, fbertina, Kubernetes feature gate
+		with("CSIMigrationAzureFile").       // sig-storage, fbertina, Kubernetes feature gate
+		with("CSIMigrationvSphere").         // sig-storage, fbertina, Kubernetes feature gate
+		with("ExternalCloudProvider").       // sig-cloud-provider, jspeed, OCP specific
+		with("InsightsOperatorPullingSCA").  // insights-operator/ccx, tremes, OCP specific
+		with("CSIDriverSharedResource").     // sig-build, adkaplan, OCP specific
+		with("BuildCSIVolumes").             // sig-build, adkaplan, OCP specific
+		with("MachineAPIProviderOpenStack"). // openstack, egarcia (#forum-openstack), OCP specific
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(


### PR DESCRIPTION
This creates an api field to allow users to enable or disable
machine-api-provider-openstack in place of
cluster-api-provider-openstack as the openstack-machine-controller
image. This feature is in tech preview in OpenShift 4.10.