### PR TITLE
config: Add ClusterName to the ClusterOperator RelatedObjects field

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -104,6 +104,9 @@ spec:
                       - name
                       - resource
                     properties:
+                      clusterName:
+                        description: cluster name of the cluster containing the referent
+                        type: string
                       group:
                         description: group of the referent.
                         type: string

--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -256,6 +256,9 @@ spec:
                             - name
                             - resource
                           properties:
+                            clusterName:
+                              description: cluster name of the cluster containing the referent
+                              type: string
                             group:
                               description: group of the referent.
                               type: string

--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -95,6 +95,9 @@ type ObjectReference struct {
 	// +kubebuilder:validation:Required
 	// +required
 	Name string `json:"name"`
+	// cluster name of the cluster containing the referent
+	// +optional
+	ClusterName string `json:"clusterName"`
 }
 
 type ConditionStatus string

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -508,11 +508,12 @@ func (ClusterOperatorStatusCondition) SwaggerDoc() map[string]string {
 }
 
 var map_ObjectReference = map[string]string{
-	"":          "ObjectReference contains enough information to let you inspect or modify the referred object.",
-	"group":     "group of the referent.",
-	"resource":  "resource of the referent.",
-	"namespace": "namespace of the referent.",
-	"name":      "name of the referent.",
+	"":            "ObjectReference contains enough information to let you inspect or modify the referred object.",
+	"group":       "group of the referent.",
+	"resource":    "resource of the referent.",
+	"namespace":   "namespace of the referent.",
+	"name":        "name of the referent.",
+	"clusterName": "cluster name of the cluster containing the referent",
 }
 
 func (ObjectReference) SwaggerDoc() map[string]string {


### PR DESCRIPTION
For operators that manage multiple clusters, allow including a cluster name. This is akin to the ClusterName field in ObjectMeta: it has no intrinsic meaning; clients can use it freely.

See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#objectmeta-v1-meta