### PR TITLE
platform/v1alpha1: Update the cluster profile annotations

### DIFF
--- a/platform/v1alpha1/platformoperators.crd.yaml
+++ b/platform/v1alpha1/platformoperators.crd.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1234
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   name: platformoperators.platform.openshift.io


### PR DESCRIPTION
Update the PlatformOperator CRD and add the required self-managed-high-availability cluster profile.

Signed-off-by: timflannagan <timflannagan@gmail.com>