### PR TITLE
update ingress component route SSA list markers

### DIFF
--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -74,6 +74,10 @@ spec:
                           name:
                             description: name is the metadata.name of the referenced secret
                             type: string
+                  x-kubernetes-list-map-keys:
+                    - namespace
+                    - name
+                  x-kubernetes-list-type: map
                 domain:
                   description: "domain is used to generate a default host name for a route when the route's host name is empty. The generated host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\". \n It is also used as the default wildcard domain suffix for ingress. The default ingresscontroller domain will follow this pattern: \"*.<domain>\". \n Once set, changing domain is not currently supported."
                   type: string
@@ -211,6 +215,9 @@ spec:
                               type: string
                               maxLength: 316
                               pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
                       consumingUsers:
                         description: consumingUsers is a slice of ServiceAccounts that need to have read permission on the servingCertKeyPairSecret secret.
                         type: array
@@ -268,6 +275,10 @@ spec:
                             resource:
                               description: resource of the referent.
                               type: string
+                  x-kubernetes-list-map-keys:
+                    - namespace
+                    - name
+                  x-kubernetes-list-type: map
                 defaultPlacement:
                   description: "defaultPlacement is set at installation time to control which nodes will host the ingress router pods by default. The options are control-plane nodes or worker nodes. \n This field works by dictating how the Cluster Ingress Operator will consider unset replicas and nodePlacement fields in IngressController resources when creating the corresponding Deployments. \n See the documentation for the IngressController replicas and nodePlacement fields for more information. \n When omitted, the default value is Workers"
                   type: string

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -56,6 +56,9 @@ type IngressSpec struct {
 	// .status.componentRoutes list, where participating operators write the status of
 	// configurable routes.
 	// +optional
+	// +listType=map
+	// +listMapKey=namespace
+	// +listMapKey=name
 	ComponentRoutes []ComponentRouteSpec `json:"componentRoutes,omitempty"`
 
 	// requiredHSTSPolicies specifies HSTS policies that are required to be set on newly created  or updated routes
@@ -111,6 +114,9 @@ type IngressStatus struct {
 	// componentRoutes is where participating operators place the current route status for routes whose
 	// hostnames and serving certificates can be customized by the cluster-admin.
 	// +optional
+	// +listType=map
+	// +listMapKey=namespace
+	// +listMapKey=name
 	ComponentRoutes []ComponentRouteStatus `json:"componentRoutes,omitempty"`
 
 	// defaultPlacement is set at installation time to control which
@@ -221,6 +227,8 @@ type ComponentRouteStatus struct {
 	//
 	// If Progressing is true, that means the component is taking some action related to the componentRoutes entry.
 	// +optional
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// relatedObjects is a list of resources which are useful when debugging or inspecting how spec.componentRoutes is applied.

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -9887,6 +9887,14 @@ func schema_openshift_api_config_v1_ComponentRouteStatus(ref common.ReferenceCal
 						},
 					},
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "conditions are used to communicate the state of the componentRoutes entry.\n\nSupported conditions include Available, Degraded and Progressing.\n\nIf available is true, the content served by the route can be accessed by users. This includes cases where a default may continue to serve content while the customized route specified by the cluster-admin is being configured.\n\nIf Degraded is true, that means something has gone wrong trying to handle the componentRoutes entry. The currentHostnames field may or may not be in effect.\n\nIf Progressing is true, that means the component is taking some action related to the componentRoutes entry.",
 							Type:        []string{"array"},
@@ -12830,6 +12838,15 @@ func schema_openshift_api_config_v1_IngressSpec(ref common.ReferenceCallback) co
 						},
 					},
 					"componentRoutes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "componentRoutes is an optional list of routes that are managed by OpenShift components that a cluster-admin is able to configure the hostname and serving certificate for. The namespace and name of each route in this list should match an existing entry in the status.componentRoutes list.\n\nTo determine the set of configurable Routes, look at namespace and name of entries in the .status.componentRoutes list, where participating operators write the status of configurable routes.",
 							Type:        []string{"array"},
@@ -12873,6 +12890,15 @@ func schema_openshift_api_config_v1_IngressStatus(ref common.ReferenceCallback) 
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"componentRoutes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "componentRoutes is where participating operators place the current route status for routes whose hostnames and serving certificates can be customized by the cluster-admin.",
 							Type:        []string{"array"},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -5262,7 +5262,11 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
-          }
+          },
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "consumingUsers": {
           "description": "consumingUsers is a slice of ServiceAccounts that need to have read permission on the servingCertKeyPairSecret secret.",
@@ -7022,7 +7026,12 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.config.v1.ComponentRouteSpec"
-          }
+          },
+          "x-kubernetes-list-map-keys": [
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "domain": {
           "description": "domain is used to generate a default host name for a route when the route's host name is empty. The generated host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\".\n\nIt is also used as the default wildcard domain suffix for ingress. The default ingresscontroller domain will follow this pattern: \"*.<domain>\".\n\nOnce set, changing domain is not currently supported.",
@@ -7048,7 +7057,12 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.config.v1.ComponentRouteStatus"
-          }
+          },
+          "x-kubernetes-list-map-keys": [
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "defaultPlacement": {
           "description": "defaultPlacement is set at installation time to control which nodes will host the ingress router pods by default. The options are control-plane nodes or worker nodes.\n\nThis field works by dictating how the Cluster Ingress Operator will consider unset replicas and nodePlacement fields in IngressController resources when creating the corresponding Deployments.\n\nSee the documentation for the IngressController replicas and nodePlacement fields for more information.\n\nWhen omitted, the default value is Workers",


### PR DESCRIPTION
ComponentRoutes are keyed by namespace,name tuples.  See the docs on the field here: https://kubernetes.io/docs/reference/using-api/server-side-apply/#merge-strategy

Not sure what to do about HSTS, that may be an evolutionary problem.

/assign @Miciah @JoelSpeed 