### PR TITLE
Machine Providers are raw extension and should not have generated clients

### DIFF
--- a/machine/v1/types_alibabaprovider.go
+++ b/machine/v1/types_alibabaprovider.go
@@ -73,7 +73,6 @@ const (
 	AlibabaResourceReferenceTypeTags AlibabaResourceReferenceType = "Tags"
 )
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AlibabaCloudMachineProviderConfig is the Schema for the alibabacloudmachineproviderconfig API

--- a/machine/v1/types_nutanixprovider.go
+++ b/machine/v1/types_nutanixprovider.go
@@ -6,7 +6,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // NutanixMachineProviderConfig is the Schema for the nutanixmachineproviderconfigs API


### PR DESCRIPTION
Neither the Alibaba or Nutanix MachineProviderConfig should have generated clientsets, as they are not CRDs and not installed within a cluster.

Removing these tags so that we can add the rest of Machine V1 to openshift/client-go