### PR TITLE
Fix rename property patch from type to method

### DIFF
--- a/imageregistry/v1/00_imageregistry.crd.yaml
+++ b/imageregistry/v1/00_imageregistry.crd.yaml
@@ -1162,12 +1162,12 @@ spec:
                             required:
                             - kms
                           properties:
-                            type:
+                            method:
                               not:
                                 enum:
                                 - KMS
                         - properties:
-                            type:
+                            method:
                               enum:
                               - KMS
                           required:
@@ -1194,7 +1194,6 @@ spec:
                               chooses the a default, which is subject to change over
                               time. Currently the default is `AES256`.
                             enum:
-                            - PlainText
                             - KMS
                             - AES256
                             type: string
@@ -1591,7 +1590,6 @@ spec:
                               chooses the a default, which is subject to change over
                               time. Currently the default is `AES256`.
                             enum:
-                            - PlainText
                             - KMS
                             - AES256
                             type: string

--- a/imageregistry/v1/00_imageregistry.crd.yaml-patch
+++ b/imageregistry/v1/00_imageregistry.crd.yaml-patch
@@ -2,12 +2,12 @@
   path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/spec/properties/storage/properties/oss/properties/encryption/anyOf
   value:
   - properties:
-      type:
+      method:
         not:
           enum: ["KMS"]
     not:
       required: ["kms"]
   - properties:
-      type:
+      method:
         enum: ["KMS"]
     required: ["kms"]

--- a/imageregistry/v1/types.go
+++ b/imageregistry/v1/types.go
@@ -318,8 +318,6 @@ const (
 	// PublicEndpoint sets the VPC endpoint to public
 	PublicEndpoint EndpointAccessibility = "Public"
 
-	// PlainText is an AlibabaEncryptionMethod. This is the default. This means no encryption
-	PlainText AlibabaEncryptionMethod = "PlainText"
 	// AES256 is an AlibabaEncryptionMethod. This means AES256 encryption
 	AES256 AlibabaEncryptionMethod = "AES256"
 	// KMS is an AlibabaEncryptionMethod. This means KMS encryption
@@ -332,7 +330,7 @@ type EncryptionAlibaba struct {
 	// Method defines the different encrytion modes available
 	// Empty value means no opinion and the platform chooses the a default, which is subject to change over time.
 	// Currently the default is `AES256`.
-	// +kubebuilder:validation:Enum="PlainText";"KMS";"AES256"
+	// +kubebuilder:validation:Enum="KMS";"AES256"
 	// +kubebuilder:default="AES256"
 	// +optional
 	Method AlibabaEncryptionMethod `json:"method"`


### PR DESCRIPTION
Found an issue with renaming the field from `Type` to `Method`. 

We thought we had tested with a latest image update, rebuild, push, and test but we missed the CRD regeneration. 

Since we do not support `PlainText` I am going to remove it from the enum and CRD.