### PR TITLE
Bug 1894268: Allow users to specify ovnkube join subnet

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
@@ -396,6 +396,24 @@ spec:
                               messages, e.g. "kern". Default is "local0"
                             type: string
                         type: object
+                      v4InternalSubnet:
+                        description: v4InternalSubnet is a v4 subnet used internally
+                          by ovn-kubernetes in case the default one is being already
+                          used by something else. It must not overlap with any other
+                          subnet being used by OpenShift or by the node network. The
+                          size of the subnet must be larger than the number of nodes.
+                          The value cannot be changed after installation. Default
+                          is 100.64.0.0/16
+                        type: string
+                      v6InternalSubnet:
+                        description: v6InternalSubnet is a v6 subnet used internally
+                          by ovn-kubernetes in case the default one is being already
+                          used by something else. It must not overlap with any other
+                          subnet being used by OpenShift or by the node network. The
+                          size of the subnet must be larger than the number of nodes.
+                          The value cannot be changed after installation. Default
+                          is fd98::/48
+                        type: string
                     type: object
                   type:
                     description: type is the type of network All NetworkTypes are

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -411,6 +411,22 @@ type OVNKubernetesConfig struct {
 	// gatewayConfig holds the configuration for node gateway options.
 	// +optional
 	GatewayConfig *GatewayConfig `json:"gatewayConfig,omitempty"`
+	// v4InternalSubnet is a v4 subnet used internally by ovn-kubernetes in case the
+	// default one is being already used by something else. It must not overlap with
+	// any other subnet being used by OpenShift or by the node network. The size of the
+	// subnet must be larger than the number of nodes. The value cannot be changed
+	// after installation.
+	// Default is 100.64.0.0/16
+	// +optional
+	V4InternalSubnet string `json:"v4InternalSubnet,omitempty"`
+	// v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the
+	// default one is being already used by something else. It must not overlap with
+	// any other subnet being used by OpenShift or by the node network. The size of the
+	// subnet must be larger than the number of nodes. The value cannot be changed
+	// after installation.
+	// Default is fd98::/48
+	// +optional
+	V6InternalSubnet string `json:"v6InternalSubnet,omitempty"`
 }
 
 type HybridOverlayConfig struct {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1107,6 +1107,8 @@ var map_OVNKubernetesConfig = map[string]string{
 	"ipsecConfig":         "ipsecConfig enables and configures IPsec for pods on the pod network within the cluster.",
 	"policyAuditConfig":   "policyAuditConfig is the configuration for network policy audit events. If unset, reported defaults are used.",
 	"gatewayConfig":       "gatewayConfig holds the configuration for node gateway options.",
+	"v4InternalSubnet":    "v4InternalSubnet is a v4 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is 100.64.0.0/16",
+	"v6InternalSubnet":    "v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is fd98::/48",
 }
 
 func (OVNKubernetesConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Some users need to be able to specify the v4 and v6 join subnets
to use for ovn-k. In particular, they may be already using the
ones that ovn-k uses as default, and they need a way to be able to
specify a different set of subnets as join subnets. This commit
creates the config option for  the same. Eventually this will be
consumed by the CNO using rendered bootstrap data and passed to the
ovn-k daemonsets.

Signed-off-by: Peng Liu <pliu@redhat.com>