### PR TITLE
Move console apis to tier 2, per what our docs say

### DIFF
--- a/cmd/openshift-compatibility-gen/generate/comment/generator.go
+++ b/cmd/openshift-compatibility-gen/generate/comment/generator.go
@@ -210,6 +210,32 @@ func (g *compatibilityLevelCommentGenerator) applyCompatibilityLevelComment() ds
 				// Documented special case, this api is level 2
 			case apiTypeName == "RangeAllocation" && level == 4:
 				// Documented special case, this api is level 4
+
+			case apiTypeName == "ConsoleCLIDownload" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleCLIDownloadList" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleExternalLogLink" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleExternalLogLinkList" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleLink" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleLinkList" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleNotification" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleNotificationList" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleQuickStart" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleQuickStartList" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleYAMLSample" && level == 2:
+				// Documented special case, this api is level 2
+			case apiTypeName == "ConsoleYAMLSampleList" && level == 2:
+				// Documented special case, this api is level 2
+
 			default:
 				g.err = fmt.Errorf("%s: generally available APIs must be supported for a minimum of 12 months", apiTypeName)
 				return false

--- a/console/v1/0000_10_consoleclidownload.crd.yaml
+++ b/console/v1/0000_10_consoleclidownload.crd.yaml
@@ -28,7 +28,7 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: "ConsoleCLIDownload is an extension for configuring openshift web console command line interface (CLI) downloads. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          description: "ConsoleCLIDownload is an extension for configuring openshift web console command line interface (CLI) downloads. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
           type: object
           required:
             - spec

--- a/console/v1/0000_10_consoleexternalloglink.crd.yaml
+++ b/console/v1/0000_10_consoleexternalloglink.crd.yaml
@@ -31,7 +31,7 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: "ConsoleExternalLogLink is an extension for customizing OpenShift web console log links. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          description: "ConsoleExternalLogLink is an extension for customizing OpenShift web console log links. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
           type: object
           required:
             - spec

--- a/console/v1/0000_10_consolelink.crd.yaml
+++ b/console/v1/0000_10_consolelink.crd.yaml
@@ -34,7 +34,7 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: "ConsoleLink is an extension for customizing OpenShift web console links. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          description: "ConsoleLink is an extension for customizing OpenShift web console links. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
           type: object
           required:
             - spec

--- a/console/v1/0000_10_consolenotification.crd.yaml
+++ b/console/v1/0000_10_consolenotification.crd.yaml
@@ -31,7 +31,7 @@ spec:
       name: v1
       schema:
         openAPIV3Schema:
-          description: "ConsoleNotification is the extension for configuring openshift web console notifications. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          description: "ConsoleNotification is the extension for configuring openshift web console notifications. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
           type: object
           required:
             - spec

--- a/console/v1/0000_10_consolequickstart.crd.yaml
+++ b/console/v1/0000_10_consolequickstart.crd.yaml
@@ -21,7 +21,7 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: "ConsoleQuickStart is an extension for guiding user through various workflows in the OpenShift web console. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          description: "ConsoleQuickStart is an extension for guiding user through various workflows in the OpenShift web console. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
           type: object
           required:
             - spec

--- a/console/v1/0000_10_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_consoleyamlsample.crd.yaml
@@ -21,7 +21,7 @@ spec:
     - name: v1
       schema:
         openAPIV3Schema:
-          description: "ConsoleYAMLSample is an extension for customizing OpenShift web console YAML samples. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          description: "ConsoleYAMLSample is an extension for customizing OpenShift web console YAML samples. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
           type: object
           required:
             - metadata

--- a/console/v1/types_console_cli_download.go
+++ b/console/v1/types_console_cli_download.go
@@ -8,8 +8,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ConsoleCLIDownload is an extension for configuring openshift web console command line interface (CLI) downloads.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleCLIDownload struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -38,8 +38,8 @@ type CLIDownloadLink struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleCLIDownloadList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/console/v1/types_console_external_log_links.go
+++ b/console/v1/types_console_external_log_links.go
@@ -8,8 +8,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ConsoleExternalLogLink is an extension for customizing OpenShift web console log links.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleExternalLogLink struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -49,8 +49,8 @@ type ConsoleExternalLogLinkSpec struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleExternalLogLinkList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/console/v1/types_console_link.go
+++ b/console/v1/types_console_link.go
@@ -8,8 +8,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ConsoleLink is an extension for customizing OpenShift web console links.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleLink struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -78,8 +78,8 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleLinkList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/console/v1/types_console_notification.go
+++ b/console/v1/types_console_notification.go
@@ -8,8 +8,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ConsoleNotification is the extension for configuring openshift web console notifications.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleNotification struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -52,8 +52,8 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleNotificationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/console/v1/types_console_quick_start.go
+++ b/console/v1/types_console_quick_start.go
@@ -12,8 +12,8 @@ import (
 // ConsoleQuickStart is an extension for guiding user through various
 // workflows in the OpenShift web console.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleQuickStart struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -127,8 +127,8 @@ type ConsoleQuickStartTaskSummary struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleQuickStartList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/console/v1/types_console_yaml_sample.go
+++ b/console/v1/types_console_yaml_sample.go
@@ -8,8 +8,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // ConsoleYAMLSample is an extension for customizing OpenShift web console YAML samples.
 //
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleYAMLSample struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -51,8 +51,8 @@ type ConsoleYAMLSampleYAML string
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
-// +openshift:compatibility-gen:level=1
+// Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).
+// +openshift:compatibility-gen:level=2
 type ConsoleYAMLSampleList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/console/v1/zz_generated.swagger_doc_generated.go
+++ b/console/v1/zz_generated.swagger_doc_generated.go
@@ -31,7 +31,7 @@ func (CLIDownloadLink) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleCLIDownload = map[string]string{
-	"": "ConsoleCLIDownload is an extension for configuring openshift web console command line interface (CLI) downloads.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "ConsoleCLIDownload is an extension for configuring openshift web console command line interface (CLI) downloads.\n\nCompatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleCLIDownload) SwaggerDoc() map[string]string {
@@ -39,7 +39,7 @@ func (ConsoleCLIDownload) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleCLIDownloadList = map[string]string{
-	"": "Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleCLIDownloadList) SwaggerDoc() map[string]string {
@@ -58,7 +58,7 @@ func (ConsoleCLIDownloadSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleExternalLogLink = map[string]string{
-	"": "ConsoleExternalLogLink is an extension for customizing OpenShift web console log links.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "ConsoleExternalLogLink is an extension for customizing OpenShift web console log links.\n\nCompatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleExternalLogLink) SwaggerDoc() map[string]string {
@@ -66,7 +66,7 @@ func (ConsoleExternalLogLink) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleExternalLogLinkList = map[string]string{
-	"": "Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleExternalLogLinkList) SwaggerDoc() map[string]string {
@@ -95,7 +95,7 @@ func (ApplicationMenuSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleLink = map[string]string{
-	"": "ConsoleLink is an extension for customizing OpenShift web console links.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "ConsoleLink is an extension for customizing OpenShift web console links.\n\nCompatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleLink) SwaggerDoc() map[string]string {
@@ -103,7 +103,7 @@ func (ConsoleLink) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleLinkList = map[string]string{
-	"": "Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleLinkList) SwaggerDoc() map[string]string {
@@ -132,7 +132,7 @@ func (NamespaceDashboardSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleNotification = map[string]string{
-	"": "ConsoleNotification is the extension for configuring openshift web console notifications.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "ConsoleNotification is the extension for configuring openshift web console notifications.\n\nCompatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleNotification) SwaggerDoc() map[string]string {
@@ -140,7 +140,7 @@ func (ConsoleNotification) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleNotificationList = map[string]string{
-	"": "Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleNotificationList) SwaggerDoc() map[string]string {
@@ -161,7 +161,7 @@ func (ConsoleNotificationSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleQuickStart = map[string]string{
-	"": "ConsoleQuickStart is an extension for guiding user through various workflows in the OpenShift web console.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "ConsoleQuickStart is an extension for guiding user through various workflows in the OpenShift web console.\n\nCompatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleQuickStart) SwaggerDoc() map[string]string {
@@ -169,7 +169,7 @@ func (ConsoleQuickStart) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleQuickStartList = map[string]string{
-	"": "Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleQuickStartList) SwaggerDoc() map[string]string {
@@ -228,7 +228,7 @@ func (ConsoleQuickStartTaskSummary) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleYAMLSample = map[string]string{
-	"": "ConsoleYAMLSample is an extension for customizing OpenShift web console YAML samples.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "ConsoleYAMLSample is an extension for customizing OpenShift web console YAML samples.\n\nCompatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleYAMLSample) SwaggerDoc() map[string]string {
@@ -236,7 +236,7 @@ func (ConsoleYAMLSample) SwaggerDoc() map[string]string {
 }
 
 var map_ConsoleYAMLSampleList = map[string]string{
-	"": "Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"": "Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).",
 }
 
 func (ConsoleYAMLSampleList) SwaggerDoc() map[string]string {


### PR DESCRIPTION
and update generator to tolerate it

see our docs here: https://docs.openshift.com/container-platform/4.9/rest_api/understanding-api-support-tiers.html#mapping-support-tiers-to-openshift-api-groups_understanding-api-tiers
