### PR TITLE
Add capabilities test

### DIFF
--- a/config/v1/types_cluster_version_test.go
+++ b/config/v1/types_cluster_version_test.go
@@ -10,14 +10,44 @@ import (
 func TestKnownClusterVersionCapabilities(t *testing.T) {
 	exists := struct{}{}
 	known := make(map[ClusterVersionCapability]struct{}, len(KnownClusterVersionCapabilities))
-	for _, cap := range KnownClusterVersionCapabilities {
-		known[cap] = exists
+	for _, capability := range KnownClusterVersionCapabilities {
+		known[capability] = exists
 	}
 
 	for set, caps := range ClusterVersionCapabilitySets {
-		for _, cap := range caps {
-			if _, ok := known[cap]; !ok {
-				t.Errorf("Capability set %s contains %s, which needs to be added to KnownClusterVersionCapabilities", set, cap)
+		for _, capability := range caps {
+			if _, ok := known[capability]; !ok {
+				t.Errorf("Capability set %s contains %s, which needs to be added to KnownClusterVersionCapabilities", set, capability)
+			}
+		}
+	}
+}
+
+// TestSubsetsVersionCapabilities verifies that all preceding sets
+// (order given by capabilitySetOrder) are subsets of following sets
+func TestSubsetsVersionCapabilities(t *testing.T) {
+	// defines the order by which subsets are tested
+	var capabilitySetOrder = []ClusterVersionCapabilitySet{
+		ClusterVersionCapabilitySetNone,
+		ClusterVersionCapabilitySet4_11,
+		ClusterVersionCapabilitySet4_12,
+		ClusterVersionCapabilitySetCurrent,
+	}
+
+	for i := 0; i < len(capabilitySetOrder)-1; i++ {
+		var setName = capabilitySetOrder[i]
+		var setName1 = capabilitySetOrder[i+1]
+
+		for _, capability := range ClusterVersionCapabilitySets[setName] {
+			found := false
+			for _, capability1 := range ClusterVersionCapabilitySets[setName1] {
+				if capability == capability1 {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Capability set %s is not a subset of %s (contains %s)", setName, setName1, capability)
 			}
 		}
 	}


### PR DESCRIPTION
This test might be useful in future releases. Taking into account the movement of separating core components and making the operators installation optional via OLM, this test verifies that set of capabilities available in preceding versions are a subset of the ones in the following.

e.g. None ⊂ v4.11 ⊂ v4.12 ⊂ Current

It verifies, that no error or mismatch occurs during adding new capabilities or releasing new OCP versions.

Also, minor change to the variable names due to builtin function name collision(cap).

Signed-off-by: Pavel Kratochvil <pakratoc@redhat.com>