### PR TITLE
[CNF-5646] Add CSISnapshot capability

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -69,6 +69,7 @@ spec:
                           - Console
                           - Insights
                           - Storage
+                          - CSISnapshot
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -176,6 +177,7 @@ spec:
                           - Console
                           - Insights
                           - Storage
+                          - CSISnapshot
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -190,6 +192,7 @@ spec:
                           - Console
                           - Insights
                           - Storage
+                          - CSISnapshot
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -225,7 +225,7 @@ type UpdateHistory struct {
 type ClusterID string
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot
 type ClusterVersionCapability string
 
 const (
@@ -262,6 +262,12 @@ const (
 	// These clusters heavily rely on that capability and may cause
 	// damage to the cluster.
 	ClusterVersionCapabilityStorage ClusterVersionCapability = "Storage"
+
+	// ClusterVersionCapabilityCSISnapshot manages the csi snapshot
+	// controller operator which is responsible for watching the
+	// VolumeSnapshot CRD objects and manages the creation and deletion
+	// lifecycle of volume snapshots
+	ClusterVersionCapabilityCSISnapshot ClusterVersionCapability = "CSISnapshot"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -272,6 +278,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityMarketplace,
 	ClusterVersionCapabilityStorage,
 	ClusterVersionCapabilityOpenShiftSamples,
+	ClusterVersionCapabilityCSISnapshot,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
@@ -316,6 +323,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityMarketplace,
 		ClusterVersionCapabilityStorage,
 		ClusterVersionCapabilityOpenShiftSamples,
+		ClusterVersionCapabilityCSISnapshot,
 	},
 	ClusterVersionCapabilitySetCurrent: {
 		ClusterVersionCapabilityBaremetal,
@@ -324,6 +332,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityMarketplace,
 		ClusterVersionCapabilityStorage,
 		ClusterVersionCapabilityOpenShiftSamples,
+		ClusterVersionCapabilityCSISnapshot,
 	},
 }
 


### PR DESCRIPTION
Add CSISnapshot capability which allows disabling CSI snapshot
controller operator which is responsible for watching the
VolumeSnapshot CRD objects and manages the creation and
deletion lifecycle of volume snapshots.