### PR TITLE
Bug 1978798: Revert "Update ovnKubernetesConfig.policyAuditConfig Default"

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
@@ -15,694 +15,475 @@ spec:
     singular: network
   scope: Cluster
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: "Network describes the cluster's desired network configuration.
-          It is consumed by the cluster-network-operator. \n Compatibility level 1:
-          Stable within a major release for a minimum of 12 months or 3 minor releases
-          (whichever is longer)."
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: NetworkSpec is the top-level network configuration object.
-            properties:
-              additionalNetworks:
-                description: additionalNetworks is a list of extra networks to make
-                  available to pods when multiple networks are enabled.
-                items:
-                  description: AdditionalNetworkDefinition configures an extra network
-                    that is available but not created by default. Instead, pods must
-                    request them by name. type must be specified, along with exactly
-                    one "Config" that matches the type.
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Network describes the cluster's desired network configuration. It is consumed by the cluster-network-operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NetworkSpec is the top-level network configuration object.
+              type: object
+              properties:
+                additionalNetworks:
+                  description: additionalNetworks is a list of extra networks to make available to pods when multiple networks are enabled.
+                  type: array
+                  items:
+                    description: AdditionalNetworkDefinition configures an extra network that is available but not created by default. Instead, pods must request them by name. type must be specified, along with exactly one "Config" that matches the type.
+                    type: object
+                    properties:
+                      name:
+                        description: name is the name of the network. This will be populated in the resulting CRD This must be unique.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the network. This will be populated in the resulting CRD If not given the network will be created in the default namespace.
+                        type: string
+                      rawCNIConfig:
+                        description: rawCNIConfig is the raw CNI configuration json to create in the NetworkAttachmentDefinition CRD
+                        type: string
+                      simpleMacvlanConfig:
+                        description: SimpleMacvlanConfig configures the macvlan interface in case of type:NetworkTypeSimpleMacvlan
+                        type: object
+                        properties:
+                          ipamConfig:
+                            description: IPAMConfig configures IPAM module will be used for IP Address Management (IPAM).
+                            type: object
+                            properties:
+                              staticIPAMConfig:
+                                description: StaticIPAMConfig configures the static IP address in case of type:IPAMTypeStatic
+                                type: object
+                                properties:
+                                  addresses:
+                                    description: Addresses configures IP address for the interface
+                                    type: array
+                                    items:
+                                      description: StaticIPAMAddresses provides IP address and Gateway for static IPAM addresses
+                                      type: object
+                                      properties:
+                                        address:
+                                          description: Address is the IP address in CIDR format
+                                          type: string
+                                        gateway:
+                                          description: Gateway is IP inside of subnet to designate as the gateway
+                                          type: string
+                                  dns:
+                                    description: DNS configures DNS for the interface
+                                    type: object
+                                    properties:
+                                      domain:
+                                        description: Domain configures the domainname the local domain used for short hostname lookups
+                                        type: string
+                                      nameservers:
+                                        description: Nameservers points DNS servers for IP lookup
+                                        type: array
+                                        items:
+                                          type: string
+                                      search:
+                                        description: Search configures priority ordered search domains for short hostname lookups
+                                        type: array
+                                        items:
+                                          type: string
+                                  routes:
+                                    description: Routes configures IP routes for the interface
+                                    type: array
+                                    items:
+                                      description: StaticIPAMRoutes provides Destination/Gateway pairs for static IPAM routes
+                                      type: object
+                                      properties:
+                                        destination:
+                                          description: Destination points the IP route destination
+                                          type: string
+                                        gateway:
+                                          description: Gateway is the route's next-hop IP address If unset, a default gateway is assumed (as determined by the CNI plugin).
+                                          type: string
+                              type:
+                                description: Type is the type of IPAM module will be used for IP Address Management(IPAM). The supported values are IPAMTypeDHCP, IPAMTypeStatic
+                                type: string
+                          master:
+                            description: master is the host interface to create the macvlan interface from. If not specified, it will be default route interface
+                            type: string
+                          mode:
+                            description: 'mode is the macvlan mode: bridge, private, vepa, passthru. The default is bridge'
+                            type: string
+                          mtu:
+                            description: mtu is the mtu to use for the macvlan interface. if unset, host's kernel will select the value.
+                            type: integer
+                            format: int32
+                            minimum: 0
+                      type:
+                        description: type is the type of network The supported values are NetworkTypeRaw, NetworkTypeSimpleMacvlan
+                        type: string
+                clusterNetwork:
+                  description: clusterNetwork is the IP address pool to use for pod IPs. Some network providers, e.g. OpenShift SDN, support multiple ClusterNetworks. Others only support one. This is equivalent to the cluster-cidr.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks
+                    type: object
+                    properties:
+                      cidr:
+                        type: string
+                      hostPrefix:
+                        type: integer
+                        format: int32
+                        minimum: 0
+                defaultNetwork:
+                  description: defaultNetwork is the "default" network that all pods will receive
+                  type: object
                   properties:
-                    name:
-                      description: name is the name of the network. This will be populated
-                        in the resulting CRD This must be unique.
-                      type: string
-                    namespace:
-                      description: namespace is the namespace of the network. This
-                        will be populated in the resulting CRD If not given the network
-                        will be created in the default namespace.
-                      type: string
-                    rawCNIConfig:
-                      description: rawCNIConfig is the raw CNI configuration json
-                        to create in the NetworkAttachmentDefinition CRD
-                      type: string
-                    simpleMacvlanConfig:
-                      description: SimpleMacvlanConfig configures the macvlan interface
-                        in case of type:NetworkTypeSimpleMacvlan
+                    kuryrConfig:
+                      description: KuryrConfig configures the kuryr plugin
+                      type: object
                       properties:
-                        ipamConfig:
-                          description: IPAMConfig configures IPAM module will be used
-                            for IP Address Management (IPAM).
-                          properties:
-                            staticIPAMConfig:
-                              description: StaticIPAMConfig configures the static
-                                IP address in case of type:IPAMTypeStatic
-                              properties:
-                                addresses:
-                                  description: Addresses configures IP address for
-                                    the interface
-                                  items:
-                                    description: StaticIPAMAddresses provides IP address
-                                      and Gateway for static IPAM addresses
-                                    properties:
-                                      address:
-                                        description: Address is the IP address in
-                                          CIDR format
-                                        type: string
-                                      gateway:
-                                        description: Gateway is IP inside of subnet
-                                          to designate as the gateway
-                                        type: string
-                                    type: object
-                                  type: array
-                                dns:
-                                  description: DNS configures DNS for the interface
-                                  properties:
-                                    domain:
-                                      description: Domain configures the domainname
-                                        the local domain used for short hostname lookups
-                                      type: string
-                                    nameservers:
-                                      description: Nameservers points DNS servers
-                                        for IP lookup
-                                      items:
-                                        type: string
-                                      type: array
-                                    search:
-                                      description: Search configures priority ordered
-                                        search domains for short hostname lookups
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                routes:
-                                  description: Routes configures IP routes for the
-                                    interface
-                                  items:
-                                    description: StaticIPAMRoutes provides Destination/Gateway
-                                      pairs for static IPAM routes
-                                    properties:
-                                      destination:
-                                        description: Destination points the IP route
-                                          destination
-                                        type: string
-                                      gateway:
-                                        description: Gateway is the route's next-hop
-                                          IP address If unset, a default gateway is
-                                          assumed (as determined by the CNI plugin).
-                                        type: string
-                                    type: object
-                                  type: array
-                              type: object
-                            type:
-                              description: Type is the type of IPAM module will be
-                                used for IP Address Management(IPAM). The supported
-                                values are IPAMTypeDHCP, IPAMTypeStatic
-                              type: string
-                          type: object
-                        master:
-                          description: master is the host interface to create the
-                            macvlan interface from. If not specified, it will be default
-                            route interface
-                          type: string
-                        mode:
-                          description: 'mode is the macvlan mode: bridge, private,
-                            vepa, passthru. The default is bridge'
-                          type: string
-                        mtu:
-                          description: mtu is the mtu to use for the macvlan interface.
-                            if unset, host's kernel will select the value.
+                        controllerProbesPort:
+                          description: The port kuryr-controller will listen for readiness and liveness requests.
+                          type: integer
                           format: int32
                           minimum: 0
+                        daemonProbesPort:
+                          description: The port kuryr-daemon will listen for readiness and liveness requests.
                           type: integer
+                          format: int32
+                          minimum: 0
+                        enablePortPoolsPrepopulation:
+                          description: enablePortPoolsPrepopulation when true will make Kuryr prepopulate each newly created port pool with a minimum number of ports. Kuryr uses Neutron port pooling to fight the fact that it takes a significant amount of time to create one. It creates a number of ports when the first pod that is configured to use the dedicated network for pods is created in a namespace, and keeps them ready to be attached to pods. Port prepopulation is disabled by default.
+                          type: boolean
+                        mtu:
+                          description: mtu is the MTU that Kuryr should use when creating pod networks in Neutron. The value has to be lower or equal to the MTU of the nodes network and Neutron has to allow creation of tenant networks with such MTU. If unset Pod networks will be created with the same MTU as the nodes network has.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        openStackServiceNetwork:
+                          description: openStackServiceNetwork contains the CIDR of network from which to allocate IPs for OpenStack Octavia's Amphora VMs. Please note that with Amphora driver Octavia uses two IPs from that network for each loadbalancer - one given by OpenShift and second for VRRP connections. As the first one is managed by OpenShift's and second by Neutron's IPAMs, those need to come from different pools. Therefore `openStackServiceNetwork` needs to be at least twice the size of `serviceNetwork`, and whole `serviceNetwork` must be overlapping with `openStackServiceNetwork`. cluster-network-operator will then make sure VRRP IPs are taken from the ranges inside `openStackServiceNetwork` that are not overlapping with `serviceNetwork`, effectivly preventing conflicts. If not set cluster-network-operator will use `serviceNetwork` expanded by decrementing the prefix size by 1.
+                          type: string
+                        poolBatchPorts:
+                          description: poolBatchPorts sets a number of ports that should be created in a single batch request to extend the port pool. The default is 3. For more information about port pools see enablePortPoolsPrepopulation setting.
+                          type: integer
+                          minimum: 0
+                        poolMaxPorts:
+                          description: poolMaxPorts sets a maximum number of free ports that are being kept in a port pool. If the number of ports exceeds this setting, free ports will get deleted. Setting 0 will disable this upper bound, effectively preventing pools from shrinking and this is the default value. For more information about port pools see enablePortPoolsPrepopulation setting.
+                          type: integer
+                          minimum: 0
+                        poolMinPorts:
+                          description: poolMinPorts sets a minimum number of free ports that should be kept in a port pool. If the number of ports is lower than this setting, new ports will get created and added to pool. The default is 1. For more information about port pools see enablePortPoolsPrepopulation setting.
+                          type: integer
+                          minimum: 1
+                    openshiftSDNConfig:
+                      description: openShiftSDNConfig configures the openshift-sdn plugin
                       type: object
+                      properties:
+                        enableUnidling:
+                          description: enableUnidling controls whether or not the service proxy will support idling and unidling of services. By default, unidling is enabled.
+                          type: boolean
+                        mode:
+                          description: mode is one of "Multitenant", "Subnet", or "NetworkPolicy"
+                          type: string
+                        mtu:
+                          description: mtu is the mtu to use for the tunnel interface. Defaults to 1450 if unset. This must be 50 bytes smaller than the machine's uplink.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        useExternalOpenvswitch:
+                          description: 'useExternalOpenvswitch used to control whether the operator would deploy an OVS DaemonSet itself or expect someone else to start OVS. As of 4.6, OVS is always run as a system service, and this flag is ignored. DEPRECATED: non-functional as of 4.6'
+                          type: boolean
+                        vxlanPort:
+                          description: vxlanPort is the port to use for all vxlan packets. The default is 4789.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                    ovnKubernetesConfig:
+                      description: ovnKubernetesConfig configures the ovn-kubernetes plugin.
+                      type: object
+                      properties:
+                        gatewayConfig:
+                          description: gatewayConfig holds the configuration for node gateway options.
+                          type: object
+                          properties:
+                            routingViaHost:
+                              description: RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.
+                              type: boolean
+                              default: false
+                        genevePort:
+                          description: geneve port is the UDP port to be used by geneve encapulation. Default is 6081
+                          type: integer
+                          format: int32
+                          minimum: 1
+                        hybridOverlayConfig:
+                          description: HybridOverlayConfig configures an additional overlay network for peers that are not using OVN.
+                          type: object
+                          properties:
+                            hybridClusterNetwork:
+                              description: HybridClusterNetwork defines a network space given to nodes on an additional overlay network.
+                              type: array
+                              items:
+                                description: ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  hostPrefix:
+                                    type: integer
+                                    format: int32
+                                    minimum: 0
+                            hybridOverlayVXLANPort:
+                              description: HybridOverlayVXLANPort defines the VXLAN port number to be used by the additional overlay network. Default is 4789
+                              type: integer
+                              format: int32
+                        ipsecConfig:
+                          description: ipsecConfig enables and configures IPsec for pods on the pod network within the cluster.
+                          type: object
+                        mtu:
+                          description: mtu is the MTU to use for the tunnel interface. This must be 100 bytes smaller than the uplink mtu. Default is 1400
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        policyAuditConfig:
+                          description: policyAuditConfig is the configuration for network policy audit events. If unset, reported defaults are used.
+                          type: object
+                          properties:
+                            destination:
+                              description: 'destination is the location for policy log messages. Regardless of this config, persistent logs will always be dumped to the host at /var/log/ovn/ however Additionally syslog output may be configured as follows. Valid values are: - "libc" -> to use the libc syslog() function of the host node''s journdald process - "udp:host:port" -> for sending syslog over UDP - "unix:file" -> for using the UNIX domain socket directly - "null" -> to discard all messages logged to syslog The default is "null"'
+                              type: string
+                              default: "null"
+                            maxFileSize:
+                              description: maxFilesSize is the max size an ACL_audit log file is allowed to reach before rotation occurs Units are in MB and the Default is 50MB
+                              type: integer
+                              format: int32
+                              default: 50
+                              minimum: 1
+                            rateLimit:
+                              description: rateLimit is the approximate maximum number of messages to generate per-second per-node. If unset the default of 20 msg/sec is used.
+                              type: integer
+                              format: int32
+                              default: 20
+                              minimum: 1
+                            syslogFacility:
+                              description: syslogFacility the RFC5424 facility for generated messages, e.g. "kern". Default is "local0"
+                              type: string
+                              default: local0
+                        v4InternalSubnet:
+                          description: v4InternalSubnet is a v4 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is 100.64.0.0/16
+                          type: string
+                        v6InternalSubnet:
+                          description: v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is fd98::/48
+                          type: string
                     type:
-                      description: type is the type of network The supported values
-                        are NetworkTypeRaw, NetworkTypeSimpleMacvlan
+                      description: type is the type of network All NetworkTypes are supported except for NetworkTypeRaw
                       type: string
+                deployKubeProxy:
+                  description: deployKubeProxy specifies whether or not a standalone kube-proxy should be deployed by the operator. Some network providers include kube-proxy or similar functionality. If unset, the plugin will attempt to select the correct value, which is false when OpenShift SDN and ovn-kubernetes are used and true otherwise.
+                  type: boolean
+                disableMultiNetwork:
+                  description: disableMultiNetwork specifies whether or not multiple pod network support should be disabled. If unset, this property defaults to 'false' and multiple network support is enabled.
+                  type: boolean
+                disableNetworkDiagnostics:
+                  description: disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck CRs from a test pod to every node, apiserver and LB should be disabled or not. If unset, this property defaults to 'false' and network diagnostics is enabled. Setting this to 'true' would reduce the additional load of the pods performing the checks.
+                  type: boolean
+                  default: false
+                exportNetworkFlows:
+                  description: exportNetworkFlows enables and configures the export of network flow metadata from the pod network by using protocols NetFlow, SFlow or IPFIX. Currently only supported on OVN-Kubernetes plugin. If unset, flows will not be exported to any collector.
                   type: object
-                type: array
-              clusterNetwork:
-                description: clusterNetwork is the IP address pool to use for pod
-                  IPs. Some network providers, e.g. OpenShift SDN, support multiple
-                  ClusterNetworks. Others only support one. This is equivalent to
-                  the cluster-cidr.
-                items:
-                  description: ClusterNetworkEntry is a subnet from which to allocate
-                    PodIPs. A network of size HostPrefix (in CIDR notation) will be
-                    allocated when nodes join the cluster. If the HostPrefix field
-                    is not used by the plugin, it can be left unset. Not all network
-                    providers support multiple ClusterNetworks
                   properties:
-                    cidr:
-                      type: string
-                    hostPrefix:
-                      format: int32
-                      minimum: 0
-                      type: integer
+                    ipfix:
+                      description: ipfix defines IPFIX configuration.
+                      type: object
+                      properties:
+                        collectors:
+                          description: ipfixCollectors is list of strings formatted as ip:port with a maximum of ten items
+                          type: array
+                          maxItems: 10
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                    netFlow:
+                      description: netFlow defines the NetFlow configuration.
+                      type: object
+                      properties:
+                        collectors:
+                          description: netFlow defines the NetFlow collectors that will consume the flow data exported from OVS. It is a list of strings formatted as ip:port with a maximum of ten items
+                          type: array
+                          maxItems: 10
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                    sFlow:
+                      description: sFlow defines the SFlow configuration.
+                      type: object
+                      properties:
+                        collectors:
+                          description: sFlowCollectors is list of strings formatted as ip:port with a maximum of ten items
+                          type: array
+                          maxItems: 10
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                kubeProxyConfig:
+                  description: kubeProxyConfig lets us configure desired proxy configuration. If not specified, sensible defaults will be chosen by OpenShift directly. Not consumed by all network providers - currently only openshift-sdn.
                   type: object
-                type: array
-              defaultNetwork:
-                description: defaultNetwork is the "default" network that all pods
-                  will receive
-                properties:
-                  kuryrConfig:
-                    description: KuryrConfig configures the kuryr plugin
-                    properties:
-                      controllerProbesPort:
-                        description: The port kuryr-controller will listen for readiness
-                          and liveness requests.
-                        format: int32
-                        minimum: 0
-                        type: integer
-                      daemonProbesPort:
-                        description: The port kuryr-daemon will listen for readiness
-                          and liveness requests.
-                        format: int32
-                        minimum: 0
-                        type: integer
-                      enablePortPoolsPrepopulation:
-                        description: enablePortPoolsPrepopulation when true will make
-                          Kuryr prepopulate each newly created port pool with a minimum
-                          number of ports. Kuryr uses Neutron port pooling to fight
-                          the fact that it takes a significant amount of time to create
-                          one. It creates a number of ports when the first pod that
-                          is configured to use the dedicated network for pods is created
-                          in a namespace, and keeps them ready to be attached to pods.
-                          Port prepopulation is disabled by default.
-                        type: boolean
-                      mtu:
-                        description: mtu is the MTU that Kuryr should use when creating
-                          pod networks in Neutron. The value has to be lower or equal
-                          to the MTU of the nodes network and Neutron has to allow
-                          creation of tenant networks with such MTU. If unset Pod
-                          networks will be created with the same MTU as the nodes
-                          network has.
-                        format: int32
-                        minimum: 0
-                        type: integer
-                      openStackServiceNetwork:
-                        description: openStackServiceNetwork contains the CIDR of
-                          network from which to allocate IPs for OpenStack Octavia's
-                          Amphora VMs. Please note that with Amphora driver Octavia
-                          uses two IPs from that network for each loadbalancer - one
-                          given by OpenShift and second for VRRP connections. As the
-                          first one is managed by OpenShift's and second by Neutron's
-                          IPAMs, those need to come from different pools. Therefore
-                          `openStackServiceNetwork` needs to be at least twice the
-                          size of `serviceNetwork`, and whole `serviceNetwork` must
-                          be overlapping with `openStackServiceNetwork`. cluster-network-operator
-                          will then make sure VRRP IPs are taken from the ranges inside
-                          `openStackServiceNetwork` that are not overlapping with
-                          `serviceNetwork`, effectivly preventing conflicts. If not
-                          set cluster-network-operator will use `serviceNetwork` expanded
-                          by decrementing the prefix size by 1.
-                        type: string
-                      poolBatchPorts:
-                        description: poolBatchPorts sets a number of ports that should
-                          be created in a single batch request to extend the port
-                          pool. The default is 3. For more information about port
-                          pools see enablePortPoolsPrepopulation setting.
-                        minimum: 0
-                        type: integer
-                      poolMaxPorts:
-                        description: poolMaxPorts sets a maximum number of free ports
-                          that are being kept in a port pool. If the number of ports
-                          exceeds this setting, free ports will get deleted. Setting
-                          0 will disable this upper bound, effectively preventing
-                          pools from shrinking and this is the default value. For
-                          more information about port pools see enablePortPoolsPrepopulation
-                          setting.
-                        minimum: 0
-                        type: integer
-                      poolMinPorts:
-                        description: poolMinPorts sets a minimum number of free ports
-                          that should be kept in a port pool. If the number of ports
-                          is lower than this setting, new ports will get created and
-                          added to pool. The default is 1. For more information about
-                          port pools see enablePortPoolsPrepopulation setting.
-                        minimum: 1
-                        type: integer
-                    type: object
-                  openshiftSDNConfig:
-                    description: openShiftSDNConfig configures the openshift-sdn plugin
-                    properties:
-                      enableUnidling:
-                        description: enableUnidling controls whether or not the service
-                          proxy will support idling and unidling of services. By default,
-                          unidling is enabled.
-                        type: boolean
-                      mode:
-                        description: mode is one of "Multitenant", "Subnet", or "NetworkPolicy"
-                        type: string
-                      mtu:
-                        description: mtu is the mtu to use for the tunnel interface.
-                          Defaults to 1450 if unset. This must be 50 bytes smaller
-                          than the machine's uplink.
-                        format: int32
-                        minimum: 0
-                        type: integer
-                      useExternalOpenvswitch:
-                        description: 'useExternalOpenvswitch used to control whether
-                          the operator would deploy an OVS DaemonSet itself or expect
-                          someone else to start OVS. As of 4.6, OVS is always run
-                          as a system service, and this flag is ignored. DEPRECATED:
-                          non-functional as of 4.6'
-                        type: boolean
-                      vxlanPort:
-                        description: vxlanPort is the port to use for all vxlan packets.
-                          The default is 4789.
-                        format: int32
-                        minimum: 0
-                        type: integer
-                    type: object
-                  ovnKubernetesConfig:
-                    description: ovnKubernetesConfig configures the ovn-kubernetes
-                      plugin.
-                    properties:
-                      gatewayConfig:
-                        description: gatewayConfig holds the configuration for node
-                          gateway options.
-                        properties:
-                          routingViaHost:
-                            default: false
-                            description: RoutingViaHost allows pod egress traffic
-                              to exit via the ovn-k8s-mp0 management port into the
-                              host before sending it out. If this is not set, traffic
-                              will always egress directly from OVN to outside without
-                              touching the host stack. Setting this to true means
-                              hardware offload will not be supported. Default is false
-                              if GatewayConfig is specified.
-                            type: boolean
-                        type: object
-                      genevePort:
-                        description: geneve port is the UDP port to be used by geneve
-                          encapulation. Default is 6081
-                        format: int32
-                        minimum: 1
-                        type: integer
-                      hybridOverlayConfig:
-                        description: HybridOverlayConfig configures an additional
-                          overlay network for peers that are not using OVN.
-                        properties:
-                          hybridClusterNetwork:
-                            description: HybridClusterNetwork defines a network space
-                              given to nodes on an additional overlay network.
-                            items:
-                              description: ClusterNetworkEntry is a subnet from which
-                                to allocate PodIPs. A network of size HostPrefix (in
-                                CIDR notation) will be allocated when nodes join the
-                                cluster. If the HostPrefix field is not used by the
-                                plugin, it can be left unset. Not all network providers
-                                support multiple ClusterNetworks
-                              properties:
-                                cidr:
-                                  type: string
-                                hostPrefix:
-                                  format: int32
-                                  minimum: 0
-                                  type: integer
-                              type: object
-                            type: array
-                          hybridOverlayVXLANPort:
-                            description: HybridOverlayVXLANPort defines the VXLAN
-                              port number to be used by the additional overlay network.
-                              Default is 4789
-                            format: int32
-                            type: integer
-                        type: object
-                      ipsecConfig:
-                        description: ipsecConfig enables and configures IPsec for
-                          pods on the pod network within the cluster.
-                        type: object
-                      mtu:
-                        description: mtu is the MTU to use for the tunnel interface.
-                          This must be 100 bytes smaller than the uplink mtu. Default
-                          is 1400
-                        format: int32
-                        minimum: 0
-                        type: integer
-                      policyAuditConfig:
-                        default: {}
-                        description: policyAuditConfig is the configuration for network
-                          policy audit events. If unset, reported defaults are used.
-                        properties:
-                          destination:
-                            default: "null"
-                            description: 'destination is the location for policy log
-                              messages. Regardless of this config, persistent logs
-                              will always be dumped to the host at /var/log/ovn/ however
-                              Additionally syslog output may be configured as follows.
-                              Valid values are: - "libc" -> to use the libc syslog()
-                              function of the host node''s journdald process - "udp:host:port"
-                              -> for sending syslog over UDP - "unix:file" -> for
-                              using the UNIX domain socket directly - "null" -> to
-                              discard all messages logged to syslog The default is
-                              "null"'
-                            type: string
-                          maxFileSize:
-                            default: 50
-                            description: maxFilesSize is the max size an ACL_audit
-                              log file is allowed to reach before rotation occurs
-                              Units are in MB and the Default is 50MB
-                            format: int32
-                            minimum: 1
-                            type: integer
-                          rateLimit:
-                            default: 20
-                            description: rateLimit is the approximate maximum number
-                              of messages to generate per-second per-node. If unset
-                              the default of 20 msg/sec is used.
-                            format: int32
-                            minimum: 1
-                            type: integer
-                          syslogFacility:
-                            default: local0
-                            description: syslogFacility the RFC5424 facility for generated
-                              messages, e.g. "kern". Default is "local0"
-                            type: string
-                        type: object
-                      v4InternalSubnet:
-                        description: v4InternalSubnet is a v4 subnet used internally
-                          by ovn-kubernetes in case the default one is being already
-                          used by something else. It must not overlap with any other
-                          subnet being used by OpenShift or by the node network. The
-                          size of the subnet must be larger than the number of nodes.
-                          The value cannot be changed after installation. Default
-                          is 100.64.0.0/16
-                        type: string
-                      v6InternalSubnet:
-                        description: v6InternalSubnet is a v6 subnet used internally
-                          by ovn-kubernetes in case the default one is being already
-                          used by something else. It must not overlap with any other
-                          subnet being used by OpenShift or by the node network. The
-                          size of the subnet must be larger than the number of nodes.
-                          The value cannot be changed after installation. Default
-                          is fd98::/48
-                        type: string
-                    type: object
-                  type:
-                    description: type is the type of network All NetworkTypes are
-                      supported except for NetworkTypeRaw
-                    type: string
-                type: object
-              deployKubeProxy:
-                description: deployKubeProxy specifies whether or not a standalone
-                  kube-proxy should be deployed by the operator. Some network providers
-                  include kube-proxy or similar functionality. If unset, the plugin
-                  will attempt to select the correct value, which is false when OpenShift
-                  SDN and ovn-kubernetes are used and true otherwise.
-                type: boolean
-              disableMultiNetwork:
-                description: disableMultiNetwork specifies whether or not multiple
-                  pod network support should be disabled. If unset, this property
-                  defaults to 'false' and multiple network support is enabled.
-                type: boolean
-              disableNetworkDiagnostics:
-                default: false
-                description: disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck
-                  CRs from a test pod to every node, apiserver and LB should be disabled
-                  or not. If unset, this property defaults to 'false' and network
-                  diagnostics is enabled. Setting this to 'true' would reduce the
-                  additional load of the pods performing the checks.
-                type: boolean
-              exportNetworkFlows:
-                description: exportNetworkFlows enables and configures the export
-                  of network flow metadata from the pod network by using protocols
-                  NetFlow, SFlow or IPFIX. Currently only supported on OVN-Kubernetes
-                  plugin. If unset, flows will not be exported to any collector.
-                properties:
-                  ipfix:
-                    description: ipfix defines IPFIX configuration.
-                    properties:
-                      collectors:
-                        description: ipfixCollectors is list of strings formatted
-                          as ip:port with a maximum of ten items
-                        items:
-                          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-                          type: string
-                        maxItems: 10
-                        minItems: 1
+                  properties:
+                    bindAddress:
+                      description: The address to "bind" on Defaults to 0.0.0.0
+                      type: string
+                    iptablesSyncPeriod:
+                      description: 'An internal kube-proxy parameter. In older releases of OCP, this sometimes needed to be adjusted in large clusters for performance reasons, but this is no longer necessary, and there is no reason to change this from the default value. Default: 30s'
+                      type: string
+                    proxyArguments:
+                      description: Any additional arguments to pass to the kubeproxy process
+                      type: object
+                      additionalProperties:
+                        description: ProxyArgumentList is a list of arguments to pass to the kubeproxy process
                         type: array
-                    type: object
-                  netFlow:
-                    description: netFlow defines the NetFlow configuration.
-                    properties:
-                      collectors:
-                        description: netFlow defines the NetFlow collectors that will
-                          consume the flow data exported from OVS. It is a list of
-                          strings formatted as ip:port with a maximum of ten items
                         items:
-                          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
                           type: string
-                        maxItems: 10
-                        minItems: 1
-                        type: array
-                    type: object
-                  sFlow:
-                    description: sFlow defines the SFlow configuration.
-                    properties:
-                      collectors:
-                        description: sFlowCollectors is list of strings formatted
-                          as ip:port with a maximum of ten items
-                        items:
-                          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-                          type: string
-                        maxItems: 10
-                        minItems: 1
-                        type: array
-                    type: object
-                type: object
-              kubeProxyConfig:
-                description: kubeProxyConfig lets us configure desired proxy configuration.
-                  If not specified, sensible defaults will be chosen by OpenShift
-                  directly. Not consumed by all network providers - currently only
-                  openshift-sdn.
-                properties:
-                  bindAddress:
-                    description: The address to "bind" on Defaults to 0.0.0.0
-                    type: string
-                  iptablesSyncPeriod:
-                    description: 'An internal kube-proxy parameter. In older releases
-                      of OCP, this sometimes needed to be adjusted in large clusters
-                      for performance reasons, but this is no longer necessary, and
-                      there is no reason to change this from the default value. Default:
-                      30s'
-                    type: string
-                  proxyArguments:
-                    additionalProperties:
-                      description: ProxyArgumentList is a list of arguments to pass
-                        to the kubeproxy process
-                      items:
-                        type: string
-                      type: array
-                    description: Any additional arguments to pass to the kubeproxy
-                      process
-                    type: object
-                type: object
-              logLevel:
-                default: Normal
-                description: "logLevel is an intent based logging for an overall component.
-                  \ It does not give fine grained control, but it is a simple way
-                  to manage coarse grained logging choices that operators have to
-                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
-                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                enum:
-                - ""
-                - Normal
-                - Debug
-                - Trace
-                - TraceAll
-                type: string
-              managementState:
-                description: managementState indicates whether and how the operator
-                  should manage the component
-                pattern: ^(Managed|Unmanaged|Force|Removed)$
-                type: string
-              migration:
-                description: migration enables and configures the cluster network
-                  migration. The migration procedure allows to change the network
-                  type and the MTU.
-                properties:
-                  mtu:
-                    description: mtu contains the MTU migration configuration. Set
-                      this to allow changing the MTU values for the default network.
-                      If unset, the operation of changing the MTU for the default
-                      network will be rejected.
-                    properties:
-                      machine:
-                        description: machine contains MTU migration configuration
-                          for the machine's uplink. Needs to be migrated along with
-                          the default network MTU unless the current uplink MTU already
-                          accommodates the default network MTU.
-                        properties:
-                          from:
-                            description: from is the MTU to migrate from.
-                            format: int32
-                            minimum: 0
-                            type: integer
-                          to:
-                            description: to is the MTU to migrate to.
-                            format: int32
-                            minimum: 0
-                            type: integer
-                        type: object
-                      network:
-                        description: network contains information about MTU migration
-                          for the default network. Migrations are only allowed to
-                          MTU values lower than the machine's uplink MTU by the minimum
-                          appropriate offset.
-                        properties:
-                          from:
-                            description: from is the MTU to migrate from.
-                            format: int32
-                            minimum: 0
-                            type: integer
-                          to:
-                            description: to is the MTU to migrate to.
-                            format: int32
-                            minimum: 0
-                            type: integer
-                        type: object
-                    type: object
-                  networkType:
-                    description: networkType is the target type of network migration.
-                      Set this to the target network type to allow changing the default
-                      network. If unset, the operation of changing cluster default
-                      network plugin will be rejected. The supported values are OpenShiftSDN,
-                      OVNKubernetes
-                    type: string
-                type: object
-              observedConfig:
-                description: observedConfig holds a sparse config that controller
-                  has observed from the cluster state.  It exists in spec because
-                  it is an input to the level for the operator
-                nullable: true
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              operatorLogLevel:
-                default: Normal
-                description: "operatorLogLevel is an intent based logging for the
-                  operator itself.  It does not give fine grained control, but it
-                  is a simple way to manage coarse grained logging choices that operators
-                  have to interpret for themselves. \n Valid values are: \"Normal\",
-                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                enum:
-                - ""
-                - Normal
-                - Debug
-                - Trace
-                - TraceAll
-                type: string
-              serviceNetwork:
-                description: serviceNetwork is the ip address pool to use for Service
-                  IPs Currently, all existing network providers only support a single
-                  value here, but this is an array to allow for growth.
-                items:
+                logLevel:
+                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                   type: string
-                type: array
-              unsupportedConfigOverrides:
-                description: 'unsupportedConfigOverrides holds a sparse config that
-                  will override any previously set options.  It only needs to be the
-                  fields to override it will end up overlaying in the following order:
-                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
-                nullable: true
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              useMultiNetworkPolicy:
-                description: useMultiNetworkPolicy enables a controller which allows
-                  for MultiNetworkPolicy objects to be used on additional networks
-                  as created by Multus CNI. MultiNetworkPolicy are similar to NetworkPolicy
-                  objects, but NetworkPolicy objects only apply to the primary interface.
-                  With MultiNetworkPolicy, you can control the traffic that a pod
-                  can receive over the secondary interfaces. If unset, this property
-                  defaults to 'false' and MultiNetworkPolicy objects are ignored.
-                  If 'disableMultiNetwork' is 'true' then the value of this field
-                  is ignored.
-                type: boolean
-            type: object
-          status:
-            description: NetworkStatus is detailed operator status, which is distilled
-              up to the Network clusteroperator object.
-            properties:
-              conditions:
-                description: conditions is a list of conditions and their status
-                items:
-                  description: OperatorCondition is just the standard condition fields.
-                  properties:
-                    lastTransitionTime:
-                      format: date-time
-                      type: string
-                    message:
-                      type: string
-                    reason:
-                      type: string
-                    status:
-                      type: string
-                    type:
-                      type: string
+                  default: Normal
+                  enum:
+                    - ""
+                    - Normal
+                    - Debug
+                    - Trace
+                    - TraceAll
+                managementState:
+                  description: managementState indicates whether and how the operator should manage the component
+                  type: string
+                  pattern: ^(Managed|Unmanaged|Force|Removed)$
+                migration:
+                  description: migration enables and configures the cluster network migration. The migration procedure allows to change the network type and the MTU.
                   type: object
-                type: array
-              generations:
-                description: generations are used to determine when an item needs
-                  to be reconciled or has changed in a way that needs a reaction.
-                items:
-                  description: GenerationStatus keeps track of the generation for
-                    a given resource so that decisions about forced updates can be
-                    made.
                   properties:
-                    group:
-                      description: group is the group of the thing you're tracking
+                    mtu:
+                      description: mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.
+                      type: object
+                      properties:
+                        machine:
+                          description: machine contains MTU migration configuration for the machine's uplink. Needs to be migrated along with the default network MTU unless the current uplink MTU already accommodates the default network MTU.
+                          type: object
+                          properties:
+                            from:
+                              description: from is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: to is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                        network:
+                          description: network contains information about MTU migration for the default network. Migrations are only allowed to MTU values lower than the machine's uplink MTU by the minimum appropriate offset.
+                          type: object
+                          properties:
+                            from:
+                              description: from is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: to is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                    networkType:
+                      description: networkType is the target type of network migration. Set this to the target network type to allow changing the default network. If unset, the operation of changing cluster default network plugin will be rejected. The supported values are OpenShiftSDN, OVNKubernetes
                       type: string
-                    hash:
-                      description: hash is an optional field set for resources without
-                        generation that are content sensitive like secrets and configmaps
-                      type: string
-                    lastGeneration:
-                      description: lastGeneration is the last generation of the workload
-                        controller involved
-                      format: int64
-                      type: integer
-                    name:
-                      description: name is the name of the thing you're tracking
-                      type: string
-                    namespace:
-                      description: namespace is where the thing you're tracking is
-                      type: string
-                    resource:
-                      description: resource is the resource type of the thing you're
-                        tracking
-                      type: string
+                observedConfig:
+                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
                   type: object
-                type: array
-              observedGeneration:
-                description: observedGeneration is the last generation change you've
-                  dealt with
-                format: int64
-                type: integer
-              readyReplicas:
-                description: readyReplicas indicates how many replicas are ready and
-                  at the desired state
-                format: int32
-                type: integer
-              version:
-                description: version is the level this availability applies to
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                operatorLogLevel:
+                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                  type: string
+                  default: Normal
+                  enum:
+                    - ""
+                    - Normal
+                    - Debug
+                    - Trace
+                    - TraceAll
+                serviceNetwork:
+                  description: serviceNetwork is the ip address pool to use for Service IPs Currently, all existing network providers only support a single value here, but this is an array to allow for growth.
+                  type: array
+                  items:
+                    type: string
+                unsupportedConfigOverrides:
+                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                useMultiNetworkPolicy:
+                  description: useMultiNetworkPolicy enables a controller which allows for MultiNetworkPolicy objects to be used on additional networks as created by Multus CNI. MultiNetworkPolicy are similar to NetworkPolicy objects, but NetworkPolicy objects only apply to the primary interface. With MultiNetworkPolicy, you can control the traffic that a pod can receive over the secondary interfaces. If unset, this property defaults to 'false' and MultiNetworkPolicy objects are ignored. If 'disableMultiNetwork' is 'true' then the value of this field is ignored.
+                  type: boolean
+            status:
+              description: NetworkStatus is detailed operator status, which is distilled up to the Network clusteroperator object.
+              type: object
+              properties:
+                conditions:
+                  description: conditions is a list of conditions and their status
+                  type: array
+                  items:
+                    description: OperatorCondition is just the standard condition fields.
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                generations:
+                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                  type: array
+                  items:
+                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the thing you're tracking
+                        type: string
+                      hash:
+                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
+                        type: string
+                      lastGeneration:
+                        description: lastGeneration is the last generation of the workload controller involved
+                        type: integer
+                        format: int64
+                      name:
+                        description: name is the name of the thing you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the thing you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the thing you're tracking
+                        type: string
+                observedGeneration:
+                  description: observedGeneration is the last generation change you've dealt with
+                  type: integer
+                  format: int64
+                readyReplicas:
+                  description: readyReplicas indicates how many replicas are ready and at the desired state
+                  type: integer
+                  format: int32
+                version:
+                  description: version is the level this availability applies to
+                  type: string
+      served: true
+      storage: true

--- a/operator/v1/0000_70_cluster-network-operator_01.crd.yaml-patch
+++ b/operator/v1/0000_70_cluster-network-operator_01.crd.yaml-patch
@@ -1,3 +1,0 @@
-- op: add
-  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/spec/properties/defaultNetwork/properties/ovnKubernetesConfig/properties/policyAuditConfig/default
-  value: {}


### PR DESCRIPTION
Remove the unecessary yaml patch for the ClusterNetworkOperator
CRD since this wasn't working as intended anyways. See bz for more info

This reverts commit 6f0ce8c5f8b21d0262af50e99f3f9a6dcc0008e3.