### PR TITLE
[CNF-5647] add ImageRegistry capability

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -70,6 +70,7 @@ spec:
                           - Insights
                           - Storage
                           - CSISnapshot
+                          - ImageRegistry
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -178,6 +179,7 @@ spec:
                           - Insights
                           - Storage
                           - CSISnapshot
+                          - ImageRegistry
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -193,6 +195,7 @@ spec:
                           - Insights
                           - Storage
                           - CSISnapshot
+                          - ImageRegistry
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -225,7 +225,7 @@ type UpdateHistory struct {
 type ClusterID string
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;ImageRegistry
 type ClusterVersionCapability string
 
 const (
@@ -268,6 +268,10 @@ const (
 	// VolumeSnapshot CRD objects and manages the creation and deletion
 	// lifecycle of volume snapshots
 	ClusterVersionCapabilityCSISnapshot ClusterVersionCapability = "CSISnapshot"
+
+	// ClusterVersionCapabilityImageRegistry manages the image registry which
+	// allows to distribute Docker images
+	ClusterVersionCapabilityImageRegistry ClusterVersionCapability = "ImageRegistry"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -279,6 +283,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityStorage,
 	ClusterVersionCapabilityOpenShiftSamples,
 	ClusterVersionCapabilityCSISnapshot,
+	ClusterVersionCapabilityImageRegistry,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
@@ -333,6 +338,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityStorage,
 		ClusterVersionCapabilityOpenShiftSamples,
 		ClusterVersionCapabilityCSISnapshot,
+		ClusterVersionCapabilityImageRegistry,
 	},
 }
 


### PR DESCRIPTION
Capability manages the image registry which allows to distribute
Docker images