### PR TITLE
WIP: [RFE-2181] To support transparent proxy configuration

### DIFF
--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -27,6 +27,11 @@ type Proxy struct {
 
 // ProxySpec contains cluster proxy creation configuration.
 type ProxySpec struct {
+	// proxyType identifies the configuration is explicitly mentioned in this spec or
+	// transparent proxy configured so that other parameters are ignored.
+	// This enables add additionalCABundle. If the proxyType is nil, default explicit type is considered.
+	ProxyType int32 `json:"proxyType,omitempty"`
+
 	// httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
 	// +optional
 	HTTPProxy string `json:"httpProxy,omitempty"`

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -8,6 +8,10 @@ import (
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+const (
+	ExplicitProxy = iota
+	TransparentProxy
+)
 // Proxy holds cluster-wide information on how to configure default proxies for the cluster. The canonical name is `cluster`
 //
 // Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -79,6 +79,11 @@ type ProxySpec struct {
 
 // ProxyStatus shows current known state of the cluster proxy.
 type ProxyStatus struct {
+	// proxyType identifies the configuration is explicitly mentioned in this spec or
+	// transparent proxy configured so that other parameters are ignored.
+	// This enables add additionalCABundle. If the proxyType is nil, default explicit type is considered.
+	ProxyType int32 `json:"proxyType,omitempty"`
+
 	// httpProxy is the URL of the proxy for HTTP requests.
 	// +optional
 	HTTPProxy string `json:"httpProxy,omitempty"`

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -9,8 +9,8 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 const (
-	ExplicitProxy = iota
-	TransparentProxy
+	ExplicitProxy string = "explicit"
+	TransparentProxy = "transparent"
 )
 // Proxy holds cluster-wide information on how to configure default proxies for the cluster. The canonical name is `cluster`
 //

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -34,7 +34,7 @@ type ProxySpec struct {
 	// proxyType identifies the configuration is explicitly mentioned in this spec or
 	// transparent proxy configured so that other parameters are ignored.
 	// This enables add additionalCABundle. If the proxyType is nil, default explicit type is considered.
-	ConfigType int32 `json:"configType,omitempty"`
+	ConfigType string `json:"configType,omitempty"`
 
 	// httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
 	// +optional
@@ -86,7 +86,7 @@ type ProxyStatus struct {
 	// proxyType identifies the configuration is explicitly mentioned in this spec or
 	// transparent proxy configured so that other parameters are ignored.
 	// This enables add additionalCABundle. If the proxyType is nil, default explicit type is considered.
-	ConfigType int32 `json:"configType,omitempty"`
+	ConfigType string `json:"configType,omitempty"`
 
 	// httpProxy is the URL of the proxy for HTTP requests.
 	// +optional

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -34,7 +34,7 @@ type ProxySpec struct {
 	// proxyType identifies the configuration is explicitly mentioned in this spec or
 	// transparent proxy configured so that other parameters are ignored.
 	// This enables add additionalCABundle. If the proxyType is nil, default explicit type is considered.
-	ProxyType int32 `json:"proxyType,omitempty"`
+	ConfigType int32 `json:"configType,omitempty"`
 
 	// httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
 	// +optional
@@ -86,7 +86,7 @@ type ProxyStatus struct {
 	// proxyType identifies the configuration is explicitly mentioned in this spec or
 	// transparent proxy configured so that other parameters are ignored.
 	// This enables add additionalCABundle. If the proxyType is nil, default explicit type is considered.
-	ProxyType int32 `json:"proxyType,omitempty"`
+	ConfigType int32 `json:"configType,omitempty"`
 
 	// httpProxy is the URL of the proxy for HTTP requests.
 	// +optional

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/api
+module github.com/TrilokGeer/api
 
 go 1.16
 


### PR DESCRIPTION
Added configType support during installation to signify transparent or explicit proxy configuration to enable user-ca-bundle configured with cluster proxy and determine configuration type for cluster-wide proxy.