### PR TITLE
config/v1/types_cluster_version: Add architecture field

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -80,6 +80,15 @@ spec:
                 clusterID:
                   description: clusterID uniquely identifies this cluster. This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values). This is a required field.
                   type: string
+                desiredArchitecture:
+                  description: desiredArchitecture is an optional field that indicates the desired value of the cluster architecture. Setting this value will trigger an upgrade if the value does not match the current cluster architecture.
+                  type: string
+                  enum:
+                    - multi
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
                 desiredUpdate:
                   description: "desiredUpdate is an optional field that indicates the desired value of the cluster version. Setting this value will trigger an upgrade (if the current version does not match the desired version). The set of recommended update values is listed as part of available updates in status, and setting values outside that range may cause the upgrade to fail. You may specify the version field without setting image if an update exists with that version in the availableUpdates or history. \n If an upgrade fails the operator will halt and report status about the failing component. Setting the desired update value back to the previous version will cause a rollback to be attempted. Not all rollbacks will succeed."
                   type: object
@@ -133,6 +142,15 @@ spec:
                 - observedGeneration
                 - versionHash
               properties:
+                architecture:
+                  description: architecture identifies the architecture of the cluster nodes. If the cluster architecture is heterogeneous, whereby the cluster has nodes running on different architectures, "multi" is used.
+                  type: string
+                  enum:
+                    - multi
+                    - amd64
+                    - arm64
+                    - ppc64le
+                    - s390x
                 availableUpdates:
                   description: availableUpdates contains updates recommended for this cluster. Updates which appear in conditionalUpdates but not in availableUpdates may expose this cluster to known issues. This list may be empty if no updates are recommended, if the update service is unavailable, or if an invalid channel has been specified.
                   type: array

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -56,6 +56,13 @@ type ClusterVersionSpec struct {
 	// +optional
 	DesiredUpdate *Update `json:"desiredUpdate,omitempty"`
 
+	// desiredArchitecture is an optional field that indicates the desired
+	// value of the cluster architecture. Setting this value will trigger
+	// an upgrade if the value does not match the current cluster
+	// architecture.
+	// +optional
+	DesiredArchitecture ClusterVersionArchitecture `json:"desiredArchitecture,omitempty"`
+
 	// upstream may be used to specify the preferred update server. By default
 	// it will use the appropriate update server for the cluster and region.
 	//
@@ -81,11 +88,11 @@ type ClusterVersionSpec struct {
 	Overrides []ComponentOverride `json:"overrides,omitempty"`
 }
 
-// ClusterVersionStatus reports the status of the cluster versioning,
-// including any upgrades that are in progress. The current field will
-// be set to whichever version the cluster is reconciling to, and the
-// conditions array will report whether the update succeeded, is in
-// progress, or is failing.
+// ClusterVersionStatus reports the cluster architecture and the status
+// of the cluster versioning, including any upgrades that are in progress.
+// The current field will be set to whichever version the cluster is
+// reconciling to, and the conditions array will report whether the update
+// succeeded, is in progress, or is failing.
 // +k8s:deepcopy-gen=true
 type ClusterVersionStatus struct {
 	// desired is the version that the cluster is reconciling towards.
@@ -94,6 +101,12 @@ type ClusterVersionStatus struct {
 	// +kubebuilder:validation:Required
 	// +required
 	Desired Release `json:"desired"`
+
+	// architecture identifies the architecture of the cluster nodes. If
+	// the cluster architecture is heterogeneous, whereby the cluster
+	// has nodes running on different architectures, "multi" is used.
+	// +optional
+	Architecture ClusterVersionArchitecture `json:"architecture,omitempty"`
 
 	// history contains a list of the most recent versions applied to the cluster.
 	// This value may be empty during cluster startup, and then will be updated
@@ -223,6 +236,33 @@ type UpdateHistory struct {
 
 // ClusterID is string RFC4122 uuid.
 type ClusterID string
+
+// ClusterVersionArchitecture enumerates valid cluster architectures.
+// +kubebuilder:validation:Enum=multi;amd64;arm64;ppc64le;s390x
+type ClusterVersionArchitecture string
+
+const (
+	// ClusterVersionArchitectureMulti identifies a heterogeneous architecture.
+	// A heterogeneous cluster is a cluster with nodes running on different
+	// architectures.
+	ClusterVersionArchitectureMulti ClusterVersionArchitecture = "multi"
+
+	// ClusterVersionArchitectureAmd64 identifies a cluster with nodes
+	// running on the amd64 architecture.
+	ClusterVersionArchitectureAmd64 ClusterVersionArchitecture = "amd64"
+
+	// ClusterVersionArchitectureArm64 identifies a cluster with nodes
+	// running on the arm64 architecture.
+	ClusterVersionArchitectureArm64 ClusterVersionArchitecture = "arm64"
+
+	// ClusterVersionArchitecturePpc64le identifies a cluster with nodes
+	// running on the ppc64le architecture.
+	ClusterVersionArchitecturePpc64le ClusterVersionArchitecture = "ppc64le"
+
+	// ClusterVersionArchitectureS390x identifies a cluster with nodes
+	// running on the s390x architecture.
+	ClusterVersionArchitectureS390x ClusterVersionArchitecture = "s390x"
+)
 
 // ClusterVersionCapability enumerates optional, core cluster components.
 // +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -577,13 +577,14 @@ func (ClusterVersionList) SwaggerDoc() map[string]string {
 }
 
 var map_ClusterVersionSpec = map[string]string{
-	"":              "ClusterVersionSpec is the desired version state of the cluster. It includes the version the cluster should be at, how the cluster is identified, and where the cluster should look for version updates.",
-	"clusterID":     "clusterID uniquely identifies this cluster. This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values). This is a required field.",
-	"desiredUpdate": "desiredUpdate is an optional field that indicates the desired value of the cluster version. Setting this value will trigger an upgrade (if the current version does not match the desired version). The set of recommended update values is listed as part of available updates in status, and setting values outside that range may cause the upgrade to fail. You may specify the version field without setting image if an update exists with that version in the availableUpdates or history.\n\nIf an upgrade fails the operator will halt and report status about the failing component. Setting the desired update value back to the previous version will cause a rollback to be attempted. Not all rollbacks will succeed.",
-	"upstream":      "upstream may be used to specify the preferred update server. By default it will use the appropriate update server for the cluster and region.",
-	"channel":       "channel is an identifier for explicitly requesting that a non-default set of updates be applied to this cluster. The default channel will be contain stable updates that are appropriate for production clusters.",
-	"capabilities":  "capabilities configures the installation of optional, core cluster components.  A null value here is identical to an empty object; see the child properties for default semantics.",
-	"overrides":     "overrides is list of overides for components that are managed by cluster version operator. Marking a component unmanaged will prevent the operator from creating or updating the object.",
+	"":                    "ClusterVersionSpec is the desired version state of the cluster. It includes the version the cluster should be at, how the cluster is identified, and where the cluster should look for version updates.",
+	"clusterID":           "clusterID uniquely identifies this cluster. This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values). This is a required field.",
+	"desiredUpdate":       "desiredUpdate is an optional field that indicates the desired value of the cluster version. Setting this value will trigger an upgrade (if the current version does not match the desired version). The set of recommended update values is listed as part of available updates in status, and setting values outside that range may cause the upgrade to fail. You may specify the version field without setting image if an update exists with that version in the availableUpdates or history.\n\nIf an upgrade fails the operator will halt and report status about the failing component. Setting the desired update value back to the previous version will cause a rollback to be attempted. Not all rollbacks will succeed.",
+	"desiredArchitecture": "desiredArchitecture is an optional field that indicates the desired value of the cluster architecture. Setting this value will trigger an upgrade if the value does not match the current cluster architecture.",
+	"upstream":            "upstream may be used to specify the preferred update server. By default it will use the appropriate update server for the cluster and region.",
+	"channel":             "channel is an identifier for explicitly requesting that a non-default set of updates be applied to this cluster. The default channel will be contain stable updates that are appropriate for production clusters.",
+	"capabilities":        "capabilities configures the installation of optional, core cluster components.  A null value here is identical to an empty object; see the child properties for default semantics.",
+	"overrides":           "overrides is list of overides for components that are managed by cluster version operator. Marking a component unmanaged will prevent the operator from creating or updating the object.",
 }
 
 func (ClusterVersionSpec) SwaggerDoc() map[string]string {
@@ -591,8 +592,9 @@ func (ClusterVersionSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ClusterVersionStatus = map[string]string{
-	"":                   "ClusterVersionStatus reports the status of the cluster versioning, including any upgrades that are in progress. The current field will be set to whichever version the cluster is reconciling to, and the conditions array will report whether the update succeeded, is in progress, or is failing.",
+	"":                   "ClusterVersionStatus reports the cluster architecture and the status of the cluster versioning, including any upgrades that are in progress. The current field will be set to whichever version the cluster is reconciling to, and the conditions array will report whether the update succeeded, is in progress, or is failing.",
 	"desired":            "desired is the version that the cluster is reconciling towards. If the cluster is not yet fully initialized desired will be set with the information available, which may be an image or a tag.",
+	"architecture":       "architecture identifies the architecture of the cluster nodes. If the cluster architecture is heterogeneous, whereby the cluster has nodes running on different architectures, \"multi\" is used.",
 	"history":            "history contains a list of the most recent versions applied to the cluster. This value may be empty during cluster startup, and then will be updated when a new update is being applied. The newest update is first in the list and it is ordered by recency. Updates in the history have state Completed if the rollout completed - if an update was failing or halfway applied the state will be Partial. Only a limited amount of update history is preserved.",
 	"observedGeneration": "observedGeneration reports which version of the spec is being synced. If this value is not equal to metadata.generation, then the desired and conditions fields may represent a previous version.",
 	"versionHash":        "versionHash is a fingerprint of the content that the cluster will be updated with. It is used by the operator to avoid unnecessary work and is for internal use only.",


### PR DESCRIPTION
As described in [enhancement], add architecture fields to ClusterVersionSpec and to ClusterVersionStatus. The former indicates the desired architecture and the later indicates the current architecture. A cluster's architecture can be either homogeneous or heterogeneous. A single valid architecture value, e.g. "amd64", indicates an homogeneous cluster and "multi" indicates a heterogeneous cluster.

[enhancement]: https://github.com/openshift/enhancements/blob/836516786ce47bf74a8a3dfe8a2fa7f1143e94c9/enhancements/multi-arch/heterogeneous-architecture-clusters.md