### PR TITLE
[IngressController] Add IBMLoadBalancerParameters

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -292,10 +292,27 @@ spec:
                                 - Local
                                 type: string
                             type: object
+                          ibm:
+                            description: "ibm provides configuration settings that
+                              are specific to IBM Cloud load balancers. \n If empty,
+                              defaults will be applied. See specific ibm fields for
+                              details about their defaults."
+                            properties:
+                              subnets:
+                                description: "subnets is the comma-separated list
+                                  of subnets that the load balancer is attached to.
+                                  \n It is used to specify one or more subnets in
+                                  one zone that the VPC load balancer deploys to.
+                                  Values can be specified as VPC subnet IDs, VPC subnet
+                                  names, or VPC subnet CIDRs. \n See \"service.kubernetes.io/ibm-load-balancer-cloud-provider-vpc-subnets\"
+                                  at https://cloud.ibm.com/docs/containers?topic=containers-vpc-lbaas"
+                                type: string
+                            type: object
                           type:
                             description: type is the underlying infrastructure provider
                               for the load balancer. Allowed values are "AWS", "Azure",
-                              "BareMetal", "GCP", "Nutanix", "OpenStack", and "VSphere".
+                              "BareMetal", "GCP", "IBM", "Nutanix", "OpenStack", and
+                              "VSphere".
                             enum:
                             - AWS
                             - Azure
@@ -1515,10 +1532,27 @@ spec:
                                 - Local
                                 type: string
                             type: object
+                          ibm:
+                            description: "ibm provides configuration settings that
+                              are specific to IBM Cloud load balancers. \n If empty,
+                              defaults will be applied. See specific ibm fields for
+                              details about their defaults."
+                            properties:
+                              subnets:
+                                description: "subnets is the comma-separated list
+                                  of subnets that the load balancer is attached to.
+                                  \n It is used to specify one or more subnets in
+                                  one zone that the VPC load balancer deploys to.
+                                  Values can be specified as VPC subnet IDs, VPC subnet
+                                  names, or VPC subnet CIDRs. \n See \"service.kubernetes.io/ibm-load-balancer-cloud-provider-vpc-subnets\"
+                                  at https://cloud.ibm.com/docs/containers?topic=containers-vpc-lbaas"
+                                type: string
+                            type: object
                           type:
                             description: type is the underlying infrastructure provider
                               for the load balancer. Allowed values are "AWS", "Azure",
-                              "BareMetal", "GCP", "Nutanix", "OpenStack", and "VSphere".
+                              "BareMetal", "GCP", "IBM", "Nutanix", "OpenStack", and
+                              "VSphere".
                             enum:
                             - AWS
                             - Azure

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -391,7 +391,7 @@ type LoadBalancerStrategy struct {
 // +union
 type ProviderLoadBalancerParameters struct {
 	// type is the underlying infrastructure provider for the load balancer.
-	// Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Nutanix",
+	// Allowed values are "AWS", "Azure", "BareMetal", "GCP", "IBM", "Nutanix",
 	// "OpenStack", and "VSphere".
 	//
 	// +unionDiscriminator
@@ -416,10 +416,19 @@ type ProviderLoadBalancerParameters struct {
 	//
 	// +optional
 	GCP *GCPLoadBalancerParameters `json:"gcp,omitempty"`
+
+	// ibm provides configuration settings that are specific to IBM Cloud
+	// load balancers.
+	//
+	// If empty, defaults will be applied. See specific ibm fields for
+	// details about their defaults.
+	//
+	// +optional
+	IBM *IBMLoadBalancerParameters `json:"ibm,omitempty"`
 }
 
 // LoadBalancerProviderType is the underlying infrastructure provider for the
-// load balancer. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Nutanix",
+// load balancer. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "IBM", "Nutanix",
 // "OpenStack", and "VSphere".
 //
 // +kubebuilder:validation:Enum=AWS;Azure;BareMetal;GCP;Nutanix;OpenStack;VSphere;IBM
@@ -515,6 +524,21 @@ const (
 	GCPGlobalAccess GCPClientAccess = "Global"
 	GCPLocalAccess  GCPClientAccess = "Local"
 )
+
+// IBMLoadBalancerParameters provides configuration settings that are
+// specific to IBM Cloud load balancers.
+type IBMLoadBalancerParameters struct {
+	// subnets is the comma-separated list of subnets that the load balancer is attached to.
+	//
+	// It is used to specify one or more subnets in one zone that the VPC load balancer deploys to.
+	// Values can be specified as VPC subnet IDs, VPC subnet names, or VPC subnet CIDRs.
+	//
+	// See "service.kubernetes.io/ibm-load-balancer-cloud-provider-vpc-subnets" at
+	// https://cloud.ibm.com/docs/containers?topic=containers-vpc-lbaas
+	//
+	// +optional
+	Subnets string `json:"subnets,omitempty"`
+}
 
 // AWSClassicLoadBalancerParameters holds configuration parameters for an
 // AWS Classic load balancer.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -630,6 +630,15 @@ func (HostNetworkStrategy) SwaggerDoc() map[string]string {
 	return map_HostNetworkStrategy
 }
 
+var map_IBMLoadBalancerParameters = map[string]string{
+	"":        "IBMLoadBalancerParameters provides configuration settings that are specific to IBM Cloud load balancers.",
+	"subnets": "subnets is the comma-separated list of subnets that the load balancer is attached to.\n\nIt is used to specify one or more subnets in one zone that the VPC load balancer deploys to. Values can be specified as VPC subnet IDs, VPC subnet names, or VPC subnet CIDRs.\n\nSee \"service.kubernetes.io/ibm-load-balancer-cloud-provider-vpc-subnets\" at https://cloud.ibm.com/docs/containers?topic=containers-vpc-lbaas",
+}
+
+func (IBMLoadBalancerParameters) SwaggerDoc() map[string]string {
+	return map_IBMLoadBalancerParameters
+}
+
 var map_IngressController = map[string]string{
 	"":       "IngressController describes a managed ingress controller for the cluster. The controller can service OpenShift Route and Kubernetes Ingress resources.\n\nWhen an IngressController is created, a new ingress controller deployment is created to allow external traffic to reach the services that expose Ingress or Route resources. Updating this resource may lead to disruption for public facing network connections as a new ingress controller revision may be rolled out.\n\nhttps://kubernetes.io/docs/concepts/services-networking/ingress-controllers\n\nWhenever possible, sensible defaults for the platform are used. See each field for more details.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
 	"spec":   "spec is the specification of the desired behavior of the IngressController.",
@@ -829,9 +838,10 @@ func (PrivateStrategy) SwaggerDoc() map[string]string {
 
 var map_ProviderLoadBalancerParameters = map[string]string{
 	"":     "ProviderLoadBalancerParameters holds desired load balancer information specific to the underlying infrastructure provider.",
-	"type": "type is the underlying infrastructure provider for the load balancer. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Nutanix\", \"OpenStack\", and \"VSphere\".",
+	"type": "type is the underlying infrastructure provider for the load balancer. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"IBM\", \"Nutanix\", \"OpenStack\", and \"VSphere\".",
 	"aws":  "aws provides configuration settings that are specific to AWS load balancers.\n\nIf empty, defaults will be applied. See specific aws fields for details about their defaults.",
 	"gcp":  "gcp provides configuration settings that are specific to GCP load balancers.\n\nIf empty, defaults will be applied. See specific gcp fields for details about their defaults.",
+	"ibm":  "ibm provides configuration settings that are specific to IBM Cloud load balancers.\n\nIf empty, defaults will be applied. See specific ibm fields for details about their defaults.",
 }
 
 func (ProviderLoadBalancerParameters) SwaggerDoc() map[string]string {


### PR DESCRIPTION
What:
1. Add IBMLoadBalancerParameters on the same model as existing AWS and GCP LoadBalancerParameters.
2. Add IBMLoadBalancerParameters .Subnets field which will be used by the ingress controller operator to add support for narrowing down the subnets the ingress LB service is attached to . This directly match the "service.kubernetes.io/ibm-load-balancer-cloud-provider-vpc-subnets" described at https://cloud.ibm.com/docs/containers?topic=containers-vpc-lbaas