### PR TITLE
Bug 2060697: Correct json tag on AWS Placement PartitionNumber

### DIFF
--- a/machine/v1beta1/types_awsprovider.go
+++ b/machine/v1beta1/types_awsprovider.go
@@ -200,7 +200,7 @@ type Placement struct {
 	// +kubebuilder:validation:Minimum:=1
 	// +kubebuilder:validation:Maximum:=7
 	// +optional
-	PartitionNumber int32 `json:"number,omitempty"`
+	PartitionNumber int32 `json:"partitionNumber,omitempty"`
 }
 
 // LocalAWSPlacementGroupReference contains enough information to let you locate the

--- a/machine/v1beta1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1beta1/zz_generated.swagger_doc_generated.go
@@ -138,7 +138,7 @@ var map_Placement = map[string]string{
 	"availabilityZone": "AvailabilityZone is the availability zone of the instance",
 	"tenancy":          "Tenancy indicates if instance should run on shared or single-tenant hardware. There are supported 3 options: default, dedicated and host.",
 	"group":            "Group specifies a reference to an AWSPlacementGroup resource to create the Machine within. If the group specified does not exist, the Machine will not be created and will enter the failed phase.",
-	"number":           "PartitionNumber specifies the numbered partition in which instances should be launched. It is recommended to only use this value if multiple MachineSets share a single Placement Group, in which case, each MachineSet should represent an individual partition number. If unset, when a Partition placement group is used, AWS will attempt to distribute instances evenly between partitions. If PartitionNumber is set when used with a non Partition type Placement Group, this will be considered an error.",
+	"partitionNumber":  "PartitionNumber specifies the numbered partition in which instances should be launched. It is recommended to only use this value if multiple MachineSets share a single Placement Group, in which case, each MachineSet should represent an individual partition number. If unset, when a Partition placement group is used, AWS will attempt to distribute instances evenly between partitions. If PartitionNumber is set when used with a non Partition type Placement Group, this will be considered an error.",
 }
 
 func (Placement) SwaggerDoc() map[string]string {


### PR DESCRIPTION
QE picked up this small error during testing. After various iterations of #1091 the name of this field was changed. It makes sense for it to be `paritionNumber` in a customer facing context