### PR TITLE
Bug 2039256: config/ingress: Remove broken hostname validation

### DIFF
--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -53,7 +53,6 @@ spec:
                       hostname:
                         description: hostname is the hostname that should be used by the route.
                         type: string
-                        format: hostname
                       name:
                         description: "name is the logical name of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized."
                         type: string
@@ -228,11 +227,9 @@ spec:
                         items:
                           description: Hostname is an alias for hostname string validation.
                           type: string
-                          format: hostname
                       defaultHostname:
                         description: defaultHostname is the hostname of this route prior to customization.
                         type: string
-                        format: hostname
                       name:
                         description: "name is the logical name of the route to customize. It does not have to be the actual name of a route resource but it cannot be renamed. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized."
                         type: string

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -91,7 +91,6 @@ type IngressSpec struct {
 type ConsumingUser string
 
 // Hostname is an alias for hostname string validation.
-// +kubebuilder:validation:Format=hostname
 type Hostname string
 
 type IngressStatus struct {


### PR DESCRIPTION
The hostname validation for the custom route configuration API prohibits valid hostnames, such as hostnames with TLDs that include digits.  This API was added in OpenShift 4.8, and we cannot tighten OpenAPI validation of a shipped API.  Moreover, allowing some invalid values while rejecting other invalid values in the API is more confusing than consistently allowing invalid values in the API and then handling invalid values in the component that owns the route.  Thus this PR removes the validation entirely.

* `config/v1/types_ingress.go` (`Hostname`): Remove validation.
* `config/v1/0000_10_config-operator_01_ingress.crd.yaml`: Regenerate.

---

This PR supersedes #1120.  