### PR TITLE
Ensure enumeration of ControlPlaneMachineSetMachineType type alias

### DIFF
--- a/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -122,8 +122,10 @@ spec:
                     - machines_v1beta1_machine_openshift_io
                   properties:
                     machineType:
-                      description: MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet. Currently, the only valid value is machine.v1beta1.machine.openshift.io.
+                      description: MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet. Currently, the only valid value is machines_v1beta1_machine_openshift_io.
                       type: string
+                      enum:
+                        - machines_v1beta1_machine_openshift_io
                     machines_v1beta1_machine_openshift_io:
                       description: OpenShiftMachineV1Beta1Machine defines the template for creating Machines from the v1beta1.machine.openshift.io API group.
                       type: object

--- a/machine/v1/types_controlplanemachineset.go
+++ b/machine/v1/types_controlplanemachineset.go
@@ -73,7 +73,7 @@ type ControlPlaneMachineSetSpec struct {
 // + future version of the Machine API Machine.
 type ControlPlaneMachineSetTemplate struct {
 	// MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet.
-	// Currently, the only valid value is machine.v1beta1.machine.openshift.io.
+	// Currently, the only valid value is machines_v1beta1_machine_openshift_io.
 	// +unionDiscriminator
 	// +kubebuilder:validation:Required
 	MachineType ControlPlaneMachineSetMachineType `json:"machineType"`
@@ -86,6 +86,7 @@ type ControlPlaneMachineSetTemplate struct {
 
 // ControlPlaneMachineSetMachineType is a enumeration of valid Machine types
 // supported by the ControlPlaneMachineSet.
+// +kubebuilder:validation:Enum:=machines_v1beta1_machine_openshift_io
 type ControlPlaneMachineSetMachineType string
 
 const (

--- a/machine/v1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1/zz_generated.swagger_doc_generated.go
@@ -292,7 +292,7 @@ func (ControlPlaneMachineSetStrategy) SwaggerDoc() map[string]string {
 
 var map_ControlPlaneMachineSetTemplate = map[string]string{
 	"":                                      "ControlPlaneMachineSetTemplate is a template used by the ControlPlaneMachineSet to create the Machines that it will manage in the future. ",
-	"machineType":                           "MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet. Currently, the only valid value is machine.v1beta1.machine.openshift.io.",
+	"machineType":                           "MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet. Currently, the only valid value is machines_v1beta1_machine_openshift_io.",
 	"machines_v1beta1_machine_openshift_io": "OpenShiftMachineV1Beta1Machine defines the template for creating Machines from the v1beta1.machine.openshift.io API group.",
 }
 


### PR DESCRIPTION
I noticed that the kubebuilder validation for the enum was missing and that the comment was out of date