### PR TITLE
Azure: Add EncryptionType field to ManagedDiskParameters

### DIFF
--- a/machine/v1beta1/types_azureprovider.go
+++ b/machine/v1beta1/types_azureprovider.go
@@ -234,6 +234,10 @@ type ManagedDiskParameters struct {
 	// DiskEncryptionSet is the disk encryption set properties
 	// +optional
 	DiskEncryptionSet *DiskEncryptionSetParameters `json:"diskEncryptionSet,omitempty"`
+	// EncryptionType is the type of diisk encryption used.
+	// Possible values include: 'EncryptionAtRestWithPlatformKey', 'EncryptionAtRestWithCustomerKey', and 'EncryptionAtRestWithPlatformAndCustomerKeys'.
+	// +optional
+	EncryptionType string `json:"encryptionType,omitempty"`
 }
 
 // DiskEncryptionSetParameters is the disk encryption set properties


### PR DESCRIPTION
This allows the type of Azure disk encryption to be specified.

https://issues.redhat.com/browse/CORS-1889
https://issues.redhat.com/browse/CORS-1890
https://issues.redhat.com/browse/CORS-1891