### PR TITLE
Cluster scope for config/v1 node CRD

### DIFF
--- a/config/v1/0000_10_config-operator_01_node.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_node.crd.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: NodeList
     plural: nodes
     singular: node
-  scope: Namespaced
+  scope: Cluster
   versions:
     - name: v1
       schema:

--- a/config/v1/0000_10_config-operator_01_node.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_node.crd.yaml
@@ -82,9 +82,5 @@ spec:
                             type: string
       served: true
       storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+      subresources:
+        status: {}

--- a/config/v1/types_node.go
+++ b/config/v1/types_node.go
@@ -10,6 +10,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 //
 // Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 // +openshift:compatibility-gen:level=1
+// +kubebuilder:resource:path=nodes,scope=Cluster
 type Node struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/v1/types_node.go
+++ b/config/v1/types_node.go
@@ -11,6 +11,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 // +openshift:compatibility-gen:level=1
 // +kubebuilder:resource:path=nodes,scope=Cluster
+// +kubebuilder:subresource:status
 type Node struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Node CRD added in openshift/api#1107 should be made cluster scoped instead of namespace scoped since the enhancement proposals [1] [2] also intends to make cluster level changes.

[1] https://github.com/openshift/enhancements/blob/master/enhancements/worker-latency-profile/worker-latency-profile.md#proposal
[2] https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/mco-cgroupsv2-support.md#api-extensions

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>