### PR TITLE
Bug 2034879: Ensure name and owner are required within lifecycle hooks

### DIFF
--- a/machine/v1beta1/0000_10_machine.crd.yaml
+++ b/machine/v1beta1/0000_10_machine.crd.yaml
@@ -80,6 +80,9 @@ spec:
                       items:
                         description: LifecycleHook represents a single instance of a lifecycle hook
                         type: object
+                        required:
+                          - name
+                          - owner
                         properties:
                           name:
                             description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
@@ -98,6 +101,9 @@ spec:
                       items:
                         description: LifecycleHook represents a single instance of a lifecycle hook
                         type: object
+                        required:
+                          - name
+                          - owner
                         properties:
                           name:
                             description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.

--- a/machine/v1beta1/0000_10_machineset.crd.yaml
+++ b/machine/v1beta1/0000_10_machineset.crd.yaml
@@ -173,6 +173,9 @@ spec:
                               items:
                                 description: LifecycleHook represents a single instance of a lifecycle hook
                                 type: object
+                                required:
+                                  - name
+                                  - owner
                                 properties:
                                   name:
                                     description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
@@ -191,6 +194,9 @@ spec:
                               items:
                                 description: LifecycleHook represents a single instance of a lifecycle hook
                                 type: object
+                                required:
+                                  - name
+                                  - owner
                                 properties:
                                   name:
                                     description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.

--- a/machine/v1beta1/types_machine.go
+++ b/machine/v1beta1/types_machine.go
@@ -222,7 +222,7 @@ type LifecycleHook struct {
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
 	// +kubebuilder:validation:MinLength:=3
 	// +kubebuilder:validation:MaxLength:=256
-	// +required
+	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
 	// Owner defines the owner of the lifecycle hook.
@@ -232,7 +232,7 @@ type LifecycleHook struct {
 	// or an administrator managing the hook.
 	// +kubebuilder:validation:MinLength:=3
 	// +kubebuilder:validation:MaxLength:=512
-	// +required
+	// +kubebuilder:validation:Required
 	Owner string `json:"owner"`
 }
 


### PR DESCRIPTION
The `required` validation does not get parsed by the controller-gen tool and therefore the correct fields are not set on the generated CRD. I have updated these to use the correct kubebuilder tags to fix the code generation and ensure that the name and owner fields are required within the openapi schema