### PR TITLE
Add console capability

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -66,6 +66,7 @@ spec:
                           - openshift-samples
                           - baremetal
                           - marketplace
+                          - console
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -169,6 +170,7 @@ spec:
                           - openshift-samples
                           - baremetal
                           - marketplace
+                          - console
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -180,6 +182,7 @@ spec:
                           - openshift-samples
                           - baremetal
                           - marketplace
+                          - console
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -260,7 +260,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
-// +kubebuilder:validation:Enum=None;v4.11;vCurrent
+// +kubebuilder:validation:Enum=None;v4.11;v4.12;vCurrent
 type ClusterVersionCapabilitySet string
 
 const (
@@ -274,6 +274,12 @@ const (
 	// version of OpenShift is installed.
 	ClusterVersionCapabilitySet4_11 ClusterVersionCapabilitySet = "v4.11"
 
+	// ClusterVersionCapabilitySet4_12 is the recommended set of
+	// optional capabilities to enable for the 4.12 version of
+	// OpenShift.  This list will remain the same no matter which
+	// version of OpenShift is installed.
+	ClusterVersionCapabilitySet4_12 ClusterVersionCapabilitySet = "v4.12"
+
 	// ClusterVersionCapabilitySetCurrent is the recommended set
 	// of optional capabilities to enable for the cluster's
 	// current version of OpenShift.
@@ -285,6 +291,12 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 	ClusterVersionCapabilitySetNone: {},
 	ClusterVersionCapabilitySet4_11: {
 		ClusterVersionCapabilityBaremetal,
+		ClusterVersionCapabilityMarketplace,
+		ClusterVersionCapabilityOpenShiftSamples,
+	},
+	ClusterVersionCapabilitySet4_12: {
+		ClusterVersionCapabilityBaremetal,
+		ClusterVersionCapabilityConsole,
 		ClusterVersionCapabilityMarketplace,
 		ClusterVersionCapabilityOpenShiftSamples,
 	},

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -225,7 +225,7 @@ type UpdateHistory struct {
 type ClusterID string
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;console
 type ClusterVersionCapability string
 
 const (
@@ -245,11 +245,16 @@ const (
 	// supplies Operator Lifecycle Manager (OLM) users with default catalogs of
 	// "optional" operators.
 	ClusterVersionCapabilityMarketplace ClusterVersionCapability = "marketplace"
+
+	// ClusterVersionCapabilityConsole manages the Console operator which
+	// installs and maintains the web console.
+	ClusterVersionCapabilityConsole ClusterVersionCapability = "console"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
 var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityBaremetal,
+	ClusterVersionCapabilityConsole,
 	ClusterVersionCapabilityMarketplace,
 	ClusterVersionCapabilityOpenShiftSamples,
 }
@@ -279,14 +284,15 @@ const (
 var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVersionCapability{
 	ClusterVersionCapabilitySetNone: {},
 	ClusterVersionCapabilitySet4_11: {
-		ClusterVersionCapabilityOpenShiftSamples,
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityMarketplace,
+		ClusterVersionCapabilityOpenShiftSamples,
 	},
 	ClusterVersionCapabilitySetCurrent: {
-		ClusterVersionCapabilityOpenShiftSamples,
 		ClusterVersionCapabilityBaremetal,
+		ClusterVersionCapabilityConsole,
 		ClusterVersionCapabilityMarketplace,
+		ClusterVersionCapabilityOpenShiftSamples,
 	},
 }
 


### PR DESCRIPTION
Introduces the console as a new capability and adds new `versioned capability set` for the current version of OCP.

https://issues.redhat.com/browse/CONSOLE-3221