### PR TITLE
Add exceptions to compatibility level rules and fix security api compatibility levels

### DIFF
--- a/cmd/openshift-compatibility-gen/generate/comment/generator.go
+++ b/cmd/openshift-compatibility-gen/generate/comment/generator.go
@@ -201,8 +201,19 @@ func (g *compatibilityLevelCommentGenerator) applyCompatibilityLevelComment() ds
 			g.err = fmt.Errorf("%s: APIs whose versions do not conform to kube apiVersion format cannot be exposed: the %s API must be tagged with +%s", apiTypeName, apiTypeName, internalTagName)
 			return false
 		case ga && level != 1:
-			g.err = fmt.Errorf("%s: generally available APIs must be supported for a minimum of 12 months", apiTypeName)
-			return false
+			switch {
+			case apiTypeName == "PodSecurityPolicySubjectReview" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "PodSecurityPolicySelfSubjectReview" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "PodSecurityPolicyReview" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "RangeAllocation" && level == 4:
+				// Documented special case, this api is level 4
+			default:
+				g.err = fmt.Errorf("%s: generally available APIs must be supported for a minimum of 12 months", apiTypeName)
+				return false
+			}
 		case beta && level == 1:
 			g.err = fmt.Errorf("%s: pre-release (beta) APIs must offer level 2 compatibility: the %s API should be versioned as generally available if you with to offer level 1 compatibility", apiTypeName, apiTypeName)
 			return false

--- a/security/v1/generated.proto
+++ b/security/v1/generated.proto
@@ -40,8 +40,8 @@ message IDRange {
 
 // PodSecurityPolicyReview checks which service accounts (not users, since that would be cluster-wide) can create the `PodTemplateSpec` in question.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 message PodSecurityPolicyReview {
   // spec is the PodSecurityPolicy to check.
   optional PodSecurityPolicyReviewSpec spec = 1;
@@ -73,8 +73,8 @@ message PodSecurityPolicyReviewStatus {
 
 // PodSecurityPolicySelfSubjectReview checks whether this user/SA tuple can create the PodTemplateSpec
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 message PodSecurityPolicySelfSubjectReview {
   // spec defines specification the PodSecurityPolicySelfSubjectReview.
   optional PodSecurityPolicySelfSubjectReviewSpec spec = 1;
@@ -91,8 +91,8 @@ message PodSecurityPolicySelfSubjectReviewSpec {
 
 // PodSecurityPolicySubjectReview checks whether a particular user/SA tuple can create the PodTemplateSpec.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 message PodSecurityPolicySubjectReview {
   // spec defines specification for the PodSecurityPolicySubjectReview.
   optional PodSecurityPolicySubjectReviewSpec spec = 1;
@@ -134,8 +134,8 @@ message PodSecurityPolicySubjectReviewStatus {
 
 // RangeAllocation is used so we can easily expose a RangeAllocation typed for security group
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+// +openshift:compatibility-gen:level=4
 message RangeAllocation {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 

--- a/security/v1/types.go
+++ b/security/v1/types.go
@@ -307,8 +307,8 @@ type SecurityContextConstraintsList struct {
 
 // PodSecurityPolicySubjectReview checks whether a particular user/SA tuple can create the PodTemplateSpec.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type PodSecurityPolicySubjectReview struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -356,8 +356,8 @@ type PodSecurityPolicySubjectReviewStatus struct {
 
 // PodSecurityPolicySelfSubjectReview checks whether this user/SA tuple can create the PodTemplateSpec
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type PodSecurityPolicySelfSubjectReview struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -380,8 +380,8 @@ type PodSecurityPolicySelfSubjectReviewSpec struct {
 
 // PodSecurityPolicyReview checks which service accounts (not users, since that would be cluster-wide) can create the `PodTemplateSpec` in question.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type PodSecurityPolicyReview struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -427,8 +427,8 @@ type ServiceAccountPodSecurityPolicyReviewStatus struct {
 
 // RangeAllocation is used so we can easily expose a RangeAllocation typed for security group
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+// +openshift:compatibility-gen:level=4
 type RangeAllocation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`

--- a/security/v1/zz_generated.swagger_doc_generated.go
+++ b/security/v1/zz_generated.swagger_doc_generated.go
@@ -41,7 +41,7 @@ func (IDRange) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicyReview = map[string]string{
-	"":       "PodSecurityPolicyReview checks which service accounts (not users, since that would be cluster-wide) can create the `PodTemplateSpec` in question.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"":       "PodSecurityPolicyReview checks which service accounts (not users, since that would be cluster-wide) can create the `PodTemplateSpec` in question.\n\nCompatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 	"spec":   "spec is the PodSecurityPolicy to check.",
 	"status": "status represents the current information/status for the PodSecurityPolicyReview.",
 }
@@ -70,7 +70,7 @@ func (PodSecurityPolicyReviewStatus) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicySelfSubjectReview = map[string]string{
-	"":       "PodSecurityPolicySelfSubjectReview checks whether this user/SA tuple can create the PodTemplateSpec\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"":       "PodSecurityPolicySelfSubjectReview checks whether this user/SA tuple can create the PodTemplateSpec\n\nCompatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 	"spec":   "spec defines specification the PodSecurityPolicySelfSubjectReview.",
 	"status": "status represents the current information/status for the PodSecurityPolicySelfSubjectReview.",
 }
@@ -89,7 +89,7 @@ func (PodSecurityPolicySelfSubjectReviewSpec) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicySubjectReview = map[string]string{
-	"":       "PodSecurityPolicySubjectReview checks whether a particular user/SA tuple can create the PodTemplateSpec.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"":       "PodSecurityPolicySubjectReview checks whether a particular user/SA tuple can create the PodTemplateSpec.\n\nCompatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 	"spec":   "spec defines specification for the PodSecurityPolicySubjectReview.",
 	"status": "status represents the current information/status for the PodSecurityPolicySubjectReview.",
 }
@@ -121,7 +121,7 @@ func (PodSecurityPolicySubjectReviewStatus) SwaggerDoc() map[string]string {
 }
 
 var map_RangeAllocation = map[string]string{
-	"":      "RangeAllocation is used so we can easily expose a RangeAllocation typed for security group\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"":      "RangeAllocation is used so we can easily expose a RangeAllocation typed for security group\n\nCompatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
 	"range": "range is a string representing a unique label for a range of uids, \"1000000000-2000000000/10000\".",
 	"data":  "data is a byte array representing the serialized state of a range allocation.  It is a bitmap with each bit set to one to represent a range is taken.",
 }


### PR DESCRIPTION
Per https://docs.openshift.com/container-platform/4.9/rest_api/understanding-api-support-tiers.html some of the security types are tier 4, not tier 1.  This PR fixes them and makes the generator logic tolerant of that setting.
