### PR TITLE
BZ 2088533: add subresource.status{} to sharedsecrets and sharedconfigmaps

### DIFF
--- a/sharedresource/v1alpha1/0000_10_sharedconfigmap.crd.yaml
+++ b/sharedresource/v1alpha1/0000_10_sharedconfigmap.crd.yaml
@@ -103,3 +103,5 @@ spec:
                         type: string
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      subresources:
+        status: {}

--- a/sharedresource/v1alpha1/0000_10_sharedsecret.crd.yaml
+++ b/sharedresource/v1alpha1/0000_10_sharedsecret.crd.yaml
@@ -103,3 +103,5 @@ spec:
                         type: string
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      subresources:
+        status: {}


### PR DESCRIPTION
relevant slack in case someone needs to [read](https://coreos.slack.com/archives/C01CQA76KMX/p1652975216903949).