### PR TITLE
Add missing unionDiscriminator tag to NutanixResourceIdentifier

### DIFF
--- a/machine/v1/types_nutanixprovider.go
+++ b/machine/v1/types_nutanixprovider.go
@@ -81,6 +81,7 @@ const (
 // +union
 type NutanixResourceIdentifier struct {
 	// Type is the identifier type to use for this resource.
+	// +unionDiscriminator
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum:=uuid;name
 	Type NutanixIdentifierType `json:"type"`

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -27198,9 +27198,9 @@ func schema_openshift_api_machine_v1_NutanixResourceIdentifier(ref common.Refere
 				Extensions: spec.Extensions{
 					"x-kubernetes-unions": []interface{}{
 						map[string]interface{}{
+							"discriminator": "type",
 							"fields-to-discriminateBy": map[string]interface{}{
 								"name": "Name",
-								"type": "Type",
 								"uuid": "UUID",
 							},
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -15798,9 +15798,9 @@
       },
       "x-kubernetes-unions": [
         {
+          "discriminator": "type",
           "fields-to-discriminateBy": {
             "name": "Name",
-            "type": "Type",
             "uuid": "UUID"
           }
         }


### PR DESCRIPTION
The openapi gen is complaining that this tag is missing, though the script exits 0 🤔 
```
E0823 11:21:07.360904   75629 openapi.go:487] [github.com/openshift/api/machine/v1.NutanixResourceIdentifier]: union members must be optional: github.com/openshift/api/machine/v1.NutanixResourceIdentifier.Type
```

But yes, it highlighted that this tag is missing from the union discriminant