### PR TITLE
USHIFT-333: route/v1: Fix CRD to allow path for non-TLS routes

### DIFF
--- a/route/v1/route.crd.yaml
+++ b/route/v1/route.crd.yaml
@@ -69,6 +69,10 @@ spec:
               - properties:
                   path:
                     maxLength: 0
+              - properties:
+                  tls:
+                    enum:
+                    - null
               - not:
                   properties:
                     tls:

--- a/route/v1/route.crd.yaml-patch
+++ b/route/v1/route.crd.yaml-patch
@@ -6,6 +6,9 @@
     - properties:
         path:
           maxLength: 0
+    - properties:
+        tls:
+          enum: [null]
     - not:
         properties:
           tls:

--- a/route/v1/test-route-validation.sh
+++ b/route/v1/test-route-validation.sh
@@ -57,6 +57,39 @@ spec:
 EOF
 expect_fail 'passthrough with nonempty path'
 
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  path: /
+  to:
+    kind: Service
+    name: router-internal-default
+EOF
+expect_pass 'non-TLS with nonempty path'
+delete_route
+
+oc create -f - <<'EOF'
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: openshift-ingress
+  name: testroute
+spec:
+  host: test.foo
+  path: /
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: router-internal-default
+EOF
+expect_pass 'edge-terminated with nonempty path'
+delete_route
 
 oc create -f - <<'EOF'
 apiVersion: route.openshift.io/v1


### PR DESCRIPTION
Fix the Route CRD validation for allow routes with null `spec.tls` and nonempty `spec.path`.

* `route/v1/route.crd.yaml-patch`: Add a case to allow `spec.path` to be nonempty when `spec.tls` is null.  The existing case to allow `spec.path` when `spec.tls.termination` is not "passthrough" is insufficient when `spec.tls` is not specified at all.
* `route/v1/route.crd.yaml`: Regenerate.
* `route/v1/test-route-validation.sh`: Add test cases "non-TLS with nonempty path" and "edge-terminated with nonempty path".