### PR TITLE
Add basic authentication configuration support for Project Helm repositories

### DIFF
--- a/helm/v1beta1/0000_10-project-helm-chart-repository.crd.yaml
+++ b/helm/v1beta1/0000_10-project-helm-chart-repository.crd.yaml
@@ -44,8 +44,17 @@ spec:
                   description: Required configuration for connecting to the chart repo
                   type: object
                   properties:
+                    basicAuthConfig:
+                      description: basicAuthConfig is an optional reference to a secret by name that contains the basic authentication credentials to present when connecting to the server. The key "username" is used locate the username. The key "password" is used to locate the password. The namespace for this secret must be same as the namespace where the project helm chart repository is getting instantiated.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced secret
+                          type: string
                     ca:
-                      description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca-bundle.crt" is used to locate the data. If empty, the default system roots are used. The namespace for this configmap should be same as the namespace where the project helm chart repository is getting instantiated.
+                      description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca-bundle.crt" is used to locate the data. If empty, the default system roots are used. The namespace for this configmap must be same as the namespace where the project helm chart repository is getting instantiated.
                       type: object
                       required:
                         - name
@@ -54,7 +63,7 @@ spec:
                           description: name is the metadata.name of the referenced config map
                           type: string
                     tlsClientConfig:
-                      description: tlsClientConfig is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate and private key to present when connecting to the server. The key "tls.crt" is used to locate the client certificate. The key "tls.key" is used to locate the private key. The namespace for this secret should be same as the namespace where the project helm chart repository is getting instantiated.
+                      description: tlsClientConfig is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate and private key to present when connecting to the server. The key "tls.crt" is used to locate the client certificate. The key "tls.key" is used to locate the private key. The namespace for this secret must be same as the namespace where the project helm chart repository is getting instantiated.
                       type: object
                       required:
                         - name

--- a/helm/v1beta1/types_project_helm_chart_repository.go
+++ b/helm/v1beta1/types_project_helm_chart_repository.go
@@ -61,7 +61,7 @@ type ConnectionConfigNamespaceScoped struct {
 	// It is used as a trust anchor to validate the TLS certificate presented by the remote server.
 	// The key "ca-bundle.crt" is used to locate the data.
 	// If empty, the default system roots are used.
-	// The namespace for this configmap should be same as the namespace where the project helm chart repository is getting instantiated.
+	// The namespace for this configmap must be same as the namespace where the project helm chart repository is getting instantiated.
 	// +optional
 	CA configv1.ConfigMapNameReference `json:"ca,omitempty"`
 
@@ -69,9 +69,17 @@ type ConnectionConfigNamespaceScoped struct {
 	// PEM-encoded TLS client certificate and private key to present when connecting to the server.
 	// The key "tls.crt" is used to locate the client certificate.
 	// The key "tls.key" is used to locate the private key.
-	// The namespace for this secret should be same as the namespace where the project helm chart repository is getting instantiated.
+	// The namespace for this secret must be same as the namespace where the project helm chart repository is getting instantiated.
 	// +optional
 	TLSClientConfig configv1.SecretNameReference `json:"tlsClientConfig,omitempty"`
+
+	// basicAuthConfig is an optional reference to a secret by name that contains
+	// the basic authentication credentials to present when connecting to the server.
+	// The key "username" is used locate the username.
+	// The key "password" is used to locate the password.
+	// The namespace for this secret must be same as the namespace where the project helm chart repository is getting instantiated.
+	// +optional
+	BasicAuthConfig configv1.SecretNameReference `json:"basicAuthConfig,omitempty"`
 }
 
 // Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).

--- a/helm/v1beta1/zz_generated.deepcopy.go
+++ b/helm/v1beta1/zz_generated.deepcopy.go
@@ -33,6 +33,7 @@ func (in *ConnectionConfigNamespaceScoped) DeepCopyInto(out *ConnectionConfigNam
 	*out = *in
 	out.CA = in.CA
 	out.TLSClientConfig = in.TLSClientConfig
+	out.BasicAuthConfig = in.BasicAuthConfig
 	return
 }
 


### PR DESCRIPTION
This change introduces the `BasicAuthConfig` field in the `ConnectionConfigNamespaceScoped` struct; this struct is a reference to a secret within a namespace containing the `username` and `password` fields to be used when connecting to a Helm chart repository such as ChartMuseum.

This is a dependency for https://github.com/openshift/console/pull/11782, which configures the connection utilizing the `username` and `password` fields mentioned above.