### PR TITLE
Remove CSIMigrationAWS and CSIMigrationGCE feature gate references

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -109,8 +109,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		Disabled: []string{},
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
-		with("CSIMigrationAWS").             // sig-storage, jsafrane, Kubernetes feature gate
-		with("CSIMigrationGCE").             // sig-storage, fbertina, Kubernetes feature gate
 		with("CSIMigrationAzureFile").       // sig-storage, fbertina, Kubernetes feature gate
 		with("CSIMigrationvSphere").         // sig-storage, fbertina, Kubernetes feature gate
 		with("ExternalCloudProvider").       // sig-cloud-provider, jspeed, OCP specific


### PR DESCRIPTION
These 2 CSI migration features went GA in k8s 1.25 and the gates are [locked to true](https://github.com/kubernetes/kubernetes/blob/67d75db8905f16bb0d9d0a14b13a8736cb614533/pkg/features/kube_features.go#L904). They were removed from the list of disabled feature gates in https://github.com/openshift/api/pull/1260 but not from the `TechPreviewNoUpgrade` gates, which will cause issues when `TechPreviewNoUpgrade` is enabled.

https://issues.redhat.com/browse/STOR-749
https://issues.redhat.com/browse/STOR-762

/cc @openshift/storage @soltysh
