### PR TITLE
Bring back tls/go.mod file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/crd-schema-gen.mk \
 )
 
-GO_PACKAGES :=$(addsuffix ...,$(addprefix ./,$(filter-out vendor/,$(filter-out hack/,$(wildcard */)))))
+EXCLUDE_DIRS := _output/ dependencymagnet/ hack/ third_party/ tls/ vendor/
+GO_PACKAGES :=$(addsuffix ...,$(addprefix ./,$(filter-out $(EXCLUDE_DIRS), $(wildcard */))))
 GO_BUILD_PACKAGES :=$(GO_PACKAGES)
 GO_BUILD_PACKAGES_EXPANDED :=$(GO_BUILD_PACKAGES)
 # LDFLAGS are not needed for dummy builds (saving time on calling git commands)

--- a/tls/go.mod
+++ b/tls/go.mod
@@ -1,0 +1,6 @@
+// This file is required to ensure the vendoring treats
+// the tls package as a separate one and properly omits it
+// in most vendoring cases.
+module github.com/openshift/api/tls
+
+go 1.18


### PR DESCRIPTION
In https://github.com/openshift/api/pull/1226 I removed unused file, but it turns out it's needed for vendoring to work properly. While at it, I fixed the `Makefile` with the correct excluded dirs.

Found while working on https://github.com/openshift/api/pull/1248