### PR TITLE
Drop GA-ed features (CSIMigrationAWS, CSIMigrationGCE, PodSecurity)

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -130,11 +130,8 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		"APIPriorityAndFairness",         // sig-apimachinery, deads2k
 		"RotateKubeletServerCertificate", // sig-pod, sjenning
 		"DownwardAPIHugePages",           // sig-node, rphillips
-		"PodSecurity",                    // sig-auth, s-urbaniak
 	},
 	Disabled: []string{
-		"CSIMigrationAWS",       // sig-storage, jsafrane
-		"CSIMigrationGCE",       // sig-storage, jsafrane
 		"CSIMigrationAzureFile", // sig-storage, jsafrane
 		"CSIMigrationvSphere",   // sig-storage, jsafrane
 	},

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -18,74 +18,62 @@ func TestFeatureBuilder(t *testing.T) {
 		},
 		{
 			name:   "disable-existing",
-			actual: newDefaultFeatures().without("PodSecurity").toFeatures(),
+			actual: newDefaultFeatures().without("APIPriorityAndFairness").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
-					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
 					"DownwardAPIHugePages",
 				},
 				Disabled: []string{
-					"CSIMigrationAWS",
-					"CSIMigrationGCE",
 					"CSIMigrationAzureFile",
 					"CSIMigrationvSphere",
-					"PodSecurity",
+					"APIPriorityAndFairness",
 				},
 			},
 		},
 		{
 			name:   "enable-existing",
-			actual: newDefaultFeatures().with("CSIMigrationAWS").toFeatures(),
+			actual: newDefaultFeatures().with("CSIMigrationAzureFile").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
 					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
 					"DownwardAPIHugePages",
-					"PodSecurity",
-					"CSIMigrationAWS",
+					"CSIMigrationAzureFile",
 				},
 				Disabled: []string{
-					"CSIMigrationGCE",
-					"CSIMigrationAzureFile",
 					"CSIMigrationvSphere",
 				},
 			},
 		},
 		{
 			name:   "disable-more",
-			actual: newDefaultFeatures().without("PodSecurity", "other").toFeatures(),
+			actual: newDefaultFeatures().without("APIPriorityAndFairness", "other").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
-					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
 					"DownwardAPIHugePages",
 				},
 				Disabled: []string{
-					"CSIMigrationAWS",
-					"CSIMigrationGCE",
 					"CSIMigrationAzureFile",
 					"CSIMigrationvSphere",
-					"PodSecurity",
+					"APIPriorityAndFairness",
 					"other",
 				},
 			},
 		},
 		{
 			name:   "enable-more",
-			actual: newDefaultFeatures().with("CSIMigrationAWS", "other").toFeatures(),
+			actual: newDefaultFeatures().with("CSIMigrationAzureFile", "other").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
 					"APIPriorityAndFairness",
 					"RotateKubeletServerCertificate",
 					"DownwardAPIHugePages",
-					"PodSecurity",
-					"CSIMigrationAWS",
+					"CSIMigrationAzureFile",
 					"other",
 				},
 				Disabled: []string{
-					"CSIMigrationGCE",
-					"CSIMigrationAzureFile",
 					"CSIMigrationvSphere",
 				},
 			},


### PR DESCRIPTION
This is needed for landing k8s 1.25, since these 3 features are GA-ed upstream and locked to always on.

/assign @jsafrane @stlaz 