### PR TITLE
route/v1: Add CRD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ $(call add-crd-gen,operatorcontrolplane,./operatorcontrolplane/v1alpha1,./operat
 $(call add-crd-gen,machine-beta,./machine/v1beta1,./machine/v1beta1,./machine/v1beta1)
 $(call add-crd-gen,machine,./machine/v1,./machine/v1,./machine/v1)
 $(call add-crd-gen,monitoring-alpha,./monitoring/v1alpha1,./monitoring/v1alpha1,./monitoring/v1alpha1)
+$(call add-crd-gen,route,./route/v1,./route/v1,./route/v1)
 
 RUNTIME ?= podman
 RUNTIME_IMAGE_NAME ?= openshift-api-generator

--- a/route/v1/generated.proto
+++ b/route/v1/generated.proto
@@ -132,7 +132,10 @@ message RouteSpec {
   // If not specified a route name will typically be automatically
   // chosen.
   // Must follow DNS952 subdomain conventions.
+  //
   // +optional
+  // +kubebuilder:validation:MaxLength=253
+  // +kubebuilder:validation:Pattern=`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`
   optional string host = 1;
 
   // subdomain is a DNS subdomain that is requested within the ingress controller's
@@ -149,9 +152,14 @@ message RouteSpec {
   // `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.
   //
   // +optional
+  // +kubebuilder:validation:MaxLength=253
+  // +kubebuilder:validation:Pattern=`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`
   optional string subdomain = 8;
 
   // path that the router watches for, to route traffic for to the service. Optional
+  //
+  // +optional
+  // +kubebuilder:validation:Pattern=`^/`
   optional string path = 2;
 
   // to is an object the route should use as the primary backend. Only the Service kind
@@ -162,6 +170,8 @@ message RouteSpec {
   // alternateBackends allows up to 3 additional backends to be assigned to the route.
   // Only the Service kind is allowed, and it will be defaulted to Service.
   // Use the weight field in RouteTargetReference object to specify relative preference.
+  //
+  // +kubebuilder:validation:MaxItems=3
   repeated RouteTargetReference alternateBackends = 4;
 
   // If specified, the port to be used by the router. Most routers will use all
@@ -174,6 +184,9 @@ message RouteSpec {
 
   // Wildcard policy if any for the route.
   // Currently only 'Subdomain' or 'None' is allowed.
+  //
+  // +kubebuilder:validation:Enum=None;Subdomain;""
+  // +kubebuilder:default=None
   optional string wildcardPolicy = 7;
 }
 
@@ -190,14 +203,22 @@ message RouteStatus {
 // kind is allowed. Use 'weight' field to emphasize one over others.
 message RouteTargetReference {
   // The kind of target that the route is referring to. Currently, only 'Service' is allowed
+  //
+  // +kubebuilder:validation:Enum=Service;""
+  // +kubebuilder:default=Service
   optional string kind = 1;
 
   // name of the service/target that is being referred to. e.g. name of the service
+  //
+  // +kubebuilder:validation:MinLength=1
   optional string name = 2;
 
   // weight as an integer between 0 and 256, default 100, that specifies the target's relative weight
   // against other target reference objects. 0 suppresses requests to this backend.
+  //
   // +optional
+  // +kubebuilder:validation:Minimum=0
+  // +kubebuilder:validation:Maximum=256
   optional int32 weight = 3;
 }
 
@@ -222,6 +243,8 @@ message TLSConfig {
   // * edge - TLS termination is done by the router and http is used to communicate with the backend (default)
   // * passthrough - Traffic is sent straight to the destination without the router providing TLS termination
   // * reencrypt - TLS termination is done by the router and https is used to communicate with the backend
+  //
+  // +kubebuilder:validation:Enum=edge;reencrypt;passthrough
   optional string termination = 1;
 
   // certificate provides certificate contents. This should be a single serving certificate, not a certificate

--- a/route/v1/route.crd.yaml
+++ b/route/v1/route.crd.yaml
@@ -1,0 +1,388 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1228
+  name: routes.route.openshift.io
+spec:
+  group: route.openshift.io
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.ingress[0].host
+      name: Host
+      type: string
+    - jsonPath: .status.ingress[0].conditions[?(@.type=="Admitted")].status
+      name: Admitted
+      type: string
+    - jsonPath: .spec.to.name
+      name: Service
+      type: string
+    - jsonPath: .spec.tls.type
+      name: TLS
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "A route allows developers to expose services through an HTTP(S)
+          aware load balancing and proxy layer via a public DNS entry. The route may
+          further specify TLS options and a certificate, or specify a public CNAME
+          that the router should also accept for HTTP and HTTPS traffic. An administrator
+          typically configures their router to be visible outside the cluster firewall,
+          and may also add additional security, caching, or traffic controls on the
+          service content. Routers usually talk directly to the service endpoints.
+          \n Once a route is created, the `host` field may not be changed. Generally,
+          routers use the oldest route with a given host when resolving conflicts.
+          \n Routers are subject to additional customization and may support additional
+          controls via the annotations field. \n Because administrators may configure
+          multiple routers, the route status field is used to return information to
+          clients about the names and states of the route under each router. If a
+          client chooses a duplicate name, for instance, the route status conditions
+          are used to indicate the route cannot be chosen. \n To enable HTTP/2 ALPN
+          on a route it requires a custom (non-wildcard) certificate. This prevents
+          connection coalescing by clients, notably web browsers. We do not support
+          HTTP/2 ALPN on routes that use the default certificate because of the risk
+          of connection re-use/coalescing. Routes that do not have their own custom
+          certificate will not be HTTP/2 ALPN-enabled on either the frontend or the
+          backend. \n Compatibility level 1: Stable within a major release for a minimum
+          of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            allOf:
+            - anyOf:
+              - properties:
+                  path:
+                    maxLength: 0
+              - not:
+                  properties:
+                    tls:
+                      properties:
+                        termination:
+                          enum:
+                          - passthrough
+            - anyOf:
+              - not:
+                  properties:
+                    host:
+                      maxLength: 0
+              - not:
+                  properties:
+                    wildcardPolicy:
+                      enum:
+                      - Subdomain
+            description: spec is the desired state of the route
+            properties:
+              alternateBackends:
+                description: alternateBackends allows up to 3 additional backends
+                  to be assigned to the route. Only the Service kind is allowed, and
+                  it will be defaulted to Service. Use the weight field in RouteTargetReference
+                  object to specify relative preference.
+                items:
+                  description: RouteTargetReference specifies the target that resolve
+                    into endpoints. Only the 'Service' kind is allowed. Use 'weight'
+                    field to emphasize one over others.
+                  properties:
+                    kind:
+                      default: Service
+                      description: The kind of target that the route is referring
+                        to. Currently, only 'Service' is allowed
+                      enum:
+                      - Service
+                      - ""
+                      type: string
+                    name:
+                      description: name of the service/target that is being referred
+                        to. e.g. name of the service
+                      minLength: 1
+                      type: string
+                    weight:
+                      description: weight as an integer between 0 and 256, default
+                        100, that specifies the target's relative weight against other
+                        target reference objects. 0 suppresses requests to this backend.
+                      format: int32
+                      maximum: 256
+                      minimum: 0
+                      type: integer
+                  required:
+                  - kind
+                  - name
+                  type: object
+                maxItems: 3
+                type: array
+              host:
+                description: host is an alias/DNS that points to the service. Optional.
+                  If not specified a route name will typically be automatically chosen.
+                  Must follow DNS952 subdomain conventions.
+                maxLength: 253
+                pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                type: string
+              path:
+                description: path that the router watches for, to route traffic for
+                  to the service. Optional
+                pattern: ^/
+                type: string
+              port:
+                description: If specified, the port to be used by the router. Most
+                  routers will use all endpoints exposed by the service by default
+                  - set this value to instruct routers which port to use.
+                properties:
+                  targetPort:
+                    allOf:
+                    - not:
+                        enum:
+                        - 0
+                    - not:
+                        enum:
+                        - ""
+                    x-kubernetes-int-or-string: true
+                required:
+                - targetPort
+                type: object
+              subdomain:
+                description: "subdomain is a DNS subdomain that is requested within
+                  the ingress controller's domain (as a subdomain). If host is set
+                  this field is ignored. An ingress controller may choose to ignore
+                  this suggested name, in which case the controller will report the
+                  assigned name in the status.ingress array or refuse to admit the
+                  route. If this value is set and the server does not support this
+                  field host will be populated automatically. Otherwise host is left
+                  empty. The field may have multiple parts separated by a dot, but
+                  not all ingress controllers may honor the request. This field may
+                  not be changed after creation except by a user with the update routes/custom-host
+                  permission. \n Example: subdomain `frontend` automatically receives
+                  the router subdomain `apps.mycluster.com` to have a full hostname
+                  `frontend.apps.mycluster.com`."
+                maxLength: 253
+                pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                type: string
+              tls:
+                allOf:
+                - anyOf:
+                  - properties:
+                      caCertificate:
+                        maxLength: 0
+                      certificate:
+                        maxLength: 0
+                      destinationCACertificate:
+                        maxLength: 0
+                      key:
+                        maxLength: 0
+                  - not:
+                      properties:
+                        termination:
+                          enum:
+                          - passthrough
+                - anyOf:
+                  - properties:
+                      destinationCACertificate:
+                        maxLength: 0
+                  - not:
+                      properties:
+                        termination:
+                          enum:
+                          - edge
+                - anyOf:
+                  - properties:
+                      insecureEdgeTerminationPolicy:
+                        enum:
+                        - ""
+                        - None
+                        - Allow
+                        - Redirect
+                  - not:
+                      properties:
+                        termination:
+                          enum:
+                          - edge
+                          - reencrypt
+                - anyOf:
+                  - properties:
+                      insecureEdgeTerminationPolicy:
+                        enum:
+                        - ""
+                        - None
+                        - Redirect
+                  - not:
+                      properties:
+                        termination:
+                          enum:
+                          - passthrough
+                description: The tls field provides the ability to configure certificates
+                  and termination for the route.
+                properties:
+                  caCertificate:
+                    description: caCertificate provides the cert authority certificate
+                      contents
+                    type: string
+                  certificate:
+                    description: certificate provides certificate contents. This should
+                      be a single serving certificate, not a certificate chain. Do
+                      not include a CA certificate.
+                    type: string
+                  destinationCACertificate:
+                    description: destinationCACertificate provides the contents of
+                      the ca certificate of the final destination.  When using reencrypt
+                      termination this file should be provided in order to have routers
+                      use it for health checks on the secure connection. If this field
+                      is not specified, the router may provide its own destination
+                      CA and perform hostname validation using the short service name
+                      (service.namespace.svc), which allows infrastructure generated
+                      certificates to automatically verify.
+                    type: string
+                  insecureEdgeTerminationPolicy:
+                    description: "insecureEdgeTerminationPolicy indicates the desired
+                      behavior for insecure connections to a route. While each router
+                      may make its own decisions on which ports to expose, this is
+                      normally port 80. \n * Allow - traffic is sent to the server
+                      on the insecure port (default) * Disable - no traffic is allowed
+                      on the insecure port. * Redirect - clients are redirected to
+                      the secure port."
+                    type: string
+                  key:
+                    description: key provides key file contents
+                    type: string
+                  termination:
+                    description: "termination indicates termination type. \n * edge
+                      - TLS termination is done by the router and http is used to
+                      communicate with the backend (default) * passthrough - Traffic
+                      is sent straight to the destination without the router providing
+                      TLS termination * reencrypt - TLS termination is done by the
+                      router and https is used to communicate with the backend"
+                    enum:
+                    - edge
+                    - reencrypt
+                    - passthrough
+                    type: string
+                required:
+                - termination
+                type: object
+              to:
+                description: to is an object the route should use as the primary backend.
+                  Only the Service kind is allowed, and it will be defaulted to Service.
+                  If the weight field (0-256 default 100) is set to zero, no traffic
+                  will be sent to this backend.
+                properties:
+                  kind:
+                    default: Service
+                    description: The kind of target that the route is referring to.
+                      Currently, only 'Service' is allowed
+                    enum:
+                    - Service
+                    - ""
+                    type: string
+                  name:
+                    description: name of the service/target that is being referred
+                      to. e.g. name of the service
+                    minLength: 1
+                    type: string
+                  weight:
+                    description: weight as an integer between 0 and 256, default 100,
+                      that specifies the target's relative weight against other target
+                      reference objects. 0 suppresses requests to this backend.
+                    format: int32
+                    maximum: 256
+                    minimum: 0
+                    type: integer
+                required:
+                - kind
+                - name
+                type: object
+              wildcardPolicy:
+                default: None
+                description: Wildcard policy if any for the route. Currently only
+                  'Subdomain' or 'None' is allowed.
+                enum:
+                - None
+                - Subdomain
+                - ""
+                type: string
+            required:
+            - to
+            type: object
+          status:
+            description: status is the current state of the route
+            properties:
+              ingress:
+                description: ingress describes the places where the route may be exposed.
+                  The list of ingress points may contain duplicate Host or RouterName
+                  values. Routes are considered live once they are `Ready`
+                items:
+                  description: RouteIngress holds information about the places where
+                    a route is exposed.
+                  properties:
+                    conditions:
+                      description: Conditions is the state of the route, may be empty.
+                      items:
+                        description: RouteIngressCondition contains details for the
+                          current condition of this route on a particular router.
+                        properties:
+                          lastTransitionTime:
+                            description: RFC 3339 date and time when this condition
+                              last transitioned
+                            format: date-time
+                            type: string
+                          message:
+                            description: Human readable message indicating details
+                              about last transition.
+                            type: string
+                          reason:
+                            description: (brief) reason for the condition's last transition,
+                              and is usually a machine and human readable constant
+                            type: string
+                          status:
+                            description: Status is the status of the condition. Can
+                              be True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the condition. Currently
+                              only Admitted.
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    host:
+                      description: Host is the host string under which the route is
+                        exposed; this value is required
+                      type: string
+                    routerCanonicalHostname:
+                      description: CanonicalHostname is the external host name for
+                        the router that can be used as a CNAME for the host requested
+                        for this route. This value is optional and may not be set
+                        in all cases.
+                      type: string
+                    routerName:
+                      description: Name is a name chosen by the router to identify
+                        itself; this value is required
+                      type: string
+                    wildcardPolicy:
+                      description: Wildcard policy is the wildcard policy that was
+                        allowed where this route is exposed.
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/route/v1/route.crd.yaml-patch
+++ b/route/v1/route.crd.yaml-patch
@@ -1,0 +1,83 @@
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/spec/allOf
+  value:
+  # spec.path must be empty when using passthrough TLS.
+  - anyOf:
+    - properties:
+        path:
+          maxLength: 0
+    - not:
+        properties:
+          tls:
+            properties:
+              termination:
+                enum: ["passthrough"]
+  # spec.host must be nonempty for a wildcard route.
+  - anyOf:
+    - not:
+        properties:
+          host:
+            maxLength: 0
+    - not:
+        properties:
+          wildcardPolicy:
+            enum: ["Subdomain"]
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/spec/properties/port/properties/targetPort
+  value:
+    # spec.port.targetPort cannot be the integer 0 or the empty string.  (Note
+    # that negative integer values are allowed, as is the string "0".)
+    allOf:
+    - not:
+        enum: [0]
+    - not:
+        enum: [""]
+    x-kubernetes-int-or-string: true
+- op: add
+  path: /spec/versions/name=v1/schema/openAPIV3Schema/properties/spec/properties/tls/allOf
+  value:
+  # spec.tls.certificate, spec.tls.key, spec.tls.caCertificate, and
+  # spec.tls.destinationCACertificate must omitted when using passthrough TLS.
+  - anyOf:
+    - properties:
+        certificate:
+          maxLength: 0
+        key:
+          maxLength: 0
+        caCertificate:
+          maxLength: 0
+        destinationCACertificate:
+          maxLength: 0
+    - not:
+        properties:
+          termination:
+            enum: ["passthrough"]
+  # spec.tls.destinationCACertificate must be omitted when using edge-terminated
+  # TLS.
+  - anyOf:
+    - properties:
+        destinationCACertificate:
+          maxLength: 0
+    - not:
+        properties:
+          termination:
+            enum: ["edge"]
+  # Any insecure edge-termination policy may be used if we terminate TLS.
+  - anyOf:
+    - properties:
+        insecureEdgeTerminationPolicy:
+          enum: ["", "None", "Allow", "Redirect"]
+    - not:
+        properties:
+          termination:
+            enum: ["edge","reencrypt"]
+  # Any insecure edge-termination policy *except* for "Allow" maybe used when
+  # using passthrough TLS.
+  - anyOf:
+    - properties:
+        insecureEdgeTerminationPolicy:
+          enum: ["", "None", "Redirect"]
+    - not:
+        properties:
+          termination:
+            enum: ["passthrough"]

--- a/route/v1/test-route-validation.sh
+++ b/route/v1/test-route-validation.sh
@@ -1,0 +1,443 @@
+#!/bin/bash
+
+# This shell script runs a series of `oc` commands to create various OpenShift
+# route objects, some invalid and some valid, and verifies that the API rejects
+# the invalid ones and admits the valid ones.  Note that this script does not
+# verify defaulting behavior and does not examine the rejection reason; it only
+# checks whether the `oc create` command succeeds or fails.  This script
+# requires a cluster and a kubeconfig in a location where oc will find it.
+
+set -uo pipefail
+
+expect_pass() {
+  rc=$?
+  if [[ $rc != 0 ]]
+  then
+    tput setaf 1
+    echo "expected success: $*, got exit code $rc"
+    tput sgr0
+    exit 1
+  fi
+  tput setaf 2
+  echo "got expected success: $*"
+  tput sgr0
+}
+
+expect_fail() {
+  rc=$?
+  if [[ $rc = 0 ]]
+  then
+    tput setaf 1
+    echo "expected failure: $*, got exit code $rc"
+    exit 1
+  fi
+  tput setaf 2
+  echo "got expected failure: $*"
+  tput sgr0
+}
+
+delete_route() {
+  oc -n openshift-ingress delete routes.route/testroute || exit 1
+}
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  path: /
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+    name: router-internal-default
+EOF
+expect_fail 'passthrough with nonempty path'
+
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  path: x
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: router-internal-default
+EOF
+expect_fail 'path starting with non-slash character'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  to:
+    kind: Service
+    name: router-internal-default
+  wildcardPolicy: Subdomain
+EOF
+expect_fail 'spec.wildcardPolicy: Subdomain requires a nonempty value for spec.host'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  port:
+    targetPort: ""
+EOF
+expect_fail 'cannot have empty spec.port.targetPort'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  port:
+    targetPort: 0
+EOF
+expect_fail 'cannot have numeric 0 value for spec.port.targetPort'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  port:
+    targetPort: "0" 
+EOF
+expect_pass 'can have string "0" value for spec.port.targetPort'
+delete_route
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  port:
+    targetPort: 1
+EOF
+expect_pass 'can have numeric 1 value for spec.port.targetPort'
+delete_route
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  port:
+    targetPort: x
+EOF
+expect_pass 'can have string "x" value for spec.port.targetPort'
+delete_route
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  tls:
+    termination: passthrough
+  to:
+    kind: Nonsense
+    name: router-internal-default
+EOF
+expect_fail 'nonsense value for spec.to.kind'
+
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+    name: ""
+EOF
+expect_fail 'spec.to.name cannot be empty'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+    weight: -1
+EOF
+expect_fail 'spec.to.weight cannot be negative'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+    weight: 300
+EOF
+expect_fail 'spec.to.weight cannot exceed 256'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+    weight: 100
+EOF
+expect_pass 'spec.to.weight has a valid value'
+delete_route
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  alternateBackends:
+  - name: router-internal-default
+  - name: router-internal-default
+  - name: router-internal-default
+  - name: router-internal-default
+EOF
+expect_fail 'cannot have >3 values under spec.alternateBackends'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  alternateBackends:
+  - name: router-internal-default
+  - name: ""
+  - name: router-internal-default
+EOF
+expect_fail 'cannot have empty spec.alternateBackends[*].name'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  alternateBackends:
+  - name: router-internal-default
+  - name: router-internal-default
+  - name: router-internal-default
+EOF
+expect_pass 'valid spec.alternateBackends'
+delete_route
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  tls:
+    termination: passthrough
+    certificate: "x"
+EOF
+expect_fail 'cannot have both spec.tls.termination: passthrough and nonempty spec.tls.certificate'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  tls:
+    termination: passthrough
+    key: "x"
+EOF
+expect_fail 'cannot have both spec.tls.termination: passthrough and nonempty spec.tls.key'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  tls:
+    termination: passthrough
+    caCertificate: "x"
+EOF
+expect_fail 'cannot have both spec.tls.termination: passthrough and nonempty spec.tls.caCertificate'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  tls:
+    termination: passthrough
+    destinationCACertificate: "x"
+EOF
+expect_fail 'cannot have both spec.tls.termination: passthrough and nonempty spec.tls.destinationCACertificate'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  tls:
+    termination: edge
+    destinationCACertificate: "x"
+EOF
+expect_fail 'cannot have both spec.tls.termination: edge and nonempty spec.tls.destinationCACertificate'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: nonsense
+EOF
+expect_fail 'cannot have nonsense value for spec.tls.insecureEdgeTerminationPolicy'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Allow
+EOF
+expect_fail 'cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow'
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+EOF
+expect_pass 'spec.tls.termination: passthrough is compatible with spec.tls.insecureEdgeTerminationPolicy: Redirect'
+delete_route
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  to:
+    name: router-internal-default
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: None
+EOF
+expect_pass 'spec.tls.termination: passthrough is compatible with spec.tls.insecureEdgeTerminationPolicy: None'
+delete_route

--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -8,6 +8,8 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // A route allows developers to expose services through an HTTP(S) aware load balancing and proxy
 // layer via a public DNS entry. The route may further specify TLS options and a certificate, or
@@ -82,7 +84,10 @@ type RouteSpec struct {
 	// If not specified a route name will typically be automatically
 	// chosen.
 	// Must follow DNS952 subdomain conventions.
+	//
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`
 	Host string `json:"host,omitempty" protobuf:"bytes,1,opt,name=host"`
 	// subdomain is a DNS subdomain that is requested within the ingress controller's
 	// domain (as a subdomain). If host is set this field is ignored. An ingress
@@ -98,9 +103,14 @@ type RouteSpec struct {
 	// `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`
 	Subdomain string `json:"subdomain,omitempty" protobuf:"bytes,8,opt,name=subdomain"`
 
 	// path that the router watches for, to route traffic for to the service. Optional
+	//
+	// +optional
+	// +kubebuilder:validation:Pattern=`^/`
 	Path string `json:"path,omitempty" protobuf:"bytes,2,opt,name=path"`
 
 	// to is an object the route should use as the primary backend. Only the Service kind
@@ -111,6 +121,8 @@ type RouteSpec struct {
 	// alternateBackends allows up to 3 additional backends to be assigned to the route.
 	// Only the Service kind is allowed, and it will be defaulted to Service.
 	// Use the weight field in RouteTargetReference object to specify relative preference.
+	//
+	// +kubebuilder:validation:MaxItems=3
 	AlternateBackends []RouteTargetReference `json:"alternateBackends,omitempty" protobuf:"bytes,4,rep,name=alternateBackends"`
 
 	// If specified, the port to be used by the router. Most routers will use all
@@ -123,6 +135,9 @@ type RouteSpec struct {
 
 	// Wildcard policy if any for the route.
 	// Currently only 'Subdomain' or 'None' is allowed.
+	//
+	// +kubebuilder:validation:Enum=None;Subdomain;""
+	// +kubebuilder:default=None
 	WildcardPolicy WildcardPolicyType `json:"wildcardPolicy,omitempty" protobuf:"bytes,7,opt,name=wildcardPolicy"`
 }
 
@@ -130,14 +145,22 @@ type RouteSpec struct {
 // kind is allowed. Use 'weight' field to emphasize one over others.
 type RouteTargetReference struct {
 	// The kind of target that the route is referring to. Currently, only 'Service' is allowed
+	//
+	// +kubebuilder:validation:Enum=Service;""
+	// +kubebuilder:default=Service
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
 
 	// name of the service/target that is being referred to. e.g. name of the service
+	//
+	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 
 	// weight as an integer between 0 and 256, default 100, that specifies the target's relative weight
 	// against other target reference objects. 0 suppresses requests to this backend.
+	//
 	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=256
 	Weight *int32 `json:"weight" protobuf:"varint,3,opt,name=weight"`
 }
 
@@ -222,6 +245,8 @@ type TLSConfig struct {
 	// * edge - TLS termination is done by the router and http is used to communicate with the backend (default)
 	// * passthrough - Traffic is sent straight to the destination without the router providing TLS termination
 	// * reencrypt - TLS termination is done by the router and https is used to communicate with the backend
+	//
+	// +kubebuilder:validation:Enum=edge;reencrypt;passthrough
 	Termination TLSTerminationType `json:"termination" protobuf:"bytes,1,opt,name=termination,casttype=TLSTerminationType"`
 
 	// certificate provides certificate contents. This should be a single serving certificate, not a certificate


### PR DESCRIPTION
* `Makefile`: Add an "update-codegen-crd-route" target.
* `route/v1/route.crd.yaml`: New file.  Define a CRD for the Route API.
* `route/v1/route.crd.yaml-patch`: New file.  Patch `route-crd.yaml` with validation that cannot be expressed using kubebuilder tags.
* `route/v1/test-route-validation.sh`: New file.  Verify that the API admits valid routes and rejects invalid routes.
* `route/v1/types.go`: Add kubebuilder validation tags.

---

The motivation for this PR is to supersede <https://github.com/openshift/router/blob/master/deploy/route_crd.yaml>, which does not perform any validation, for use in environments where OpenShift router is used without openshift-apiserver.  

This implements most of the validation that openshift-apiserver does; see <https://github.com/openshift/openshift-apiserver/blob/master/pkg/route/apis/route/validation/validation.go>, and see <https://gist.github.com/Miciah/cfa92327b66bf697a1d66cccb7633cc7> for a shell-script that tests the validation.  One remaining gap is that the CRD doesn't default `spec.host`.  The CRD also doesn't do the ratcheting logic for `spec.host` validation.  