### PR TITLE
Bug 2039256: kubebuilder validation format hostname is not RFC compliant

### DIFF
--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -53,7 +53,7 @@ spec:
                       hostname:
                         description: hostname is the hostname that should be used by the route.
                         type: string
-                        format: hostname
+                        pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
                       name:
                         description: "name is the logical name of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized."
                         type: string
@@ -226,13 +226,13 @@ spec:
                         type: array
                         minItems: 1
                         items:
-                          description: Hostname is an alias for hostname string validation.
+                          description: "Hostname is an alias for hostname string validation. \n The left operand of the | is the original kubebuilder hostname validation format, which is incorrect because it allows upper case letters, disallows hyphen or number in the TLD, and allows labels to start/end in non-alphanumeric characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256. ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$ \n The right operand of the | is a new pattern that mimics the current API route admission validation on hostname, except that it allows hostnames longer than the maximum length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$ \n Both operand patterns are made available so that modifications on ingress spec can still happen after an invalid hostname was saved via validation by the incorrect left operand of the | operator."
                           type: string
-                          format: hostname
+                          pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
                       defaultHostname:
                         description: defaultHostname is the hostname of this route prior to customization.
                         type: string
-                        format: hostname
+                        pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
                       name:
                         description: "name is the logical name of the route to customize. It does not have to be the actual name of a route resource but it cannot be renamed. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized."
                         type: string

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -91,7 +91,20 @@ type IngressSpec struct {
 type ConsumingUser string
 
 // Hostname is an alias for hostname string validation.
-// +kubebuilder:validation:Format=hostname
+//
+// The left operand of the | is the original kubebuilder hostname validation format, which is incorrect because it
+// allows upper case letters, disallows hyphen or number in the TLD, and allows labels to start/end in non-alphanumeric
+// characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256.
+// ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$
+//
+// The right operand of the | is a new pattern that mimics the current API route admission validation on hostname,
+// except that it allows hostnames longer than the maximum length:
+// ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+//
+// Both operand patterns are made available so that modifications on ingress spec can still happen after an invalid hostname
+// was saved via validation by the incorrect left operand of the | operator.
+//
+// +kubebuilder:validation:Pattern=`^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$`
 type Hostname string
 
 type IngressStatus struct {


### PR DESCRIPTION
We use the[ go-openapi/strfmt library for the "hostname"](https://github.com/go-openapi/strfmt/blob/master/default.go#L59) kubebuilder validation format in `componentRoutes`. This format does not accept numbers or hyphens in the TLD as noted in https://bugzilla.redhat.com/show_bug.cgi?id=2039256#c3.

I checked with the openshift/api team and they recommended replacing the hostname format with my own regex, but I have to be careful with downgrades. Therefore I changed the regex pattern to be looser.

The old pattern that came from go-openapi/strfmt: 
`^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$`

The new pattern is simply an `|` of the old pattern with the correct, tighter, pattern (formatted here for clarity): 
`^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$ |
^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$`

Based on previous code review, the tighter side of the `|` removes the uppercase A-Z provision, removes \p{S} (symbols), and \p{L} (international language letters).  Also enforces labels must start/end in alphanumeric characters, and one-word hostnames accepted.

I also checked with go-openapi owners in go-openapi/strfmt#94 about changing the library regex, but the solution they prefer doesn't fit for a solution for us.

Also fixes duplicate bug (with higher priority) https://bugzilla.redhat.com/show_bug.cgi?id=2049473