### PR TITLE
config/v1/types_cluster_version: Add KnownClusterVersionCapabilities

### DIFF
--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -247,6 +247,13 @@ const (
 	ClusterVersionCapabilityMarketplace ClusterVersionCapability = "marketplace"
 )
 
+// KnownClusterVersionCapabilities includes all known optional, core cluster components.
+var KnownClusterVersionCapabilities = []ClusterVersionCapability{
+	ClusterVersionCapabilityBaremetal,
+	ClusterVersionCapabilityMarketplace,
+	ClusterVersionCapabilityOpenShiftSamples,
+}
+
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
 // +kubebuilder:validation:Enum=None;v4.11;vCurrent
 type ClusterVersionCapabilitySet string

--- a/config/v1/types_cluster_version_test.go
+++ b/config/v1/types_cluster_version_test.go
@@ -1,0 +1,24 @@
+package v1
+
+import (
+	"testing"
+)
+
+// TestKnownClusterVersionCapabilities verifies that all capabilities
+// referenced by capability sets are contained in
+// KnownClusterVersionCapabilities.
+func TestKnownClusterVersionCapabilities(t *testing.T) {
+	exists := struct{}{}
+	known := make(map[ClusterVersionCapability]struct{}, len(KnownClusterVersionCapabilities))
+	for _, cap := range KnownClusterVersionCapabilities {
+		known[cap] = exists
+	}
+
+	for set, caps := range ClusterVersionCapabilitySets {
+		for _, cap := range caps {
+			if _, ok := known[cap]; !ok {
+				t.Errorf("Capability set %s contains %s, which needs to be added to KnownClusterVersionCapabilities", set, cap)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Currently validators are [treating the union of all known sets as the set of all capabilities][1], but it is possible that some future
capability belongs to no set.  By adding a knew variable to hold all known capabilities, we avoid validators rejecting that no-set capability as unknown.

This could have been a new `All` set that held all known capabilities, but:

* We can add new sets in the future, but because of backwards compatibility requirements, we can never remove an existing set.

* We already have `v4.11` and `vCurrent` covering the set of all known capabilities.  Having three different sets with slightly different forward-looking semantics is more overhead for capability-selecting administrators than we want to bite off for 4.11.  As we get to later 4.y with more sets, the semantic distinctions may become more clear, and we can revisit adding `All` then.

[1]: https://github.com/openshift/installer/blob/c83637b2d18aa9a192f3e3b7de2114e9312d32e2/pkg/types/validation/installconfig.go#L732