### PR TITLE
Bug 1986504: Fix "(MISSING) ?" error

### DIFF
--- a/oauth/v1/generated.proto
+++ b/oauth/v1/generated.proto
@@ -24,7 +24,7 @@ message ClusterRoleScopeRestriction {
 }
 
 // OAuthAccessToken describes an OAuth access token.
-// The name of a token must be prefixed with a `sha256~` string, must not contain "/" or "%" characters and must be at
+// The name of a token must be prefixed with a `sha256~` string, must not contain either a slash or percent characters and must be at
 // least 32 characters long.
 //
 // The name of the token is constructed from the actual token by sha256-hashing it and using URL-safe unpadded

--- a/oauth/v1/types.go
+++ b/oauth/v1/types.go
@@ -9,7 +9,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // OAuthAccessToken describes an OAuth access token.
-// The name of a token must be prefixed with a `sha256~` string, must not contain "/" or "%" characters and must be at
+// The name of a token must be prefixed with a `sha256~` string, must not contain either a slash or percent characters and must be at
 // least 32 characters long.
 //
 // The name of the token is constructed from the actual token by sha256-hashing it and using URL-safe unpadded

--- a/oauth/v1/zz_generated.swagger_doc_generated.go
+++ b/oauth/v1/zz_generated.swagger_doc_generated.go
@@ -23,7 +23,7 @@ func (ClusterRoleScopeRestriction) SwaggerDoc() map[string]string {
 }
 
 var map_OAuthAccessToken = map[string]string{
-	"":                         "OAuthAccessToken describes an OAuth access token. The name of a token must be prefixed with a `sha256~` string, must not contain \"/\" or \"%\" characters and must be at least 32 characters long.\n\nThe name of the token is constructed from the actual token by sha256-hashing it and using URL-safe unpadded base64-encoding (as described in RFC4648) on the hashed result.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"":                         "OAuthAccessToken describes an OAuth access token. The name of a token must be prefixed with a `sha256~` string, must not contain either a slash or percent characters and must be at least 32 characters long.\n\nThe name of the token is constructed from the actual token by sha256-hashing it and using URL-safe unpadded base64-encoding (as described in RFC4648) on the hashed result.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
 	"clientName":               "ClientName references the client that created this token.",
 	"expiresIn":                "ExpiresIn is the seconds from CreationTime before this token expires.",
 	"scopes":                   "Scopes is an array of the requested scopes.",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1986504

This Pull Request fixes an error seen when invoking `oc explain oauthaccesstoken`:

```
...
DESCRIPTION:
     OAuthAccessToken describes an OAuth access token. The name of a token must
     be prefixed with a `sha256~` string, must not contain "/" or "%!"(MISSING)
     characters and must be at least 32 characters long.
...
```

The problem here is that this character needs to be rendered properly in both asciidoc+html (our manual pages) and `oc explain`. Therefore, I decided to replace both characters with words describing them.
