### PR TITLE
ensure omitempty set on default placement to ensure ingress serialization comptaible for production hypershift deployments

### DIFF
--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -128,7 +128,7 @@ type IngressStatus struct {
 	//
 	// +kubebuilder:validation:Enum:="ControlPlane";"Workers";""
 	// +optional
-	DefaultPlacement DefaultPlacement `json:"defaultPlacement"`
+	DefaultPlacement DefaultPlacement `json:"defaultPlacement,omitempty"`
 }
 
 // ComponentRouteSpec allows for configuration of a route's hostname and serving certificate.


### PR DESCRIPTION
There is currently a problem when defaultPlacement does not have omitempty where the ingress config serialization of hypershift is incompatible when hypershift is managing 4.10 clusters. In order for that engine to appropriately work (the hypershift operator manages multiple independent clusters that can be at independent minor versions within a skew) this status field needs to be omitempty to ensure an invalid field is not serialized that then breaks the config being serialized in the control-plane operator (scoped to an individual cluster) associated with the 4.10 API.