### PR TITLE
Bug 2106086: operator/ingress: Fix healthCheckInterval pattern

### DIFF
--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -1253,7 +1253,7 @@ spec:
                       value is 5s. \n Currently the minimum allowed value is 1s and
                       the maximum allowed value is 2147483647ms (24.85 days).  Both
                       are subject to change over time."
-                    pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+$
+                    pattern: ^(0|([0-9]+(\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+)$
                     type: string
                   maxConnections:
                     description: "maxConnections defines the maximum number of simultaneous

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -1432,7 +1432,7 @@ type IngressControllerTuningOptions struct {
 	// 2147483647ms (24.85 days).  Both are subject to change over time.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Pattern=^0|([0-9]+(\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+$
+	// +kubebuilder:validation:Pattern=^(0|([0-9]+(\.[0-9]+)?(ns|us|µs|μs|ms|s|m|h))+)$
 	// +kubebuilder:validation:Type:=string
 	// +optional
 	HealthCheckInterval *metav1.Duration `json:"healthCheckInterval,omitempty"`


### PR DESCRIPTION
Reject values for `healthCheckInterval` such as "0abc".

* `operator/v1/types_ingress.go` (`IngressControllerTuningOptions`): Fix validation for `healthCheckInterval`.
* `operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml`: Regenerate.