### PR TITLE
Remove the 'proxy' comment for the Prism endpoint fields in the Infrastructure type

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -97,7 +97,7 @@ spec:
                         - prismElements
                       properties:
                         prismCentral:
-                          description: prismCentral holds the endpoint address and port to access the Nutanix Prism Central.
+                          description: prismCentral holds the endpoint address and port to access the Nutanix Prism Central. When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
                           type: object
                           required:
                             - address
@@ -124,7 +124,7 @@ spec:
                               - name
                             properties:
                               endpoint:
-                                description: endpoint holds the endpoint address and port data of the Prism Element (cluster).
+                                description: endpoint holds the endpoint address and port data of the Prism Element (cluster). When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
                                 type: object
                                 required:
                                   - address

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -707,6 +707,9 @@ type AlibabaCloudResourceTag struct {
 // This only includes fields that can be modified in the cluster.
 type NutanixPlatformSpec struct {
 	// prismCentral holds the endpoint address and port to access the Nutanix Prism Central.
+	// When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy.
+	// Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the
+	// proxy spec.noProxy list.
 	// +kubebuilder:validation:Required
 	PrismCentral NutanixPrismEndpoint `json:"prismCentral"`
 
@@ -744,6 +747,9 @@ type NutanixPrismElementEndpoint struct {
 	Name string `json:"name"`
 
 	// endpoint holds the endpoint address and port data of the Prism Element (cluster).
+	// When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy.
+	// Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the
+	// proxy spec.noProxy list.
 	// +kubebuilder:validation:Required
 	Endpoint NutanixPrismEndpoint `json:"endpoint"`
 }

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1206,7 +1206,7 @@ func (KubevirtPlatformStatus) SwaggerDoc() map[string]string {
 
 var map_NutanixPlatformSpec = map[string]string{
 	"":              "NutanixPlatformSpec holds the desired state of the Nutanix infrastructure provider. This only includes fields that can be modified in the cluster.",
-	"prismCentral":  "prismCentral holds the endpoint address and port to access the Nutanix Prism Central.",
+	"prismCentral":  "prismCentral holds the endpoint address and port to access the Nutanix Prism Central. When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.",
 	"prismElements": "prismElements holds one or more endpoint address and port data to access the Nutanix Prism Elements (clusters) of the Nutanix Prism Central. Currently we only support one Prism Element (cluster) for an OpenShift cluster, where all the Nutanix resources (VMs, subnets, volumes, etc.) used in the OpenShift cluster are located. In the future, we may support Nutanix resources (VMs, etc.) spread over multiple Prism Elements (clusters) of the Prism Central.",
 }
 
@@ -1227,7 +1227,7 @@ func (NutanixPlatformStatus) SwaggerDoc() map[string]string {
 var map_NutanixPrismElementEndpoint = map[string]string{
 	"":         "NutanixPrismElementEndpoint holds the name and endpoint data for a Prism Element (cluster)",
 	"name":     "name is the name of the Prism Element (cluster). This value will correspond with the cluster field configured on other resources (eg Machines, PVCs, etc).",
-	"endpoint": "endpoint holds the endpoint address and port data of the Prism Element (cluster).",
+	"endpoint": "endpoint holds the endpoint address and port data of the Prism Element (cluster). When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.",
 }
 
 func (NutanixPrismElementEndpoint) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Remove the 'proxy' comment for the Prism endpoint fields in the Infrastructure type.