### PR TITLE
Bug 2103680: Change the type of DisableNetworkDiagnostics to a pointer

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
@@ -415,7 +415,6 @@ spec:
                   defaults to 'false' and multiple network support is enabled.
                 type: boolean
               disableNetworkDiagnostics:
-                default: false
                 description: disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck
                   CRs from a test pod to every node, apiserver and LB should be disabled
                   or not. If unset, this property defaults to 'false' and network

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -89,8 +89,7 @@ type NetworkSpec struct {
 	// If unset, this property defaults to 'false' and network diagnostics is enabled.
 	// Setting this to 'true' would reduce the additional load of the pods performing the checks.
 	// +optional
-	// +kubebuilder:default:=false
-	DisableNetworkDiagnostics bool `json:"disableNetworkDiagnostics"`
+	DisableNetworkDiagnostics *bool `json:"disableNetworkDiagnostics,omitempty"`
 
 	// kubeProxyConfig lets us configure desired proxy configuration.
 	// If not specified, sensible defaults will be chosen by OpenShift directly.

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -2526,6 +2526,11 @@ func (in *NetworkSpec) DeepCopyInto(out *NetworkSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisableNetworkDiagnostics != nil {
+		in, out := &in.DisableNetworkDiagnostics, &out.DisableNetworkDiagnostics
+		*out = new(bool)
+		**out = **in
+	}
 	if in.KubeProxyConfig != nil {
 		in, out := &in.KubeProxyConfig, &out.KubeProxyConfig
 		*out = new(ProxyConfig)


### PR DESCRIPTION
Change the type of DisableNetworkDiagnostics to a pointer to allow for the variable to be unset.

Signed-off-by: Patryk Diak <pdiak@redhat.com>