### PR TITLE
Bug 2074243: `DefaultPlacement` allow empty enum value and remove default

### DIFF
--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -271,10 +271,10 @@ spec:
                 defaultPlacement:
                   description: "defaultPlacement is set at installation time to control which nodes will host the ingress router pods by default. The options are control-plane nodes or worker nodes. \n This field works by dictating how the Cluster Ingress Operator will consider unset replicas and nodePlacement fields in IngressController resources when creating the corresponding Deployments. \n See the documentation for the IngressController replicas and nodePlacement fields for more information. \n When omitted, the default value is Workers"
                   type: string
-                  default: Workers
                   enum:
                     - ControlPlane
                     - Workers
+                    - ""
       served: true
       storage: true
       subresources:

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -126,8 +126,7 @@ type IngressStatus struct {
 	//
 	// When omitted, the default value is Workers
 	//
-	// +kubebuilder:validation:Enum:="ControlPlane";"Workers"
-	// +kubebuilder:default:="Workers"
+	// +kubebuilder:validation:Enum:="ControlPlane";"Workers";""
 	// +optional
 	DefaultPlacement DefaultPlacement `json:"defaultPlacement"`
 }


### PR DESCRIPTION
The `DefaultPlacement` config status field should allow the `""` value
to be used during an Update for this subresource. This should allow the
status subresource to be updated even when `DefaultPlacement` has an
empty value.

Also removed the `kubebuilder:default:="Workers"` specifier because the
controller already regards an empty value as `"Workers"`, there's no
need for it to be explicitly set when omitted.