### PR TITLE
Bug 2042366: Set list-type map on Machine Deletion Hooks

### DIFF
--- a/machine/v1beta1/0000_10_machine.crd.yaml
+++ b/machine/v1beta1/0000_10_machine.crd.yaml
@@ -95,6 +95,9 @@ spec:
                             type: string
                             maxLength: 512
                             minLength: 3
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                     preTerminate:
                       description: PreTerminate hooks prevent the machine from being terminated. PreTerminate hooks be actioned after the Machine has been drained.
                       type: array
@@ -116,6 +119,9 @@ spec:
                             type: string
                             maxLength: 512
                             minLength: 3
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
                 metadata:
                   description: ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.
                   type: object

--- a/machine/v1beta1/0000_10_machineset.crd.yaml
+++ b/machine/v1beta1/0000_10_machineset.crd.yaml
@@ -188,6 +188,9 @@ spec:
                                     type: string
                                     maxLength: 512
                                     minLength: 3
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             preTerminate:
                               description: PreTerminate hooks prevent the machine from being terminated. PreTerminate hooks be actioned after the Machine has been drained.
                               type: array
@@ -209,6 +212,9 @@ spec:
                                     type: string
                                     maxLength: 512
                                     minLength: 3
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                         metadata:
                           description: ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.
                           type: object

--- a/machine/v1beta1/types_machine.go
+++ b/machine/v1beta1/types_machine.go
@@ -204,11 +204,15 @@ type MachineSpec struct {
 type LifecycleHooks struct {
 	// PreDrain hooks prevent the machine from being drained.
 	// This also blocks further lifecycle events, such as termination.
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	PreDrain []LifecycleHook `json:"preDrain,omitempty"`
 
 	// PreTerminate hooks prevent the machine from being terminated.
 	// PreTerminate hooks be actioned after the Machine has been drained.
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	PreTerminate []LifecycleHook `json:"preTerminate,omitempty"`
 }


### PR DESCRIPTION
@sttts Picked this up while reviewing the etcd protection enhancement. We specify that multiple operators should be able to add and remove their own hooks from these lists, by default, they are treated as atomic which means the operators need to be careful not to accidentally remove other operators hooks.

With this change, using server side apply the lists should now merge correctly and each operator should be able to manage their own hooks independently.

Tested manually, steps described in the bug