### PR TITLE
Allow consistent verification across platforms with container verify target

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -3,7 +3,7 @@ FROM fedora:latest
 ENV GOPATH=/go
 ENV PATH=/go/bin:/usr/local/go/bin:$PATH
 
-RUN dnf -y install make git unzip wget findutils
+RUN dnf -y install make git unzip wget findutils gcc diffutils
 
 RUN wget https://go.dev/dl/go1.17.6.linux-amd64.tar.gz && \
     rm -rf /usr/local/go && \

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ update-scripts:
 	hack/update-swagger-docs.sh
 .PHONY: update-scripts
 
+verify-with-container: Dockerfile.build
+	$(RUNTIME) build -t $(RUNTIME_IMAGE_NAME) -f Dockerfile.build .
+	$(RUNTIME) run -ti --rm -v $(PWD):/go/src/github.com/openshift/api:z -w /go/src/github.com/openshift/api $(RUNTIME_IMAGE_NAME) make verify
+
 generate-with-container: Dockerfile.build
 	$(RUNTIME) build -t $(RUNTIME_IMAGE_NAME) -f Dockerfile.build .
 	$(RUNTIME) run -ti --rm -v $(PWD):/go/src/github.com/openshift/api:z -w /go/src/github.com/openshift/api $(RUNTIME_IMAGE_NAME) make update


### PR DESCRIPTION
As a mac user, I can generate assets with `RUNTIME=docker make generate-with-container`. However, this takes a really long time so on occasion, it might be easier to update (eg godoc changes into swagger) the assets manually.

At the moment, because I run the generation in container, the assets are built for linux, not darwin, so the verify target fails. I know others have also had issues with running verify locally so I thought it might be useful to have a container based verify for those who aren't able to run it within their own development environments easily.