### PR TITLE
machine: azureprovider: AzureUltraSSDCapabilityState const rename

### DIFF
--- a/machine/v1beta1/types_azureprovider.go
+++ b/machine/v1beta1/types_azureprovider.go
@@ -389,8 +389,8 @@ type AzureUltraSSDCapabilityState string
 
 // These are the valid AzureUltraSSDCapabilityState states.
 const (
-	// "AzureUltraSSDCapabilityTrue" means the Azure UltraSSDCapability is Enabled
-	AzureUltraSSDCapabilityTrue AzureUltraSSDCapabilityState = "Enabled"
-	// "AzureUltraSSDCapabilityFalse" means the Azure UltraSSDCapability is Disabled
-	AzureUltraSSDCapabilityFalse AzureUltraSSDCapabilityState = "Disabled"
+	// "AzureUltraSSDCapabilityEnabled" means the Azure UltraSSDCapability is Enabled
+	AzureUltraSSDCapabilityEnabled AzureUltraSSDCapabilityState = "Enabled"
+	// "AzureUltraSSDCapabilityDisabled" means the Azure UltraSSDCapability is Disabled
+	AzureUltraSSDCapabilityDisabled AzureUltraSSDCapabilityState = "Disabled"
 )


### PR DESCRIPTION
Renaming the AzureUltraSSDCapabilityState consts to be more coherent with the available `Enabled/Disabled` values.
This was an inconsistency recently introduced by: https://github.com/openshift/api/pull/1119 which we would like to fix before the new API gets added to a release.