### PR TITLE
Update Dockerfile to account for Go 1.17 dependencies

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,13 +1,12 @@
-FROM fedora:latest
+FROM fedora:36
 
 ENV GOPATH=/go
 ENV PATH=/go/bin:$PATH
 
 RUN dnf -y install make git unzip golang wget
-RUN go get -u -v golang.org/x/tools/cmd/...
+RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN wget https://github.com/google/protobuf/releases/download/v3.0.2/protoc-3.0.2-linux-x86_64.zip && \
     mkdir protoc && \
     unzip protoc-3.0.2-linux-x86_64.zip -d protoc/ && \
     mv protoc/bin/protoc /usr/bin && \
     rm -rf protoc
-

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,9 +1,15 @@
-FROM fedora:36
+FROM fedora:latest
 
 ENV GOPATH=/go
-ENV PATH=/go/bin:$PATH
+ENV PATH=/go/bin:/usr/local/go/bin:$PATH
 
-RUN dnf -y install make git unzip golang wget
+RUN dnf -y install make git unzip wget
+
+RUN wget https://go.dev/dl/go1.17.6.linux-amd64.tar.gz && \
+    rm -rf /usr/local/go && \
+    tar -C /usr/local -xzf go1.17.6.linux-amd64.tar.gz && \
+    rm go1.17.6.linux-amd64.tar.gz
+
 RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN wget https://github.com/google/protobuf/releases/download/v3.0.2/protoc-3.0.2-linux-x86_64.zip && \
     mkdir protoc && \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,7 +3,7 @@ FROM fedora:latest
 ENV GOPATH=/go
 ENV PATH=/go/bin:/usr/local/go/bin:$PATH
 
-RUN dnf -y install make git unzip wget
+RUN dnf -y install make git unzip wget findutils
 
 RUN wget https://go.dev/dl/go1.17.6.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \


### PR DESCRIPTION
I tried to run `make generate-with-container` but it failed due to Go 1.17 specific issues:
```
hack/update-swagger-docs.sh
Generating swagger type docs for apiserver/v1 at apiserver/v1
# sigs.k8s.io/json/internal/golang/encoding/json
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1249:12: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1255:18: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
```
The Fedora 35 (latest) image doesn't contain Go 1.17, so I've updated the tag to use Fedora 36 which I appreciate is not ideal, perhaps we need to wait for the `latest` tag to move to 36?

Additionally, the `go get -u -v` no longer works in Go 1.17, so I've moved that over to `go install`. Seems the generate only uses `goimports` so I also scoped the install down to just `goimports` to make it more obvious what tools we are using.