### PR TITLE
TechPreviewNoUpgrade: add Crun feature to set

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -119,6 +119,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("NodeSwap").                    // sig-node, ehashman, Kubernetes feature gate
 		with("MachineAPIProviderOpenStack"). // openstack, egarcia (#forum-openstack), OCP specific
 		with("CGroupsV2").                   // sig-node, harche, OCP specific
+		with("Crun").                        // sig-node, haircommander, OCP specific
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(


### PR DESCRIPTION
While it technically doesn't do anything (As the crun feature is toggled by TechPreviewNoUpgrade),
it does make users aware of the feature they're enabling with TechPreviewNoUpgrade

Signed-off-by: Peter Hunt~ <pehunt@redhat.com>