### PR TITLE
Add enum validation for Placement Group Management State

### DIFF
--- a/machine/v1/0000_10_awsplacementgroup.crd.yaml
+++ b/machine/v1/0000_10_awsplacementgroup.crd.yaml
@@ -91,6 +91,9 @@ spec:
                     managementState:
                       description: ManagementState determines whether the placement group is expected to be managed by this CRD or whether it is user managed. A managed placement group may be moved to unmanaged, however an unmanaged group may not be moved back to managed.
                       type: string
+                      enum:
+                        - Managed
+                        - Unmanaged
             status:
               type: object
               properties:

--- a/machine/v1/types_awsplacementgroup.go
+++ b/machine/v1/types_awsplacementgroup.go
@@ -44,6 +44,7 @@ type AWSPlacementGroupManagementSpec struct {
 	// A managed placement group may be moved to unmanaged, however an unmanaged
 	// group may not be moved back to managed.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum:=Managed;Unmanaged
 	// +unionDiscriminator
 	ManagementState ManagementState `json:"managementState"`
 


### PR DESCRIPTION
This field is meant to be an enum of either of the Managed|Unmanaged values, as it is required, we do not allow the empty string value.

I've added this directly to the field rather than the enum so that we don't enforce the same validation on other uses of this enum which may not be required