### PR TITLE
Bug 2033536: Alibaba infrastructure config: Updating kube validation on optional s…

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -210,7 +210,7 @@ spec:
                         resourceGroupID:
                           description: resourceGroupID is the ID of the resource group for the cluster.
                           type: string
-                          pattern: ^rg-[0-9A-Za-z]+$
+                          pattern: ^(rg-[0-9A-Za-z]+)?$
                         resourceTags:
                           description: resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.
                           type: array

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -665,7 +665,7 @@ type AlibabaCloudPlatformStatus struct {
 	// +required
 	Region string `json:"region"`
 	// resourceGroupID is the ID of the resource group for the cluster.
-	// +kubebuilder:validation:Pattern=`^rg-[0-9A-Za-z]+$`
+	// +kubebuilder:validation:Pattern=`^(rg-[0-9A-Za-z]+)?$`
 	// +optional
 	ResourceGroupID string `json:"resourceGroupID,omitempty"`
 	// resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.


### PR DESCRIPTION
…tring

When testing recently with the recent optional field the validation has been failing when golang defaults the empty string to "". The fix here is to make the string be optionally `""`.

```
Dec 17 17:02:54 citest-4zx6j-bootstrap bootkube.sh[2351]: "cluster-infrastructure-02-config.yml": failed to update status for infrastructures.v1.config.openshift.io/cluster -n : Infrastructure.config.openshift.io "cluster" is invalid: status.platformStatus.alibabaCloud.resourceGroupID: Invalid value: "": status.platformStatus.alibabaCloud.resourceGroupID in body should match '^rg-[0-9A-Za-z]+$'
```