### PR TITLE
change the `ResourceGroupID` to optional on alibabacloud provider

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -202,7 +202,6 @@ spec:
                       type: object
                       required:
                         - region
-                        - resourceGroupID
                       properties:
                         region:
                           description: region specifies the region for Alibaba Cloud resources created for the cluster.
@@ -211,7 +210,6 @@ spec:
                         resourceGroupID:
                           description: resourceGroupID is the ID of the resource group for the cluster.
                           type: string
-                          pattern: ^rg-[0-9A-Za-z]+$
                         resourceTags:
                           description: resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.
                           type: array

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -665,10 +665,8 @@ type AlibabaCloudPlatformStatus struct {
 	// +required
 	Region string `json:"region"`
 	// resourceGroupID is the ID of the resource group for the cluster.
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`^rg-[0-9A-Za-z]+$`
-	// +required
-	ResourceGroupID string `json:"resourceGroupID"`
+	// +optional
+	ResourceGroupID string `json:"resourceGroupID,omitempty"`
 	// resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.
 	// +kubebuilder:validation:MaxItems=20
 	// +listType=map


### PR DESCRIPTION
The `ResourceGroupID` is not required, so change the `ResourceGroupID` to optional.