### PR TITLE
Add enum validation to .spec.* fields in config/v1 node CRD

### DIFF
--- a/config/v1/0000_10_config-operator_01_node.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_node.crd.yaml
@@ -39,9 +39,17 @@ spec:
                 cgroupMode:
                   description: CgroupMode determines the cgroups version on the node
                   type: string
+                  enum:
+                    - v1
+                    - v2
+                    - ""
                 workerLatencyProfile:
                   description: WorkerLatencyProfile determins the how fast the kubelet is updating the status and corresponding reaction of the cluster
                   type: string
+                  enum:
+                    - Default
+                    - MediumUpdateAverageReaction
+                    - LowUpdateSlowReaction
             status:
               description: status holds observed values.
               type: object

--- a/config/v1/types_node.go
+++ b/config/v1/types_node.go
@@ -47,6 +47,7 @@ type NodeStatus struct {
 	WorkerLatencyProfileStatus WorkerLatencyProfileStatus `json:"workerLatencyProfileStatus,omitempty"`
 }
 
+// +kubebuilder:validation:Enum=v1;v2;""
 type CgroupMode string
 
 const (
@@ -56,6 +57,7 @@ const (
 	CgroupModeDefault CgroupMode = CgroupModeV1
 )
 
+// +kubebuilder:validation:Enum=Default;MediumUpdateAverageReaction;LowUpdateSlowReaction
 type WorkerLatencyProfileType string
 
 const (


### PR DESCRIPTION
Added validation to workerLatencyProfile, cgroupMode fields in config.openshift.io/v1/node CRD.

Signed-off-by: Swarup Ghosh <swghosh@redhat.com>