### PR TITLE
CFE-555: Add additional fields to configure DNS management on ingresscontrollers

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -217,6 +217,16 @@ spec:
                     description: loadBalancer holds parameters for the load balancer.
                       Present only if type is LoadBalancerService.
                     properties:
+                      dnsManagementPolicy:
+                        default: Managed
+                        description: 'dnsManagementPolicy indicates if the lifecyle
+                          of the wildcard DNS record associated with the load balancer
+                          service will be managed by the ingress operator. It defaults
+                          to Managed. Valid values are: Managed and Unmanaged.'
+                        enum:
+                        - Managed
+                        - Unmanaged
+                        type: string
                       providerParameters:
                         description: "providerParameters holds desired load balancer
                           information specific to the underlying infrastructure provider.
@@ -1464,6 +1474,16 @@ spec:
                     description: loadBalancer holds parameters for the load balancer.
                       Present only if type is LoadBalancerService.
                     properties:
+                      dnsManagementPolicy:
+                        default: Managed
+                        description: 'dnsManagementPolicy indicates if the lifecyle
+                          of the wildcard DNS record associated with the load balancer
+                          service will be managed by the ingress operator. It defaults
+                          to Managed. Valid values are: Managed and Unmanaged.'
+                        enum:
+                        - Managed
+                        - Unmanaged
+                        type: string
                       providerParameters:
                         description: "providerParameters holds desired load balancer
                           information specific to the underlying infrastructure provider.

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -384,7 +384,32 @@ type LoadBalancerStrategy struct {
 	//
 	// +optional
 	ProviderParameters *ProviderLoadBalancerParameters `json:"providerParameters,omitempty"`
+
+	// dnsManagementPolicy indicates if the lifecyle of the wildcard DNS record
+	// associated with the load balancer service will be managed by
+	// the ingress operator. It defaults to Managed.
+	// Valid values are: Managed and Unmanaged.
+	//
+	// +kubebuilder:default:="Managed"
+	// +kubebuilder:validation:Optional
+	// +optional
+	DNSManagementPolicy LoadBalancerDNSManagementPolicy `json:"dnsManagementPolicy"`
 }
+
+// LoadBalancerDNSManagementPolicy is a policy for configuring how
+// ingresscontrollers manage DNS.
+//
+// +kubebuilder:validation:Enum=Managed;Unmanaged
+type LoadBalancerDNSManagementPolicy string
+
+const (
+	// ManagedLoadBalancerDNS specifies that the operator manages
+	// a wildcard DNS record for the ingresscontroller.
+	ManagedLoadBalancerDNS LoadBalancerDNSManagementPolicy = "Managed"
+	// UnmanagedLoadBalancerDNS specifies that the operator does not manage
+	// any wildcard DNS record for the ingresscontroller.
+	UnmanagedLoadBalancerDNS LoadBalancerDNSManagementPolicy = "Unmanaged"
+)
 
 // ProviderLoadBalancerParameters holds desired load balancer information
 // specific to the underlying infrastructure provider.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -781,9 +781,10 @@ func (IngressControllerTuningOptions) SwaggerDoc() map[string]string {
 }
 
 var map_LoadBalancerStrategy = map[string]string{
-	"":                   "LoadBalancerStrategy holds parameters for a load balancer.",
-	"scope":              "scope indicates the scope at which the load balancer is exposed. Possible values are \"External\" and \"Internal\".",
-	"providerParameters": "providerParameters holds desired load balancer information specific to the underlying infrastructure provider.\n\nIf empty, defaults will be applied. See specific providerParameters fields for details about their defaults.",
+	"":                    "LoadBalancerStrategy holds parameters for a load balancer.",
+	"scope":               "scope indicates the scope at which the load balancer is exposed. Possible values are \"External\" and \"Internal\".",
+	"providerParameters":  "providerParameters holds desired load balancer information specific to the underlying infrastructure provider.\n\nIf empty, defaults will be applied. See specific providerParameters fields for details about their defaults.",
+	"dnsManagementPolicy": "dnsManagementPolicy indicates if the lifecyle of the wildcard DNS record associated with the load balancer service will be managed by the ingress operator. It defaults to Managed. Valid values are: Managed and Unmanaged.",
 }
 
 func (LoadBalancerStrategy) SwaggerDoc() map[string]string {

--- a/operatoringress/v1/0000_50_dns-record.yaml
+++ b/operatoringress/v1/0000_50_dns-record.yaml
@@ -23,7 +23,7 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
-          description: "DNSRecord is a DNS record managed in the zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. \n Cluster admin manipulation of this resource is not supported. This resource is only for internal communication of OpenShift operators. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          description: "DNSRecord is a DNS record managed in the zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone. \n Cluster admin manipulation of this resource is not supported. This resource is only for internal communication of OpenShift operators. \n If DNSManagementPolicy is \"Unmanaged\", the operator will not be responsible for managing the DNS records on the cloud provider. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
           type: object
           properties:
             apiVersion:
@@ -43,6 +43,13 @@ spec:
                 - recordType
                 - targets
               properties:
+                dnsManagementPolicy:
+                  description: "dnsManagementPolicy denotes the current policy applied on the DNS record. Records that have policy set as \"Unmanaged\" are ignored by the ingress operator.  This means that the DNS record on the cloud provider is not managed by the operator, and the \"Published\" status condition will be updated to \"Unknown\" status, since it is externally managed. Any existing record on the cloud provider can be deleted at the discretion of the cluster admin. \n This field defaults to Managed. Valid values are \"Managed\" and \"Unmanaged\"."
+                  type: string
+                  default: Managed
+                  enum:
+                    - Managed
+                    - Unmanaged
                 dnsName:
                   description: dnsName is the hostname of the DNS record
                   type: string
@@ -80,7 +87,7 @@ spec:
                     type: object
                     properties:
                       conditions:
-                        description: "conditions are any conditions associated with the record in the zone. \n If publishing the record fails, the \"Failed\" condition will be set with a reason and message describing the cause of the failure."
+                        description: "conditions are any conditions associated with the record in the zone. \n If publishing the record succeeds, the \"Published\" condition will be set with status \"True\" and upon failure it will be set to \"False\" along with the reason and message describing the cause of the failure."
                         type: array
                         items:
                           description: DNSZoneCondition is just the standard condition fields.

--- a/operatoringress/v1/zz_generated.swagger_doc_generated.go
+++ b/operatoringress/v1/zz_generated.swagger_doc_generated.go
@@ -12,7 +12,7 @@ package v1
 
 // AUTO-GENERATED FUNCTIONS START HERE
 var map_DNSRecord = map[string]string{
-	"":       "DNSRecord is a DNS record managed in the zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone.\n\nCluster admin manipulation of this resource is not supported. This resource is only for internal communication of OpenShift operators.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+	"":       "DNSRecord is a DNS record managed in the zones defined by dns.config.openshift.io/cluster .spec.publicZone and .spec.privateZone.\n\nCluster admin manipulation of this resource is not supported. This resource is only for internal communication of OpenShift operators.\n\nIf DNSManagementPolicy is \"Unmanaged\", the operator will not be responsible for managing the DNS records on the cloud provider.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
 	"spec":   "spec is the specification of the desired behavior of the dnsRecord.",
 	"status": "status is the most recently observed status of the dnsRecord.",
 }
@@ -30,11 +30,12 @@ func (DNSRecordList) SwaggerDoc() map[string]string {
 }
 
 var map_DNSRecordSpec = map[string]string{
-	"":           "DNSRecordSpec contains the details of a DNS record.",
-	"dnsName":    "dnsName is the hostname of the DNS record",
-	"targets":    "targets are record targets.",
-	"recordType": "recordType is the DNS record type. For example, \"A\" or \"CNAME\".",
-	"recordTTL":  "recordTTL is the record TTL in seconds. If zero, the default is 30. RecordTTL will not be used in AWS regions Alias targets, but will be used in CNAME targets, per AWS API contract.",
+	"":                    "DNSRecordSpec contains the details of a DNS record.",
+	"dnsName":             "dnsName is the hostname of the DNS record",
+	"targets":             "targets are record targets.",
+	"recordType":          "recordType is the DNS record type. For example, \"A\" or \"CNAME\".",
+	"recordTTL":           "recordTTL is the record TTL in seconds. If zero, the default is 30. RecordTTL will not be used in AWS regions Alias targets, but will be used in CNAME targets, per AWS API contract.",
+	"dnsManagementPolicy": "dnsManagementPolicy denotes the current policy applied on the DNS record. Records that have policy set as \"Unmanaged\" are ignored by the ingress operator.  This means that the DNS record on the cloud provider is not managed by the operator, and the \"Published\" status condition will be updated to \"Unknown\" status, since it is externally managed. Any existing record on the cloud provider can be deleted at the discretion of the cluster admin.\n\nThis field defaults to Managed. Valid values are \"Managed\" and \"Unmanaged\".",
 }
 
 func (DNSRecordSpec) SwaggerDoc() map[string]string {
@@ -62,7 +63,7 @@ func (DNSZoneCondition) SwaggerDoc() map[string]string {
 var map_DNSZoneStatus = map[string]string{
 	"":           "DNSZoneStatus is the status of a record within a specific zone.",
 	"dnsZone":    "dnsZone is the zone where the record is published.",
-	"conditions": "conditions are any conditions associated with the record in the zone.\n\nIf publishing the record fails, the \"Failed\" condition will be set with a reason and message describing the cause of the failure.",
+	"conditions": "conditions are any conditions associated with the record in the zone.\n\nIf publishing the record succeeds, the \"Published\" condition will be set with status \"True\" and upon failure it will be set to \"False\" along with the reason and message describing the cause of the failure.",
 }
 
 func (DNSZoneStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
 Add additional fields to configure DNS management on ingresscontrollers
 ---
 This PR, introduces 2 fields to the IngressController API,
 - `DNSManagementPolicy` of type `LoadBalancerDNSManagementPolicy` to the ingresscontroller spec. 
 - `DNSManagementPolicy` to the DNSRecord spec.
 
 
RFE: https://issues.redhat.com/browse/RFE-895
EP: https://github.com/openshift/enhancements/pull/1114