### PR TITLE
Add cpms shortname to ControlPlaneMachineSet

### DIFF
--- a/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/machine/v1/types_controlplanemachineset.go
+++ b/machine/v1/types_controlplanemachineset.go
@@ -11,7 +11,7 @@ import (
 
 // ControlPlaneMachineSet ensures that a specified number of control plane machine replicas are running at any given time.
 // +k8s:openapi-gen=true
-// +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:resource:scope=Namespaced,shortName=cpms
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas",description="Desired Replicas"


### PR DESCRIPTION
@damdo and I have been testing the ControlPlaneMachineSet a lot lately and typing `controlplanemachineset` every time is long. While I appreciate that adding shortnames can lead to ambiguity and we normally try to promote using fully groupified names, I'm expecting that `cpms` is a relatively unique short name that we are unlikely to duplicate in or around the near future, or at least, before I sort the upstream kubectl warning for ambiguous resources.

It would be nice to have this shortname for convenience sake