### PR TITLE
feature-flags: Create a feature flag for Platform Operators Tech Preview

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -117,6 +117,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("BuildCSIVolumes").             // sig-build, adkaplan, OCP specific
 		with("NodeSwap").                    // sig-node, ehashman, Kubernetes feature gate
 		with("MachineAPIProviderOpenStack"). // openstack, egarcia (#forum-openstack), OCP specific
+		with("PlatformOperators").           // OLM, dsover & cchantse, OCP specific
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(


### PR DESCRIPTION
Adds a new feature flag for the Platform Operators Openshift-only feature. 

Signed-off-by: Daniel Sover <dsover@redhat.com>