### PR TITLE
Add Machine v1 client-go dependencies

### DIFF
--- a/machine/v1/register.go
+++ b/machine/v1/register.go
@@ -12,7 +12,20 @@ var (
 	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	// Install is a function which adds this version to a scheme
 	Install = schemeBuilder.AddToScheme
+
+	// SchemeGroupVersion generated code relies on this name
+	// Deprecated
+	SchemeGroupVersion = GroupVersion
+	// AddToScheme exists solely to keep the old generators creating valid code
+	// DEPRECATED
+	AddToScheme = schemeBuilder.AddToScheme
 )
+
+// Resource generated code relies on this being here, but it logically belongs to the group
+// DEPRECATED
+func Resource(resource string) schema.GroupResource {
+	return schema.GroupResource{Group: GroupName, Resource: resource}
+}
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {


### PR DESCRIPTION
Generated clients require these functions and variables to be exported, currently the PR https://github.com/openshift/client-go/pull/212 to add the client is failing because these do not exist