### PR TITLE
Bug 2081457: kubebuilder validation format hostname is not RFC compliant

### DIFF
--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -72,7 +72,7 @@ spec:
                       description: hostname is the hostname that should be used by
                         the route.
                       type: string
-                      format: hostname
+                      pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
                     name:
                       description: "name is the logical name of the route to customize.
                         \n The namespace and name of this componentRoute must match
@@ -239,14 +239,28 @@ spec:
                       type: array
                       minItems: 1
                       items:
-                        description: Hostname is an alias for hostname string validation.
+                        description: "Hostname is an alias for hostname string validation.
+                          \n The left operand of the | is the original kubebuilder
+                          hostname validation format, which is incorrect because it
+                          allows upper case letters, disallows hyphen or number in
+                          the TLD, and allows labels to start/end in non-alphanumeric
+                          characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256.
+                          ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$
+                          \n The right operand of the | is a new pattern that mimics
+                          the current API route admission validation on hostname,
+                          except that it allows hostnames longer than the maximum
+                          length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                          \n Both operand patterns are made available so that modifications
+                          on ingress spec can still happen after an invalid hostname
+                          was saved via validation by the incorrect left operand of
+                          the | operator."
                         type: string
-                        format: hostname
+                        pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
                     defaultHostname:
                       description: defaultHostname is the hostname of this route prior
                         to customization.
                       type: string
-                      format: hostname
+                      pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
                     name:
                       description: "name is the logical name of the route to customize.
                         It does not have to be the actual name of a route resource

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -63,7 +63,20 @@ type IngressSpec struct {
 type ConsumingUser string
 
 // Hostname is an alias for hostname string validation.
-// +kubebuilder:validation:Format=hostname
+//
+// The left operand of the | is the original kubebuilder hostname validation format, which is incorrect because it
+// allows upper case letters, disallows hyphen or number in the TLD, and allows labels to start/end in non-alphanumeric
+// characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256.
+// ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$
+//
+// The right operand of the | is a new pattern that mimics the current API route admission validation on hostname,
+// except that it allows hostnames longer than the maximum length:
+// ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+//
+// Both operand patterns are made available so that modifications on ingress spec can still happen after an invalid hostname
+// was saved via validation by the incorrect left operand of the | operator.
+//
+// +kubebuilder:validation:Pattern=`^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$`
 type Hostname string
 
 type IngressStatus struct {


### PR DESCRIPTION
Cherry-pick #1120 to [release-4.8]