### PR TITLE
Add a field in ClusterCSIDriver type to skip creation of storageclass

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -57,6 +57,14 @@ spec:
           spec:
             description: spec holds user settable values for configuration
             properties:
+              disableStorageClass:
+                default: false
+                description: DisableStorageClass determines if creation of storageclass
+                  for this driver should be skipped. By default Openshift creates
+                  storageclass for every CSI driver it installs via CSI operator.
+                  Setting this value to true will skip automatic creation of storageclass
+                  for driver being installed. Defaults to false.
+                type: boolean
               logLevel:
                 default: Normal
                 description: "logLevel is an intent based logging for an overall component.

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -57,14 +57,6 @@ spec:
           spec:
             description: spec holds user settable values for configuration
             properties:
-              disableStorageClass:
-                default: false
-                description: DisableStorageClass determines if creation of storageclass
-                  for this driver should be skipped. By default Openshift creates
-                  storageclass for every CSI driver it installs via CSI operator.
-                  Setting this value to true will skip automatic creation of storageclass
-                  for driver being installed. Defaults to false.
-                type: boolean
               logLevel:
                 default: Normal
                 description: "logLevel is an intent based logging for an overall component.
@@ -104,6 +96,17 @@ spec:
                 - Debug
                 - Trace
                 - TraceAll
+                type: string
+              storageClassState:
+                default: nil
+                description: StorageClassState determines if CSI operator should create
+                  and sync storage classes. If this field value is nil or managed
+                  - CSI operator will continously reconcile storage class and create
+                  if necessary. If this field value is unmanaged - CSI operator will
+                  not reconcile any previously created storage class. If this field
+                  value is removed - CSI operator will delete the storage class it
+                  created previously. Defaults to nil
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
                 type: string
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that

--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -98,15 +98,20 @@ spec:
                 - TraceAll
                 type: string
               storageClassState:
-                default: nil
                 description: StorageClassState determines if CSI operator should create
-                  and sync storage classes. If this field value is nil or managed
-                  - CSI operator will continously reconcile storage class and create
-                  if necessary. If this field value is unmanaged - CSI operator will
+                  and manage storage classes. If this field value is empty or Managed
+                  - CSI operator will continuously reconcile storage class and create
+                  if necessary. If this field value is Unmanaged - CSI operator will
                   not reconcile any previously created storage class. If this field
-                  value is removed - CSI operator will delete the storage class it
-                  created previously. Defaults to nil
-                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                  value is Removed - CSI operator will delete the storage class it
+                  created previously. When omitted, this means the user has no opinion
+                  and the platform chooses a reasonable default, which is subject
+                  to change over time. The current default behaviour is Managed.
+                enum:
+                - ""
+                - Managed
+                - Unmanaged
+                - Removed
                 type: string
               unsupportedConfigOverrides:
                 description: 'unsupportedConfigOverrides holds a sparse config that

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -40,6 +40,29 @@ type ClusterCSIDriver struct {
 // CSIDriverName is the name of the CSI driver
 type CSIDriverName string
 
+// +kubebuilder:validation:Enum="";Managed;Unmanaged;Removed
+// StorageClassStateName defines various configuration states for storageclass management
+// and reconciliation by CSI operator.
+type StorageClassStateName string
+
+const (
+	// ManagedStorageClass means that the operator is actively managing its storage classes.
+	// Most manual changes made by cluster admin to storageclass will be wiped away by CSI
+	// operator if StorageClassState is set to Managed.
+	ManagedStorageClass StorageClassStateName = "Managed"
+	// UnmanagedStorageClass means that the operator is not actively managing storage classes.
+	// If StorageClassState is Unmanaged then CSI operator will not be actively reconciling storage class
+	// it previously created. This can be useful if cluster admin wants to modify storage class installed
+	// by CSI operator.
+	UnmanagedStorageClass StorageClassStateName = "Unmanaged"
+	// RemovedStorageClass instructs the operator to remove the storage class.
+	// If StorageClassState is Removed - CSI operator will delete storage classes it created
+	// previously. This can be useful in clusters where cluster admins want to prevent
+	// creation of dynamically provisioned volumes but still need rest of the features
+	// provided by CSI operator and driver.
+	RemovedStorageClass StorageClassStateName = "Removed"
+)
+
 // If you are adding a new driver name here, ensure that 0000_90_cluster_csi_driver_01_config.crd.yaml-merge-patch file is also updated with new driver name.
 const (
 	AWSEBSCSIDriver          CSIDriverName = "ebs.csi.aws.com"
@@ -61,16 +84,17 @@ const (
 // ClusterCSIDriverSpec is the desired behavior of CSI driver operator
 type ClusterCSIDriverSpec struct {
 	OperatorSpec `json:",inline"`
-	// StorageClassState determines if CSI operator should create and sync storage classes.
-	// If this field value is nil or managed - CSI operator will continously reconcile
+	// StorageClassState determines if CSI operator should create and manage storage classes.
+	// If this field value is empty or Managed - CSI operator will continuously reconcile
 	// storage class and create if necessary.
-	// If this field value is unmanaged - CSI operator will not reconcile any previously created
+	// If this field value is Unmanaged - CSI operator will not reconcile any previously created
 	// storage class.
-	// If this field value is removed - CSI operator will delete the storage class it created previously.
-	// Defaults to nil
+	// If this field value is Removed - CSI operator will delete the storage class it created previously.
+	// When omitted, this means the user has no opinion and the platform chooses a reasonable default,
+	// which is subject to change over time.
+	// The current default behaviour is Managed.
 	// +optional
-	// +kubebuilder:default=nil
-	StorageClassState *ManagementState `json:"storageClassState,omitempty"`
+	StorageClassState StorageClassStateName `json:"storageClassState,omitempty"`
 }
 
 // ClusterCSIDriverStatus is the observed status of CSI driver operator

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -61,13 +61,16 @@ const (
 // ClusterCSIDriverSpec is the desired behavior of CSI driver operator
 type ClusterCSIDriverSpec struct {
 	OperatorSpec `json:",inline"`
-	// DisableStorageClass determines if creation of storageclass for this driver
-	// should be skipped. By default Openshift creates storageclass for every CSI
-	// driver it installs via CSI operator. Setting this value to true will skip
-	// automatic creation of storageclass for driver being installed.
-	// Defaults to false.
-	// +kubebuilder:default=false
-	DisableStorageClass bool `json:"disableStorageClass,omitempty"`
+	// StorageClassState determines if CSI operator should create and sync storage classes.
+	// If this field value is nil or managed - CSI operator will continously reconcile
+	// storage class and create if necessary.
+	// If this field value is unmanaged - CSI operator will not reconcile any previously created
+	// storage class.
+	// If this field value is removed - CSI operator will delete the storage class it created previously.
+	// Defaults to nil
+	// +optional
+	// +kubebuilder:default=nil
+	StorageClassState *ManagementState `json:"storageClassState,omitempty"`
 }
 
 // ClusterCSIDriverStatus is the observed status of CSI driver operator

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -61,6 +61,13 @@ const (
 // ClusterCSIDriverSpec is the desired behavior of CSI driver operator
 type ClusterCSIDriverSpec struct {
 	OperatorSpec `json:",inline"`
+	// DisableStorageClass determines if creation of storageclass for this driver
+	// should be skipped. By default Openshift creates storageclass for every CSI
+	// driver it installs via CSI operator. Setting this value to true will skip
+	// automatic creation of storageclass for driver being installed.
+	// Defaults to false.
+	// +kubebuilder:default=false
+	DisableStorageClass bool `json:"disableStorageClass,omitempty"`
 }
 
 // ClusterCSIDriverStatus is the observed status of CSI driver operator

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -344,7 +344,8 @@ func (ClusterCSIDriverList) SwaggerDoc() map[string]string {
 }
 
 var map_ClusterCSIDriverSpec = map[string]string{
-	"": "ClusterCSIDriverSpec is the desired behavior of CSI driver operator",
+	"":                    "ClusterCSIDriverSpec is the desired behavior of CSI driver operator",
+	"disableStorageClass": "DisableStorageClass determines if creation of storageclass for this driver should be skipped. By default Openshift creates storageclass for every CSI driver it installs via CSI operator. Setting this value to true will skip automatic creation of storageclass for driver being installed. Defaults to false.",
 }
 
 func (ClusterCSIDriverSpec) SwaggerDoc() map[string]string {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -345,7 +345,7 @@ func (ClusterCSIDriverList) SwaggerDoc() map[string]string {
 
 var map_ClusterCSIDriverSpec = map[string]string{
 	"":                  "ClusterCSIDriverSpec is the desired behavior of CSI driver operator",
-	"storageClassState": "StorageClassState determines if CSI operator should create and sync storage classes. If this field value is nil or managed - CSI operator will continously reconcile storage class and create if necessary. If this field value is unmanaged - CSI operator will not reconcile any previously created storage class. If this field value is removed - CSI operator will delete the storage class it created previously. Defaults to nil",
+	"storageClassState": "StorageClassState determines if CSI operator should create and manage storage classes. If this field value is empty or Managed - CSI operator will continuously reconcile storage class and create if necessary. If this field value is Unmanaged - CSI operator will not reconcile any previously created storage class. If this field value is Removed - CSI operator will delete the storage class it created previously. When omitted, this means the user has no opinion and the platform chooses a reasonable default, which is subject to change over time. The current default behaviour is Managed.",
 }
 
 func (ClusterCSIDriverSpec) SwaggerDoc() map[string]string {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -344,8 +344,8 @@ func (ClusterCSIDriverList) SwaggerDoc() map[string]string {
 }
 
 var map_ClusterCSIDriverSpec = map[string]string{
-	"":                    "ClusterCSIDriverSpec is the desired behavior of CSI driver operator",
-	"disableStorageClass": "DisableStorageClass determines if creation of storageclass for this driver should be skipped. By default Openshift creates storageclass for every CSI driver it installs via CSI operator. Setting this value to true will skip automatic creation of storageclass for driver being installed. Defaults to false.",
+	"":                  "ClusterCSIDriverSpec is the desired behavior of CSI driver operator",
+	"storageClassState": "StorageClassState determines if CSI operator should create and sync storage classes. If this field value is nil or managed - CSI operator will continously reconcile storage class and create if necessary. If this field value is unmanaged - CSI operator will not reconcile any previously created storage class. If this field value is removed - CSI operator will delete the storage class it created previously. Defaults to nil",
 }
 
 func (ClusterCSIDriverSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Add a field to skip creation of StorageClass for CSI driver.

xref https://github.com/openshift/enhancements/pull/1152


cc @openshift/storage 
