### PR TITLE
update to release.openshift.io/feature-set to match OCP 4.12

### DIFF
--- a/config/v1alpha1/0000_10_config-operator_01_insightsdatagather.crd.yaml
+++ b/config/v1alpha1/0000_10_config-operator_01_insightsdatagather.crd.yaml
@@ -6,7 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: insightsdatagathers.config.openshift.io
 spec:
   group: config.openshift.io

--- a/monitoring/v1alpha1/0000_50_monitoring_01_alertingrules.crd.yaml
+++ b/monitoring/v1alpha1/0000_50_monitoring_01_alertingrules.crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1179
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     description: OpenShift Monitoring alerting rules
   name: alertingrules.monitoring.openshift.io
 spec:

--- a/monitoring/v1alpha1/0000_50_monitoring_02_alertrelabelconfigs.crd.yaml
+++ b/monitoring/v1alpha1/0000_50_monitoring_02_alertrelabelconfigs.crd.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1179
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     description: OpenShift Monitoring alert relabel configurations
   name: alertrelabelconfigs.monitoring.openshift.io
 spec:

--- a/platform/v1alpha1/platformoperators.crd.yaml
+++ b/platform/v1alpha1/platformoperators.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
     api-approved.openshift.io: https://github.com/openshift/api/pull/1234
   creationTimestamp: null
   name: platformoperators.platform.openshift.io


### PR DESCRIPTION
This was added in
openshift/cluster-version-operator#821 to allow
more featuresets and allow for a future migration to include actual gates

/assign @JoelSpeed 
/cc @wking 