### PR TITLE
config/v1: Change ClusterVersion capability from 'console' to 'Console'

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -66,7 +66,7 @@ spec:
                           - openshift-samples
                           - baremetal
                           - marketplace
-                          - console
+                          - Console
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -171,7 +171,7 @@ spec:
                           - openshift-samples
                           - baremetal
                           - marketplace
-                          - console
+                          - Console
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -183,7 +183,7 @@ spec:
                           - openshift-samples
                           - baremetal
                           - marketplace
-                          - console
+                          - Console
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -225,7 +225,7 @@ type UpdateHistory struct {
 type ClusterID string
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;console
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console
 type ClusterVersionCapability string
 
 const (
@@ -248,7 +248,7 @@ const (
 
 	// ClusterVersionCapabilityConsole manages the Console operator which
 	// installs and maintains the web console.
-	ClusterVersionCapabilityConsole ClusterVersionCapability = "console"
+	ClusterVersionCapabilityConsole ClusterVersionCapability = "Console"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.

--- a/console/v1/0000_10_consoleclidownload.crd.yaml
+++ b/console/v1/0000_10_consoleclidownload.crd.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: console
+    capability.openshift.io/name: Console
   name: consoleclidownloads.console.openshift.io
 spec:
   group: console.openshift.io

--- a/console/v1/0000_10_consoleexternalloglink.crd.yaml
+++ b/console/v1/0000_10_consoleexternalloglink.crd.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: console
+    capability.openshift.io/name: Console
   name: consoleexternalloglinks.console.openshift.io
 spec:
   group: console.openshift.io

--- a/console/v1/0000_10_consolelink.crd.yaml
+++ b/console/v1/0000_10_consolelink.crd.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: console
+    capability.openshift.io/name: Console
   name: consolelinks.console.openshift.io
 spec:
   group: console.openshift.io

--- a/console/v1/0000_10_consolenotification.crd.yaml
+++ b/console/v1/0000_10_consolenotification.crd.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: console
+    capability.openshift.io/name: Console
   name: consolenotifications.console.openshift.io
 spec:
   group: console.openshift.io

--- a/console/v1/0000_10_consolequickstart.crd.yaml
+++ b/console/v1/0000_10_consolequickstart.crd.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: console
+    capability.openshift.io/name: Console
   name: consolequickstarts.console.openshift.io
 spec:
   group: console.openshift.io

--- a/console/v1/0000_10_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_consoleyamlsample.crd.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: console
+    capability.openshift.io/name: Console
   name: consoleyamlsamples.console.openshift.io
 spec:
   group: console.openshift.io

--- a/console/v1alpha1/0000_10_consoleplugin.crd.yaml
+++ b/console/v1alpha1/0000_10_consoleplugin.crd.yaml
@@ -8,7 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: console
+    capability.openshift.io/name: Console
   name: consoleplugins.console.openshift.io
 spec:
   group: console.openshift.io


### PR DESCRIPTION
The lowercase form just landed via 9db3a0ce01 (#1232), CC @raspbeep, and that matched the lower-case precedent which we had been using for these enumerated capabilities.  But [the Kube-API preference is for PascalCase][1], so this commit pivots to that form.  Because we are so close on the heels of the original change, we don't need to preserve any references to the outgoing form.  Adjusting the 4.11 references like `openshift-samples` will take more dancing, and can happen in follow-up
work.  Generated with:

```console
$ sed -i 's|\(capability[.]openshift[.]io/name\): console|\1: Console|' $(git grep -l 'capability.openshift.io/name: console')
$ sed -i 's/console/Console/' config/v1/*version*
```

And then backing out one godocs hit that the above made:

```console
$ sed -i 's/the web Console/the web console/' config/v1/*version*
```

[1]: https://github.com/openshift/enhancements/blame/b3f5408be4505e37c0bdb7f8b2630a92a5d01457/dev-guide/api-conventions.md#L195