### PR TITLE
CSI migration for Azure Disk and Cinder is GA in 4.11

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -115,9 +115,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("CSIDriverAzureFile").          // sig-storage, fbertina, OCP specific
 		with("CSIDriverVSphere").            // sig-storage, jsafrane, OCP specific
 		with("CSIMigrationAWS").             // sig-storage, jsafrane, Kubernetes feature gate
-		with("CSIMigrationOpenStack").       // sig-storage, jsafrane, Kubernetes feature gate
 		with("CSIMigrationGCE").             // sig-storage, fbertina, Kubernetes feature gate
-		with("CSIMigrationAzureDisk").       // sig-storage, fbertina, Kubernetes feature gate
 		with("CSIMigrationAzureFile").       // sig-storage, fbertina, Kubernetes feature gate
 		with("CSIMigrationvSphere").         // sig-storage, fbertina, Kubernetes feature gate
 		with("ExternalCloudProvider").       // sig-cloud-provider, jspeed, OCP specific
@@ -147,9 +145,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 	},
 	Disabled: []string{
 		"CSIMigrationAWS",       // sig-storage, jsafrane
-		"CSIMigrationOpenStack", // sig-storage, jsafrane
 		"CSIMigrationGCE",       // sig-storage, jsafrane
-		"CSIMigrationAzureDisk", // sig-storage, jsafrane
 		"CSIMigrationAzureFile", // sig-storage, jsafrane
 		"CSIMigrationvSphere",   // sig-storage, jsafrane
 	},

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -27,9 +27,7 @@ func TestFeatureBuilder(t *testing.T) {
 				},
 				Disabled: []string{
 					"CSIMigrationAWS",
-					"CSIMigrationOpenStack",
 					"CSIMigrationGCE",
-					"CSIMigrationAzureDisk",
 					"CSIMigrationAzureFile",
 					"CSIMigrationvSphere",
 					"PodSecurity",
@@ -48,9 +46,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"CSIMigrationAWS",
 				},
 				Disabled: []string{
-					"CSIMigrationOpenStack",
 					"CSIMigrationGCE",
-					"CSIMigrationAzureDisk",
 					"CSIMigrationAzureFile",
 					"CSIMigrationvSphere",
 				},
@@ -67,9 +63,7 @@ func TestFeatureBuilder(t *testing.T) {
 				},
 				Disabled: []string{
 					"CSIMigrationAWS",
-					"CSIMigrationOpenStack",
 					"CSIMigrationGCE",
-					"CSIMigrationAzureDisk",
 					"CSIMigrationAzureFile",
 					"CSIMigrationvSphere",
 					"PodSecurity",
@@ -90,9 +84,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"other",
 				},
 				Disabled: []string{
-					"CSIMigrationOpenStack",
 					"CSIMigrationGCE",
-					"CSIMigrationAzureDisk",
 					"CSIMigrationAzureFile",
 					"CSIMigrationvSphere",
 				},


### PR DESCRIPTION
CSI migration for Azure Disk and Cinder will be GA in OCP 4.11.

https://issues.redhat.com/browse/STOR-615
https://issues.redhat.com/browse/STOR-670

CC @openshift/storage 