### PR TITLE
Bug 2100312: monitoring: include lowercase action in relabel_config validation

### DIFF
--- a/monitoring/v1alpha1/0000_50_monitoring_02_alertrelabelconfigs.crd.yaml
+++ b/monitoring/v1alpha1/0000_50_monitoring_02_alertrelabelconfigs.crd.yaml
@@ -46,7 +46,7 @@ spec:
                     type: object
                     properties:
                       action:
-                        description: 'action to perform based on regex matching. Must be one of: replace, keep, drop, hashmod, labelmap, labeldrop, or labelkeep.  Default is: ''replace'''
+                        description: 'action to perform based on regex matching. Must be one of: Replace, Keep, Drop, HashMod, LabelMap, LabelDrop, or LabelKeep.  Default is: ''Replace'''
                         type: string
                         default: Replace
                         enum:
@@ -58,27 +58,27 @@ spec:
                           - LabelDrop
                           - LabelKeep
                       modulus:
-                        description: modulus to take of the hash of the source label values.  This can be combined with the 'hashmod' action to set 'target_label' to the 'modulus' of a hash of the concatenated 'source_labels'.
+                        description: modulus to take of the hash of the source label values.  This can be combined with the 'HashMod' action to set 'target_label' to the 'modulus' of a hash of the concatenated 'source_labels'.
                         type: integer
                         format: int64
                       regex:
                         description: 'regex against which the extracted value is matched. Default is: ''(.*)'''
                         type: string
                       replacement:
-                        description: 'replacement value against which a regex replace is performed if the regular expression matches. This is required if the action is ''replace'' or ''labelmap''. Regex capture groups are available. Default is: ''$1'''
+                        description: 'replacement value against which a regex replace is performed if the regular expression matches. This is required if the action is ''Replace'' or ''LabelMap''. Regex capture groups are available. Default is: ''$1'''
                         type: string
                       separator:
                         description: separator placed between concatenated source label values. When omitted, Prometheus will use its default value of ';'.
                         type: string
                       sourceLabels:
-                        description: sourceLabels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the replace, keep, and drop actions.
+                        description: sourceLabels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the Replace, Keep, and Drop actions.
                         type: array
                         items:
                           description: LabelName is a valid Prometheus label name which may only contain ASCII letters, numbers, and underscores.
                           type: string
                           pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                       targetLabel:
-                        description: targetLabel to which the resulting value is written in a replace action. It is mandatory for 'replace' and 'hashmod' actions. Regex capture groups are available.
+                        description: targetLabel to which the resulting value is written in a 'Replace' action. It is mandatory for 'Replace' and 'HashMod' actions. Regex capture groups are available.
                         type: string
             status:
               description: status describes the current state of this AlertRelabelConfig object.

--- a/monitoring/v1alpha1/types.go
+++ b/monitoring/v1alpha1/types.go
@@ -291,7 +291,7 @@ type LabelName string
 type RelabelConfig struct {
 	// sourceLabels select values from existing labels. Their content is
 	// concatenated using the configured separator and matched against the
-	// configured regular expression for the replace, keep, and drop actions.
+	// configured regular expression for the Replace, Keep, and Drop actions.
 	//
 	// +optional
 	SourceLabels []LabelName `json:"sourceLabels,omitempty"`
@@ -302,8 +302,8 @@ type RelabelConfig struct {
 	// +optional
 	Separator string `json:"separator,omitempty"`
 
-	// targetLabel to which the resulting value is written in a replace action.
-	// It is mandatory for 'replace' and 'hashmod' actions. Regex capture groups
+	// targetLabel to which the resulting value is written in a 'Replace' action.
+	// It is mandatory for 'Replace' and 'HashMod' actions. Regex capture groups
 	// are available.
 	//
 	// +optional
@@ -315,21 +315,21 @@ type RelabelConfig struct {
 	Regex string `json:"regex,omitempty"`
 
 	// modulus to take of the hash of the source label values.  This can be
-	// combined with the 'hashmod' action to set 'target_label' to the 'modulus'
+	// combined with the 'HashMod' action to set 'target_label' to the 'modulus'
 	// of a hash of the concatenated 'source_labels'.
 	//
 	// +optional
 	Modulus uint64 `json:"modulus,omitempty"`
 
 	// replacement value against which a regex replace is performed if the regular
-	// expression matches. This is required if the action is 'replace' or
-	// 'labelmap'. Regex capture groups are available. Default is: '$1'
+	// expression matches. This is required if the action is 'Replace' or
+	// 'LabelMap'. Regex capture groups are available. Default is: '$1'
 	//
 	// +optional
 	Replacement string `json:"replacement,omitempty"`
 
-	// action to perform based on regex matching. Must be one of: replace, keep,
-	// drop, hashmod, labelmap, labeldrop, or labelkeep.  Default is: 'replace'
+	// action to perform based on regex matching. Must be one of: Replace, Keep,
+	// Drop, HashMod, LabelMap, LabelDrop, or LabelKeep.  Default is: 'Replace'
 	//
 	// +kubebuilder:validation:Enum=Replace;Keep;Drop;HashMod;LabelMap;LabelDrop;LabelKeep
 	// +kubebuilder:default=Replace

--- a/monitoring/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/monitoring/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -97,13 +97,13 @@ func (PrometheusRuleRef) SwaggerDoc() map[string]string {
 
 var map_RelabelConfig = map[string]string{
 	"":             "RelabelConfig allows dynamic rewriting of label sets for alerts. See Prometheus documentation: - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config",
-	"sourceLabels": "sourceLabels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the replace, keep, and drop actions.",
+	"sourceLabels": "sourceLabels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the Replace, Keep, and Drop actions.",
 	"separator":    "separator placed between concatenated source label values. When omitted, Prometheus will use its default value of ';'.",
-	"targetLabel":  "targetLabel to which the resulting value is written in a replace action. It is mandatory for 'replace' and 'hashmod' actions. Regex capture groups are available.",
+	"targetLabel":  "targetLabel to which the resulting value is written in a 'Replace' action. It is mandatory for 'Replace' and 'HashMod' actions. Regex capture groups are available.",
 	"regex":        "regex against which the extracted value is matched. Default is: '(.*)'",
-	"modulus":      "modulus to take of the hash of the source label values.  This can be combined with the 'hashmod' action to set 'target_label' to the 'modulus' of a hash of the concatenated 'source_labels'.",
-	"replacement":  "replacement value against which a regex replace is performed if the regular expression matches. This is required if the action is 'replace' or 'labelmap'. Regex capture groups are available. Default is: '$1'",
-	"action":       "action to perform based on regex matching. Must be one of: replace, keep, drop, hashmod, labelmap, labeldrop, or labelkeep.  Default is: 'replace'",
+	"modulus":      "modulus to take of the hash of the source label values.  This can be combined with the 'HashMod' action to set 'target_label' to the 'modulus' of a hash of the concatenated 'source_labels'.",
+	"replacement":  "replacement value against which a regex replace is performed if the regular expression matches. This is required if the action is 'Replace' or 'LabelMap'. Regex capture groups are available. Default is: '$1'",
+	"action":       "action to perform based on regex matching. Must be one of: Replace, Keep, Drop, HashMod, LabelMap, LabelDrop, or LabelKeep.  Default is: 'Replace'",
 }
 
 func (RelabelConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
The action in alert relabel configs documents actions with starting with
a lowercase letter but the validation only passes capitalized actions.
The resulting prometheus yaml is always lowercase and controllers call
ToLower anyway. Accepting both lowercase actions and capitalied actions
is consistent with what prometheus-operator accepts.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>