### PR TITLE
OCPBUGS-1234 : [CFE-580] Extend user tags limit to 40 based on AWS limits

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -425,8 +425,8 @@ spec:
                         description: resourceTags is a list of additional tags to
                           apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
                           for information on tagging AWS resources. AWS supports a
-                          maximum of 50 tags per resource. OpenShift reserves 25 tags
-                          for its use, leaving 25 tags available for the user.
+                          maximum of 50 tags per resource. OpenShift reserves 10 tags
+                          for its use, leaving 40 tags available for the user.
                         items:
                           description: AWSResourceTag is a tag to apply to AWS resources
                             created for the cluster.
@@ -450,7 +450,7 @@ spec:
                           - key
                           - value
                           type: object
-                        maxItems: 25
+                        maxItems: 40
                         type: array
                       serviceEndpoints:
                         description: ServiceEndpoints list contains custom endpoints

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -369,9 +369,9 @@ type AWSPlatformStatus struct {
 
 	// resourceTags is a list of additional tags to apply to AWS resources created for the cluster.
 	// See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources.
-	// AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags
+	// AWS supports a maximum of 50 tags per resource. OpenShift reserves 10 tags for its use, leaving 40 tags
 	// available for the user.
-	// +kubebuilder:validation:MaxItems=25
+	// +kubebuilder:validation:MaxItems=40
 	// +optional
 	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
 }
@@ -652,7 +652,7 @@ type VSpherePlatformStatus struct {
 // This only includes fields that can be modified in the cluster.
 type IBMCloudPlatformSpec struct{}
 
-//IBMCloudPlatformStatus holds the current status of the IBMCloud infrastructure provider.
+// IBMCloudPlatformStatus holds the current status of the IBMCloud infrastructure provider.
 type IBMCloudPlatformStatus struct {
 	// Location is where the cluster has been deployed
 	Location string `json:"location,omitempty"`

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -993,7 +993,7 @@ var map_AWSPlatformStatus = map[string]string{
 	"":                 "AWSPlatformStatus holds the current status of the Amazon Web Services infrastructure provider.",
 	"region":           "region holds the default AWS region for new AWS resources created by the cluster.",
 	"serviceEndpoints": "ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.",
-	"resourceTags":     "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.",
+	"resourceTags":     "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 10 tags for its use, leaving 40 tags available for the user.",
 }
 
 func (AWSPlatformStatus) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -8263,7 +8263,7 @@ func schema_openshift_api_config_v1_AWSPlatformStatus(ref common.ReferenceCallba
 					},
 					"resourceTags": {
 						SchemaProps: spec.SchemaProps{
-							Description: "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.",
+							Description: "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 10 tags for its use, leaving 40 tags available for the user.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4142,7 +4142,7 @@
           "default": ""
         },
         "resourceTags": {
-          "description": "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.",
+          "description": "resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 10 tags for its use, leaving 40 tags available for the user.",
           "type": "array",
           "items": {
             "default": {},


### PR DESCRIPTION
Extend user tag limit to 40 based on AWS limits. 10 tags are reserved for OpenShift use. Previously, there has been a confusion on the tag limit for S3 bucket vs S3 bucket object tag limit. S3 bucket object tag limit is 10 while the requirement is for S3 bucket which has limit of 50 tags.
Reference : https://docs.aws.amazon.com/AmazonS3/latest/userguide/CostAllocTagging.html