### PR TITLE
Drop IPv6DualStackNoUpgrade featureset

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -40,9 +40,6 @@ var (
 
 	// TopologyManager enables ToplogyManager support. Upgrades are enabled with this feature.
 	LatencySensitive FeatureSet = "LatencySensitive"
-
-	// IPv6DualStackNoUpgrade enables dual-stack. Turning this feature set on IS NOT SUPPORTED, CANNOT BE UNDONE, and PREVENTS UPGRADES.
-	IPv6DualStackNoUpgrade FeatureSet = "IPv6DualStackNoUpgrade"
 )
 
 type FeatureGateSpec struct {
@@ -124,11 +121,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	LatencySensitive: newDefaultFeatures().
 		with(
 			"TopologyManager", // sig-pod, sjenning
-		).
-		toFeatures(),
-	IPv6DualStackNoUpgrade: newDefaultFeatures().
-		with(
-			"IPv6DualStack", // sig-network, danwinship
 		).
 		toFeatures(),
 }


### PR DESCRIPTION
The FeatureSet has been unnecessary for several releases, but never got removed.

Note that there is no reason to keep it around for backward compatibility, because it blocks upgrades, so upgrading users cannot possibly have it defined. Right?