### PR TITLE
format manifests

### DIFF
--- a/authorization/v1/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
+++ b/authorization/v1/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
@@ -16,143 +16,200 @@ spec:
     singular: rolebindingrestriction
   scope: Namespaced
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "RoleBindingRestriction is an object that can be matched against a subject (user, group, or service account) to determine whether rolebindings on that subject are allowed in the namespace to which the RoleBindingRestriction belongs.  If any one of those RoleBindingRestriction objects matches a subject, rolebindings on that subject in the namespace are allowed. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec defines the matcher.
-              type: object
-              properties:
-                grouprestriction:
-                  description: GroupRestriction matches against group subjects.
-                  type: object
-                  properties:
-                    groups:
-                      description: Groups is a list of groups used to match against an individual user's groups. If the user is a member of one of the whitelisted groups, the user is allowed to be bound to a role.
-                      type: array
-                      items:
-                        type: string
-                      nullable: true
-                    labels:
-                      description: Selectors specifies a list of label selectors over group labels.
-                      type: array
-                      items:
-                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-                        type: object
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                            type: array
-                            items:
-                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                              type: object
-                              required:
-                                - key
-                                - operator
-                              properties:
-                                key:
-                                  description: key is the label key that the selector applies to.
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "RoleBindingRestriction is an object that can be matched against
+          a subject (user, group, or service account) to determine whether rolebindings
+          on that subject are allowed in the namespace to which the RoleBindingRestriction
+          belongs.  If any one of those RoleBindingRestriction objects matches a subject,
+          rolebindings on that subject in the namespace are allowed. \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the matcher.
+            properties:
+              grouprestriction:
+                description: GroupRestriction matches against group subjects.
+                nullable: true
+                properties:
+                  groups:
+                    description: Groups is a list of groups used to match against
+                      an individual user's groups. If the user is a member of one
+                      of the whitelisted groups, the user is allowed to be bound to
+                      a role.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  labels:
+                    description: Selectors specifies a list of label selectors over
+                      group labels.
+                    items:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
                                   type: string
-                                operator:
-                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                  type: array
-                                  items:
-                                    type: string
-                          matchLabels:
-                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: array
+                            required:
+                            - key
+                            - operator
                             type: object
-                            additionalProperties:
-                              type: string
-                        x-kubernetes-map-type: atomic
-                      nullable: true
-                  nullable: true
-                serviceaccountrestriction:
-                  description: ServiceAccountRestriction matches against service-account subjects.
-                  type: object
-                  properties:
-                    namespaces:
-                      description: Namespaces specifies a list of literal namespace names.
-                      type: array
-                      items:
-                        type: string
-                    serviceaccounts:
-                      description: ServiceAccounts specifies a list of literal service-account names.
-                      type: array
-                      items:
-                        description: ServiceAccountReference specifies a service account and namespace by their names.
-                        type: object
-                        properties:
-                          name:
-                            description: Name is the name of the service account.
+                          type: array
+                        matchLabels:
+                          additionalProperties:
                             type: string
-                          namespace:
-                            description: Namespace is the namespace of the service account.  Service accounts from inside the whitelisted namespaces are allowed to be bound to roles.  If Namespace is empty, then the namespace of the RoleBindingRestriction in which the ServiceAccountReference is embedded is used.
-                            type: string
-                  nullable: true
-                userrestriction:
-                  description: UserRestriction matches against user subjects.
-                  type: object
-                  properties:
-                    groups:
-                      description: Groups specifies a list of literal group names.
-                      type: array
-                      items:
-                        type: string
-                      nullable: true
-                    labels:
-                      description: Selectors specifies a list of label selectors over user labels.
-                      type: array
-                      items:
-                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
-                        type: object
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                            type: array
-                            items:
-                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                              type: object
-                              required:
-                                - key
-                                - operator
-                              properties:
-                                key:
-                                  description: key is the label key that the selector applies to.
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    nullable: true
+                    type: array
+                type: object
+              serviceaccountrestriction:
+                description: ServiceAccountRestriction matches against service-account
+                  subjects.
+                nullable: true
+                properties:
+                  namespaces:
+                    description: Namespaces specifies a list of literal namespace
+                      names.
+                    items:
+                      type: string
+                    type: array
+                  serviceaccounts:
+                    description: ServiceAccounts specifies a list of literal service-account
+                      names.
+                    items:
+                      description: ServiceAccountReference specifies a service account
+                        and namespace by their names.
+                      properties:
+                        name:
+                          description: Name is the name of the service account.
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the service account.  Service
+                            accounts from inside the whitelisted namespaces are allowed
+                            to be bound to roles.  If Namespace is empty, then the
+                            namespace of the RoleBindingRestriction in which the ServiceAccountReference
+                            is embedded is used.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              userrestriction:
+                description: UserRestriction matches against user subjects.
+                nullable: true
+                properties:
+                  groups:
+                    description: Groups specifies a list of literal group names.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  labels:
+                    description: Selectors specifies a list of label selectors over
+                      user labels.
+                    items:
+                      description: A label selector is a label query over a set of
+                        resources. The result of matchLabels and matchExpressions
+                        are ANDed. An empty label selector matches all objects. A
+                        null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
                                   type: string
-                                operator:
-                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                  type: array
-                                  items:
-                                    type: string
-                          matchLabels:
-                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: array
+                            required:
+                            - key
+                            - operator
                             type: object
-                            additionalProperties:
-                              type: string
-                        x-kubernetes-map-type: atomic
-                      nullable: true
-                    users:
-                      description: Users specifies a list of literal user names.
-                      type: array
-                      items:
-                        type: string
-                  nullable: true
-      served: true
-      storage: true
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    nullable: true
+                    type: array
+                  users:
+                    description: Users specifies a list of literal user names.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
@@ -13,125 +13,155 @@ spec:
     listKind: ClusterOperatorList
     plural: clusteroperators
     shortNames:
-      - co
+    - co
     singular: clusteroperator
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: The version the operator is at.
-          jsonPath: .status.versions[?(@.name=="operator")].version
-          name: Version
-          type: string
-        - description: Whether the operator is running and stable.
-          jsonPath: .status.conditions[?(@.type=="Available")].status
-          name: Available
-          type: string
-        - description: Whether the operator is processing changes.
-          jsonPath: .status.conditions[?(@.type=="Progressing")].status
-          name: Progressing
-          type: string
-        - description: Whether the operator is degraded.
-          jsonPath: .status.conditions[?(@.type=="Degraded")].status
-          name: Degraded
-          type: string
-        - description: The time the operator's Available status last changed.
-          jsonPath: .status.conditions[?(@.type=="Available")].lastTransitionTime
-          name: Since
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ClusterOperator is the Custom Resource object which holds the current state of an operator. This object is used by operators to convey their state to the rest of the cluster. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds configuration that could apply to any operator.
-              type: object
-            status:
-              description: status holds the information about the state of an operator.  It is consistent with status information across the Kubernetes ecosystem.
-              type: object
-              properties:
-                conditions:
-                  description: conditions describes the state of the operator's managed and monitored components.
-                  type: array
-                  items:
-                    description: ClusterOperatorStatusCondition represents the state of the operator's managed and monitored components.
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the time of the last update to the current status property.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message provides additional information about the current condition. This is only to be consumed by humans.  It may contain Line Feed characters (U+000A), which should be rendered as new lines.
-                        type: string
-                      reason:
-                        description: reason is the CamelCase reason for the condition's current status.
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                      type:
-                        description: type specifies the aspect reported by this condition.
-                        type: string
-                extension:
-                  description: extension contains any additional status information specific to the operator which owns this status object.
+  - additionalPrinterColumns:
+    - description: The version the operator is at.
+      jsonPath: .status.versions[?(@.name=="operator")].version
+      name: Version
+      type: string
+    - description: Whether the operator is running and stable.
+      jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - description: Whether the operator is processing changes.
+      jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - description: Whether the operator is degraded.
+      jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - description: The time the operator's Available status last changed.
+      jsonPath: .status.conditions[?(@.type=="Available")].lastTransitionTime
+      name: Since
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterOperator is the Custom Resource object which holds the
+          current state of an operator. This object is used by operators to convey
+          their state to the rest of the cluster. \n Compatibility level 1: Stable
+          within a major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds configuration that could apply to any operator.
+            type: object
+          status:
+            description: status holds the information about the state of an operator.  It
+              is consistent with status information across the Kubernetes ecosystem.
+            properties:
+              conditions:
+                description: conditions describes the state of the operator's managed
+                  and monitored components.
+                items:
+                  description: ClusterOperatorStatusCondition represents the state
+                    of the operator's managed and monitored components.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status property.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message provides additional information about the
+                        current condition. This is only to be consumed by humans.  It
+                        may contain Line Feed characters (U+000A), which should be
+                        rendered as new lines.
+                      type: string
+                    reason:
+                      description: reason is the CamelCase reason for the condition's
+                        current status.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the aspect reported by this condition.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                relatedObjects:
-                  description: 'relatedObjects is a list of objects that are "interesting" or related to this operator.  Common uses are: 1. the detailed resource driving the operator 2. operator namespaces 3. operand namespaces'
-                  type: array
-                  items:
-                    description: ObjectReference contains enough information to let you inspect or modify the referred object.
-                    type: object
-                    required:
-                      - group
-                      - name
-                      - resource
-                    properties:
-                      group:
-                        description: group of the referent.
-                        type: string
-                      name:
-                        description: name of the referent.
-                        type: string
-                      namespace:
-                        description: namespace of the referent.
-                        type: string
-                      resource:
-                        description: resource of the referent.
-                        type: string
-                versions:
-                  description: versions is a slice of operator and operand version tuples.  Operators which manage multiple operands will have multiple operand entries in the array.  Available operators must report the version of the operator itself with the name "operator". An operator reports a new "operator" version when it has rolled out the new version to all of its operands.
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - name
-                      - version
-                    properties:
-                      name:
-                        description: name is the name of the particular operand this version is for.  It usually matches container images, not operators.
-                        type: string
-                      version:
-                        description: version indicates which version of a particular operand is currently being managed.  It must always match the Available operand.  If 1.0.0 is Available, then this must indicate 1.0.0 even if the operator is trying to rollout 1.1.0
-                        type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              extension:
+                description: extension contains any additional status information
+                  specific to the operator which owns this status object.
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              relatedObjects:
+                description: 'relatedObjects is a list of objects that are "interesting"
+                  or related to this operator.  Common uses are: 1. the detailed resource
+                  driving the operator 2. operator namespaces 3. operand namespaces'
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    group:
+                      description: group of the referent.
+                      type: string
+                    name:
+                      description: name of the referent.
+                      type: string
+                    namespace:
+                      description: namespace of the referent.
+                      type: string
+                    resource:
+                      description: resource of the referent.
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - resource
+                  type: object
+                type: array
+              versions:
+                description: versions is a slice of operator and operand version tuples.  Operators
+                  which manage multiple operands will have multiple operand entries
+                  in the array.  Available operators must report the version of the
+                  operator itself with the name "operator". An operator reports a
+                  new "operator" version when it has rolled out the new version to
+                  all of its operands.
+                items:
+                  properties:
+                    name:
+                      description: name is the name of the particular operand this
+                        version is for.  It usually matches container images, not
+                        operators.
+                      type: string
+                    version:
+                      description: version indicates which version of a particular
+                        operand is currently being managed.  It must always match
+                        the Available operand.  If 1.0.0 is Available, then this must
+                        indicate 1.0.0 even if the operator is trying to rollout 1.1.0
+                      type: string
+                  required:
+                  - name
+                  - version
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -14,407 +14,617 @@ spec:
     singular: clusterversion
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.history[?(@.state=="Completed")].version
-          name: Version
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Available")].status
-          name: Available
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Progressing")].status
-          name: Progressing
-          type: string
-        - jsonPath: .status.conditions[?(@.type=="Progressing")].lastTransitionTime
-          name: Since
-          type: date
-        - jsonPath: .status.conditions[?(@.type=="Progressing")].message
-          name: Status
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ClusterVersion is the configuration for the ClusterVersionOperator. This is where parameters related to automatic updates can be set. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec is the desired state of the cluster version - the operator will work to ensure that the desired version is applied to the cluster.
-              type: object
-              required:
-                - clusterID
-              properties:
-                capabilities:
-                  description: capabilities configures the installation of optional, core cluster components.  A null value here is identical to an empty object; see the child properties for default semantics.
-                  type: object
-                  properties:
-                    additionalEnabledCapabilities:
-                      description: additionalEnabledCapabilities extends the set of managed capabilities beyond the baseline defined in baselineCapabilitySet.  The default is an empty set.
-                      type: array
-                      items:
-                        description: ClusterVersionCapability enumerates optional, core cluster components.
-                        type: string
-                        enum:
-                          - openshift-samples
-                          - baremetal
-                          - marketplace
-                          - Console
-                          - Insights
-                          - Storage
-                          - CSISnapshot
-                      x-kubernetes-list-type: atomic
-                    baselineCapabilitySet:
-                      description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
-                      type: string
+  - additionalPrinterColumns:
+    - jsonPath: .status.history[?(@.state=="Completed")].version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Available")].status
+      name: Available
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+      name: Progressing
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].lastTransitionTime
+      name: Since
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Progressing")].message
+      name: Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterVersion is the configuration for the ClusterVersionOperator.
+          This is where parameters related to automatic updates can be set. \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the cluster version - the operator
+              will work to ensure that the desired version is applied to the cluster.
+            properties:
+              capabilities:
+                description: capabilities configures the installation of optional,
+                  core cluster components.  A null value here is identical to an empty
+                  object; see the child properties for default semantics.
+                properties:
+                  additionalEnabledCapabilities:
+                    description: additionalEnabledCapabilities extends the set of
+                      managed capabilities beyond the baseline defined in baselineCapabilitySet.  The
+                      default is an empty set.
+                    items:
+                      description: ClusterVersionCapability enumerates optional, core
+                        cluster components.
                       enum:
-                        - None
-                        - v4.11
-                        - v4.12
-                        - vCurrent
-                channel:
-                  description: channel is an identifier for explicitly requesting that a non-default set of updates be applied to this cluster. The default channel will be contain stable updates that are appropriate for production clusters.
-                  type: string
-                clusterID:
-                  description: clusterID uniquely identifies this cluster. This is expected to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in hexadecimal values). This is a required field.
-                  type: string
-                desiredUpdate:
-                  description: "desiredUpdate is an optional field that indicates the desired value of the cluster version. Setting this value will trigger an upgrade (if the current version does not match the desired version). The set of recommended update values is listed as part of available updates in status, and setting values outside that range may cause the upgrade to fail. You may specify the version field without setting image if an update exists with that version in the availableUpdates or history. \n If an upgrade fails the operator will halt and report status about the failing component. Setting the desired update value back to the previous version will cause a rollback to be attempted. Not all rollbacks will succeed."
-                  type: object
+                      - openshift-samples
+                      - baremetal
+                      - marketplace
+                      - Console
+                      - Insights
+                      - Storage
+                      - CSISnapshot
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  baselineCapabilitySet:
+                    description: baselineCapabilitySet selects an initial set of optional
+                      capabilities to enable, which can be extended via additionalEnabledCapabilities.  If
+                      unset, the cluster will choose a default, and the default may
+                      change over time. The current default is vCurrent.
+                    enum:
+                    - None
+                    - v4.11
+                    - v4.12
+                    - vCurrent
+                    type: string
+                type: object
+              channel:
+                description: channel is an identifier for explicitly requesting that
+                  a non-default set of updates be applied to this cluster. The default
+                  channel will be contain stable updates that are appropriate for
+                  production clusters.
+                type: string
+              clusterID:
+                description: clusterID uniquely identifies this cluster. This is expected
+                  to be an RFC4122 UUID value (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+                  in hexadecimal values). This is a required field.
+                type: string
+              desiredUpdate:
+                description: "desiredUpdate is an optional field that indicates the
+                  desired value of the cluster version. Setting this value will trigger
+                  an upgrade (if the current version does not match the desired version).
+                  The set of recommended update values is listed as part of available
+                  updates in status, and setting values outside that range may cause
+                  the upgrade to fail. You may specify the version field without setting
+                  image if an update exists with that version in the availableUpdates
+                  or history. \n If an upgrade fails the operator will halt and report
+                  status about the failing component. Setting the desired update value
+                  back to the previous version will cause a rollback to be attempted.
+                  Not all rollbacks will succeed."
+                properties:
+                  force:
+                    description: force allows an administrator to update to an image
+                      that has failed verification or upgradeable checks. This option
+                      should only be used when the authenticity of the provided image
+                      has been verified out of band because the provided image will
+                      run with full administrative access to the cluster. Do not use
+                      this flag with images that comes from unknown or potentially
+                      malicious sources.
+                    type: boolean
+                  image:
+                    description: image is a container image location that contains
+                      the update. When this field is part of spec, image is optional
+                      if version is specified and the availableUpdates field contains
+                      a matching version.
+                    type: string
+                  version:
+                    description: version is a semantic versioning identifying the
+                      update version. When this field is part of spec, version is
+                      optional if image is specified.
+                    type: string
+                type: object
+              overrides:
+                description: overrides is list of overides for components that are
+                  managed by cluster version operator. Marking a component unmanaged
+                  will prevent the operator from creating or updating the object.
+                items:
+                  description: ComponentOverride allows overriding cluster version
+                    operator's behavior for a component.
                   properties:
-                    force:
-                      description: force allows an administrator to update to an image that has failed verification or upgradeable checks. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources.
+                    group:
+                      description: group identifies the API group that the kind is
+                        in.
+                      type: string
+                    kind:
+                      description: kind indentifies which object to override.
+                      type: string
+                    name:
+                      description: name is the component's name.
+                      type: string
+                    namespace:
+                      description: namespace is the component's namespace. If the
+                        resource is cluster scoped, the namespace should be empty.
+                      type: string
+                    unmanaged:
+                      description: 'unmanaged controls if cluster version operator
+                        should stop managing the resources in this cluster. Default:
+                        false'
                       type: boolean
-                    image:
-                      description: image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.
-                      type: string
-                    version:
-                      description: version is a semantic versioning identifying the update version. When this field is part of spec, version is optional if image is specified.
-                      type: string
-                overrides:
-                  description: overrides is list of overides for components that are managed by cluster version operator. Marking a component unmanaged will prevent the operator from creating or updating the object.
-                  type: array
-                  items:
-                    description: ComponentOverride allows overriding cluster version operator's behavior for a component.
-                    type: object
-                    required:
-                      - group
-                      - kind
-                      - name
-                      - namespace
-                      - unmanaged
-                    properties:
-                      group:
-                        description: group identifies the API group that the kind is in.
-                        type: string
-                      kind:
-                        description: kind indentifies which object to override.
-                        type: string
-                      name:
-                        description: name is the component's name.
-                        type: string
-                      namespace:
-                        description: namespace is the component's namespace. If the resource is cluster scoped, the namespace should be empty.
-                        type: string
-                      unmanaged:
-                        description: 'unmanaged controls if cluster version operator should stop managing the resources in this cluster. Default: false'
-                        type: boolean
-                upstream:
-                  description: upstream may be used to specify the preferred update server. By default it will use the appropriate update server for the cluster and region.
-                  type: string
-            status:
-              description: status contains information about the available updates and any in-progress updates.
-              type: object
-              required:
-                - availableUpdates
-                - desired
-                - observedGeneration
-                - versionHash
-              properties:
-                availableUpdates:
-                  description: availableUpdates contains updates recommended for this cluster. Updates which appear in conditionalUpdates but not in availableUpdates may expose this cluster to known issues. This list may be empty if no updates are recommended, if the update service is unavailable, or if an invalid channel has been specified.
-                  type: array
-                  items:
-                    description: Release represents an OpenShift release image and associated metadata.
-                    type: object
-                    properties:
-                      channels:
-                        description: channels is the set of Cincinnati channels to which the release currently belongs.
-                        type: array
-                        items:
-                          type: string
-                      image:
-                        description: image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.
-                        type: string
-                      url:
-                        description: url contains information about this release. This URL is set by the 'url' metadata property on a release or the metadata returned by the update API and should be displayed as a link in user interfaces. The URL field may not be set for test or nightly releases.
-                        type: string
-                      version:
-                        description: version is a semantic versioning identifying the update version. When this field is part of spec, version is optional if image is specified.
-                        type: string
-                  nullable: true
-                capabilities:
-                  description: capabilities describes the state of optional, core cluster components.
+                  required:
+                  - group
+                  - kind
+                  - name
+                  - namespace
+                  - unmanaged
                   type: object
-                  properties:
-                    enabledCapabilities:
-                      description: enabledCapabilities lists all the capabilities that are currently managed.
-                      type: array
-                      items:
-                        description: ClusterVersionCapability enumerates optional, core cluster components.
-                        type: string
-                        enum:
-                          - openshift-samples
-                          - baremetal
-                          - marketplace
-                          - Console
-                          - Insights
-                          - Storage
-                          - CSISnapshot
-                      x-kubernetes-list-type: atomic
-                    knownCapabilities:
-                      description: knownCapabilities lists all the capabilities known to the current cluster.
-                      type: array
-                      items:
-                        description: ClusterVersionCapability enumerates optional, core cluster components.
-                        type: string
-                        enum:
-                          - openshift-samples
-                          - baremetal
-                          - marketplace
-                          - Console
-                          - Insights
-                          - Storage
-                          - CSISnapshot
-                      x-kubernetes-list-type: atomic
-                conditionalUpdates:
-                  description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.
-                  type: array
-                  items:
-                    description: ConditionalUpdate represents an update which is recommended to some clusters on the version the current cluster is reconciling, but which may not be recommended for the current cluster.
-                    type: object
-                    required:
-                      - release
-                      - risks
-                    properties:
-                      conditions:
-                        description: 'conditions represents the observations of the conditional update''s current status. Known types are: * Evaluating, for whether the cluster-version operator will attempt to evaluate any risks[].matchingRules. * Recommended, for whether the update is recommended for the current cluster.'
-                        type: array
-                        items:
-                          description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                          type: object
-                          required:
-                            - lastTransitionTime
-                            - message
-                            - reason
-                            - status
-                            - type
-                          properties:
-                            lastTransitionTime:
-                              description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                              type: string
-                              format: date-time
-                            message:
-                              description: message is a human readable message indicating details about the transition. This may be an empty string.
-                              type: string
-                              maxLength: 32768
-                            observedGeneration:
-                              description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                              type: integer
-                              format: int64
-                              minimum: 0
-                            reason:
-                              description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                              type: string
-                              maxLength: 1024
-                              minLength: 1
-                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            status:
-                              description: status of the condition, one of True, False, Unknown.
-                              type: string
-                              enum:
-                                - "True"
-                                - "False"
-                                - Unknown
-                            type:
-                              description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                              type: string
-                              maxLength: 316
-                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        x-kubernetes-list-map-keys:
-                          - type
-                        x-kubernetes-list-type: map
-                      release:
-                        description: release is the target of the update.
-                        type: object
-                        properties:
-                          channels:
-                            description: channels is the set of Cincinnati channels to which the release currently belongs.
-                            type: array
-                            items:
-                              type: string
-                          image:
-                            description: image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.
-                            type: string
-                          url:
-                            description: url contains information about this release. This URL is set by the 'url' metadata property on a release or the metadata returned by the update API and should be displayed as a link in user interfaces. The URL field may not be set for test or nightly releases.
-                            type: string
-                          version:
-                            description: version is a semantic versioning identifying the update version. When this field is part of spec, version is optional if image is specified.
-                            type: string
-                      risks:
-                        description: risks represents the range of issues associated with updating to the target release. The cluster-version operator will evaluate all entries, and only recommend the update if there is at least one entry and all entries recommend the update.
-                        type: array
-                        minItems: 1
-                        items:
-                          description: ConditionalUpdateRisk represents a reason and cluster-state for not recommending a conditional update.
-                          type: object
-                          required:
-                            - matchingRules
-                            - message
-                            - name
-                            - url
-                          properties:
-                            matchingRules:
-                              description: matchingRules is a slice of conditions for deciding which clusters match the risk and which do not. The slice is ordered by decreasing precedence. The cluster-version operator will walk the slice in order, and stop after the first it can successfully evaluate. If no condition can be successfully evaluated, the update will not be recommended.
-                              type: array
-                              minItems: 1
-                              items:
-                                description: ClusterCondition is a union of typed cluster conditions.  The 'type' property determines which of the type-specific properties are relevant. When evaluated on a cluster, the condition may match, not match, or fail to evaluate.
-                                type: object
-                                required:
-                                  - type
-                                properties:
-                                  promql:
-                                    description: promQL represents a cluster condition based on PromQL.
-                                    type: object
-                                    required:
-                                      - promql
-                                    properties:
-                                      promql:
-                                        description: PromQL is a PromQL query classifying clusters. This query query should return a 1 in the match case and a 0 in the does-not-match case. Queries which return no time series, or which return values besides 0 or 1, are evaluation failures.
-                                        type: string
-                                  type:
-                                    description: type represents the cluster-condition type. This defines the members and semantics of any additional properties.
-                                    type: string
-                                    enum:
-                                      - Always
-                                      - PromQL
-                              x-kubernetes-list-type: atomic
-                            message:
-                              description: message provides additional information about the risk of updating, in the event that matchingRules match the cluster state. This is only to be consumed by humans. It may contain Line Feed characters (U+000A), which should be rendered as new lines.
-                              type: string
-                              minLength: 1
-                            name:
-                              description: name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state.
-                              type: string
-                              minLength: 1
-                            url:
-                              description: url contains information about this risk.
-                              type: string
-                              format: uri
-                              minLength: 1
-                        x-kubernetes-list-map-keys:
-                          - name
-                        x-kubernetes-list-type: map
-                  x-kubernetes-list-type: atomic
-                conditions:
-                  description: conditions provides information about the cluster version. The condition "Available" is set to true if the desiredUpdate has been reached. The condition "Progressing" is set to true if an update is being applied. The condition "Degraded" is set to true if an update is currently blocked by a temporary or permanent error. Conditions are only valid for the current desiredUpdate when metadata.generation is equal to status.generation.
-                  type: array
-                  items:
-                    description: ClusterOperatorStatusCondition represents the state of the operator's managed and monitored components.
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the time of the last update to the current status property.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message provides additional information about the current condition. This is only to be consumed by humans.  It may contain Line Feed characters (U+000A), which should be rendered as new lines.
-                        type: string
-                      reason:
-                        description: reason is the CamelCase reason for the condition's current status.
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                      type:
-                        description: type specifies the aspect reported by this condition.
-                        type: string
-                desired:
-                  description: desired is the version that the cluster is reconciling towards. If the cluster is not yet fully initialized desired will be set with the information available, which may be an image or a tag.
-                  type: object
+                type: array
+              upstream:
+                description: upstream may be used to specify the preferred update
+                  server. By default it will use the appropriate update server for
+                  the cluster and region.
+                type: string
+            required:
+            - clusterID
+            type: object
+          status:
+            description: status contains information about the available updates and
+              any in-progress updates.
+            properties:
+              availableUpdates:
+                description: availableUpdates contains updates recommended for this
+                  cluster. Updates which appear in conditionalUpdates but not in availableUpdates
+                  may expose this cluster to known issues. This list may be empty
+                  if no updates are recommended, if the update service is unavailable,
+                  or if an invalid channel has been specified.
+                items:
+                  description: Release represents an OpenShift release image and associated
+                    metadata.
                   properties:
                     channels:
-                      description: channels is the set of Cincinnati channels to which the release currently belongs.
-                      type: array
+                      description: channels is the set of Cincinnati channels to which
+                        the release currently belongs.
                       items:
                         type: string
+                      type: array
                     image:
-                      description: image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.
+                      description: image is a container image location that contains
+                        the update. When this field is part of spec, image is optional
+                        if version is specified and the availableUpdates field contains
+                        a matching version.
                       type: string
                     url:
-                      description: url contains information about this release. This URL is set by the 'url' metadata property on a release or the metadata returned by the update API and should be displayed as a link in user interfaces. The URL field may not be set for test or nightly releases.
+                      description: url contains information about this release. This
+                        URL is set by the 'url' metadata property on a release or
+                        the metadata returned by the update API and should be displayed
+                        as a link in user interfaces. The URL field may not be set
+                        for test or nightly releases.
                       type: string
                     version:
-                      description: version is a semantic versioning identifying the update version. When this field is part of spec, version is optional if image is specified.
+                      description: version is a semantic versioning identifying the
+                        update version. When this field is part of spec, version is
+                        optional if image is specified.
                       type: string
-                history:
-                  description: history contains a list of the most recent versions applied to the cluster. This value may be empty during cluster startup, and then will be updated when a new update is being applied. The newest update is first in the list and it is ordered by recency. Updates in the history have state Completed if the rollout completed - if an update was failing or halfway applied the state will be Partial. Only a limited amount of update history is preserved.
-                  type: array
-                  items:
-                    description: UpdateHistory is a single attempted update to the cluster.
-                    type: object
-                    required:
-                      - completionTime
-                      - image
-                      - startedTime
-                      - state
-                      - verified
-                    properties:
-                      acceptedRisks:
-                        description: acceptedRisks records risks which were accepted to initiate the update. For example, it may menition an Upgradeable=False or missing signature that was overriden via desiredUpdate.force, or an update that was initiated despite not being in the availableUpdates set of recommended update targets.
-                        type: string
-                      completionTime:
-                        description: completionTime, if set, is when the update was fully applied. The update that is currently being applied will have a null completion time. Completion time will always be set for entries that are not the current update (usually to the started time of the next update).
-                        type: string
-                        format: date-time
-                        nullable: true
-                      image:
-                        description: image is a container image location that contains the update. This value is always populated.
-                        type: string
-                      startedTime:
-                        description: startedTime is the time at which the update was started.
-                        type: string
-                        format: date-time
-                      state:
-                        description: state reflects whether the update was fully applied. The Partial state indicates the update is not fully applied, while the Completed state indicates the update was successfully rolled out at least once (all parts of the update successfully applied).
-                        type: string
-                      verified:
-                        description: verified indicates whether the provided update was properly verified before it was installed. If this is false the cluster may not be trusted. Verified does not cover upgradeable checks that depend on the cluster state at the time when the update target was accepted.
-                        type: boolean
-                      version:
-                        description: version is a semantic versioning identifying the update version. If the requested image does not define a version, or if a failure occurs retrieving the image, this value may be empty.
-                        type: string
-                observedGeneration:
-                  description: observedGeneration reports which version of the spec is being synced. If this value is not equal to metadata.generation, then the desired and conditions fields may represent a previous version.
-                  type: integer
-                  format: int64
-                versionHash:
-                  description: versionHash is a fingerprint of the content that the cluster will be updated with. It is used by the operator to avoid unnecessary work and is for internal use only.
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  type: object
+                nullable: true
+                type: array
+              capabilities:
+                description: capabilities describes the state of optional, core cluster
+                  components.
+                properties:
+                  enabledCapabilities:
+                    description: enabledCapabilities lists all the capabilities that
+                      are currently managed.
+                    items:
+                      description: ClusterVersionCapability enumerates optional, core
+                        cluster components.
+                      enum:
+                      - openshift-samples
+                      - baremetal
+                      - marketplace
+                      - Console
+                      - Insights
+                      - Storage
+                      - CSISnapshot
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  knownCapabilities:
+                    description: knownCapabilities lists all the capabilities known
+                      to the current cluster.
+                    items:
+                      description: ClusterVersionCapability enumerates optional, core
+                        cluster components.
+                      enum:
+                      - openshift-samples
+                      - baremetal
+                      - marketplace
+                      - Console
+                      - Insights
+                      - Storage
+                      - CSISnapshot
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+              conditionalUpdates:
+                description: conditionalUpdates contains the list of updates that
+                  may be recommended for this cluster if it meets specific required
+                  conditions. Consumers interested in the set of updates that are
+                  actually recommended for this cluster should use availableUpdates.
+                  This list may be empty if no updates are recommended, if the update
+                  service is unavailable, or if an empty or invalid channel has been
+                  specified.
+                items:
+                  description: ConditionalUpdate represents an update which is recommended
+                    to some clusters on the version the current cluster is reconciling,
+                    but which may not be recommended for the current cluster.
+                  properties:
+                    conditions:
+                      description: 'conditions represents the observations of the
+                        conditional update''s current status. Known types are: * Evaluating,
+                        for whether the cluster-version operator will attempt to evaluate
+                        any risks[].matchingRules. * Recommended, for whether the
+                        update is recommended for the current cluster.'
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    release:
+                      description: release is the target of the update.
+                      properties:
+                        channels:
+                          description: channels is the set of Cincinnati channels
+                            to which the release currently belongs.
+                          items:
+                            type: string
+                          type: array
+                        image:
+                          description: image is a container image location that contains
+                            the update. When this field is part of spec, image is
+                            optional if version is specified and the availableUpdates
+                            field contains a matching version.
+                          type: string
+                        url:
+                          description: url contains information about this release.
+                            This URL is set by the 'url' metadata property on a release
+                            or the metadata returned by the update API and should
+                            be displayed as a link in user interfaces. The URL field
+                            may not be set for test or nightly releases.
+                          type: string
+                        version:
+                          description: version is a semantic versioning identifying
+                            the update version. When this field is part of spec, version
+                            is optional if image is specified.
+                          type: string
+                      type: object
+                    risks:
+                      description: risks represents the range of issues associated
+                        with updating to the target release. The cluster-version operator
+                        will evaluate all entries, and only recommend the update if
+                        there is at least one entry and all entries recommend the
+                        update.
+                      items:
+                        description: ConditionalUpdateRisk represents a reason and
+                          cluster-state for not recommending a conditional update.
+                        properties:
+                          matchingRules:
+                            description: matchingRules is a slice of conditions for
+                              deciding which clusters match the risk and which do
+                              not. The slice is ordered by decreasing precedence.
+                              The cluster-version operator will walk the slice in
+                              order, and stop after the first it can successfully
+                              evaluate. If no condition can be successfully evaluated,
+                              the update will not be recommended.
+                            items:
+                              description: ClusterCondition is a union of typed cluster
+                                conditions.  The 'type' property determines which
+                                of the type-specific properties are relevant. When
+                                evaluated on a cluster, the condition may match, not
+                                match, or fail to evaluate.
+                              properties:
+                                promql:
+                                  description: promQL represents a cluster condition
+                                    based on PromQL.
+                                  properties:
+                                    promql:
+                                      description: PromQL is a PromQL query classifying
+                                        clusters. This query query should return a
+                                        1 in the match case and a 0 in the does-not-match
+                                        case. Queries which return no time series,
+                                        or which return values besides 0 or 1, are
+                                        evaluation failures.
+                                      type: string
+                                  required:
+                                  - promql
+                                  type: object
+                                type:
+                                  description: type represents the cluster-condition
+                                    type. This defines the members and semantics of
+                                    any additional properties.
+                                  enum:
+                                  - Always
+                                  - PromQL
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          message:
+                            description: message provides additional information about
+                              the risk of updating, in the event that matchingRules
+                              match the cluster state. This is only to be consumed
+                              by humans. It may contain Line Feed characters (U+000A),
+                              which should be rendered as new lines.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: name is the CamelCase reason for not recommending
+                              a conditional update, in the event that matchingRules
+                              match the cluster state.
+                            minLength: 1
+                            type: string
+                          url:
+                            description: url contains information about this risk.
+                            format: uri
+                            minLength: 1
+                            type: string
+                        required:
+                        - matchingRules
+                        - message
+                        - name
+                        - url
+                        type: object
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - release
+                  - risks
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              conditions:
+                description: conditions provides information about the cluster version.
+                  The condition "Available" is set to true if the desiredUpdate has
+                  been reached. The condition "Progressing" is set to true if an update
+                  is being applied. The condition "Degraded" is set to true if an
+                  update is currently blocked by a temporary or permanent error. Conditions
+                  are only valid for the current desiredUpdate when metadata.generation
+                  is equal to status.generation.
+                items:
+                  description: ClusterOperatorStatusCondition represents the state
+                    of the operator's managed and monitored components.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status property.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message provides additional information about the
+                        current condition. This is only to be consumed by humans.  It
+                        may contain Line Feed characters (U+000A), which should be
+                        rendered as new lines.
+                      type: string
+                    reason:
+                      description: reason is the CamelCase reason for the condition's
+                        current status.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the aspect reported by this condition.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              desired:
+                description: desired is the version that the cluster is reconciling
+                  towards. If the cluster is not yet fully initialized desired will
+                  be set with the information available, which may be an image or
+                  a tag.
+                properties:
+                  channels:
+                    description: channels is the set of Cincinnati channels to which
+                      the release currently belongs.
+                    items:
+                      type: string
+                    type: array
+                  image:
+                    description: image is a container image location that contains
+                      the update. When this field is part of spec, image is optional
+                      if version is specified and the availableUpdates field contains
+                      a matching version.
+                    type: string
+                  url:
+                    description: url contains information about this release. This
+                      URL is set by the 'url' metadata property on a release or the
+                      metadata returned by the update API and should be displayed
+                      as a link in user interfaces. The URL field may not be set for
+                      test or nightly releases.
+                    type: string
+                  version:
+                    description: version is a semantic versioning identifying the
+                      update version. When this field is part of spec, version is
+                      optional if image is specified.
+                    type: string
+                type: object
+              history:
+                description: history contains a list of the most recent versions applied
+                  to the cluster. This value may be empty during cluster startup,
+                  and then will be updated when a new update is being applied. The
+                  newest update is first in the list and it is ordered by recency.
+                  Updates in the history have state Completed if the rollout completed
+                  - if an update was failing or halfway applied the state will be
+                  Partial. Only a limited amount of update history is preserved.
+                items:
+                  description: UpdateHistory is a single attempted update to the cluster.
+                  properties:
+                    acceptedRisks:
+                      description: acceptedRisks records risks which were accepted
+                        to initiate the update. For example, it may menition an Upgradeable=False
+                        or missing signature that was overriden via desiredUpdate.force,
+                        or an update that was initiated despite not being in the availableUpdates
+                        set of recommended update targets.
+                      type: string
+                    completionTime:
+                      description: completionTime, if set, is when the update was
+                        fully applied. The update that is currently being applied
+                        will have a null completion time. Completion time will always
+                        be set for entries that are not the current update (usually
+                        to the started time of the next update).
+                      format: date-time
+                      nullable: true
+                      type: string
+                    image:
+                      description: image is a container image location that contains
+                        the update. This value is always populated.
+                      type: string
+                    startedTime:
+                      description: startedTime is the time at which the update was
+                        started.
+                      format: date-time
+                      type: string
+                    state:
+                      description: state reflects whether the update was fully applied.
+                        The Partial state indicates the update is not fully applied,
+                        while the Completed state indicates the update was successfully
+                        rolled out at least once (all parts of the update successfully
+                        applied).
+                      type: string
+                    verified:
+                      description: verified indicates whether the provided update
+                        was properly verified before it was installed. If this is
+                        false the cluster may not be trusted. Verified does not cover
+                        upgradeable checks that depend on the cluster state at the
+                        time when the update target was accepted.
+                      type: boolean
+                    version:
+                      description: version is a semantic versioning identifying the
+                        update version. If the requested image does not define a version,
+                        or if a failure occurs retrieving the image, this value may
+                        be empty.
+                      type: string
+                  required:
+                  - completionTime
+                  - image
+                  - startedTime
+                  - state
+                  - verified
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration reports which version of the spec
+                  is being synced. If this value is not equal to metadata.generation,
+                  then the desired and conditions fields may represent a previous
+                  version.
+                format: int64
+                type: integer
+              versionHash:
+                description: versionHash is a fingerprint of the content that the
+                  cluster will be updated with. It is used by the operator to avoid
+                  unnecessary work and is for internal use only.
+                type: string
+            required:
+            - availableUpdates
+            - desired
+            - observedGeneration
+            - versionHash
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_03_config-operator_01_proxy.crd.yaml
+++ b/config/v1/0000_03_config-operator_01_proxy.crd.yaml
@@ -16,63 +16,91 @@ spec:
     singular: proxy
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Proxy holds cluster-wide information on how to configure default proxies for the cluster. The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec holds user-settable values for the proxy configuration
-              type: object
-              properties:
-                httpProxy:
-                  description: httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Proxy holds cluster-wide information on how to configure default
+          proxies for the cluster. The canonical name is `cluster` \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds user-settable values for the proxy configuration
+            properties:
+              httpProxy:
+                description: httpProxy is the URL of the proxy for HTTP requests.  Empty
+                  means unset and will not result in an env var.
+                type: string
+              httpsProxy:
+                description: httpsProxy is the URL of the proxy for HTTPS requests.  Empty
+                  means unset and will not result in an env var.
+                type: string
+              noProxy:
+                description: noProxy is a comma-separated list of hostnames and/or
+                  CIDRs and/or IPs for which the proxy should not be used. Empty means
+                  unset and will not result in an env var.
+                type: string
+              readinessEndpoints:
+                description: readinessEndpoints is a list of endpoints used to verify
+                  readiness of the proxy.
+                items:
                   type: string
-                httpsProxy:
-                  description: httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
-                  type: string
-                noProxy:
-                  description: noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used. Empty means unset and will not result in an env var.
-                  type: string
-                readinessEndpoints:
-                  description: readinessEndpoints is a list of endpoints used to verify readiness of the proxy.
-                  type: array
-                  items:
+                type: array
+              trustedCA:
+                description: "trustedCA is a reference to a ConfigMap containing a
+                  CA certificate bundle. The trustedCA field should only be consumed
+                  by a proxy validator. The validator is responsible for reading the
+                  certificate bundle from the required key \"ca-bundle.crt\", merging
+                  it with the system default trust bundle, and writing the merged
+                  trust bundle to a ConfigMap named \"trusted-ca-bundle\" in the \"openshift-config-managed\"
+                  namespace. Clients that expect to make proxy connections must use
+                  the trusted-ca-bundle for all HTTPS requests to the proxy, and may
+                  use the trusted-ca-bundle for non-proxy HTTPS requests as well.
+                  \n The namespace for the ConfigMap referenced by trustedCA is \"openshift-config\".
+                  Here is an example ConfigMap (in yaml): \n apiVersion: v1 kind:
+                  ConfigMap metadata: name: user-ca-bundle namespace: openshift-config
+                  data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom CA certificate
+                  bundle. -----END CERTIFICATE-----"
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
                     type: string
-                trustedCA:
-                  description: "trustedCA is a reference to a ConfigMap containing a CA certificate bundle. The trustedCA field should only be consumed by a proxy validator. The validator is responsible for reading the certificate bundle from the required key \"ca-bundle.crt\", merging it with the system default trust bundle, and writing the merged trust bundle to a ConfigMap named \"trusted-ca-bundle\" in the \"openshift-config-managed\" namespace. Clients that expect to make proxy connections must use the trusted-ca-bundle for all HTTPS requests to the proxy, and may use the trusted-ca-bundle for non-proxy HTTPS requests as well. \n The namespace for the ConfigMap referenced by trustedCA is \"openshift-config\". Here is an example ConfigMap (in yaml): \n apiVersion: v1 kind: ConfigMap metadata: name: user-ca-bundle namespace: openshift-config data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom CA certificate bundle. -----END CERTIFICATE-----"
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced config map
-                      type: string
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-              properties:
-                httpProxy:
-                  description: httpProxy is the URL of the proxy for HTTP requests.
-                  type: string
-                httpsProxy:
-                  description: httpsProxy is the URL of the proxy for HTTPS requests.
-                  type: string
-                noProxy:
-                  description: noProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used.
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              httpProxy:
+                description: httpProxy is the URL of the proxy for HTTP requests.
+                type: string
+              httpsProxy:
+                description: httpsProxy is the URL of the proxy for HTTPS requests.
+                type: string
+              noProxy:
+                description: noProxy is a comma-separated list of hostnames and/or
+                  CIDRs for which the proxy should not be used.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_03_marketplace-operator_01_operatorhub.crd.yaml
+++ b/config/v1/0000_03_marketplace-operator_01_operatorhub.crd.yaml
@@ -3,10 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    capability.openshift.io/name: marketplace
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: "marketplace"
   name: operatorhubs.config.openshift.io
 spec:
   group: config.openshift.io
@@ -17,68 +17,93 @@ spec:
     singular: operatorhub
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "OperatorHub is the Schema for the operatorhubs API. It can be used to change the state of the default hub sources for OperatorHub on the cluster from enabled to disabled and vice versa. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: OperatorHubSpec defines the desired state of OperatorHub
-              type: object
-              properties:
-                disableAllDefaultSources:
-                  description: disableAllDefaultSources allows you to disable all the default hub sources. If this is true, a specific entry in sources can be used to enable a default source. If this is false, a specific entry in sources can be used to disable or enable a default source.
-                  type: boolean
-                sources:
-                  description: sources is the list of default hub sources and their configuration. If the list is empty, it implies that the default hub sources are enabled on the cluster unless disableAllDefaultSources is true. If disableAllDefaultSources is true and sources is not empty, the configuration present in sources will take precedence. The list of default hub sources and their current state will always be reflected in the status block.
-                  type: array
-                  items:
-                    description: HubSource is used to specify the hub source and its configuration
-                    type: object
-                    properties:
-                      disabled:
-                        description: disabled is used to disable a default hub source on cluster
-                        type: boolean
-                      name:
-                        description: name is the name of one of the default hub sources
-                        type: string
-                        maxLength: 253
-                        minLength: 1
-            status:
-              description: OperatorHubStatus defines the observed state of OperatorHub. The current state of the default hub sources will always be reflected here.
-              type: object
-              properties:
-                sources:
-                  description: sources encapsulates the result of applying the configuration for each hub source
-                  type: array
-                  items:
-                    description: HubSourceStatus is used to reflect the current state of applying the configuration to a default source
-                    type: object
-                    properties:
-                      disabled:
-                        description: disabled is used to disable a default hub source on cluster
-                        type: boolean
-                      message:
-                        description: message provides more information regarding failures
-                        type: string
-                      name:
-                        description: name is the name of one of the default hub sources
-                        type: string
-                        maxLength: 253
-                        minLength: 1
-                      status:
-                        description: status indicates success or failure in applying the configuration
-                        type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "OperatorHub is the Schema for the operatorhubs API. It can be
+          used to change the state of the default hub sources for OperatorHub on the
+          cluster from enabled to disabled and vice versa. \n Compatibility level
+          1: Stable within a major release for a minimum of 12 months or 3 minor releases
+          (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OperatorHubSpec defines the desired state of OperatorHub
+            properties:
+              disableAllDefaultSources:
+                description: disableAllDefaultSources allows you to disable all the
+                  default hub sources. If this is true, a specific entry in sources
+                  can be used to enable a default source. If this is false, a specific
+                  entry in sources can be used to disable or enable a default source.
+                type: boolean
+              sources:
+                description: sources is the list of default hub sources and their
+                  configuration. If the list is empty, it implies that the default
+                  hub sources are enabled on the cluster unless disableAllDefaultSources
+                  is true. If disableAllDefaultSources is true and sources is not
+                  empty, the configuration present in sources will take precedence.
+                  The list of default hub sources and their current state will always
+                  be reflected in the status block.
+                items:
+                  description: HubSource is used to specify the hub source and its
+                    configuration
+                  properties:
+                    disabled:
+                      description: disabled is used to disable a default hub source
+                        on cluster
+                      type: boolean
+                    name:
+                      description: name is the name of one of the default hub sources
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: OperatorHubStatus defines the observed state of OperatorHub.
+              The current state of the default hub sources will always be reflected
+              here.
+            properties:
+              sources:
+                description: sources encapsulates the result of applying the configuration
+                  for each hub source
+                items:
+                  description: HubSourceStatus is used to reflect the current state
+                    of applying the configuration to a default source
+                  properties:
+                    disabled:
+                      description: disabled is used to disable a default hub source
+                        on cluster
+                      type: boolean
+                    message:
+                      description: message provides more information regarding failures
+                      type: string
+                    name:
+                      description: name is the name of one of the default hub sources
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    status:
+                      description: status indicates success or failure in applying
+                        the configuration
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_apiserver.crd.yaml
@@ -16,162 +16,295 @@ spec:
     singular: apiserver
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "APIServer holds configuration (like serving certificates, client CA and CORS domains) shared by all API servers in the system, among them especially kube-apiserver and openshift-apiserver. The canonical name of an instance is 'cluster'. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                additionalCORSAllowedOrigins:
-                  description: additionalCORSAllowedOrigins lists additional, user-defined regular expressions describing hosts for which the API server allows access using the CORS headers. This may be needed to access the API and the integrated OAuth server from JavaScript applications. The values are regular expressions that correspond to the Golang regular expression language.
-                  type: array
-                  items:
-                    type: string
-                audit:
-                  description: audit specifies the settings for audit configuration to be applied to all OpenShift-provided API servers in the cluster.
-                  type: object
-                  default:
-                    profile: Default
-                  properties:
-                    customRules:
-                      description: customRules specify profiles per group. These profile take precedence over the top-level profile field if they apply. They are evaluation from top to bottom and the first one that matches, applies.
-                      type: array
-                      items:
-                        description: AuditCustomRule describes a custom rule for an audit profile that takes precedence over the top-level profile.
-                        type: object
-                        required:
-                          - group
-                          - profile
-                        properties:
-                          group:
-                            description: group is a name of group a request user must be member of in order to this profile to apply.
-                            type: string
-                            minLength: 1
-                          profile:
-                            description: "profile specifies the name of the desired audit policy configuration to be deployed to all OpenShift-provided API servers in the cluster. \n The following profiles are provided: - Default: the existing default policy. - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n If unset, the 'Default' profile is used as the default."
-                            type: string
-                            enum:
-                              - Default
-                              - WriteRequestBodies
-                              - AllRequestBodies
-                              - None
-                      x-kubernetes-list-map-keys:
-                        - group
-                      x-kubernetes-list-type: map
-                    profile:
-                      description: "profile specifies the name of the desired top-level audit profile to be applied to all requests sent to any of the OpenShift-provided API servers in the cluster (kube-apiserver, openshift-apiserver and oauth-apiserver), with the exception of those requests that match one or more of the customRules. \n The following profiles are provided: - Default: default policy which means MetaData level logging with the exception of events (not logged at all), oauthaccesstokens and oauthauthorizetokens (both logged at RequestBody level). - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n Warning: It is not recommended to disable audit logging by using the `None` profile unless you are fully aware of the risks of not logging data that can be beneficial when troubleshooting issues. If you disable audit logging and a support situation arises, you might need to enable audit logging and reproduce the issue in order to troubleshoot properly. \n If unset, the 'Default' profile is used as the default."
-                      type: string
-                      default: Default
-                      enum:
-                        - Default
-                        - WriteRequestBodies
-                        - AllRequestBodies
-                        - None
-                clientCA:
-                  description: 'clientCA references a ConfigMap containing a certificate bundle for the signers that will be recognized for incoming client certificates in addition to the operator managed signers. If this is empty, then only operator managed signers are valid. You usually only have to set this if you have your own PKI you wish to honor client certificates from. The ConfigMap must exist in the openshift-config namespace and contain the following required fields: - ConfigMap.Data["ca-bundle.crt"] - CA bundle.'
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced config map
-                      type: string
-                encryption:
-                  description: encryption allows the configuration of encryption of resources at the datastore layer.
-                  type: object
-                  properties:
-                    type:
-                      description: "type defines what encryption type should be used to encrypt resources at the datastore layer. When this field is unset (i.e. when it is set to the empty string), identity is implied. The behavior of unset can and will change over time.  Even if encryption is enabled by default, the meaning of unset may change to a different encryption type based on changes in best practices. \n When encryption is enabled, all sensitive resources shipped with the platform are encrypted. This list of sensitive resources can and will change over time.  The current authoritative list is: \n 1. secrets 2. configmaps 3. routes.route.openshift.io 4. oauthaccesstokens.oauth.openshift.io 5. oauthauthorizetokens.oauth.openshift.io"
-                      type: string
-                      enum:
-                        - ""
-                        - identity
-                        - aescbc
-                servingCerts:
-                  description: servingCert is the TLS cert info for serving secure traffic. If not specified, operator managed certificates will be used for serving secure traffic.
-                  type: object
-                  properties:
-                    namedCertificates:
-                      description: namedCertificates references secrets containing the TLS cert info for serving secure traffic to specific hostnames. If no named certificates are provided, or no named certificates match the server name as understood by a client, the defaultServingCertificate will be used.
-                      type: array
-                      items:
-                        description: APIServerNamedServingCert maps a server DNS name, as understood by a client, to a certificate.
-                        type: object
-                        properties:
-                          names:
-                            description: names is a optional list of explicit DNS names (leading wildcards allowed) that should use this certificate to serve secure traffic. If no names are provided, the implicit names will be extracted from the certificates. Exact names trump over wildcard names. Explicit names defined here trump over extracted implicit names.
-                            type: array
-                            items:
-                              type: string
-                          servingCertificate:
-                            description: 'servingCertificate references a kubernetes.io/tls type secret containing the TLS cert info for serving secure traffic. The secret must exist in the openshift-config namespace and contain the following required fields: - Secret.Data["tls.key"] - TLS private key. - Secret.Data["tls.crt"] - TLS certificate.'
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                tlsSecurityProfile:
-                  description: "tlsSecurityProfile specifies settings for TLS connections for externally exposed servers. \n If unset, a default (which may change between releases) is chosen. Note that only Old, Intermediate and Custom profiles are currently supported, and the maximum available MinTLSVersions is VersionTLS12."
-                  type: object
-                  properties:
-                    custom:
-                      description: "custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion: TLSv1.1"
-                      type: object
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "APIServer holds configuration (like serving certificates, client
+          CA and CORS domains) shared by all API servers in the system, among them
+          especially kube-apiserver and openshift-apiserver. The canonical name of
+          an instance is 'cluster'. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              additionalCORSAllowedOrigins:
+                description: additionalCORSAllowedOrigins lists additional, user-defined
+                  regular expressions describing hosts for which the API server allows
+                  access using the CORS headers. This may be needed to access the
+                  API and the integrated OAuth server from JavaScript applications.
+                  The values are regular expressions that correspond to the Golang
+                  regular expression language.
+                items:
+                  type: string
+                type: array
+              audit:
+                default:
+                  profile: Default
+                description: audit specifies the settings for audit configuration
+                  to be applied to all OpenShift-provided API servers in the cluster.
+                properties:
+                  customRules:
+                    description: customRules specify profiles per group. These profile
+                      take precedence over the top-level profile field if they apply.
+                      They are evaluation from top to bottom and the first one that
+                      matches, applies.
+                    items:
+                      description: AuditCustomRule describes a custom rule for an
+                        audit profile that takes precedence over the top-level profile.
                       properties:
-                        ciphers:
-                          description: "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA"
-                          type: array
+                        group:
+                          description: group is a name of group a request user must
+                            be member of in order to this profile to apply.
+                          minLength: 1
+                          type: string
+                        profile:
+                          description: "profile specifies the name of the desired
+                            audit policy configuration to be deployed to all OpenShift-provided
+                            API servers in the cluster. \n The following profiles
+                            are provided: - Default: the existing default policy.
+                            - WriteRequestBodies: like 'Default', but logs request
+                            and response HTTP payloads for write requests (create,
+                            update, patch). - AllRequestBodies: like 'WriteRequestBodies',
+                            but also logs request and response HTTP payloads for read
+                            requests (get, list). - None: no requests are logged at
+                            all, not even oauthaccesstokens and oauthauthorizetokens.
+                            \n If unset, the 'Default' profile is used as the default."
+                          enum:
+                          - Default
+                          - WriteRequestBodies
+                          - AllRequestBodies
+                          - None
+                          type: string
+                      required:
+                      - group
+                      - profile
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - group
+                    x-kubernetes-list-type: map
+                  profile:
+                    default: Default
+                    description: "profile specifies the name of the desired top-level
+                      audit profile to be applied to all requests sent to any of the
+                      OpenShift-provided API servers in the cluster (kube-apiserver,
+                      openshift-apiserver and oauth-apiserver), with the exception
+                      of those requests that match one or more of the customRules.
+                      \n The following profiles are provided: - Default: default policy
+                      which means MetaData level logging with the exception of events
+                      (not logged at all), oauthaccesstokens and oauthauthorizetokens
+                      (both logged at RequestBody level). - WriteRequestBodies: like
+                      'Default', but logs request and response HTTP payloads for write
+                      requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies',
+                      but also logs request and response HTTP payloads for read requests
+                      (get, list). - None: no requests are logged at all, not even
+                      oauthaccesstokens and oauthauthorizetokens. \n Warning: It is
+                      not recommended to disable audit logging by using the `None`
+                      profile unless you are fully aware of the risks of not logging
+                      data that can be beneficial when troubleshooting issues. If
+                      you disable audit logging and a support situation arises, you
+                      might need to enable audit logging and reproduce the issue in
+                      order to troubleshoot properly. \n If unset, the 'Default' profile
+                      is used as the default."
+                    enum:
+                    - Default
+                    - WriteRequestBodies
+                    - AllRequestBodies
+                    - None
+                    type: string
+                type: object
+              clientCA:
+                description: 'clientCA references a ConfigMap containing a certificate
+                  bundle for the signers that will be recognized for incoming client
+                  certificates in addition to the operator managed signers. If this
+                  is empty, then only operator managed signers are valid. You usually
+                  only have to set this if you have your own PKI you wish to honor
+                  client certificates from. The ConfigMap must exist in the openshift-config
+                  namespace and contain the following required fields: - ConfigMap.Data["ca-bundle.crt"]
+                  - CA bundle.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              encryption:
+                description: encryption allows the configuration of encryption of
+                  resources at the datastore layer.
+                properties:
+                  type:
+                    description: "type defines what encryption type should be used
+                      to encrypt resources at the datastore layer. When this field
+                      is unset (i.e. when it is set to the empty string), identity
+                      is implied. The behavior of unset can and will change over time.
+                      \ Even if encryption is enabled by default, the meaning of unset
+                      may change to a different encryption type based on changes in
+                      best practices. \n When encryption is enabled, all sensitive
+                      resources shipped with the platform are encrypted. This list
+                      of sensitive resources can and will change over time.  The current
+                      authoritative list is: \n 1. secrets 2. configmaps 3. routes.route.openshift.io
+                      4. oauthaccesstokens.oauth.openshift.io 5. oauthauthorizetokens.oauth.openshift.io"
+                    enum:
+                    - ""
+                    - identity
+                    - aescbc
+                    type: string
+                type: object
+              servingCerts:
+                description: servingCert is the TLS cert info for serving secure traffic.
+                  If not specified, operator managed certificates will be used for
+                  serving secure traffic.
+                properties:
+                  namedCertificates:
+                    description: namedCertificates references secrets containing the
+                      TLS cert info for serving secure traffic to specific hostnames.
+                      If no named certificates are provided, or no named certificates
+                      match the server name as understood by a client, the defaultServingCertificate
+                      will be used.
+                    items:
+                      description: APIServerNamedServingCert maps a server DNS name,
+                        as understood by a client, to a certificate.
+                      properties:
+                        names:
+                          description: names is a optional list of explicit DNS names
+                            (leading wildcards allowed) that should use this certificate
+                            to serve secure traffic. If no names are provided, the
+                            implicit names will be extracted from the certificates.
+                            Exact names trump over wildcard names. Explicit names
+                            defined here trump over extracted implicit names.
                           items:
                             type: string
-                        minTLSVersion:
-                          description: "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion: TLSv1.1 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12"
+                          type: array
+                        servingCertificate:
+                          description: 'servingCertificate references a kubernetes.io/tls
+                            type secret containing the TLS cert info for serving secure
+                            traffic. The secret must exist in the openshift-config
+                            namespace and contain the following required fields: -
+                            Secret.Data["tls.key"] - TLS private key. - Secret.Data["tls.crt"]
+                            - TLS certificate.'
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      type: object
+                    type: array
+                type: object
+              tlsSecurityProfile:
+                description: "tlsSecurityProfile specifies settings for TLS connections
+                  for externally exposed servers. \n If unset, a default (which may
+                  change between releases) is chosen. Note that only Old, Intermediate
+                  and Custom profiles are currently supported, and the maximum available
+                  MinTLSVersions is VersionTLS12."
+                properties:
+                  custom:
+                    description: "custom is a user-defined TLS security profile. Be
+                      extremely careful using a custom profile as invalid configurations
+                      can be catastrophic. An example custom profile looks like this:
+                      \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305
+                      - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256
+                      minTLSVersion: TLSv1.1"
+                    nullable: true
+                    properties:
+                      ciphers:
+                        description: "ciphers is used to specify the cipher algorithms
+                          that are negotiated during the TLS handshake.  Operators
+                          may remove entries their operands do not support.  For example,
+                          to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA"
+                        items:
                           type: string
-                          enum:
-                            - VersionTLS10
-                            - VersionTLS11
-                            - VersionTLS12
-                            - VersionTLS13
-                      nullable: true
-                    intermediate:
-                      description: "intermediate is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 minTLSVersion: TLSv1.2"
-                      type: object
-                      nullable: true
-                    modern:
-                      description: "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 minTLSVersion: TLSv1.3 \n NOTE: Currently unsupported."
-                      type: object
-                      nullable: true
-                    old:
-                      description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256 - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA - ECDHE-RSA-AES128-SHA - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384 - ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256 - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384 - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA - DES-CBC3-SHA minTLSVersion: TLSv1.0"
-                      type: object
-                      nullable: true
-                    type:
-                      description: "type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations \n The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. \n Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries."
-                      type: string
-                      enum:
-                        - Old
-                        - Intermediate
-                        - Modern
-                        - Custom
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                        type: array
+                      minTLSVersion:
+                        description: "minTLSVersion is used to specify the minimal
+                          version of the TLS protocol that is negotiated during the
+                          TLS handshake. For example, to use TLS versions 1.1, 1.2
+                          and 1.3 (yaml): \n minTLSVersion: TLSv1.1 \n NOTE: currently
+                          the highest minTLSVersion allowed is VersionTLS12"
+                        enum:
+                        - VersionTLS10
+                        - VersionTLS11
+                        - VersionTLS12
+                        - VersionTLS13
+                        type: string
+                    type: object
+                  intermediate:
+                    description: "intermediate is a TLS security profile based on:
+                      \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+                      \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                      - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256
+                      - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305
+                      - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 -
+                      DHE-RSA-AES256-GCM-SHA384 minTLSVersion: TLSv1.2"
+                    nullable: true
+                    type: object
+                  modern:
+                    description: "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+                      \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                      - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 minTLSVersion:
+                      TLSv1.3 \n NOTE: Currently unsupported."
+                    nullable: true
+                    type: object
+                  old:
+                    description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+                      \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256
+                      - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256
+                      - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384
+                      - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305
+                      - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 -
+                      DHE-RSA-AES256-GCM-SHA384 - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256
+                      - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA - ECDHE-RSA-AES128-SHA
+                      - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384 - ECDHE-ECDSA-AES256-SHA
+                      - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256 - DHE-RSA-AES256-SHA256
+                      - AES128-GCM-SHA256 - AES256-GCM-SHA384 - AES128-SHA256 - AES256-SHA256
+                      - AES128-SHA - AES256-SHA - DES-CBC3-SHA minTLSVersion: TLSv1.0"
+                    nullable: true
+                    type: object
+                  type:
+                    description: "type is one of Old, Intermediate, Modern or Custom.
+                      Custom provides the ability to specify individual TLS security
+                      profile parameters. Old, Intermediate and Modern are TLS security
+                      profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+                      \n The profiles are intent based, so they may change over time
+                      as new ciphers are developed and existing ciphers are found
+                      to be insecure.  Depending on precisely which ciphers are available
+                      to a process, the list may be reduced. \n Note that the Modern
+                      profile is currently not supported because it is not yet well
+                      adopted by common software libraries."
+                    enum:
+                    - Old
+                    - Intermediate
+                    - Modern
+                    - Custom
+                    type: string
+                type: object
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_authentication.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd.yaml
@@ -16,86 +16,148 @@ spec:
     singular: authentication
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Authentication specifies cluster-wide settings for authentication (like OAuth and webhook token authenticators). The canonical name of an instance is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                oauthMetadata:
-                  description: 'oauthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for an external OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 If oauthMetadata.name is non-empty, this value has precedence over any metadata reference stored in status. The key "oauthMetadata" is used to locate the data. If specified and the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config.'
-                  type: object
-                  required:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Authentication specifies cluster-wide settings for authentication
+          (like OAuth and webhook token authenticators). The canonical name of an
+          instance is `cluster`. \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              oauthMetadata:
+                description: 'oauthMetadata contains the discovery endpoint data for
+                  OAuth 2.0 Authorization Server Metadata for an external OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw ''/.well-known/oauth-authorization-server'' For further
+                  details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  If oauthMetadata.name is non-empty, this value has precedence over
+                  any metadata reference stored in status. The key "oauthMetadata"
+                  is used to locate the data. If specified and the config map or expected
+                  key is not found, no metadata is served. If the specified metadata
+                  is not valid, no metadata is served. The namespace for this config
+                  map is openshift-config.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountIssuer:
+                description: 'serviceAccountIssuer is the identifier of the bound
+                  service account token issuer. The default is https://kubernetes.default.svc
+                  WARNING: Updating this field will result in the invalidation of
+                  all bound tokens with the previous issuer value. Unless the holder
+                  of a bound token has explicit support for a change in issuer, they
+                  will not request a new bound token until pod restart or until their
+                  existing token exceeds 80% of its duration.'
+                type: string
+              type:
+                description: type identifies the cluster managed, user facing authentication
+                  mode in use. Specifically, it manages the component that responds
+                  to login attempts. The default is IntegratedOAuth.
+                type: string
+              webhookTokenAuthenticator:
+                description: webhookTokenAuthenticator configures a remote token reviewer.
+                  These remote authentication webhooks can be used to verify bearer
+                  tokens via the tokenreviews.authentication.k8s.io REST API. This
+                  is required to honor bearer tokens that are provisioned by an external
+                  authentication service.
+                properties:
+                  kubeConfig:
+                    description: "kubeConfig references a secret that contains kube
+                      config file data which describes how to access the remote webhook
+                      service. The namespace for the referenced secret is openshift-config.
+                      \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                      \n The key \"kubeConfig\" is used to locate the data. If the
+                      secret or expected key is not found, the webhook is not honored.
+                      If the specified kube config data is not valid, the webhook
+                      is not honored."
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
                     - name
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced config map
-                      type: string
-                serviceAccountIssuer:
-                  description: 'serviceAccountIssuer is the identifier of the bound service account token issuer. The default is https://kubernetes.default.svc WARNING: Updating this field will result in the invalidation of all bound tokens with the previous issuer value. Unless the holder of a bound token has explicit support for a change in issuer, they will not request a new bound token until pod restart or until their existing token exceeds 80% of its duration.'
-                  type: string
-                type:
-                  description: type identifies the cluster managed, user facing authentication mode in use. Specifically, it manages the component that responds to login attempts. The default is IntegratedOAuth.
-                  type: string
-                webhookTokenAuthenticator:
-                  description: webhookTokenAuthenticator configures a remote token reviewer. These remote authentication webhooks can be used to verify bearer tokens via the tokenreviews.authentication.k8s.io REST API. This is required to honor bearer tokens that are provisioned by an external authentication service.
-                  type: object
-                  required:
-                    - kubeConfig
+                    type: object
+                required:
+                - kubeConfig
+                type: object
+              webhookTokenAuthenticators:
+                description: webhookTokenAuthenticators is DEPRECATED, setting it
+                  has no effect.
+                items:
+                  description: deprecatedWebhookTokenAuthenticator holds the necessary
+                    configuration options for a remote token authenticator. It's the
+                    same as WebhookTokenAuthenticator but it's missing the 'required'
+                    validation on KubeConfig field.
                   properties:
                     kubeConfig:
-                      description: "kubeConfig references a secret that contains kube config file data which describes how to access the remote webhook service. The namespace for the referenced secret is openshift-config. \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication \n The key \"kubeConfig\" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored."
-                      type: object
-                      required:
-                        - name
+                      description: 'kubeConfig contains kube config file data which
+                        describes how to access the remote webhook service. For further
+                        details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                        The key "kubeConfig" is used to locate the data. If the secret
+                        or expected key is not found, the webhook is not honored.
+                        If the specified kube config data is not valid, the webhook
+                        is not honored. The namespace for this secret is determined
+                        by the point of use.'
                       properties:
                         name:
-                          description: name is the metadata.name of the referenced secret
+                          description: name is the metadata.name of the referenced
+                            secret
                           type: string
-                webhookTokenAuthenticators:
-                  description: webhookTokenAuthenticators is DEPRECATED, setting it has no effect.
-                  type: array
-                  items:
-                    description: deprecatedWebhookTokenAuthenticator holds the necessary configuration options for a remote token authenticator. It's the same as WebhookTokenAuthenticator but it's missing the 'required' validation on KubeConfig field.
-                    type: object
-                    properties:
-                      kubeConfig:
-                        description: 'kubeConfig contains kube config file data which describes how to access the remote webhook service. For further details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication The key "kubeConfig" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored. The namespace for this secret is determined by the point of use.'
-                        type: object
-                        required:
-                          - name
-                        properties:
-                          name:
-                            description: name is the metadata.name of the referenced secret
-                            type: string
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-              properties:
-                integratedOAuthMetadata:
-                  description: 'integratedOAuthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for the in-cluster integrated OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 This contains the observed value based on cluster state. An explicitly set value in spec.oauthMetadata has precedence over this field. This field has no meaning if authentication spec.type is not set to IntegratedOAuth. The key "oauthMetadata" is used to locate the data. If the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config-managed.'
+                      required:
+                      - name
+                      type: object
                   type: object
-                  required:
-                    - name
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced config map
-                      type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              integratedOAuthMetadata:
+                description: 'integratedOAuthMetadata contains the discovery endpoint
+                  data for OAuth 2.0 Authorization Server Metadata for the in-cluster
+                  integrated OAuth server. This discovery document can be viewed from
+                  its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                  For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  This contains the observed value based on cluster state. An explicitly
+                  set value in spec.oauthMetadata has precedence over this field.
+                  This field has no meaning if authentication spec.type is not set
+                  to IntegratedOAuth. The key "oauthMetadata" is used to locate the
+                  data. If the config map or expected key is not found, no metadata
+                  is served. If the specified metadata is not valid, no metadata is
+                  served. The namespace for this config map is openshift-config-managed.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_build.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_build.crd.yaml
@@ -17,259 +17,391 @@ spec:
   preserveUnknownFields: false
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Build configures the behavior of OpenShift builds for the entire cluster. This includes default settings that can be overridden in BuildConfig objects, and overrides which are applied to all builds. \n The canonical name is \"cluster\" \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec holds user-settable values for the build controller configuration
-              type: object
-              properties:
-                additionalTrustedCA:
-                  description: "AdditionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted for image pushes and pulls during builds. The namespace for this config map is openshift-config. \n DEPRECATED: Additional CAs for image pull and push should be set on image.config.openshift.io/cluster instead."
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced config map
-                      type: string
-                buildDefaults:
-                  description: BuildDefaults controls the default information for Builds
-                  type: object
-                  properties:
-                    defaultProxy:
-                      description: "DefaultProxy contains the default proxy settings for all build operations, including image pull/push and source download. \n Values can be overrode by setting the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables in the build config's strategy."
-                      type: object
-                      properties:
-                        httpProxy:
-                          description: httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
-                          type: string
-                        httpsProxy:
-                          description: httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
-                          type: string
-                        noProxy:
-                          description: noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used. Empty means unset and will not result in an env var.
-                          type: string
-                        readinessEndpoints:
-                          description: readinessEndpoints is a list of endpoints used to verify readiness of the proxy.
-                          type: array
-                          items:
-                            type: string
-                        trustedCA:
-                          description: "trustedCA is a reference to a ConfigMap containing a CA certificate bundle. The trustedCA field should only be consumed by a proxy validator. The validator is responsible for reading the certificate bundle from the required key \"ca-bundle.crt\", merging it with the system default trust bundle, and writing the merged trust bundle to a ConfigMap named \"trusted-ca-bundle\" in the \"openshift-config-managed\" namespace. Clients that expect to make proxy connections must use the trusted-ca-bundle for all HTTPS requests to the proxy, and may use the trusted-ca-bundle for non-proxy HTTPS requests as well. \n The namespace for the ConfigMap referenced by trustedCA is \"openshift-config\". Here is an example ConfigMap (in yaml): \n apiVersion: v1 kind: ConfigMap metadata: name: user-ca-bundle namespace: openshift-config data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom CA certificate bundle. -----END CERTIFICATE-----"
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            name:
-                              description: name is the metadata.name of the referenced config map
-                              type: string
-                    env:
-                      description: Env is a set of default environment variables that will be applied to the build if the specified variables do not exist on the build
-                      type: array
-                      items:
-                        description: EnvVar represents an environment variable present in a Container.
-                        type: object
-                        required:
-                          - name
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value. Cannot be used if value is not empty.
-                            type: object
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                type: object
-                                required:
-                                  - key
-                                properties:
-                                  key:
-                                    description: The key to select.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or its key must be defined
-                                    type: boolean
-                                x-kubernetes-map-type: atomic
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
-                                type: object
-                                required:
-                                  - fieldPath
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the specified API version.
-                                    type: string
-                                x-kubernetes-map-type: atomic
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
-                                type: object
-                                required:
-                                  - resource
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes, optional for env vars'
-                                    type: string
-                                  divisor:
-                                    description: Specifies the output format of the exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                x-kubernetes-map-type: atomic
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's namespace
-                                type: object
-                                required:
-                                  - key
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its key must be defined
-                                    type: boolean
-                                x-kubernetes-map-type: atomic
-                    gitProxy:
-                      description: "GitProxy contains the proxy settings for git operations only. If set, this will override any Proxy settings for all git commands, such as git clone. \n Values that are not set here will be inherited from DefaultProxy."
-                      type: object
-                      properties:
-                        httpProxy:
-                          description: httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
-                          type: string
-                        httpsProxy:
-                          description: httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
-                          type: string
-                        noProxy:
-                          description: noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used. Empty means unset and will not result in an env var.
-                          type: string
-                        readinessEndpoints:
-                          description: readinessEndpoints is a list of endpoints used to verify readiness of the proxy.
-                          type: array
-                          items:
-                            type: string
-                        trustedCA:
-                          description: "trustedCA is a reference to a ConfigMap containing a CA certificate bundle. The trustedCA field should only be consumed by a proxy validator. The validator is responsible for reading the certificate bundle from the required key \"ca-bundle.crt\", merging it with the system default trust bundle, and writing the merged trust bundle to a ConfigMap named \"trusted-ca-bundle\" in the \"openshift-config-managed\" namespace. Clients that expect to make proxy connections must use the trusted-ca-bundle for all HTTPS requests to the proxy, and may use the trusted-ca-bundle for non-proxy HTTPS requests as well. \n The namespace for the ConfigMap referenced by trustedCA is \"openshift-config\". Here is an example ConfigMap (in yaml): \n apiVersion: v1 kind: ConfigMap metadata: name: user-ca-bundle namespace: openshift-config data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom CA certificate bundle. -----END CERTIFICATE-----"
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            name:
-                              description: name is the metadata.name of the referenced config map
-                              type: string
-                    imageLabels:
-                      description: ImageLabels is a list of docker labels that are applied to the resulting image. User can override a default label by providing a label with the same name in their Build/BuildConfig.
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          name:
-                            description: Name defines the name of the label. It must have non-zero length.
-                            type: string
-                          value:
-                            description: Value defines the literal value of the label.
-                            type: string
-                    resources:
-                      description: Resources defines resource requirements to execute the build.
-                      type: object
-                      properties:
-                        limits:
-                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                          type: object
-                          additionalProperties:
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
-                        requests:
-                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                          type: object
-                          additionalProperties:
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            x-kubernetes-int-or-string: true
-                buildOverrides:
-                  description: BuildOverrides controls override settings for builds
-                  type: object
-                  properties:
-                    forcePull:
-                      description: ForcePull overrides, if set, the equivalent value in the builds, i.e. false disables force pull for all builds, true enables force pull for all builds, independently of what each build specifies itself
-                      type: boolean
-                    imageLabels:
-                      description: ImageLabels is a list of docker labels that are applied to the resulting image. If user provided a label in their Build/BuildConfig with the same name as one in this list, the user's label will be overwritten.
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          name:
-                            description: Name defines the name of the label. It must have non-zero length.
-                            type: string
-                          value:
-                            description: Value defines the literal value of the label.
-                            type: string
-                    nodeSelector:
-                      description: NodeSelector is a selector which must be true for the build pod to fit on a node
-                      type: object
-                      additionalProperties:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Build configures the behavior of OpenShift builds for the entire
+          cluster. This includes default settings that can be overridden in BuildConfig
+          objects, and overrides which are applied to all builds. \n The canonical
+          name is \"cluster\" \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec holds user-settable values for the build controller
+              configuration
+            properties:
+              additionalTrustedCA:
+                description: "AdditionalTrustedCA is a reference to a ConfigMap containing
+                  additional CAs that should be trusted for image pushes and pulls
+                  during builds. The namespace for this config map is openshift-config.
+                  \n DEPRECATED: Additional CAs for image pull and push should be
+                  set on image.config.openshift.io/cluster instead."
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              buildDefaults:
+                description: BuildDefaults controls the default information for Builds
+                properties:
+                  defaultProxy:
+                    description: "DefaultProxy contains the default proxy settings
+                      for all build operations, including image pull/push and source
+                      download. \n Values can be overrode by setting the `HTTP_PROXY`,
+                      `HTTPS_PROXY`, and `NO_PROXY` environment variables in the build
+                      config's strategy."
+                    properties:
+                      httpProxy:
+                        description: httpProxy is the URL of the proxy for HTTP requests.  Empty
+                          means unset and will not result in an env var.
                         type: string
-                    tolerations:
-                      description: Tolerations is a list of Tolerations that will override any existing tolerations set on a build pod.
-                      type: array
-                      items:
-                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
-                        type: object
+                      httpsProxy:
+                        description: httpsProxy is the URL of the proxy for HTTPS
+                          requests.  Empty means unset and will not result in an env
+                          var.
+                        type: string
+                      noProxy:
+                        description: noProxy is a comma-separated list of hostnames
+                          and/or CIDRs and/or IPs for which the proxy should not be
+                          used. Empty means unset and will not result in an env var.
+                        type: string
+                      readinessEndpoints:
+                        description: readinessEndpoints is a list of endpoints used
+                          to verify readiness of the proxy.
+                        items:
+                          type: string
+                        type: array
+                      trustedCA:
+                        description: "trustedCA is a reference to a ConfigMap containing
+                          a CA certificate bundle. The trustedCA field should only
+                          be consumed by a proxy validator. The validator is responsible
+                          for reading the certificate bundle from the required key
+                          \"ca-bundle.crt\", merging it with the system default trust
+                          bundle, and writing the merged trust bundle to a ConfigMap
+                          named \"trusted-ca-bundle\" in the \"openshift-config-managed\"
+                          namespace. Clients that expect to make proxy connections
+                          must use the trusted-ca-bundle for all HTTPS requests to
+                          the proxy, and may use the trusted-ca-bundle for non-proxy
+                          HTTPS requests as well. \n The namespace for the ConfigMap
+                          referenced by trustedCA is \"openshift-config\". Here is
+                          an example ConfigMap (in yaml): \n apiVersion: v1 kind:
+                          ConfigMap metadata: name: user-ca-bundle namespace: openshift-config
+                          data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom
+                          CA certificate bundle. -----END CERTIFICATE-----"
                         properties:
-                          effect:
-                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
                             type: string
-                          key:
-                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  env:
+                    description: Env is a set of default environment variables that
+                      will be applied to the build if the specified variables do not
+                      exist on the build
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  gitProxy:
+                    description: "GitProxy contains the proxy settings for git operations
+                      only. If set, this will override any Proxy settings for all
+                      git commands, such as git clone. \n Values that are not set
+                      here will be inherited from DefaultProxy."
+                    properties:
+                      httpProxy:
+                        description: httpProxy is the URL of the proxy for HTTP requests.  Empty
+                          means unset and will not result in an env var.
+                        type: string
+                      httpsProxy:
+                        description: httpsProxy is the URL of the proxy for HTTPS
+                          requests.  Empty means unset and will not result in an env
+                          var.
+                        type: string
+                      noProxy:
+                        description: noProxy is a comma-separated list of hostnames
+                          and/or CIDRs and/or IPs for which the proxy should not be
+                          used. Empty means unset and will not result in an env var.
+                        type: string
+                      readinessEndpoints:
+                        description: readinessEndpoints is a list of endpoints used
+                          to verify readiness of the proxy.
+                        items:
+                          type: string
+                        type: array
+                      trustedCA:
+                        description: "trustedCA is a reference to a ConfigMap containing
+                          a CA certificate bundle. The trustedCA field should only
+                          be consumed by a proxy validator. The validator is responsible
+                          for reading the certificate bundle from the required key
+                          \"ca-bundle.crt\", merging it with the system default trust
+                          bundle, and writing the merged trust bundle to a ConfigMap
+                          named \"trusted-ca-bundle\" in the \"openshift-config-managed\"
+                          namespace. Clients that expect to make proxy connections
+                          must use the trusted-ca-bundle for all HTTPS requests to
+                          the proxy, and may use the trusted-ca-bundle for non-proxy
+                          HTTPS requests as well. \n The namespace for the ConfigMap
+                          referenced by trustedCA is \"openshift-config\". Here is
+                          an example ConfigMap (in yaml): \n apiVersion: v1 kind:
+                          ConfigMap metadata: name: user-ca-bundle namespace: openshift-config
+                          data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom
+                          CA certificate bundle. -----END CERTIFICATE-----"
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
                             type: string
-                          operator:
-                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-                            type: integer
-                            format: int64
-                          value:
-                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-                            type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  imageLabels:
+                    description: ImageLabels is a list of docker labels that are applied
+                      to the resulting image. User can override a default label by
+                      providing a label with the same name in their Build/BuildConfig.
+                    items:
+                      properties:
+                        name:
+                          description: Name defines the name of the label. It must
+                            have non-zero length.
+                          type: string
+                        value:
+                          description: Value defines the literal value of the label.
+                          type: string
+                      type: object
+                    type: array
+                  resources:
+                    description: Resources defines resource requirements to execute
+                      the build.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                type: object
+              buildOverrides:
+                description: BuildOverrides controls override settings for builds
+                properties:
+                  forcePull:
+                    description: ForcePull overrides, if set, the equivalent value
+                      in the builds, i.e. false disables force pull for all builds,
+                      true enables force pull for all builds, independently of what
+                      each build specifies itself
+                    type: boolean
+                  imageLabels:
+                    description: ImageLabels is a list of docker labels that are applied
+                      to the resulting image. If user provided a label in their Build/BuildConfig
+                      with the same name as one in this list, the user's label will
+                      be overwritten.
+                    items:
+                      properties:
+                        name:
+                          description: Name defines the name of the label. It must
+                            have non-zero length.
+                          type: string
+                        value:
+                          description: Value defines the literal value of the label.
+                          type: string
+                      type: object
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector is a selector which must be true for
+                      the build pod to fit on a node
+                    type: object
+                  tolerations:
+                    description: Tolerations is a list of Tolerations that will override
+                      any existing tolerations set on a build pod.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_console.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_console.crd.yaml
@@ -16,42 +16,60 @@ spec:
     singular: console
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Console holds cluster-wide configuration for the web console, including the logout URL, and reports the public URL of the console. The canonical name is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                authentication:
-                  description: ConsoleAuthentication defines a list of optional configuration for console authentication.
-                  type: object
-                  properties:
-                    logoutRedirect:
-                      description: 'An optional, absolute URL to redirect web browsers to after logging out of the console. If not specified, it will redirect to the default login page. This is required when using an identity provider that supports single sign-on (SSO) such as: - OpenID (Keycloak, Azure) - RequestHeader (GSSAPI, SSPI, SAML) - OAuth (GitHub, GitLab, Google) Logging out of the console will destroy the user''s token. The logoutRedirect provides the user the option to perform single logout (SLO) through the identity provider to destroy their single sign-on session.'
-                      type: string
-                      pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-              properties:
-                consoleURL:
-                  description: The URL for the console. This will be derived from the host for the route that is created for the console.
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Console holds cluster-wide configuration for the web console,
+          including the logout URL, and reports the public URL of the console. The
+          canonical name is `cluster`. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              authentication:
+                description: ConsoleAuthentication defines a list of optional configuration
+                  for console authentication.
+                properties:
+                  logoutRedirect:
+                    description: 'An optional, absolute URL to redirect web browsers
+                      to after logging out of the console. If not specified, it will
+                      redirect to the default login page. This is required when using
+                      an identity provider that supports single sign-on (SSO) such
+                      as: - OpenID (Keycloak, Azure) - RequestHeader (GSSAPI, SSPI,
+                      SAML) - OAuth (GitHub, GitLab, Google) Logging out of the console
+                      will destroy the user''s token. The logoutRedirect provides
+                      the user the option to perform single logout (SLO) through the
+                      identity provider to destroy their single sign-on session.'
+                    pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$
+                    type: string
+                type: object
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              consoleURL:
+                description: The URL for the console. This will be derived from the
+                  host for the route that is created for the console.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_dns.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_dns.crd.yaml
@@ -16,57 +16,90 @@ spec:
     singular: dns
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "DNS holds cluster-wide information about DNS. The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                baseDomain:
-                  description: "baseDomain is the base domain of the cluster. All managed DNS records will be sub-domains of this base. \n For example, given the base domain `openshift.example.com`, an API server DNS record may be created for `cluster-api.openshift.example.com`. \n Once set, this field cannot be changed."
-                  type: string
-                privateZone:
-                  description: "privateZone is the location where all the DNS records that are only available internally to the cluster exist. \n If this field is nil, no private records should be created. \n Once set, this field cannot be changed."
-                  type: object
-                  properties:
-                    id:
-                      description: "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "DNS holds cluster-wide information about DNS. The canonical
+          name is `cluster` \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              baseDomain:
+                description: "baseDomain is the base domain of the cluster. All managed
+                  DNS records will be sub-domains of this base. \n For example, given
+                  the base domain `openshift.example.com`, an API server DNS record
+                  may be created for `cluster-api.openshift.example.com`. \n Once
+                  set, this field cannot be changed."
+                type: string
+              privateZone:
+                description: "privateZone is the location where all the DNS records
+                  that are only available internally to the cluster exist. \n If this
+                  field is nil, no private records should be created. \n Once set,
+                  this field cannot be changed."
+                properties:
+                  id:
+                    description: "id is the identifier that can be used to find the
+                      DNS hosted zone. \n on AWS zone can be fetched using `ID` as
+                      id in [1] on Azure zone can be fetched using `ID` as a pre-determined
+                      name in [2], on GCP zone can be fetched using `ID` as a pre-determined
+                      name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                      [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                      [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                    type: string
+                  tags:
+                    additionalProperties:
                       type: string
-                    tags:
-                      description: "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
-                      type: object
-                      additionalProperties:
-                        type: string
-                publicZone:
-                  description: "publicZone is the location where all the DNS records that are publicly accessible to the internet exist. \n If this field is nil, no public records should be created. \n Once set, this field cannot be changed."
-                  type: object
-                  properties:
-                    id:
-                      description: "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                    description: "tags can be used to query the DNS hosted zone. \n
+                      on AWS, resourcegroupstaggingapi [1] can be used to fetch a
+                      zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                    type: object
+                type: object
+              publicZone:
+                description: "publicZone is the location where all the DNS records
+                  that are publicly accessible to the internet exist. \n If this field
+                  is nil, no public records should be created. \n Once set, this field
+                  cannot be changed."
+                properties:
+                  id:
+                    description: "id is the identifier that can be used to find the
+                      DNS hosted zone. \n on AWS zone can be fetched using `ID` as
+                      id in [1] on Azure zone can be fetched using `ID` as a pre-determined
+                      name in [2], on GCP zone can be fetched using `ID` as a pre-determined
+                      name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                      [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                      [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                    type: string
+                  tags:
+                    additionalProperties:
                       type: string
-                    tags:
-                      description: "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
-                      type: object
-                      additionalProperties:
-                        type: string
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    description: "tags can be used to query the DNS hosted zone. \n
+                      on AWS, resourcegroupstaggingapi [1] can be used to fetch a
+                      zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                    type: object
+                type: object
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_featuregate.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_featuregate.crd.yaml
@@ -16,48 +16,66 @@ spec:
     singular: featuregate
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Feature holds cluster-wide information about feature gates.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                customNoUpgrade:
-                  description: customNoUpgrade allows the enabling or disabling of any feature. Turning this feature set on IS NOT SUPPORTED, CANNOT BE UNDONE, and PREVENTS UPGRADES. Because of its nature, this setting cannot be validated.  If you have any typos or accidentally apply invalid combinations your cluster may fail in an unrecoverable way.  featureSet must equal "CustomNoUpgrade" must be set to use this field.
-                  type: object
-                  properties:
-                    disabled:
-                      description: disabled is a list of all feature gates that you want to force off
-                      type: array
-                      items:
-                        type: string
-                    enabled:
-                      description: enabled is a list of all feature gates that you want to force on
-                      type: array
-                      items:
-                        type: string
-                  nullable: true
-                featureSet:
-                  description: featureSet changes the list of features in the cluster.  The default is empty.  Be very careful adjusting this setting. Turning on or off features may cause irreversible changes in your cluster which cannot be undone.
-                  type: string
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Feature holds cluster-wide information about feature gates.
+          \ The canonical name is `cluster` \n Compatibility level 1: Stable within
+          a major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              customNoUpgrade:
+                description: customNoUpgrade allows the enabling or disabling of any
+                  feature. Turning this feature set on IS NOT SUPPORTED, CANNOT BE
+                  UNDONE, and PREVENTS UPGRADES. Because of its nature, this setting
+                  cannot be validated.  If you have any typos or accidentally apply
+                  invalid combinations your cluster may fail in an unrecoverable way.  featureSet
+                  must equal "CustomNoUpgrade" must be set to use this field.
+                nullable: true
+                properties:
+                  disabled:
+                    description: disabled is a list of all feature gates that you
+                      want to force off
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    description: enabled is a list of all feature gates that you want
+                      to force on
+                    items:
+                      type: string
+                    type: array
+                type: object
+              featureSet:
+                description: featureSet changes the list of features in the cluster.  The
+                  default is empty.  Be very careful adjusting this setting. Turning
+                  on or off features may cause irreversible changes in your cluster
+                  which cannot be undone.
+                type: string
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_image.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_image.crd.yaml
@@ -16,93 +16,149 @@ spec:
     singular: image
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Image governs policies related to imagestream imports and runtime configuration for external registries. It allows cluster admins to configure which registries OpenShift is allowed to import images from, extra CA trust bundles for external registries, and policies to block or allow registry hostnames. When exposing OpenShift's image registry to the public, this also lets cluster admins specify the external hostname. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                additionalTrustedCA:
-                  description: additionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted during imagestream import, pod image pull, build image pull, and imageregistry pullthrough. The namespace for this config map is openshift-config.
-                  type: object
-                  required:
-                    - name
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Image governs policies related to imagestream imports and runtime
+          configuration for external registries. It allows cluster admins to configure
+          which registries OpenShift is allowed to import images from, extra CA trust
+          bundles for external registries, and policies to block or allow registry
+          hostnames. When exposing OpenShift's image registry to the public, this
+          also lets cluster admins specify the external hostname. \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              additionalTrustedCA:
+                description: additionalTrustedCA is a reference to a ConfigMap containing
+                  additional CAs that should be trusted during imagestream import,
+                  pod image pull, build image pull, and imageregistry pullthrough.
+                  The namespace for this config map is openshift-config.
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              allowedRegistriesForImport:
+                description: allowedRegistriesForImport limits the container image
+                  registries that normal users may import images from. Set this list
+                  to the registries that you trust to contain valid Docker images
+                  and that you want applications to be able to import from. Users
+                  with permission to create Images or ImageStreamMappings via the
+                  API are not affected by this policy - typically only administrators
+                  or system integrations will have those permissions.
+                items:
+                  description: RegistryLocation contains a location of the registry
+                    specified by the registry domain name. The domain name might include
+                    wildcards, like '*' or '??'.
                   properties:
-                    name:
-                      description: name is the metadata.name of the referenced config map
+                    domainName:
+                      description: domainName specifies a domain name for the registry
+                        In case the registry use non-standard (80 or 443) port, the
+                        port should be included in the domain name as well.
                       type: string
-                allowedRegistriesForImport:
-                  description: allowedRegistriesForImport limits the container image registries that normal users may import images from. Set this list to the registries that you trust to contain valid Docker images and that you want applications to be able to import from. Users with permission to create Images or ImageStreamMappings via the API are not affected by this policy - typically only administrators or system integrations will have those permissions.
-                  type: array
-                  items:
-                    description: RegistryLocation contains a location of the registry specified by the registry domain name. The domain name might include wildcards, like '*' or '??'.
-                    type: object
-                    properties:
-                      domainName:
-                        description: domainName specifies a domain name for the registry In case the registry use non-standard (80 or 443) port, the port should be included in the domain name as well.
-                        type: string
-                      insecure:
-                        description: insecure indicates whether the registry is secure (https) or insecure (http) By default (if not specified) the registry is assumed as secure.
-                        type: boolean
-                externalRegistryHostnames:
-                  description: externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in "hostname[:port]" format.
-                  type: array
-                  items:
-                    type: string
-                registrySources:
-                  description: registrySources contains configuration that determines how the container runtime should treat individual registries when accessing images for builds+pods. (e.g. whether or not to allow insecure access).  It does not contain configuration for the internal cluster registry.
+                    insecure:
+                      description: insecure indicates whether the registry is secure
+                        (https) or insecure (http) By default (if not specified) the
+                        registry is assumed as secure.
+                      type: boolean
                   type: object
-                  properties:
-                    allowedRegistries:
-                      description: "allowedRegistries are the only registries permitted for image pull and push actions. All other registries are denied. \n Only one of BlockedRegistries or AllowedRegistries may be set."
-                      type: array
-                      items:
-                        type: string
-                    blockedRegistries:
-                      description: "blockedRegistries cannot be used for image pull and push actions. All other registries are permitted. \n Only one of BlockedRegistries or AllowedRegistries may be set."
-                      type: array
-                      items:
-                        type: string
-                    containerRuntimeSearchRegistries:
-                      description: 'containerRuntimeSearchRegistries are registries that will be searched when pulling images that do not have fully qualified domains in their pull specs. Registries will be searched in the order provided in the list. Note: this search list only works with the container runtime, i.e CRI-O. Will NOT work with builds or imagestream imports.'
-                      type: array
-                      format: hostname
-                      minItems: 1
-                      items:
-                        type: string
-                      x-kubernetes-list-type: set
-                    insecureRegistries:
-                      description: insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.
-                      type: array
-                      items:
-                        type: string
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-              properties:
-                externalRegistryHostnames:
-                  description: externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in "hostname[:port]" format.
-                  type: array
-                  items:
-                    type: string
-                internalRegistryHostname:
-                  description: internalRegistryHostname sets the hostname for the default internal image registry. The value must be in "hostname[:port]" format. This value is set by the image registry operator which controls the internal registry hostname. For backward compatibility, users can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but this setting overrides the environment variable.
+                type: array
+              externalRegistryHostnames:
+                description: externalRegistryHostnames provides the hostnames for
+                  the default external image registry. The external hostname should
+                  be set only when the image registry is exposed externally. The first
+                  value is used in 'publicDockerImageRepository' field in ImageStreams.
+                  The value must be in "hostname[:port]" format.
+                items:
                   type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              registrySources:
+                description: registrySources contains configuration that determines
+                  how the container runtime should treat individual registries when
+                  accessing images for builds+pods. (e.g. whether or not to allow
+                  insecure access).  It does not contain configuration for the internal
+                  cluster registry.
+                properties:
+                  allowedRegistries:
+                    description: "allowedRegistries are the only registries permitted
+                      for image pull and push actions. All other registries are denied.
+                      \n Only one of BlockedRegistries or AllowedRegistries may be
+                      set."
+                    items:
+                      type: string
+                    type: array
+                  blockedRegistries:
+                    description: "blockedRegistries cannot be used for image pull
+                      and push actions. All other registries are permitted. \n Only
+                      one of BlockedRegistries or AllowedRegistries may be set."
+                    items:
+                      type: string
+                    type: array
+                  containerRuntimeSearchRegistries:
+                    description: 'containerRuntimeSearchRegistries are registries
+                      that will be searched when pulling images that do not have fully
+                      qualified domains in their pull specs. Registries will be searched
+                      in the order provided in the list. Note: this search list only
+                      works with the container runtime, i.e CRI-O. Will NOT work with
+                      builds or imagestream imports.'
+                    format: hostname
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
+                  insecureRegistries:
+                    description: insecureRegistries are registries which do not have
+                      a valid TLS certificates or only support HTTP connections.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              externalRegistryHostnames:
+                description: externalRegistryHostnames provides the hostnames for
+                  the default external image registry. The external hostname should
+                  be set only when the image registry is exposed externally. The first
+                  value is used in 'publicDockerImageRepository' field in ImageStreams.
+                  The value must be in "hostname[:port]" format.
+                items:
+                  type: string
+                type: array
+              internalRegistryHostname:
+                description: internalRegistryHostname sets the hostname for the default
+                  internal image registry. The value must be in "hostname[:port]"
+                  format. This value is set by the image registry operator which controls
+                  the internal registry hostname. For backward compatibility, users
+                  can still use OPENSHIFT_DEFAULT_REGISTRY environment variable but
+                  this setting overrides the environment variable.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_imagecontentpolicy.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_imagecontentpolicy.crd.yaml
@@ -16,53 +16,97 @@ spec:
     singular: imagecontentpolicy
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ImageContentPolicy holds cluster-wide information about how to handle registry mirror rules. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                repositoryDigestMirrors:
-                  description: "repositoryDigestMirrors allows images referenced by image digests in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in RepositoryDigestMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. To pull image from mirrors by tags, should set the \"allowMirrorByTags\". \n Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified."
-                  type: array
-                  items:
-                    description: RepositoryDigestMirrors holds cluster-wide information about how to handle mirrors in the registries config.
-                    type: object
-                    required:
-                      - source
-                    properties:
-                      allowMirrorByTags:
-                        description: allowMirrorByTags if true, the mirrors can be used to pull the images that are referenced by their tags. Default is false, the mirrors only work when pulling the images that are referenced by their digests. Pulling images by tag can potentially yield different images, depending on which endpoint we pull from. Forcing digest-pulls for mirrors avoids that issue.
-                        type: boolean
-                      mirrors:
-                        description: mirrors is zero or more repositories that may also contain the same images. If the "mirrors" is not specified, the image will continue to be pulled from the specified repository in the pull spec. No mirror will be configured. The order of mirrors in this list is treated as the user's desired priority, while source is by default considered lower priority than all mirrors. Other cluster configuration, including (but not limited to) other repositoryDigestMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering.
-                        type: array
-                        items:
-                          type: string
-                          pattern: ^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])(:[0-9]+)?(\/[^\/:\n]+)*(\/[^\/:\n]+((:[^\/:\n]+)|(@[^\n]+)))?$
-                        x-kubernetes-list-type: set
-                      source:
-                        description: source is the repository that users refer to, e.g. in image pull specifications.
-                        type: string
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ImageContentPolicy holds cluster-wide information about how
+          to handle registry mirror rules. When multiple policies are defined, the
+          outcome of the behavior is defined on each field. \n Compatibility level
+          1: Stable within a major release for a minimum of 12 months or 3 minor releases
+          (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              repositoryDigestMirrors:
+                description: "repositoryDigestMirrors allows images referenced by
+                  image digests in pods to be pulled from alternative mirrored repository
+                  locations. The image pull specification provided to the pod will
+                  be compared to the source locations described in RepositoryDigestMirrors
+                  and the image may be pulled down from any of the mirrors in the
+                  list instead of the specified repository allowing administrators
+                  to choose a potentially faster mirror. To pull image from mirrors
+                  by tags, should set the \"allowMirrorByTags\". \n Each “source”
+                  repository is treated independently; configurations for different
+                  “source” repositories don’t interact. \n If the \"mirrors\" is not
+                  specified, the image will continue to be pulled from the specified
+                  repository in the pull spec. \n When multiple policies are defined
+                  for the same “source” repository, the sets of defined mirrors will
+                  be merged together, preserving the relative order of the mirrors,
+                  if possible. For example, if policy A has mirrors `a, b, c` and
+                  policy B has mirrors `c, d, e`, the mirrors will be used in the
+                  order `a, b, c, d, e`.  If the orders of mirror entries conflict
+                  (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the
+                  resulting order is unspecified."
+                items:
+                  description: RepositoryDigestMirrors holds cluster-wide information
+                    about how to handle mirrors in the registries config.
+                  properties:
+                    allowMirrorByTags:
+                      description: allowMirrorByTags if true, the mirrors can be used
+                        to pull the images that are referenced by their tags. Default
+                        is false, the mirrors only work when pulling the images that
+                        are referenced by their digests. Pulling images by tag can
+                        potentially yield different images, depending on which endpoint
+                        we pull from. Forcing digest-pulls for mirrors avoids that
+                        issue.
+                      type: boolean
+                    mirrors:
+                      description: mirrors is zero or more repositories that may also
+                        contain the same images. If the "mirrors" is not specified,
+                        the image will continue to be pulled from the specified repository
+                        in the pull spec. No mirror will be configured. The order
+                        of mirrors in this list is treated as the user's desired priority,
+                        while source is by default considered lower priority than
+                        all mirrors. Other cluster configuration, including (but not
+                        limited to) other repositoryDigestMirrors objects, may impact
+                        the exact order mirrors are contacted in, or some mirrors
+                        may be contacted in parallel, so this should be considered
+                        a preference rather than a guarantee of ordering.
+                      items:
                         pattern: ^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])(:[0-9]+)?(\/[^\/:\n]+)*(\/[^\/:\n]+((:[^\/:\n]+)|(@[^\n]+)))?$
-                  x-kubernetes-list-map-keys:
-                    - source
-                  x-kubernetes-list-type: map
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    source:
+                      description: source is the repository that users refer to, e.g.
+                        in image pull specifications.
+                      pattern: ^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])(:[0-9]+)?(\/[^\/:\n]+)*(\/[^\/:\n]+((:[^\/:\n]+)|(@[^\n]+)))?$
+                      type: string
+                  required:
+                  - source
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - source
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_imagedigestmirrorset.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_imagedigestmirrorset.crd.yaml
@@ -13,62 +13,129 @@ spec:
     kind: ImageDigestMirrorSet
     listKind: ImageDigestMirrorSetList
     plural: imagedigestmirrorsets
-    singular: imagedigestmirrorset
     shortNames:
-      - idms
+    - idms
+    singular: imagedigestmirrorset
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ImageDigestMirrorSet holds cluster-wide information about how to handle registry mirror rules on using digest pull specification. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                imageDigestMirrors:
-                  description: "imageDigestMirrors allows images referenced by image digests in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in imageDigestMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. To use mirrors to pull images using tag specification, users should configure a list of mirrors using \"ImageTagMirrorSet\" CRD. \n If the image pull specification matches the repository of \"source\" in multiple imagedigestmirrorset objects, only the objects which define the most specific namespace match will be used. For example, if there are objects using quay.io/libpod and quay.io/libpod/busybox as the \"source\", only the objects using quay.io/libpod/busybox are going to apply for pull specification quay.io/libpod/busybox. Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified. Users who want to use a specific order of mirrors, should configure them into one list of mirrors using the expected order."
-                  type: array
-                  items:
-                    description: ImageDigestMirrors holds cluster-wide information about how to handle mirrors in the registries config.
-                    type: object
-                    required:
-                      - source
-                    properties:
-                      mirrorSourcePolicy:
-                        description: mirrorSourcePolicy defines the fallback policy if fails to pull image from the mirrors. If unset, the image will continue to be pulled from the the repository in the pull spec. sourcePolicy is valid configuration only when one or more mirrors are in the mirror list.
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ImageDigestMirrorSet holds cluster-wide information about how
+          to handle registry mirror rules on using digest pull specification. When
+          multiple policies are defined, the outcome of the behavior is defined on
+          each field. \n Compatibility level 1: Stable within a major release for
+          a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              imageDigestMirrors:
+                description: "imageDigestMirrors allows images referenced by image
+                  digests in pods to be pulled from alternative mirrored repository
+                  locations. The image pull specification provided to the pod will
+                  be compared to the source locations described in imageDigestMirrors
+                  and the image may be pulled down from any of the mirrors in the
+                  list instead of the specified repository allowing administrators
+                  to choose a potentially faster mirror. To use mirrors to pull images
+                  using tag specification, users should configure a list of mirrors
+                  using \"ImageTagMirrorSet\" CRD. \n If the image pull specification
+                  matches the repository of \"source\" in multiple imagedigestmirrorset
+                  objects, only the objects which define the most specific namespace
+                  match will be used. For example, if there are objects using quay.io/libpod
+                  and quay.io/libpod/busybox as the \"source\", only the objects using
+                  quay.io/libpod/busybox are going to apply for pull specification
+                  quay.io/libpod/busybox. Each “source” repository is treated independently;
+                  configurations for different “source” repositories don’t interact.
+                  \n If the \"mirrors\" is not specified, the image will continue
+                  to be pulled from the specified repository in the pull spec. \n
+                  When multiple policies are defined for the same “source” repository,
+                  the sets of defined mirrors will be merged together, preserving
+                  the relative order of the mirrors, if possible. For example, if
+                  policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`,
+                  the mirrors will be used in the order `a, b, c, d, e`.  If the orders
+                  of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration
+                  is not rejected but the resulting order is unspecified. Users who
+                  want to use a specific order of mirrors, should configure them into
+                  one list of mirrors using the expected order."
+                items:
+                  description: ImageDigestMirrors holds cluster-wide information about
+                    how to handle mirrors in the registries config.
+                  properties:
+                    mirrorSourcePolicy:
+                      description: mirrorSourcePolicy defines the fallback policy
+                        if fails to pull image from the mirrors. If unset, the image
+                        will continue to be pulled from the the repository in the
+                        pull spec. sourcePolicy is valid configuration only when one
+                        or more mirrors are in the mirror list.
+                      enum:
+                      - NeverContactSource
+                      - AllowContactingSource
+                      type: string
+                    mirrors:
+                      description: 'mirrors is zero or more locations that may also
+                        contain the same images. No mirror will be configured if not
+                        specified. Images can be pulled from these mirrors only if
+                        they are referenced by their digests. The mirrored location
+                        is obtained by replacing the part of the input reference that
+                        matches source by the mirrors entry, e.g. for registry.redhat.io/product/repo
+                        reference, a (source, mirror) pair *.redhat.io, mirror.local/redhat
+                        causes a mirror.local/redhat/product/repo repository to be
+                        used. The order of mirrors in this list is treated as the
+                        user''s desired priority, while source is by default considered
+                        lower priority than all mirrors. If no mirror is specified
+                        or all image pulls from the mirror list fail, the image will
+                        continue to be pulled from the repository in the pull spec
+                        unless explicitly prohibited by "mirrorSourcePolicy" Other
+                        cluster configuration, including (but not limited to) other
+                        imageDigestMirrors objects, may impact the exact order mirrors
+                        are contacted in, or some mirrors may be contacted in parallel,
+                        so this should be considered a preference rather than a guarantee
+                        of ordering. "mirrors" uses one of the following formats:
+                        host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo
+                        for more information about the format, see the document about
+                        the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
+                      items:
+                        pattern: ^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
                         type: string
-                        enum:
-                          - NeverContactSource
-                          - AllowContactingSource
-                      mirrors:
-                        description: 'mirrors is zero or more locations that may also contain the same images. No mirror will be configured if not specified. Images can be pulled from these mirrors only if they are referenced by their digests. The mirrored location is obtained by replacing the part of the input reference that matches source by the mirrors entry, e.g. for registry.redhat.io/product/repo reference, a (source, mirror) pair *.redhat.io, mirror.local/redhat causes a mirror.local/redhat/product/repo repository to be used. The order of mirrors in this list is treated as the user''s desired priority, while source is by default considered lower priority than all mirrors. If no mirror is specified or all image pulls from the mirror list fail, the image will continue to be pulled from the repository in the pull spec unless explicitly prohibited by "mirrorSourcePolicy" Other cluster configuration, including (but not limited to) other imageDigestMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering. "mirrors" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
-                        type: array
-                        items:
-                          type: string
-                          pattern: ^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
-                        x-kubernetes-list-type: set
-                      source:
-                        description: 'source matches the repository that users refer to, e.g. in image pull specifications. Setting source to a registry hostname e.g. docker.io. quay.io, or registry.redhat.io, will match the image pull specification of corressponding registry. "source" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo [*.]host for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
-                        type: string
-                        pattern: ^\*(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$|^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
-                  x-kubernetes-list-type: atomic
-            status:
-              description: status contains the observed state of the resource.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      type: array
+                      x-kubernetes-list-type: set
+                    source:
+                      description: 'source matches the repository that users refer
+                        to, e.g. in image pull specifications. Setting source to a
+                        registry hostname e.g. docker.io. quay.io, or registry.redhat.io,
+                        will match the image pull specification of corressponding
+                        registry. "source" uses one of the following formats: host[:port]
+                        host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo
+                        [*.]host for more information about the format, see the document
+                        about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
+                      pattern: ^\*(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$|^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
+                      type: string
+                  required:
+                  - source
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: status contains the observed state of the resource.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_imagetagmirrorset.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_imagetagmirrorset.crd.yaml
@@ -13,62 +13,132 @@ spec:
     kind: ImageTagMirrorSet
     listKind: ImageTagMirrorSetList
     plural: imagetagmirrorsets
-    singular: imagetagmirrorset
     shortNames:
-      - itms
+    - itms
+    singular: imagetagmirrorset
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ImageTagMirrorSet holds cluster-wide information about how to handle registry mirror rules on using tag pull specification. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                imageTagMirrors:
-                  description: "imageTagMirrors allows images referenced by image tags in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in imageTagMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. To use mirrors to pull images using digest specification only, users should configure a list of mirrors using \"ImageDigestMirrorSet\" CRD. \n If the image pull specification matches the repository of \"source\" in multiple imagetagmirrorset objects, only the objects which define the most specific namespace match will be used. For example, if there are objects using quay.io/libpod and quay.io/libpod/busybox as the \"source\", only the objects using quay.io/libpod/busybox are going to apply for pull specification quay.io/libpod/busybox. Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified. Users who want to use a deterministic order of mirrors, should configure them into one list of mirrors using the expected order."
-                  type: array
-                  items:
-                    description: ImageTagMirrors holds cluster-wide information about how to handle mirrors in the registries config.
-                    type: object
-                    required:
-                      - source
-                    properties:
-                      mirrorSourcePolicy:
-                        description: mirrorSourcePolicy defines the fallback policy if fails to pull image from the mirrors. If unset, the image will continue to be pulled from the repository in the pull spec. sourcePolicy is valid configuration only when one or more mirrors are in the mirror list.
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ImageTagMirrorSet holds cluster-wide information about how to
+          handle registry mirror rules on using tag pull specification. When multiple
+          policies are defined, the outcome of the behavior is defined on each field.
+          \n Compatibility level 1: Stable within a major release for a minimum of
+          12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              imageTagMirrors:
+                description: "imageTagMirrors allows images referenced by image tags
+                  in pods to be pulled from alternative mirrored repository locations.
+                  The image pull specification provided to the pod will be compared
+                  to the source locations described in imageTagMirrors and the image
+                  may be pulled down from any of the mirrors in the list instead of
+                  the specified repository allowing administrators to choose a potentially
+                  faster mirror. To use mirrors to pull images using digest specification
+                  only, users should configure a list of mirrors using \"ImageDigestMirrorSet\"
+                  CRD. \n If the image pull specification matches the repository of
+                  \"source\" in multiple imagetagmirrorset objects, only the objects
+                  which define the most specific namespace match will be used. For
+                  example, if there are objects using quay.io/libpod and quay.io/libpod/busybox
+                  as the \"source\", only the objects using quay.io/libpod/busybox
+                  are going to apply for pull specification quay.io/libpod/busybox.
+                  Each “source” repository is treated independently; configurations
+                  for different “source” repositories don’t interact. \n If the \"mirrors\"
+                  is not specified, the image will continue to be pulled from the
+                  specified repository in the pull spec. \n When multiple policies
+                  are defined for the same “source” repository, the sets of defined
+                  mirrors will be merged together, preserving the relative order of
+                  the mirrors, if possible. For example, if policy A has mirrors `a,
+                  b, c` and policy B has mirrors `c, d, e`, the mirrors will be used
+                  in the order `a, b, c, d, e`.  If the orders of mirror entries conflict
+                  (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the
+                  resulting order is unspecified. Users who want to use a deterministic
+                  order of mirrors, should configure them into one list of mirrors
+                  using the expected order."
+                items:
+                  description: ImageTagMirrors holds cluster-wide information about
+                    how to handle mirrors in the registries config.
+                  properties:
+                    mirrorSourcePolicy:
+                      description: mirrorSourcePolicy defines the fallback policy
+                        if fails to pull image from the mirrors. If unset, the image
+                        will continue to be pulled from the repository in the pull
+                        spec. sourcePolicy is valid configuration only when one or
+                        more mirrors are in the mirror list.
+                      enum:
+                      - NeverContactSource
+                      - AllowContactingSource
+                      type: string
+                    mirrors:
+                      description: 'mirrors is zero or more locations that may also
+                        contain the same images. No mirror will be configured if not
+                        specified. Images can be pulled from these mirrors only if
+                        they are referenced by their tags. The mirrored location is
+                        obtained by replacing the part of the input reference that
+                        matches source by the mirrors entry, e.g. for registry.redhat.io/product/repo
+                        reference, a (source, mirror) pair *.redhat.io, mirror.local/redhat
+                        causes a mirror.local/redhat/product/repo repository to be
+                        used. Pulling images by tag can potentially yield different
+                        images, depending on which endpoint we pull from. Configuring
+                        a list of mirrors using "ImageDigestMirrorSet" CRD and forcing
+                        digest-pulls for mirrors avoids that issue. The order of mirrors
+                        in this list is treated as the user''s desired priority, while
+                        source is by default considered lower priority than all mirrors.
+                        If no mirror is specified or all image pulls from the mirror
+                        list fail, the image will continue to be pulled from the repository
+                        in the pull spec unless explicitly prohibited by "mirrorSourcePolicy".
+                        Other cluster configuration, including (but not limited to)
+                        other imageTagMirrors objects, may impact the exact order
+                        mirrors are contacted in, or some mirrors may be contacted
+                        in parallel, so this should be considered a preference rather
+                        than a guarantee of ordering. "mirrors" uses one of the following
+                        formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo
+                        for more information about the format, see the document about
+                        the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
+                      items:
+                        pattern: ^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
                         type: string
-                        enum:
-                          - NeverContactSource
-                          - AllowContactingSource
-                      mirrors:
-                        description: 'mirrors is zero or more locations that may also contain the same images. No mirror will be configured if not specified. Images can be pulled from these mirrors only if they are referenced by their tags. The mirrored location is obtained by replacing the part of the input reference that matches source by the mirrors entry, e.g. for registry.redhat.io/product/repo reference, a (source, mirror) pair *.redhat.io, mirror.local/redhat causes a mirror.local/redhat/product/repo repository to be used. Pulling images by tag can potentially yield different images, depending on which endpoint we pull from. Configuring a list of mirrors using "ImageDigestMirrorSet" CRD and forcing digest-pulls for mirrors avoids that issue. The order of mirrors in this list is treated as the user''s desired priority, while source is by default considered lower priority than all mirrors. If no mirror is specified or all image pulls from the mirror list fail, the image will continue to be pulled from the repository in the pull spec unless explicitly prohibited by "mirrorSourcePolicy". Other cluster configuration, including (but not limited to) other imageTagMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering. "mirrors" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
-                        type: array
-                        items:
-                          type: string
-                          pattern: ^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
-                        x-kubernetes-list-type: set
-                      source:
-                        description: 'source matches the repository that users refer to, e.g. in image pull specifications. Setting source to a registry hostname e.g. docker.io. quay.io, or registry.redhat.io, will match the image pull specification of corressponding registry. "source" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo [*.]host for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
-                        type: string
-                        pattern: ^\*(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$|^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
-                  x-kubernetes-list-type: atomic
-            status:
-              description: status contains the observed state of the resource.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      type: array
+                      x-kubernetes-list-type: set
+                    source:
+                      description: 'source matches the repository that users refer
+                        to, e.g. in image pull specifications. Setting source to a
+                        registry hostname e.g. docker.io. quay.io, or registry.redhat.io,
+                        will match the image pull specification of corressponding
+                        registry. "source" uses one of the following formats: host[:port]
+                        host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo
+                        [*.]host for more information about the format, see the document
+                        about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
+                      pattern: ^\*(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$|^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
+                      type: string
+                  required:
+                  - source
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: status contains the observed state of the resource.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -16,227 +16,254 @@ spec:
     singular: infrastructure
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Infrastructure holds cluster-wide information about Infrastructure.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                cloudConfig:
-                  description: "cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config. \n cloudConfig should only be consumed by the kube_cloud_config controller. The controller is responsible for using the user configuration in the spec for various platforms and combining that with the user provided ConfigMap in this field to create a stitched kube cloud config. The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace with the kube cloud config is stored in `cloud.conf` key. All the clients are expected to use the generated ConfigMap only."
-                  type: object
-                  properties:
-                    key:
-                      description: Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.
-                      type: string
-                    name:
-                      type: string
-                platformSpec:
-                  description: platformSpec holds desired information specific to the underlying infrastructure provider.
-                  type: object
-                  properties:
-                    alibabaCloud:
-                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
-                      type: object
-                    aws:
-                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
-                      type: object
-                      properties:
-                        serviceEndpoints:
-                          description: serviceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
-                          type: array
-                          items:
-                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
-                            type: object
-                            properties:
-                              name:
-                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
-                                type: string
-                                pattern: ^[a-z0-9-]+$
-                              url:
-                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
-                                type: string
-                                pattern: ^https://
-                    azure:
-                      description: Azure contains settings specific to the Azure infrastructure provider.
-                      type: object
-                    baremetal:
-                      description: BareMetal contains settings specific to the BareMetal platform.
-                      type: object
-                    equinixMetal:
-                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
-                      type: object
-                    gcp:
-                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
-                      type: object
-                    ibmcloud:
-                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
-                      type: object
-                    kubevirt:
-                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
-                      type: object
-                    nutanix:
-                      description: Nutanix contains settings specific to the Nutanix infrastructure provider.
-                      type: object
-                      required:
-                        - prismCentral
-                        - prismElements
-                      properties:
-                        prismCentral:
-                          description: prismCentral holds the endpoint address and port to access the Nutanix Prism Central. When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
-                          type: object
-                          required:
-                            - address
-                            - port
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Infrastructure holds cluster-wide information about Infrastructure.
+          \ The canonical name is `cluster` \n Compatibility level 1: Stable within
+          a major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              cloudConfig:
+                description: "cloudConfig is a reference to a ConfigMap containing
+                  the cloud provider configuration file. This configuration file is
+                  used to configure the Kubernetes cloud provider integration when
+                  using the built-in cloud provider integration or the external cloud
+                  controller manager. The namespace for this config map is openshift-config.
+                  \n cloudConfig should only be consumed by the kube_cloud_config
+                  controller. The controller is responsible for using the user configuration
+                  in the spec for various platforms and combining that with the user
+                  provided ConfigMap in this field to create a stitched kube cloud
+                  config. The controller generates a ConfigMap `kube-cloud-config`
+                  in `openshift-config-managed` namespace with the kube cloud config
+                  is stored in `cloud.conf` key. All the clients are expected to use
+                  the generated ConfigMap only."
+                properties:
+                  key:
+                    description: Key allows pointing to a specific key/value inside
+                      of the configmap.  This is useful for logical file references.
+                    type: string
+                  name:
+                    type: string
+                type: object
+              platformSpec:
+                description: platformSpec holds desired information specific to the
+                  underlying infrastructure provider.
+                properties:
+                  alibabaCloud:
+                    description: AlibabaCloud contains settings specific to the Alibaba
+                      Cloud infrastructure provider.
+                    type: object
+                  aws:
+                    description: AWS contains settings specific to the Amazon Web
+                      Services infrastructure provider.
+                    properties:
+                      serviceEndpoints:
+                        description: serviceEndpoints list contains custom endpoints
+                          which will override default service endpoint of AWS Services.
+                          There must be only one ServiceEndpoint for a service.
+                        items:
+                          description: AWSServiceEndpoint store the configuration
+                            of a custom url to override existing defaults of AWS Services.
                           properties:
-                            address:
-                              description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
+                            name:
+                              description: name is the name of the AWS service. The
+                                list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                This must be provided and cannot be empty.
+                              pattern: ^[a-z0-9-]+$
                               type: string
+                            url:
+                              description: url is fully qualified URI with scheme
+                                https, that overrides the default generated endpoint
+                                for a client. This must be provided and cannot be
+                                empty.
+                              pattern: ^https://
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  azure:
+                    description: Azure contains settings specific to the Azure infrastructure
+                      provider.
+                    type: object
+                  baremetal:
+                    description: BareMetal contains settings specific to the BareMetal
+                      platform.
+                    type: object
+                  equinixMetal:
+                    description: EquinixMetal contains settings specific to the Equinix
+                      Metal infrastructure provider.
+                    type: object
+                  gcp:
+                    description: GCP contains settings specific to the Google Cloud
+                      Platform infrastructure provider.
+                    type: object
+                  ibmcloud:
+                    description: IBMCloud contains settings specific to the IBMCloud
+                      infrastructure provider.
+                    type: object
+                  kubevirt:
+                    description: Kubevirt contains settings specific to the kubevirt
+                      infrastructure provider.
+                    type: object
+                  nutanix:
+                    description: Nutanix contains settings specific to the Nutanix
+                      infrastructure provider.
+                    properties:
+                      prismCentral:
+                        description: prismCentral holds the endpoint address and port
+                          to access the Nutanix Prism Central. When a cluster-wide
+                          proxy is installed, by default, this endpoint will be accessed
+                          via the proxy. Should you wish for communication with this
+                          endpoint not to be proxied, please add the endpoint to the
+                          proxy spec.noProxy list.
+                        properties:
+                          address:
+                            description: address is the endpoint address (DNS name
+                              or IP address) of the Nutanix Prism Central or Element
+                              (cluster)
+                            maxLength: 256
+                            type: string
+                          port:
+                            description: port is the port number to access the Nutanix
+                              Prism Central or Element (cluster)
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        required:
+                        - address
+                        - port
+                        type: object
+                      prismElements:
+                        description: prismElements holds one or more endpoint address
+                          and port data to access the Nutanix Prism Elements (clusters)
+                          of the Nutanix Prism Central. Currently we only support
+                          one Prism Element (cluster) for an OpenShift cluster, where
+                          all the Nutanix resources (VMs, subnets, volumes, etc.)
+                          used in the OpenShift cluster are located. In the future,
+                          we may support Nutanix resources (VMs, etc.) spread over
+                          multiple Prism Elements (clusters) of the Prism Central.
+                        items:
+                          description: NutanixPrismElementEndpoint holds the name
+                            and endpoint data for a Prism Element (cluster)
+                          properties:
+                            endpoint:
+                              description: endpoint holds the endpoint address and
+                                port data of the Prism Element (cluster). When a cluster-wide
+                                proxy is installed, by default, this endpoint will
+                                be accessed via the proxy. Should you wish for communication
+                                with this endpoint not to be proxied, please add the
+                                endpoint to the proxy spec.noProxy list.
+                              properties:
+                                address:
+                                  description: address is the endpoint address (DNS
+                                    name or IP address) of the Nutanix Prism Central
+                                    or Element (cluster)
+                                  maxLength: 256
+                                  type: string
+                                port:
+                                  description: port is the port number to access the
+                                    Nutanix Prism Central or Element (cluster)
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - address
+                              - port
+                              type: object
+                            name:
+                              description: name is the name of the Prism Element (cluster).
+                                This value will correspond with the cluster field
+                                configured on other resources (eg Machines, PVCs,
+                                etc).
                               maxLength: 256
-                            port:
-                              description: port is the port number to access the Nutanix Prism Central or Element (cluster)
-                              type: integer
-                              format: int32
-                              maximum: 65535
-                              minimum: 1
-                        prismElements:
-                          description: prismElements holds one or more endpoint address and port data to access the Nutanix Prism Elements (clusters) of the Nutanix Prism Central. Currently we only support one Prism Element (cluster) for an OpenShift cluster, where all the Nutanix resources (VMs, subnets, volumes, etc.) used in the OpenShift cluster are located. In the future, we may support Nutanix resources (VMs, etc.) spread over multiple Prism Elements (clusters) of the Prism Central.
-                          type: array
-                          items:
-                            description: NutanixPrismElementEndpoint holds the name and endpoint data for a Prism Element (cluster)
-                            type: object
-                            required:
-                              - endpoint
-                              - name
-                            properties:
-                              endpoint:
-                                description: endpoint holds the endpoint address and port data of the Prism Element (cluster). When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
-                                type: object
-                                required:
-                                  - address
-                                  - port
-                                properties:
-                                  address:
-                                    description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
-                                    type: string
-                                    maxLength: 256
-                                  port:
-                                    description: port is the port number to access the Nutanix Prism Central or Element (cluster)
-                                    type: integer
-                                    format: int32
-                                    maximum: 65535
-                                    minimum: 1
-                              name:
-                                description: name is the name of the Prism Element (cluster). This value will correspond with the cluster field configured on other resources (eg Machines, PVCs, etc).
-                                type: string
-                                maxLength: 256
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                    openstack:
-                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
-                      type: object
-                    ovirt:
-                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
-                      type: object
-                    powervs:
-                      description: PowerVS contains settings specific to the IBM Power Systems Virtual Servers infrastructure provider.
-                      type: object
-                      properties:
-                        serviceEndpoints:
-                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
-                          type: array
-                          items:
-                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
-                            type: object
-                            required:
-                              - name
-                              - url
-                            properties:
-                              name:
-                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                type: string
-                                pattern: ^[a-z0-9-]+$
-                              url:
-                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
-                                type: string
-                                format: uri
-                                pattern: ^https://
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                    type:
-                      description: type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud", "Nutanix" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.
-                      type: string
-                      enum:
-                        - ""
-                        - AWS
-                        - Azure
-                        - BareMetal
-                        - GCP
-                        - Libvirt
-                        - OpenStack
-                        - None
-                        - VSphere
-                        - oVirt
-                        - IBMCloud
-                        - KubeVirt
-                        - EquinixMetal
-                        - PowerVS
-                        - AlibabaCloud
-                        - Nutanix
-                    vsphere:
-                      description: VSphere contains settings specific to the VSphere infrastructure provider.
-                      type: object
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-              properties:
-                apiServerInternalURI:
-                  description: apiServerInternalURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.
-                  type: string
-                apiServerURL:
-                  description: apiServerURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.
-                  type: string
-                controlPlaneTopology:
-                  description: controlPlaneTopology expresses the expectations for operands that normally run on control nodes. The default is 'HighlyAvailable', which represents the behavior operators have in a "normal" cluster. The 'SingleReplica' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation The 'External' mode indicates that the control plane is hosted externally to the cluster and that its components are not visible within the cluster.
-                  type: string
-                  default: HighlyAvailable
-                  enum:
-                    - HighlyAvailable
-                    - SingleReplica
-                    - External
-                etcdDiscoveryDomain:
-                  description: 'etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery deprecated: as of 4.7, this field is no longer set or honored.  It will be removed in a future release.'
-                  type: string
-                infrastructureName:
-                  description: infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.
-                  type: string
-                infrastructureTopology:
-                  description: 'infrastructureTopology expresses the expectations for infrastructure services that do not run on control plane nodes, usually indicated by a node selector for a `role` value other than `master`. The default is ''HighlyAvailable'', which represents the behavior operators have in a "normal" cluster. The ''SingleReplica'' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation NOTE: External topology mode is not applicable for this field.'
-                  type: string
-                  default: HighlyAvailable
-                  enum:
-                    - HighlyAvailable
-                    - SingleReplica
-                platform:
-                  description: "platform is the underlying infrastructure provider for the cluster. \n Deprecated: Use platformStatus.type instead."
-                  type: string
-                  enum:
+                              type: string
+                          required:
+                          - endpoint
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - prismCentral
+                    - prismElements
+                    type: object
+                  openstack:
+                    description: OpenStack contains settings specific to the OpenStack
+                      infrastructure provider.
+                    type: object
+                  ovirt:
+                    description: Ovirt contains settings specific to the oVirt infrastructure
+                      provider.
+                    type: object
+                  powervs:
+                    description: PowerVS contains settings specific to the IBM Power
+                      Systems Virtual Servers infrastructure provider.
+                    properties:
+                      serviceEndpoints:
+                        description: serviceEndpoints is a list of custom endpoints
+                          which will override the default service endpoints of a Power
+                          VS service.
+                        items:
+                          description: PowervsServiceEndpoint stores the configuration
+                            of a custom url to override existing defaults of PowerVS
+                            Services.
+                          properties:
+                            name:
+                              description: name is the name of the Power VS service.
+                                Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                              pattern: ^[a-z0-9-]+$
+                              type: string
+                            url:
+                              description: url is fully qualified URI with scheme
+                                https, that overrides the default generated endpoint
+                                for a client. This must be provided and cannot be
+                                empty.
+                              format: uri
+                              pattern: ^https://
+                              type: string
+                          required:
+                          - name
+                          - url
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                  type:
+                    description: type is the underlying infrastructure provider for
+                      the cluster. This value controls whether infrastructure automation
+                      such as service load balancers, dynamic volume provisioning,
+                      machine creation and deletion, and other integrations are enabled.
+                      If None, no infrastructure automation is enabled. Allowed values
+                      are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack",
+                      "VSphere", "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud",
+                      "Nutanix" and "None". Individual components may not support
+                      all platforms, and must handle unrecognized platforms as None
+                      if they do not support that platform.
+                    enum:
                     - ""
                     - AWS
                     - Azure
@@ -253,356 +280,654 @@ spec:
                     - PowerVS
                     - AlibabaCloud
                     - Nutanix
-                platformStatus:
-                  description: platformStatus holds status information specific to the underlying infrastructure provider.
-                  type: object
-                  properties:
-                    alibabaCloud:
-                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
-                      type: object
-                      required:
-                        - region
-                      properties:
-                        region:
-                          description: region specifies the region for Alibaba Cloud resources created for the cluster.
-                          type: string
-                          pattern: ^[0-9A-Za-z-]+$
-                        resourceGroupID:
-                          description: resourceGroupID is the ID of the resource group for the cluster.
-                          type: string
-                          pattern: ^(rg-[0-9A-Za-z]+)?$
-                        resourceTags:
-                          description: resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.
-                          type: array
-                          maxItems: 20
-                          items:
-                            description: AlibabaCloudResourceTag is the set of tags to add to apply to resources.
-                            type: object
-                            required:
-                              - key
-                              - value
-                            properties:
-                              key:
-                                description: key is the key of the tag.
-                                type: string
-                                maxLength: 128
-                                minLength: 1
-                              value:
-                                description: value is the value of the tag.
-                                type: string
-                                maxLength: 128
-                                minLength: 1
-                          x-kubernetes-list-map-keys:
-                            - key
-                          x-kubernetes-list-type: map
-                    aws:
-                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
-                      type: object
-                      properties:
-                        region:
-                          description: region holds the default AWS region for new AWS resources created by the cluster.
-                          type: string
-                        resourceTags:
-                          description: resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.
-                          type: array
-                          maxItems: 25
-                          items:
-                            description: AWSResourceTag is a tag to apply to AWS resources created for the cluster.
-                            type: object
-                            required:
-                              - key
-                              - value
-                            properties:
-                              key:
-                                description: key is the key of the tag
-                                type: string
-                                maxLength: 128
-                                minLength: 1
-                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
-                              value:
-                                description: value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.
-                                type: string
-                                maxLength: 256
-                                minLength: 1
-                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
-                        serviceEndpoints:
-                          description: ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
-                          type: array
-                          items:
-                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
-                            type: object
-                            properties:
-                              name:
-                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
-                                type: string
-                                pattern: ^[a-z0-9-]+$
-                              url:
-                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
-                                type: string
-                                pattern: ^https://
-                    azure:
-                      description: Azure contains settings specific to the Azure infrastructure provider.
-                      type: object
-                      properties:
-                        armEndpoint:
-                          description: armEndpoint specifies a URL to use for resource management in non-soverign clouds such as Azure Stack.
-                          type: string
-                        cloudName:
-                          description: cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the value is equal to `AzurePublicCloud`.
-                          type: string
-                          enum:
-                            - ""
-                            - AzurePublicCloud
-                            - AzureUSGovernmentCloud
-                            - AzureChinaCloud
-                            - AzureGermanCloud
-                            - AzureStackCloud
-                        networkResourceGroupName:
-                          description: networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster. If empty, the value is same as ResourceGroupName.
-                          type: string
-                        resourceGroupName:
-                          description: resourceGroupName is the Resource Group for new Azure resources created for the cluster.
-                          type: string
-                    baremetal:
-                      description: BareMetal contains settings specific to the BareMetal platform.
-                      type: object
-                      properties:
-                        apiServerInternalIP:
-                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
-                          type: string
-                        apiServerInternalIPs:
-                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                        ingressIP:
-                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
-                          type: string
-                        ingressIPs:
-                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                        nodeDNSIP:
-                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for BareMetal deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
-                          type: string
-                    equinixMetal:
-                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
-                      type: object
-                      properties:
-                        apiServerInternalIP:
-                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
-                          type: string
-                        ingressIP:
-                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
-                          type: string
-                    gcp:
-                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
-                      type: object
-                      properties:
-                        projectID:
-                          description: resourceGroupName is the Project ID for new GCP resources created for the cluster.
-                          type: string
-                        region:
-                          description: region holds the region for new GCP resources created for the cluster.
-                          type: string
-                    ibmcloud:
-                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
-                      type: object
-                      properties:
-                        cisInstanceCRN:
-                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
-                          type: string
-                        dnsInstanceCRN:
-                          description: DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain
-                          type: string
-                        location:
-                          description: Location is where the cluster has been deployed
-                          type: string
-                        providerType:
-                          description: ProviderType indicates the type of cluster that was created
-                          type: string
-                        resourceGroupName:
-                          description: ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.
-                          type: string
-                    kubevirt:
-                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
-                      type: object
-                      properties:
-                        apiServerInternalIP:
-                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
-                          type: string
-                        ingressIP:
-                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
-                          type: string
-                    nutanix:
-                      description: Nutanix contains settings specific to the Nutanix infrastructure provider.
-                      type: object
-                      properties:
-                        apiServerInternalIP:
-                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
-                          type: string
-                        apiServerInternalIPs:
-                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                        ingressIP:
-                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
-                          type: string
-                        ingressIPs:
-                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                    openstack:
-                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
-                      type: object
-                      properties:
-                        apiServerInternalIP:
-                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
-                          type: string
-                        apiServerInternalIPs:
-                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                        cloudName:
-                          description: cloudName is the name of the desired OpenStack cloud in the client configuration file (`clouds.yaml`).
-                          type: string
-                        ingressIP:
-                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
-                          type: string
-                        ingressIPs:
-                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                        nodeDNSIP:
-                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for OpenStack deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
-                          type: string
-                    ovirt:
-                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
-                      type: object
-                      properties:
-                        apiServerInternalIP:
-                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
-                          type: string
-                        apiServerInternalIPs:
-                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                        ingressIP:
-                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
-                          type: string
-                        ingressIPs:
-                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                        nodeDNSIP:
-                          description: 'deprecated: as of 4.6, this field is no longer set or honored.  It will be removed in a future release.'
-                          type: string
-                    powervs:
-                      description: PowerVS contains settings specific to the Power Systems Virtual Servers infrastructure provider.
-                      type: object
-                      properties:
-                        cisInstanceCRN:
-                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
-                          type: string
-                        dnsInstanceCRN:
-                          description: DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain
-                          type: string
-                        region:
-                          description: region holds the default Power VS region for new Power VS resources created by the cluster.
-                          type: string
-                        serviceEndpoints:
-                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
-                          type: array
-                          items:
-                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
-                            type: object
-                            required:
-                              - name
-                              - url
-                            properties:
-                              name:
-                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                type: string
-                                pattern: ^[a-z0-9-]+$
-                              url:
-                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
-                                type: string
-                                format: uri
-                                pattern: ^https://
-                        zone:
-                          description: 'zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported'
-                          type: string
-                    type:
-                      description: "type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform. \n This value will be synced with to the `status.platform` and `status.platformStatus.type`. Currently this value cannot be changed once set."
-                      type: string
-                      enum:
+                    type: string
+                  vsphere:
+                    description: VSphere contains settings specific to the VSphere
+                      infrastructure provider.
+                    type: object
+                type: object
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              apiServerInternalURI:
+                description: apiServerInternalURL is a valid URI with scheme 'https',
+                  address and optionally a port (defaulting to 443).  apiServerInternalURL
+                  can be used by components like kubelets, to contact the Kubernetes
+                  API server using the infrastructure provider rather than Kubernetes
+                  networking.
+                type: string
+              apiServerURL:
+                description: apiServerURL is a valid URI with scheme 'https', address
+                  and optionally a port (defaulting to 443).  apiServerURL can be
+                  used by components like the web console to tell users where to find
+                  the Kubernetes API.
+                type: string
+              controlPlaneTopology:
+                default: HighlyAvailable
+                description: controlPlaneTopology expresses the expectations for operands
+                  that normally run on control nodes. The default is 'HighlyAvailable',
+                  which represents the behavior operators have in a "normal" cluster.
+                  The 'SingleReplica' mode will be used in single-node deployments
+                  and the operators should not configure the operand for highly-available
+                  operation The 'External' mode indicates that the control plane is
+                  hosted externally to the cluster and that its components are not
+                  visible within the cluster.
+                enum:
+                - HighlyAvailable
+                - SingleReplica
+                - External
+                type: string
+              etcdDiscoveryDomain:
+                description: 'etcdDiscoveryDomain is the domain used to fetch the
+                  SRV records for discovering etcd servers and clients. For more info:
+                  https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
+                  deprecated: as of 4.7, this field is no longer set or honored.  It
+                  will be removed in a future release.'
+                type: string
+              infrastructureName:
+                description: infrastructureName uniquely identifies a cluster with
+                  a human friendly name. Once set it should not be changed. Must be
+                  of max length 27 and must have only alphanumeric or hyphen characters.
+                type: string
+              infrastructureTopology:
+                default: HighlyAvailable
+                description: 'infrastructureTopology expresses the expectations for
+                  infrastructure services that do not run on control plane nodes,
+                  usually indicated by a node selector for a `role` value other than
+                  `master`. The default is ''HighlyAvailable'', which represents the
+                  behavior operators have in a "normal" cluster. The ''SingleReplica''
+                  mode will be used in single-node deployments and the operators should
+                  not configure the operand for highly-available operation NOTE: External
+                  topology mode is not applicable for this field.'
+                enum:
+                - HighlyAvailable
+                - SingleReplica
+                type: string
+              platform:
+                description: "platform is the underlying infrastructure provider for
+                  the cluster. \n Deprecated: Use platformStatus.type instead."
+                enum:
+                - ""
+                - AWS
+                - Azure
+                - BareMetal
+                - GCP
+                - Libvirt
+                - OpenStack
+                - None
+                - VSphere
+                - oVirt
+                - IBMCloud
+                - KubeVirt
+                - EquinixMetal
+                - PowerVS
+                - AlibabaCloud
+                - Nutanix
+                type: string
+              platformStatus:
+                description: platformStatus holds status information specific to the
+                  underlying infrastructure provider.
+                properties:
+                  alibabaCloud:
+                    description: AlibabaCloud contains settings specific to the Alibaba
+                      Cloud infrastructure provider.
+                    properties:
+                      region:
+                        description: region specifies the region for Alibaba Cloud
+                          resources created for the cluster.
+                        pattern: ^[0-9A-Za-z-]+$
+                        type: string
+                      resourceGroupID:
+                        description: resourceGroupID is the ID of the resource group
+                          for the cluster.
+                        pattern: ^(rg-[0-9A-Za-z]+)?$
+                        type: string
+                      resourceTags:
+                        description: resourceTags is a list of additional tags to
+                          apply to Alibaba Cloud resources created for the cluster.
+                        items:
+                          description: AlibabaCloudResourceTag is the set of tags
+                            to add to apply to resources.
+                          properties:
+                            key:
+                              description: key is the key of the tag.
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                            value:
+                              description: value is the value of the tag.
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        maxItems: 20
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - key
+                        x-kubernetes-list-type: map
+                    required:
+                    - region
+                    type: object
+                  aws:
+                    description: AWS contains settings specific to the Amazon Web
+                      Services infrastructure provider.
+                    properties:
+                      region:
+                        description: region holds the default AWS region for new AWS
+                          resources created by the cluster.
+                        type: string
+                      resourceTags:
+                        description: resourceTags is a list of additional tags to
+                          apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                          for information on tagging AWS resources. AWS supports a
+                          maximum of 50 tags per resource. OpenShift reserves 25 tags
+                          for its use, leaving 25 tags available for the user.
+                        items:
+                          description: AWSResourceTag is a tag to apply to AWS resources
+                            created for the cluster.
+                          properties:
+                            key:
+                              description: key is the key of the tag
+                              maxLength: 128
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                            value:
+                              description: value is the value of the tag. Some AWS
+                                service do not support empty values. Since tags are
+                                added to resources in many services, the length of
+                                the tag value must meet the requirements of all services.
+                              maxLength: 256
+                              minLength: 1
+                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              type: string
+                          required:
+                          - key
+                          - value
+                          type: object
+                        maxItems: 25
+                        type: array
+                      serviceEndpoints:
+                        description: ServiceEndpoints list contains custom endpoints
+                          which will override default service endpoint of AWS Services.
+                          There must be only one ServiceEndpoint for a service.
+                        items:
+                          description: AWSServiceEndpoint store the configuration
+                            of a custom url to override existing defaults of AWS Services.
+                          properties:
+                            name:
+                              description: name is the name of the AWS service. The
+                                list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                This must be provided and cannot be empty.
+                              pattern: ^[a-z0-9-]+$
+                              type: string
+                            url:
+                              description: url is fully qualified URI with scheme
+                                https, that overrides the default generated endpoint
+                                for a client. This must be provided and cannot be
+                                empty.
+                              pattern: ^https://
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  azure:
+                    description: Azure contains settings specific to the Azure infrastructure
+                      provider.
+                    properties:
+                      armEndpoint:
+                        description: armEndpoint specifies a URL to use for resource
+                          management in non-soverign clouds such as Azure Stack.
+                        type: string
+                      cloudName:
+                        description: cloudName is the name of the Azure cloud environment
+                          which can be used to configure the Azure SDK with the appropriate
+                          Azure API endpoints. If empty, the value is equal to `AzurePublicCloud`.
+                        enum:
                         - ""
-                        - AWS
-                        - Azure
-                        - BareMetal
-                        - GCP
-                        - Libvirt
-                        - OpenStack
-                        - None
-                        - VSphere
-                        - oVirt
-                        - IBMCloud
-                        - KubeVirt
-                        - EquinixMetal
-                        - PowerVS
-                        - AlibabaCloud
-                        - Nutanix
-                    vsphere:
-                      description: VSphere contains settings specific to the VSphere infrastructure provider.
-                      type: object
-                      properties:
-                        apiServerInternalIP:
-                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                        - AzurePublicCloud
+                        - AzureUSGovernmentCloud
+                        - AzureChinaCloud
+                        - AzureGermanCloud
+                        - AzureStackCloud
+                        type: string
+                      networkResourceGroupName:
+                        description: networkResourceGroupName is the Resource Group
+                          for network resources like the Virtual Network and Subnets
+                          used by the cluster. If empty, the value is same as ResourceGroupName.
+                        type: string
+                      resourceGroupName:
+                        description: resourceGroupName is the Resource Group for new
+                          Azure resources created for the cluster.
+                        type: string
+                    type: object
+                  baremetal:
+                    description: BareMetal contains settings specific to the BareMetal
+                      platform.
+                    properties:
+                      apiServerInternalIP:
+                        description: "apiServerInternalIP is an IP address to contact
+                          the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. It is the IP that the
+                          Infrastructure.status.apiServerInternalURI points to. It
+                          is the IP for a self-hosted load balancer in front of the
+                          API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                        type: string
+                      apiServerInternalIPs:
+                        description: apiServerInternalIPs are the IP addresses to
+                          contact the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. These are the IPs for
+                          a self-hosted load balancer in front of the API servers.
+                          In dual stack clusters this list contains two IPs otherwise
+                          only one.
+                        format: ip
+                        items:
                           type: string
-                        apiServerInternalIPs:
-                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                        ingressIP:
-                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                        maxItems: 2
+                        type: array
+                      ingressIP:
+                        description: "ingressIP is an external IP which routes to
+                          the default ingress controller. The IP is a suitable target
+                          of a wildcard DNS record used to resolve default route host
+                          names. \n Deprecated: Use IngressIPs instead."
+                        type: string
+                      ingressIPs:
+                        description: ingressIPs are the external IPs which route to
+                          the default ingress controller. The IPs are suitable targets
+                          of a wildcard DNS record used to resolve default route host
+                          names. In dual stack clusters this list contains two IPs
+                          otherwise only one.
+                        format: ip
+                        items:
                           type: string
-                        ingressIPs:
-                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
-                          type: array
-                          format: ip
-                          maxItems: 2
-                          items:
-                            type: string
-                        nodeDNSIP:
-                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for vSphere deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                        maxItems: 2
+                        type: array
+                      nodeDNSIP:
+                        description: nodeDNSIP is the IP address for the internal
+                          DNS used by the nodes. Unlike the one managed by the DNS
+                          operator, `NodeDNSIP` provides name resolution for the nodes
+                          themselves. There is no DNS-as-a-service for BareMetal deployments.
+                          In order to minimize necessary changes to the datacenter
+                          DNS, a DNS service is hosted as a static pod to serve those
+                          hostnames to the nodes in the cluster.
+                        type: string
+                    type: object
+                  equinixMetal:
+                    description: EquinixMetal contains settings specific to the Equinix
+                      Metal infrastructure provider.
+                    properties:
+                      apiServerInternalIP:
+                        description: apiServerInternalIP is an IP address to contact
+                          the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. It is the IP that the
+                          Infrastructure.status.apiServerInternalURI points to. It
+                          is the IP for a self-hosted load balancer in front of the
+                          API servers.
+                        type: string
+                      ingressIP:
+                        description: ingressIP is an external IP which routes to the
+                          default ingress controller. The IP is a suitable target
+                          of a wildcard DNS record used to resolve default route host
+                          names.
+                        type: string
+                    type: object
+                  gcp:
+                    description: GCP contains settings specific to the Google Cloud
+                      Platform infrastructure provider.
+                    properties:
+                      projectID:
+                        description: resourceGroupName is the Project ID for new GCP
+                          resources created for the cluster.
+                        type: string
+                      region:
+                        description: region holds the region for new GCP resources
+                          created for the cluster.
+                        type: string
+                    type: object
+                  ibmcloud:
+                    description: IBMCloud contains settings specific to the IBMCloud
+                      infrastructure provider.
+                    properties:
+                      cisInstanceCRN:
+                        description: CISInstanceCRN is the CRN of the Cloud Internet
+                          Services instance managing the DNS zone for the cluster's
+                          base domain
+                        type: string
+                      dnsInstanceCRN:
+                        description: DNSInstanceCRN is the CRN of the DNS Services
+                          instance managing the DNS zone for the cluster's base domain
+                        type: string
+                      location:
+                        description: Location is where the cluster has been deployed
+                        type: string
+                      providerType:
+                        description: ProviderType indicates the type of cluster that
+                          was created
+                        type: string
+                      resourceGroupName:
+                        description: ResourceGroupName is the Resource Group for new
+                          IBMCloud resources created for the cluster.
+                        type: string
+                    type: object
+                  kubevirt:
+                    description: Kubevirt contains settings specific to the kubevirt
+                      infrastructure provider.
+                    properties:
+                      apiServerInternalIP:
+                        description: apiServerInternalIP is an IP address to contact
+                          the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. It is the IP that the
+                          Infrastructure.status.apiServerInternalURI points to. It
+                          is the IP for a self-hosted load balancer in front of the
+                          API servers.
+                        type: string
+                      ingressIP:
+                        description: ingressIP is an external IP which routes to the
+                          default ingress controller. The IP is a suitable target
+                          of a wildcard DNS record used to resolve default route host
+                          names.
+                        type: string
+                    type: object
+                  nutanix:
+                    description: Nutanix contains settings specific to the Nutanix
+                      infrastructure provider.
+                    properties:
+                      apiServerInternalIP:
+                        description: "apiServerInternalIP is an IP address to contact
+                          the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. It is the IP that the
+                          Infrastructure.status.apiServerInternalURI points to. It
+                          is the IP for a self-hosted load balancer in front of the
+                          API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                        type: string
+                      apiServerInternalIPs:
+                        description: apiServerInternalIPs are the IP addresses to
+                          contact the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. These are the IPs for
+                          a self-hosted load balancer in front of the API servers.
+                          In dual stack clusters this list contains two IPs otherwise
+                          only one.
+                        format: ip
+                        items:
                           type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                        maxItems: 2
+                        type: array
+                      ingressIP:
+                        description: "ingressIP is an external IP which routes to
+                          the default ingress controller. The IP is a suitable target
+                          of a wildcard DNS record used to resolve default route host
+                          names. \n Deprecated: Use IngressIPs instead."
+                        type: string
+                      ingressIPs:
+                        description: ingressIPs are the external IPs which route to
+                          the default ingress controller. The IPs are suitable targets
+                          of a wildcard DNS record used to resolve default route host
+                          names. In dual stack clusters this list contains two IPs
+                          otherwise only one.
+                        format: ip
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                    type: object
+                  openstack:
+                    description: OpenStack contains settings specific to the OpenStack
+                      infrastructure provider.
+                    properties:
+                      apiServerInternalIP:
+                        description: "apiServerInternalIP is an IP address to contact
+                          the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. It is the IP that the
+                          Infrastructure.status.apiServerInternalURI points to. It
+                          is the IP for a self-hosted load balancer in front of the
+                          API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                        type: string
+                      apiServerInternalIPs:
+                        description: apiServerInternalIPs are the IP addresses to
+                          contact the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. These are the IPs for
+                          a self-hosted load balancer in front of the API servers.
+                          In dual stack clusters this list contains two IPs otherwise
+                          only one.
+                        format: ip
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                      cloudName:
+                        description: cloudName is the name of the desired OpenStack
+                          cloud in the client configuration file (`clouds.yaml`).
+                        type: string
+                      ingressIP:
+                        description: "ingressIP is an external IP which routes to
+                          the default ingress controller. The IP is a suitable target
+                          of a wildcard DNS record used to resolve default route host
+                          names. \n Deprecated: Use IngressIPs instead."
+                        type: string
+                      ingressIPs:
+                        description: ingressIPs are the external IPs which route to
+                          the default ingress controller. The IPs are suitable targets
+                          of a wildcard DNS record used to resolve default route host
+                          names. In dual stack clusters this list contains two IPs
+                          otherwise only one.
+                        format: ip
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                      nodeDNSIP:
+                        description: nodeDNSIP is the IP address for the internal
+                          DNS used by the nodes. Unlike the one managed by the DNS
+                          operator, `NodeDNSIP` provides name resolution for the nodes
+                          themselves. There is no DNS-as-a-service for OpenStack deployments.
+                          In order to minimize necessary changes to the datacenter
+                          DNS, a DNS service is hosted as a static pod to serve those
+                          hostnames to the nodes in the cluster.
+                        type: string
+                    type: object
+                  ovirt:
+                    description: Ovirt contains settings specific to the oVirt infrastructure
+                      provider.
+                    properties:
+                      apiServerInternalIP:
+                        description: "apiServerInternalIP is an IP address to contact
+                          the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. It is the IP that the
+                          Infrastructure.status.apiServerInternalURI points to. It
+                          is the IP for a self-hosted load balancer in front of the
+                          API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                        type: string
+                      apiServerInternalIPs:
+                        description: apiServerInternalIPs are the IP addresses to
+                          contact the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. These are the IPs for
+                          a self-hosted load balancer in front of the API servers.
+                          In dual stack clusters this list contains two IPs otherwise
+                          only one.
+                        format: ip
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                      ingressIP:
+                        description: "ingressIP is an external IP which routes to
+                          the default ingress controller. The IP is a suitable target
+                          of a wildcard DNS record used to resolve default route host
+                          names. \n Deprecated: Use IngressIPs instead."
+                        type: string
+                      ingressIPs:
+                        description: ingressIPs are the external IPs which route to
+                          the default ingress controller. The IPs are suitable targets
+                          of a wildcard DNS record used to resolve default route host
+                          names. In dual stack clusters this list contains two IPs
+                          otherwise only one.
+                        format: ip
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                      nodeDNSIP:
+                        description: 'deprecated: as of 4.6, this field is no longer
+                          set or honored.  It will be removed in a future release.'
+                        type: string
+                    type: object
+                  powervs:
+                    description: PowerVS contains settings specific to the Power Systems
+                      Virtual Servers infrastructure provider.
+                    properties:
+                      cisInstanceCRN:
+                        description: CISInstanceCRN is the CRN of the Cloud Internet
+                          Services instance managing the DNS zone for the cluster's
+                          base domain
+                        type: string
+                      dnsInstanceCRN:
+                        description: DNSInstanceCRN is the CRN of the DNS Services
+                          instance managing the DNS zone for the cluster's base domain
+                        type: string
+                      region:
+                        description: region holds the default Power VS region for
+                          new Power VS resources created by the cluster.
+                        type: string
+                      serviceEndpoints:
+                        description: serviceEndpoints is a list of custom endpoints
+                          which will override the default service endpoints of a Power
+                          VS service.
+                        items:
+                          description: PowervsServiceEndpoint stores the configuration
+                            of a custom url to override existing defaults of PowerVS
+                            Services.
+                          properties:
+                            name:
+                              description: name is the name of the Power VS service.
+                                Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                              pattern: ^[a-z0-9-]+$
+                              type: string
+                            url:
+                              description: url is fully qualified URI with scheme
+                                https, that overrides the default generated endpoint
+                                for a client. This must be provided and cannot be
+                                empty.
+                              format: uri
+                              pattern: ^https://
+                              type: string
+                          required:
+                          - name
+                          - url
+                          type: object
+                        type: array
+                      zone:
+                        description: 'zone holds the default zone for the new Power
+                          VS resources created by the cluster. Note: Currently only
+                          single-zone OCP clusters are supported'
+                        type: string
+                    type: object
+                  type:
+                    description: "type is the underlying infrastructure provider for
+                      the cluster. This value controls whether infrastructure automation
+                      such as service load balancers, dynamic volume provisioning,
+                      machine creation and deletion, and other integrations are enabled.
+                      If None, no infrastructure automation is enabled. Allowed values
+                      are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\",
+                      \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\",
+                      \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components
+                      may not support all platforms, and must handle unrecognized
+                      platforms as None if they do not support that platform. \n This
+                      value will be synced with to the `status.platform` and `status.platformStatus.type`.
+                      Currently this value cannot be changed once set."
+                    enum:
+                    - ""
+                    - AWS
+                    - Azure
+                    - BareMetal
+                    - GCP
+                    - Libvirt
+                    - OpenStack
+                    - None
+                    - VSphere
+                    - oVirt
+                    - IBMCloud
+                    - KubeVirt
+                    - EquinixMetal
+                    - PowerVS
+                    - AlibabaCloud
+                    - Nutanix
+                    type: string
+                  vsphere:
+                    description: VSphere contains settings specific to the VSphere
+                      infrastructure provider.
+                    properties:
+                      apiServerInternalIP:
+                        description: "apiServerInternalIP is an IP address to contact
+                          the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. It is the IP that the
+                          Infrastructure.status.apiServerInternalURI points to. It
+                          is the IP for a self-hosted load balancer in front of the
+                          API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                        type: string
+                      apiServerInternalIPs:
+                        description: apiServerInternalIPs are the IP addresses to
+                          contact the Kubernetes API server that can be used by components
+                          inside the cluster, like kubelets using the infrastructure
+                          rather than Kubernetes networking. These are the IPs for
+                          a self-hosted load balancer in front of the API servers.
+                          In dual stack clusters this list contains two IPs otherwise
+                          only one.
+                        format: ip
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                      ingressIP:
+                        description: "ingressIP is an external IP which routes to
+                          the default ingress controller. The IP is a suitable target
+                          of a wildcard DNS record used to resolve default route host
+                          names. \n Deprecated: Use IngressIPs instead."
+                        type: string
+                      ingressIPs:
+                        description: ingressIPs are the external IPs which route to
+                          the default ingress controller. The IPs are suitable targets
+                          of a wildcard DNS record used to resolve default route host
+                          names. In dual stack clusters this list contains two IPs
+                          otherwise only one.
+                        format: ip
+                        items:
+                          type: string
+                        maxItems: 2
+                        type: array
+                      nodeDNSIP:
+                        description: nodeDNSIP is the IP address for the internal
+                          DNS used by the nodes. Unlike the one managed by the DNS
+                          operator, `NodeDNSIP` provides name resolution for the nodes
+                          themselves. There is no DNS-as-a-service for vSphere deployments.
+                          In order to minimize necessary changes to the datacenter
+                          DNS, a DNS service is hosted as a static pod to serve those
+                          hostnames to the nodes in the cluster.
+                        type: string
+                    type: object
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_ingress.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_ingress.crd.yaml
@@ -16,318 +16,537 @@ spec:
     singular: ingress
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Ingress holds cluster-wide information about ingress, including the default ingress domain used for routes. The canonical name is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                appsDomain:
-                  description: appsDomain is an optional domain to use instead of the one specified in the domain field when a Route is created without specifying an explicit host. If appsDomain is nonempty, this value is used to generate default host values for Route. Unlike domain, appsDomain may be modified after installation. This assumes a new ingresscontroller has been setup with a wildcard certificate.
-                  type: string
-                componentRoutes:
-                  description: "componentRoutes is an optional list of routes that are managed by OpenShift components that a cluster-admin is able to configure the hostname and serving certificate for. The namespace and name of each route in this list should match an existing entry in the status.componentRoutes list. \n To determine the set of configurable Routes, look at namespace and name of entries in the .status.componentRoutes list, where participating operators write the status of configurable routes."
-                  type: array
-                  items:
-                    description: ComponentRouteSpec allows for configuration of a route's hostname and serving certificate.
-                    type: object
-                    required:
-                      - hostname
-                      - name
-                      - namespace
-                    properties:
-                      hostname:
-                        description: hostname is the hostname that should be used by the route.
-                        type: string
-                        pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
-                      name:
-                        description: "name is the logical name of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized."
-                        type: string
-                        maxLength: 256
-                        minLength: 1
-                      namespace:
-                        description: "namespace is the namespace of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized."
-                        type: string
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                      servingCertKeyPairSecret:
-                        description: servingCertKeyPairSecret is a reference to a secret of type `kubernetes.io/tls` in the openshift-config namespace. The serving cert/key pair must match and will be used by the operator to fulfill the intent of serving with this name. If the custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed.
-                        type: object
-                        required:
-                          - name
-                        properties:
-                          name:
-                            description: name is the metadata.name of the referenced secret
-                            type: string
-                  x-kubernetes-list-map-keys:
-                    - namespace
-                    - name
-                  x-kubernetes-list-type: map
-                domain:
-                  description: "domain is used to generate a default host name for a route when the route's host name is empty. The generated host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\". \n It is also used as the default wildcard domain suffix for ingress. The default ingresscontroller domain will follow this pattern: \"*.<domain>\". \n Once set, changing domain is not currently supported."
-                  type: string
-                loadbalancer:
-                  description: loadBalancer contains the load balancer details in general which are not only specific to the underlying infrastructure provider of the current cluster and are required for Ingress Controller to work on OpenShift.
-                  type: object
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Ingress holds cluster-wide information about ingress, including
+          the default ingress domain used for routes. The canonical name is `cluster`.
+          \n Compatibility level 1: Stable within a major release for a minimum of
+          12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              appsDomain:
+                description: appsDomain is an optional domain to use instead of the
+                  one specified in the domain field when a Route is created without
+                  specifying an explicit host. If appsDomain is nonempty, this value
+                  is used to generate default host values for Route. Unlike domain,
+                  appsDomain may be modified after installation. This assumes a new
+                  ingresscontroller has been setup with a wildcard certificate.
+                type: string
+              componentRoutes:
+                description: "componentRoutes is an optional list of routes that are
+                  managed by OpenShift components that a cluster-admin is able to
+                  configure the hostname and serving certificate for. The namespace
+                  and name of each route in this list should match an existing entry
+                  in the status.componentRoutes list. \n To determine the set of configurable
+                  Routes, look at namespace and name of entries in the .status.componentRoutes
+                  list, where participating operators write the status of configurable
+                  routes."
+                items:
+                  description: ComponentRouteSpec allows for configuration of a route's
+                    hostname and serving certificate.
                   properties:
-                    platform:
-                      description: platform holds configuration specific to the underlying infrastructure provider for the ingress load balancers. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.
-                      type: object
+                    hostname:
+                      description: hostname is the hostname that should be used by
+                        the route.
+                      pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                      type: string
+                    name:
+                      description: "name is the logical name of the route to customize.
+                        \n The namespace and name of this componentRoute must match
+                        a corresponding entry in the list of status.componentRoutes
+                        if the route is to be customized."
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "namespace is the namespace of the route to customize.
+                        \n The namespace and name of this componentRoute must match
+                        a corresponding entry in the list of status.componentRoutes
+                        if the route is to be customized."
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    servingCertKeyPairSecret:
+                      description: servingCertKeyPairSecret is a reference to a secret
+                        of type `kubernetes.io/tls` in the openshift-config namespace.
+                        The serving cert/key pair must match and will be used by the
+                        operator to fulfill the intent of serving with this name.
+                        If the custom hostname uses the default routing suffix of
+                        the cluster, the Secret specification for a serving certificate
+                        will not be needed.
                       properties:
-                        aws:
-                          description: aws contains settings specific to the Amazon Web Services infrastructure provider.
-                          type: object
-                          required:
-                            - type
-                          properties:
-                            type:
-                              description: "type allows user to set a load balancer type. When this field is set the default ingresscontroller will get created using the specified LBType. If this field is not set then the default ingress controller of LBType Classic will be created. Valid values are: \n * \"Classic\": A Classic Load Balancer that makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb \n * \"NLB\": A Network Load Balancer that makes routing decisions at the transport layer (TCP/SSL). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb"
-                              type: string
-                              enum:
-                                - NLB
-                                - Classic
-                        type:
-                          description: type is the underlying infrastructure provider for the cluster. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud", "Nutanix" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.
+                        name:
+                          description: name is the metadata.name of the referenced
+                            secret
                           type: string
-                          enum:
-                            - ""
-                            - AWS
-                            - Azure
-                            - BareMetal
-                            - GCP
-                            - Libvirt
-                            - OpenStack
-                            - None
-                            - VSphere
-                            - oVirt
-                            - IBMCloud
-                            - KubeVirt
-                            - EquinixMetal
-                            - PowerVS
-                            - AlibabaCloud
-                            - Nutanix
-                requiredHSTSPolicies:
-                  description: "requiredHSTSPolicies specifies HSTS policies that are required to be set on newly created  or updated routes matching the domainPattern/s and namespaceSelector/s that are specified in the policy. Each requiredHSTSPolicy must have at least a domainPattern and a maxAge to validate a route HSTS Policy route annotation, and affect route admission. \n A candidate route is checked for HSTS Policies if it has the HSTS Policy route annotation: \"haproxy.router.openshift.io/hsts_header\" E.g. haproxy.router.openshift.io/hsts_header: max-age=31536000;preload;includeSubDomains \n - For each candidate route, if it matches a requiredHSTSPolicy domainPattern and optional namespaceSelector, then the maxAge, preloadPolicy, and includeSubdomainsPolicy must be valid to be admitted.  Otherwise, the route is rejected. - The first match, by domainPattern and optional namespaceSelector, in the ordering of the RequiredHSTSPolicies determines the route's admission status. - If the candidate route doesn't match any requiredHSTSPolicy domainPattern and optional namespaceSelector, then it may use any HSTS Policy annotation. \n The HSTS policy configuration may be changed after routes have already been created. An update to a previously admitted route may then fail if the updated route does not conform to the updated HSTS policy configuration. However, changing the HSTS policy configuration will not cause a route that is already admitted to stop working. \n Note that if there are no RequiredHSTSPolicies, any HSTS Policy annotation on the route is valid."
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - domainPatterns
-                    properties:
-                      domainPatterns:
-                        description: "domainPatterns is a list of domains for which the desired HSTS annotations are required. If domainPatterns is specified and a route is created with a spec.host matching one of the domains, the route must specify the HSTS Policy components described in the matching RequiredHSTSPolicy. \n The use of wildcards is allowed like this: *.foo.com matches everything under foo.com. foo.com only matches foo.com, so to cover foo.com and everything under it, you must specify *both*."
-                        type: array
-                        minItems: 1
-                        items:
-                          type: string
-                      includeSubDomainsPolicy:
-                        description: 'includeSubDomainsPolicy means the HSTS Policy should apply to any subdomains of the host''s domain name.  Thus, for the host bar.foo.com, if includeSubDomainsPolicy was set to RequireIncludeSubDomains: - the host app.bar.foo.com would inherit the HSTS Policy of bar.foo.com - the host bar.foo.com would inherit the HSTS Policy of bar.foo.com - the host foo.com would NOT inherit the HSTS Policy of bar.foo.com - the host def.foo.com would NOT inherit the HSTS Policy of bar.foo.com'
-                        type: string
-                        enum:
-                          - RequireIncludeSubDomains
-                          - RequireNoIncludeSubDomains
-                          - NoOpinion
-                      maxAge:
-                        description: maxAge is the delta time range in seconds during which hosts are regarded as HSTS hosts. If set to 0, it negates the effect, and hosts are removed as HSTS hosts. If set to 0 and includeSubdomains is specified, all subdomains of the host are also removed as HSTS hosts. maxAge is a time-to-live value, and if this policy is not refreshed on a client, the HSTS policy will eventually expire on that client.
-                        type: object
-                        properties:
-                          largestMaxAge:
-                            description: The largest allowed value (in seconds) of the RequiredHSTSPolicy max-age This value can be left unspecified, in which case no upper limit is enforced.
-                            type: integer
-                            format: int32
-                            maximum: 2147483647
-                            minimum: 0
-                          smallestMaxAge:
-                            description: The smallest allowed value (in seconds) of the RequiredHSTSPolicy max-age Setting max-age=0 allows the deletion of an existing HSTS header from a host.  This is a necessary tool for administrators to quickly correct mistakes. This value can be left unspecified, in which case no lower limit is enforced.
-                            type: integer
-                            format: int32
-                            maximum: 2147483647
-                            minimum: 0
-                      namespaceSelector:
-                        description: namespaceSelector specifies a label selector such that the policy applies only to those routes that are in namespaces with labels that match the selector, and are in one of the DomainPatterns. Defaults to the empty LabelSelector, which matches everything.
-                        type: object
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                            type: array
-                            items:
-                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                              type: object
-                              required:
-                                - key
-                                - operator
-                              properties:
-                                key:
-                                  description: key is the label key that the selector applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                  type: array
-                                  items:
-                                    type: string
-                          matchLabels:
-                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                            type: object
-                            additionalProperties:
-                              type: string
-                        x-kubernetes-map-type: atomic
-                      preloadPolicy:
-                        description: preloadPolicy directs the client to include hosts in its host preload list so that it never needs to do an initial load to get the HSTS header (note that this is not defined in RFC 6797 and is therefore client implementation-dependent).
-                        type: string
-                        enum:
-                          - RequirePreload
-                          - RequireNoPreload
-                          - NoOpinion
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-              properties:
-                componentRoutes:
-                  description: componentRoutes is where participating operators place the current route status for routes whose hostnames and serving certificates can be customized by the cluster-admin.
-                  type: array
-                  items:
-                    description: ComponentRouteStatus contains information allowing configuration of a route's hostname and serving certificate.
-                    type: object
-                    required:
-                      - defaultHostname
+                      required:
                       - name
-                      - namespace
-                      - relatedObjects
+                      type: object
+                  required:
+                  - hostname
+                  - name
+                  - namespace
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - namespace
+                - name
+                x-kubernetes-list-type: map
+              domain:
+                description: "domain is used to generate a default host name for a
+                  route when the route's host name is empty. The generated host name
+                  will follow this pattern: \"<route-name>.<route-namespace>.<domain>\".
+                  \n It is also used as the default wildcard domain suffix for ingress.
+                  The default ingresscontroller domain will follow this pattern: \"*.<domain>\".
+                  \n Once set, changing domain is not currently supported."
+                type: string
+              loadbalancer:
+                description: loadBalancer contains the load balancer details in general
+                  which are not only specific to the underlying infrastructure provider
+                  of the current cluster and are required for Ingress Controller to
+                  work on OpenShift.
+                properties:
+                  platform:
+                    description: platform holds configuration specific to the underlying
+                      infrastructure provider for the ingress load balancers. When
+                      omitted, this means the user has no opinion and the platform
+                      is left to choose reasonable defaults. These defaults are subject
+                      to change over time.
                     properties:
-                      conditions:
-                        description: "conditions are used to communicate the state of the componentRoutes entry. \n Supported conditions include Available, Degraded and Progressing. \n If available is true, the content served by the route can be accessed by users. This includes cases where a default may continue to serve content while the customized route specified by the cluster-admin is being configured. \n If Degraded is true, that means something has gone wrong trying to handle the componentRoutes entry. The currentHostnames field may or may not be in effect. \n If Progressing is true, that means the component is taking some action related to the componentRoutes entry."
-                        type: array
-                        items:
-                          description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                          type: object
-                          required:
-                            - lastTransitionTime
-                            - message
-                            - reason
-                            - status
-                            - type
-                          properties:
-                            lastTransitionTime:
-                              description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                              type: string
-                              format: date-time
-                            message:
-                              description: message is a human readable message indicating details about the transition. This may be an empty string.
-                              type: string
-                              maxLength: 32768
-                            observedGeneration:
-                              description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                              type: integer
-                              format: int64
-                              minimum: 0
-                            reason:
-                              description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                              type: string
-                              maxLength: 1024
-                              minLength: 1
-                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            status:
-                              description: status of the condition, one of True, False, Unknown.
-                              type: string
-                              enum:
-                                - "True"
-                                - "False"
-                                - Unknown
-                            type:
-                              description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                              type: string
-                              maxLength: 316
-                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        x-kubernetes-list-map-keys:
-                          - type
-                        x-kubernetes-list-type: map
-                      consumingUsers:
-                        description: consumingUsers is a slice of ServiceAccounts that need to have read permission on the servingCertKeyPairSecret secret.
-                        type: array
-                        maxItems: 5
-                        items:
-                          description: ConsumingUser is an alias for string which we add validation to. Currently only service accounts are supported.
-                          type: string
-                          maxLength: 512
-                          minLength: 1
-                          pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      currentHostnames:
-                        description: currentHostnames is the list of current names used by the route. Typically, this list should consist of a single hostname, but if multiple hostnames are supported by the route the operator may write multiple entries to this list.
-                        type: array
-                        minItems: 1
-                        items:
-                          description: "Hostname is an alias for hostname string validation. \n The left operand of the | is the original kubebuilder hostname validation format, which is incorrect because it allows upper case letters, disallows hyphen or number in the TLD, and allows labels to start/end in non-alphanumeric characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256. ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$ \n The right operand of the | is a new pattern that mimics the current API route admission validation on hostname, except that it allows hostnames longer than the maximum length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$ \n Both operand patterns are made available so that modifications on ingress spec can still happen after an invalid hostname was saved via validation by the incorrect left operand of the | operator."
-                          type: string
-                          pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
-                      defaultHostname:
-                        description: defaultHostname is the hostname of this route prior to customization.
+                      aws:
+                        description: aws contains settings specific to the Amazon
+                          Web Services infrastructure provider.
+                        properties:
+                          type:
+                            description: "type allows user to set a load balancer
+                              type. When this field is set the default ingresscontroller
+                              will get created using the specified LBType. If this
+                              field is not set then the default ingress controller
+                              of LBType Classic will be created. Valid values are:
+                              \n * \"Classic\": A Classic Load Balancer that makes
+                              routing decisions at either the transport layer (TCP/SSL)
+                              or the application layer (HTTP/HTTPS). See the following
+                              for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb
+                              \n * \"NLB\": A Network Load Balancer that makes routing
+                              decisions at the transport layer (TCP/SSL). See the
+                              following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb"
+                            enum:
+                            - NLB
+                            - Classic
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      type:
+                        description: type is the underlying infrastructure provider
+                          for the cluster. Allowed values are "AWS", "Azure", "BareMetal",
+                          "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "KubeVirt",
+                          "EquinixMetal", "PowerVS", "AlibabaCloud", "Nutanix" and
+                          "None". Individual components may not support all platforms,
+                          and must handle unrecognized platforms as None if they do
+                          not support that platform.
+                        enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
                         type: string
+                    type: object
+                type: object
+              requiredHSTSPolicies:
+                description: "requiredHSTSPolicies specifies HSTS policies that are
+                  required to be set on newly created  or updated routes matching
+                  the domainPattern/s and namespaceSelector/s that are specified in
+                  the policy. Each requiredHSTSPolicy must have at least a domainPattern
+                  and a maxAge to validate a route HSTS Policy route annotation, and
+                  affect route admission. \n A candidate route is checked for HSTS
+                  Policies if it has the HSTS Policy route annotation: \"haproxy.router.openshift.io/hsts_header\"
+                  E.g. haproxy.router.openshift.io/hsts_header: max-age=31536000;preload;includeSubDomains
+                  \n - For each candidate route, if it matches a requiredHSTSPolicy
+                  domainPattern and optional namespaceSelector, then the maxAge, preloadPolicy,
+                  and includeSubdomainsPolicy must be valid to be admitted.  Otherwise,
+                  the route is rejected. - The first match, by domainPattern and optional
+                  namespaceSelector, in the ordering of the RequiredHSTSPolicies determines
+                  the route's admission status. - If the candidate route doesn't match
+                  any requiredHSTSPolicy domainPattern and optional namespaceSelector,
+                  then it may use any HSTS Policy annotation. \n The HSTS policy configuration
+                  may be changed after routes have already been created. An update
+                  to a previously admitted route may then fail if the updated route
+                  does not conform to the updated HSTS policy configuration. However,
+                  changing the HSTS policy configuration will not cause a route that
+                  is already admitted to stop working. \n Note that if there are no
+                  RequiredHSTSPolicies, any HSTS Policy annotation on the route is
+                  valid."
+                items:
+                  properties:
+                    domainPatterns:
+                      description: "domainPatterns is a list of domains for which
+                        the desired HSTS annotations are required. If domainPatterns
+                        is specified and a route is created with a spec.host matching
+                        one of the domains, the route must specify the HSTS Policy
+                        components described in the matching RequiredHSTSPolicy. \n
+                        The use of wildcards is allowed like this: *.foo.com matches
+                        everything under foo.com. foo.com only matches foo.com, so
+                        to cover foo.com and everything under it, you must specify
+                        *both*."
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    includeSubDomainsPolicy:
+                      description: 'includeSubDomainsPolicy means the HSTS Policy
+                        should apply to any subdomains of the host''s domain name.  Thus,
+                        for the host bar.foo.com, if includeSubDomainsPolicy was set
+                        to RequireIncludeSubDomains: - the host app.bar.foo.com would
+                        inherit the HSTS Policy of bar.foo.com - the host bar.foo.com
+                        would inherit the HSTS Policy of bar.foo.com - the host foo.com
+                        would NOT inherit the HSTS Policy of bar.foo.com - the host
+                        def.foo.com would NOT inherit the HSTS Policy of bar.foo.com'
+                      enum:
+                      - RequireIncludeSubDomains
+                      - RequireNoIncludeSubDomains
+                      - NoOpinion
+                      type: string
+                    maxAge:
+                      description: maxAge is the delta time range in seconds during
+                        which hosts are regarded as HSTS hosts. If set to 0, it negates
+                        the effect, and hosts are removed as HSTS hosts. If set to
+                        0 and includeSubdomains is specified, all subdomains of the
+                        host are also removed as HSTS hosts. maxAge is a time-to-live
+                        value, and if this policy is not refreshed on a client, the
+                        HSTS policy will eventually expire on that client.
+                      properties:
+                        largestMaxAge:
+                          description: The largest allowed value (in seconds) of the
+                            RequiredHSTSPolicy max-age This value can be left unspecified,
+                            in which case no upper limit is enforced.
+                          format: int32
+                          maximum: 2147483647
+                          minimum: 0
+                          type: integer
+                        smallestMaxAge:
+                          description: The smallest allowed value (in seconds) of
+                            the RequiredHSTSPolicy max-age Setting max-age=0 allows
+                            the deletion of an existing HSTS header from a host.  This
+                            is a necessary tool for administrators to quickly correct
+                            mistakes. This value can be left unspecified, in which
+                            case no lower limit is enforced.
+                          format: int32
+                          maximum: 2147483647
+                          minimum: 0
+                          type: integer
+                      type: object
+                    namespaceSelector:
+                      description: namespaceSelector specifies a label selector such
+                        that the policy applies only to those routes that are in namespaces
+                        with labels that match the selector, and are in one of the
+                        DomainPatterns. Defaults to the empty LabelSelector, which
+                        matches everything.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    preloadPolicy:
+                      description: preloadPolicy directs the client to include hosts
+                        in its host preload list so that it never needs to do an initial
+                        load to get the HSTS header (note that this is not defined
+                        in RFC 6797 and is therefore client implementation-dependent).
+                      enum:
+                      - RequirePreload
+                      - RequireNoPreload
+                      - NoOpinion
+                      type: string
+                  required:
+                  - domainPatterns
+                  type: object
+                type: array
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              componentRoutes:
+                description: componentRoutes is where participating operators place
+                  the current route status for routes whose hostnames and serving
+                  certificates can be customized by the cluster-admin.
+                items:
+                  description: ComponentRouteStatus contains information allowing
+                    configuration of a route's hostname and serving certificate.
+                  properties:
+                    conditions:
+                      description: "conditions are used to communicate the state of
+                        the componentRoutes entry. \n Supported conditions include
+                        Available, Degraded and Progressing. \n If available is true,
+                        the content served by the route can be accessed by users.
+                        This includes cases where a default may continue to serve
+                        content while the customized route specified by the cluster-admin
+                        is being configured. \n If Degraded is true, that means something
+                        has gone wrong trying to handle the componentRoutes entry.
+                        The currentHostnames field may or may not be in effect. \n
+                        If Progressing is true, that means the component is taking
+                        some action related to the componentRoutes entry."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    consumingUsers:
+                      description: consumingUsers is a slice of ServiceAccounts that
+                        need to have read permission on the servingCertKeyPairSecret
+                        secret.
+                      items:
+                        description: ConsumingUser is an alias for string which we
+                          add validation to. Currently only service accounts are supported.
+                        maxLength: 512
+                        minLength: 1
+                        pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      maxItems: 5
+                      type: array
+                    currentHostnames:
+                      description: currentHostnames is the list of current names used
+                        by the route. Typically, this list should consist of a single
+                        hostname, but if multiple hostnames are supported by the route
+                        the operator may write multiple entries to this list.
+                      items:
+                        description: "Hostname is an alias for hostname string validation.
+                          \n The left operand of the | is the original kubebuilder
+                          hostname validation format, which is incorrect because it
+                          allows upper case letters, disallows hyphen or number in
+                          the TLD, and allows labels to start/end in non-alphanumeric
+                          characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256.
+                          ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$
+                          \n The right operand of the | is a new pattern that mimics
+                          the current API route admission validation on hostname,
+                          except that it allows hostnames longer than the maximum
+                          length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                          \n Both operand patterns are made available so that modifications
+                          on ingress spec can still happen after an invalid hostname
+                          was saved via validation by the incorrect left operand of
+                          the | operator."
                         pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
-                      name:
-                        description: "name is the logical name of the route to customize. It does not have to be the actual name of a route resource but it cannot be renamed. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized."
                         type: string
-                        maxLength: 256
-                        minLength: 1
-                      namespace:
-                        description: "namespace is the namespace of the route to customize. It must be a real namespace. Using an actual namespace ensures that no two components will conflict and the same component can be installed multiple times. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized."
-                        type: string
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                      relatedObjects:
-                        description: relatedObjects is a list of resources which are useful when debugging or inspecting how spec.componentRoutes is applied.
-                        type: array
-                        minItems: 1
-                        items:
-                          description: ObjectReference contains enough information to let you inspect or modify the referred object.
-                          type: object
-                          required:
-                            - group
-                            - name
-                            - resource
-                          properties:
-                            group:
-                              description: group of the referent.
-                              type: string
-                            name:
-                              description: name of the referent.
-                              type: string
-                            namespace:
-                              description: namespace of the referent.
-                              type: string
-                            resource:
-                              description: resource of the referent.
-                              type: string
-                  x-kubernetes-list-map-keys:
-                    - namespace
-                    - name
-                  x-kubernetes-list-type: map
-                defaultPlacement:
-                  description: "defaultPlacement is set at installation time to control which nodes will host the ingress router pods by default. The options are control-plane nodes or worker nodes. \n This field works by dictating how the Cluster Ingress Operator will consider unset replicas and nodePlacement fields in IngressController resources when creating the corresponding Deployments. \n See the documentation for the IngressController replicas and nodePlacement fields for more information. \n When omitted, the default value is Workers"
-                  type: string
-                  enum:
-                    - ControlPlane
-                    - Workers
-                    - ""
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      minItems: 1
+                      type: array
+                    defaultHostname:
+                      description: defaultHostname is the hostname of this route prior
+                        to customization.
+                      pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                      type: string
+                    name:
+                      description: "name is the logical name of the route to customize.
+                        It does not have to be the actual name of a route resource
+                        but it cannot be renamed. \n The namespace and name of this
+                        componentRoute must match a corresponding entry in the list
+                        of spec.componentRoutes if the route is to be customized."
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: "namespace is the namespace of the route to customize.
+                        It must be a real namespace. Using an actual namespace ensures
+                        that no two components will conflict and the same component
+                        can be installed multiple times. \n The namespace and name
+                        of this componentRoute must match a corresponding entry in
+                        the list of spec.componentRoutes if the route is to be customized."
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    relatedObjects:
+                      description: relatedObjects is a list of resources which are
+                        useful when debugging or inspecting how spec.componentRoutes
+                        is applied.
+                      items:
+                        description: ObjectReference contains enough information to
+                          let you inspect or modify the referred object.
+                        properties:
+                          group:
+                            description: group of the referent.
+                            type: string
+                          name:
+                            description: name of the referent.
+                            type: string
+                          namespace:
+                            description: namespace of the referent.
+                            type: string
+                          resource:
+                            description: resource of the referent.
+                            type: string
+                        required:
+                        - group
+                        - name
+                        - resource
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - defaultHostname
+                  - name
+                  - namespace
+                  - relatedObjects
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - namespace
+                - name
+                x-kubernetes-list-type: map
+              defaultPlacement:
+                description: "defaultPlacement is set at installation time to control
+                  which nodes will host the ingress router pods by default. The options
+                  are control-plane nodes or worker nodes. \n This field works by
+                  dictating how the Cluster Ingress Operator will consider unset replicas
+                  and nodePlacement fields in IngressController resources when creating
+                  the corresponding Deployments. \n See the documentation for the
+                  IngressController replicas and nodePlacement fields for more information.
+                  \n When omitted, the default value is Workers"
+                enum:
+                - ControlPlane
+                - Workers
+                - ""
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_network.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network.crd.yaml
@@ -17,147 +17,192 @@ spec:
   preserveUnknownFields: false
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc. Please view network.spec for an explanation on what applies when configuring this resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.
-              type: object
-              properties:
-                clusterNetwork:
-                  description: IP address pool to use for pod IPs. This field is immutable after installation.
-                  type: array
-                  items:
-                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
-                    type: object
-                    properties:
-                      cidr:
-                        description: The complete block for pod IPs.
-                        type: string
-                      hostPrefix:
-                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
-                        type: integer
-                        format: int32
-                        minimum: 0
-                externalIP:
-                  description: externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.
-                  type: object
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Network holds cluster-wide information about Network. The canonical
+          name is `cluster`. It is used to configure the desired network configuration,
+          such as: IP address pools for services/pod IPs, network plugin, etc. Please
+          view network.spec for an explanation on what applies when configuring this
+          resource. \n Compatibility level 1: Stable within a major release for a
+          minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration. As a general
+              rule, this SHOULD NOT be read directly. Instead, you should consume
+              the NetworkStatus, as it indicates the currently deployed configuration.
+              Currently, most spec fields are immutable after installation. Please
+              view the individual ones for further details on each.
+            properties:
+              clusterNetwork:
+                description: IP address pool to use for pod IPs. This field is immutable
+                  after installation.
+                items:
+                  description: ClusterNetworkEntry is a contiguous block of IP addresses
+                    from which pod IPs are allocated.
                   properties:
-                    autoAssignCIDRs:
-                      description: autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called "IngressIPs". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.
-                      type: array
-                      items:
-                        type: string
-                    policy:
-                      description: policy is a set of restrictions applied to the ExternalIP field. If nil or empty, then ExternalIP is not allowed to be set.
-                      type: object
-                      properties:
-                        allowedCIDRs:
-                          description: allowedCIDRs is the list of allowed CIDRs.
-                          type: array
-                          items:
-                            type: string
-                        rejectedCIDRs:
-                          description: rejectedCIDRs is the list of disallowed CIDRs. These take precedence over allowedCIDRs.
-                          type: array
-                          items:
-                            type: string
-                networkType:
-                  description: 'NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.'
-                  type: string
-                serviceNetwork:
-                  description: IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.
-                  type: array
-                  items:
-                    type: string
-                serviceNodePortRange:
-                  description: The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.
-                  type: string
-                  pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-              properties:
-                clusterNetwork:
-                  description: IP address pool to use for pod IPs.
-                  type: array
-                  items:
-                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
-                    type: object
-                    properties:
-                      cidr:
-                        description: The complete block for pod IPs.
-                        type: string
-                      hostPrefix:
-                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
-                        type: integer
-                        format: int32
-                        minimum: 0
-                clusterNetworkMTU:
-                  description: ClusterNetworkMTU is the MTU for inter-pod networking.
-                  type: integer
-                migration:
-                  description: Migration contains the cluster network migration configuration.
-                  type: object
-                  properties:
-                    mtu:
-                      description: MTU contains the MTU migration configuration.
-                      type: object
-                      properties:
-                        machine:
-                          description: Machine contains MTU migration configuration for the machine's uplink.
-                          type: object
-                          properties:
-                            from:
-                              description: From is the MTU to migrate from.
-                              type: integer
-                              format: int32
-                              minimum: 0
-                            to:
-                              description: To is the MTU to migrate to.
-                              type: integer
-                              format: int32
-                              minimum: 0
-                        network:
-                          description: Network contains MTU migration configuration for the default network.
-                          type: object
-                          properties:
-                            from:
-                              description: From is the MTU to migrate from.
-                              type: integer
-                              format: int32
-                              minimum: 0
-                            to:
-                              description: To is the MTU to migrate to.
-                              type: integer
-                              format: int32
-                              minimum: 0
-                    networkType:
-                      description: 'NetworkType is the target plugin that is to be deployed. Currently supported values are: OpenShiftSDN, OVNKubernetes'
+                    cidr:
+                      description: The complete block for pod IPs.
                       type: string
-                      enum:
-                        - OpenShiftSDN
-                        - OVNKubernetes
-                networkType:
-                  description: NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+                    hostPrefix:
+                      description: The size (prefix) of block to allocate to each
+                        node. If this field is not used by the plugin, it can be left
+                        unset.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                  type: object
+                type: array
+              externalIP:
+                description: externalIP defines configuration for controllers that
+                  affect Service.ExternalIP. If nil, then ExternalIP is not allowed
+                  to be set.
+                properties:
+                  autoAssignCIDRs:
+                    description: autoAssignCIDRs is a list of CIDRs from which to
+                      automatically assign Service.ExternalIP. These are assigned
+                      when the service is of type LoadBalancer. In general, this is
+                      only useful for bare-metal clusters. In Openshift 3.x, this
+                      was misleadingly called "IngressIPs". Automatically assigned
+                      External IPs are not affected by any ExternalIPPolicy rules.
+                      Currently, only one entry may be provided.
+                    items:
+                      type: string
+                    type: array
+                  policy:
+                    description: policy is a set of restrictions applied to the ExternalIP
+                      field. If nil or empty, then ExternalIP is not allowed to be
+                      set.
+                    properties:
+                      allowedCIDRs:
+                        description: allowedCIDRs is the list of allowed CIDRs.
+                        items:
+                          type: string
+                        type: array
+                      rejectedCIDRs:
+                        description: rejectedCIDRs is the list of disallowed CIDRs.
+                          These take precedence over allowedCIDRs.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              networkType:
+                description: 'NetworkType is the plugin that is to be deployed (e.g.
+                  OpenShiftSDN). This should match a value that the cluster-network-operator
+                  understands, or else no networking will be installed. Currently
+                  supported values are: - OpenShiftSDN This field is immutable after
+                  installation.'
+                type: string
+              serviceNetwork:
+                description: IP address pool for services. Currently, we only support
+                  a single entry here. This field is immutable after installation.
+                items:
                   type: string
-                serviceNetwork:
-                  description: IP address pool for services. Currently, we only support a single entry here.
-                  type: array
-                  items:
+                type: array
+              serviceNodePortRange:
+                description: The port range allowed for Services of type NodePort.
+                  If not specified, the default of 30000-32767 will be used. Such
+                  Services without a NodePort specified will have one automatically
+                  allocated from this range. This parameter can be updated after the
+                  cluster is installed.
+                pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                type: string
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              clusterNetwork:
+                description: IP address pool to use for pod IPs.
+                items:
+                  description: ClusterNetworkEntry is a contiguous block of IP addresses
+                    from which pod IPs are allocated.
+                  properties:
+                    cidr:
+                      description: The complete block for pod IPs.
+                      type: string
+                    hostPrefix:
+                      description: The size (prefix) of block to allocate to each
+                        node. If this field is not used by the plugin, it can be left
+                        unset.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                  type: object
+                type: array
+              clusterNetworkMTU:
+                description: ClusterNetworkMTU is the MTU for inter-pod networking.
+                type: integer
+              migration:
+                description: Migration contains the cluster network migration configuration.
+                properties:
+                  mtu:
+                    description: MTU contains the MTU migration configuration.
+                    properties:
+                      machine:
+                        description: Machine contains MTU migration configuration
+                          for the machine's uplink.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      network:
+                        description: Network contains MTU migration configuration
+                          for the default network.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  networkType:
+                    description: 'NetworkType is the target plugin that is to be deployed.
+                      Currently supported values are: OpenShiftSDN, OVNKubernetes'
+                    enum:
+                    - OpenShiftSDN
+                    - OVNKubernetes
                     type: string
-      served: true
-      storage: true
+                type: object
+              networkType:
+                description: NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+                type: string
+              serviceNetwork:
+                description: IP address pool for services. Currently, we only support
+                  a single entry here.
+                items:
+                  type: string
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/config/v1/0000_10_config-operator_01_node.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_node.crd.yaml
@@ -16,44 +16,51 @@ spec:
     singular: node
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Node holds cluster-wide information about node specific features. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                cgroupMode:
-                  description: CgroupMode determines the cgroups version on the node
-                  type: string
-                  enum:
-                    - v1
-                    - v2
-                    - ""
-                workerLatencyProfile:
-                  description: WorkerLatencyProfile determins the how fast the kubelet is updating the status and corresponding reaction of the cluster
-                  type: string
-                  enum:
-                    - Default
-                    - MediumUpdateAverageReaction
-                    - LowUpdateSlowReaction
-            status:
-              description: status holds observed values.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Node holds cluster-wide information about node specific features.
+          \n Compatibility level 1: Stable within a major release for a minimum of
+          12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              cgroupMode:
+                description: CgroupMode determines the cgroups version on the node
+                enum:
+                - v1
+                - v2
+                - ""
+                type: string
+              workerLatencyProfile:
+                description: WorkerLatencyProfile determins the how fast the kubelet
+                  is updating the status and corresponding reaction of the cluster
+                enum:
+                - Default
+                - MediumUpdateAverageReaction
+                - LowUpdateSlowReaction
+                type: string
+            type: object
+          status:
+            description: status holds observed values.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_oauth.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_oauth.crd.yaml
@@ -16,429 +16,683 @@ spec:
     singular: oauth
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "OAuth holds cluster-wide information about OAuth.  The canonical name is `cluster`. It is used to configure the integrated OAuth server. This configuration is only honored when the top level Authentication config has type set to IntegratedOAuth. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                identityProviders:
-                  description: identityProviders is an ordered list of ways for a user to identify themselves. When this list is empty, no identities are provisioned for users.
-                  type: array
-                  items:
-                    description: IdentityProvider provides identities for users authenticating using credentials
-                    type: object
-                    properties:
-                      basicAuth:
-                        description: basicAuth contains configuration options for the BasicAuth IdP
-                        type: object
-                        properties:
-                          ca:
-                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced config map
-                                type: string
-                          tlsClientCert:
-                            description: tlsClientCert is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate to present when connecting to the server. The key "tls.crt" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                          tlsClientKey:
-                            description: tlsClientKey is an optional reference to a secret by name that contains the PEM-encoded TLS private key for the client certificate referenced in tlsClientCert. The key "tls.key" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                          url:
-                            description: url is the remote URL to connect to
-                            type: string
-                      github:
-                        description: github enables user authentication using GitHub credentials
-                        type: object
-                        properties:
-                          ca:
-                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. This can only be configured when hostname is set to a non-empty value. The namespace for this config map is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced config map
-                                type: string
-                          clientID:
-                            description: clientID is the oauth client ID
-                            type: string
-                          clientSecret:
-                            description: clientSecret is a required reference to the secret by name containing the oauth client secret. The key "clientSecret" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                          hostname:
-                            description: hostname is the optional domain (e.g. "mycompany.com") for use with a hosted instance of GitHub Enterprise. It must match the GitHub Enterprise settings value configured at /setup/settings#hostname.
-                            type: string
-                          organizations:
-                            description: organizations optionally restricts which organizations are allowed to log in
-                            type: array
-                            items:
-                              type: string
-                          teams:
-                            description: teams optionally restricts which teams are allowed to log in. Format is <org>/<team>.
-                            type: array
-                            items:
-                              type: string
-                      gitlab:
-                        description: gitlab enables user authentication using GitLab credentials
-                        type: object
-                        properties:
-                          ca:
-                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced config map
-                                type: string
-                          clientID:
-                            description: clientID is the oauth client ID
-                            type: string
-                          clientSecret:
-                            description: clientSecret is a required reference to the secret by name containing the oauth client secret. The key "clientSecret" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                          url:
-                            description: url is the oauth server base URL
-                            type: string
-                      google:
-                        description: google enables user authentication using Google credentials
-                        type: object
-                        properties:
-                          clientID:
-                            description: clientID is the oauth client ID
-                            type: string
-                          clientSecret:
-                            description: clientSecret is a required reference to the secret by name containing the oauth client secret. The key "clientSecret" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                          hostedDomain:
-                            description: hostedDomain is the optional Google App domain (e.g. "mycompany.com") to restrict logins to
-                            type: string
-                      htpasswd:
-                        description: htpasswd enables user authentication using an HTPasswd file to validate credentials
-                        type: object
-                        properties:
-                          fileData:
-                            description: fileData is a required reference to a secret by name containing the data to use as the htpasswd file. The key "htpasswd" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. If the specified htpasswd data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                      keystone:
-                        description: keystone enables user authentication using keystone password credentials
-                        type: object
-                        properties:
-                          ca:
-                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced config map
-                                type: string
-                          domainName:
-                            description: domainName is required for keystone v3
-                            type: string
-                          tlsClientCert:
-                            description: tlsClientCert is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate to present when connecting to the server. The key "tls.crt" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                          tlsClientKey:
-                            description: tlsClientKey is an optional reference to a secret by name that contains the PEM-encoded TLS private key for the client certificate referenced in tlsClientCert. The key "tls.key" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                          url:
-                            description: url is the remote URL to connect to
-                            type: string
-                      ldap:
-                        description: ldap enables user authentication using LDAP credentials
-                        type: object
-                        properties:
-                          attributes:
-                            description: attributes maps LDAP attributes to identities
-                            type: object
-                            properties:
-                              email:
-                                description: email is the list of attributes whose values should be used as the email address. Optional. If unspecified, no email is set for the identity
-                                type: array
-                                items:
-                                  type: string
-                              id:
-                                description: id is the list of attributes whose values should be used as the user ID. Required. First non-empty attribute is used. At least one attribute is required. If none of the listed attribute have a value, authentication fails. LDAP standard identity attribute is "dn"
-                                type: array
-                                items:
-                                  type: string
-                              name:
-                                description: name is the list of attributes whose values should be used as the display name. Optional. If unspecified, no display name is set for the identity LDAP standard display name attribute is "cn"
-                                type: array
-                                items:
-                                  type: string
-                              preferredUsername:
-                                description: preferredUsername is the list of attributes whose values should be used as the preferred username. LDAP standard login attribute is "uid"
-                                type: array
-                                items:
-                                  type: string
-                          bindDN:
-                            description: bindDN is an optional DN to bind with during the search phase.
-                            type: string
-                          bindPassword:
-                            description: bindPassword is an optional reference to a secret by name containing a password to bind with during the search phase. The key "bindPassword" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                          ca:
-                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced config map
-                                type: string
-                          insecure:
-                            description: 'insecure, if true, indicates the connection should not use TLS WARNING: Should not be set to `true` with the URL scheme "ldaps://" as "ldaps://" URLs always attempt to connect using TLS, even when `insecure` is set to `true` When `true`, "ldap://" URLS connect insecurely. When `false`, "ldap://" URLs are upgraded to a TLS connection using StartTLS as specified in https://tools.ietf.org/html/rfc2830.'
-                            type: boolean
-                          url:
-                            description: 'url is an RFC 2255 URL which specifies the LDAP search parameters to use. The syntax of the URL is: ldap://host:port/basedn?attribute?scope?filter'
-                            type: string
-                      mappingMethod:
-                        description: mappingMethod determines how identities from this provider are mapped to users Defaults to "claim"
-                        type: string
-                      name:
-                        description: 'name is used to qualify the identities returned by this provider. - It MUST be unique and not shared by any other identity provider used - It MUST be a valid path segment: name cannot equal "." or ".." or contain "/" or "%" or ":" Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName'
-                        type: string
-                      openID:
-                        description: openID enables user authentication using OpenID credentials
-                        type: object
-                        properties:
-                          ca:
-                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced config map
-                                type: string
-                          claims:
-                            description: claims mappings
-                            type: object
-                            properties:
-                              email:
-                                description: email is the list of claims whose values should be used as the email address. Optional. If unspecified, no email is set for the identity
-                                type: array
-                                items:
-                                  type: string
-                                x-kubernetes-list-type: atomic
-                              groups:
-                                description: groups is the list of claims value of which should be used to synchronize groups from the OIDC provider to OpenShift for the user. If multiple claims are specified, the first one with a non-empty value is used.
-                                type: array
-                                items:
-                                  description: OpenIDClaim represents a claim retrieved from an OpenID provider's tokens or userInfo responses
-                                  type: string
-                                  minLength: 1
-                                x-kubernetes-list-type: atomic
-                              name:
-                                description: name is the list of claims whose values should be used as the display name. Optional. If unspecified, no display name is set for the identity
-                                type: array
-                                items:
-                                  type: string
-                                x-kubernetes-list-type: atomic
-                              preferredUsername:
-                                description: preferredUsername is the list of claims whose values should be used as the preferred username. If unspecified, the preferred username is determined from the value of the sub claim
-                                type: array
-                                items:
-                                  type: string
-                                x-kubernetes-list-type: atomic
-                          clientID:
-                            description: clientID is the oauth client ID
-                            type: string
-                          clientSecret:
-                            description: clientSecret is a required reference to the secret by name containing the oauth client secret. The key "clientSecret" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced secret
-                                type: string
-                          extraAuthorizeParameters:
-                            description: extraAuthorizeParameters are any custom parameters to add to the authorize request.
-                            type: object
-                            additionalProperties:
-                              type: string
-                          extraScopes:
-                            description: extraScopes are any scopes to request in addition to the standard "openid" scope.
-                            type: array
-                            items:
-                              type: string
-                          issuer:
-                            description: issuer is the URL that the OpenID Provider asserts as its Issuer Identifier. It must use the https scheme with no query or fragment component.
-                            type: string
-                      requestHeader:
-                        description: requestHeader enables user authentication using request header credentials
-                        type: object
-                        properties:
-                          ca:
-                            description: ca is a required reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. Specifically, it allows verification of incoming requests to prevent header spoofing. The key "ca.crt" is used to locate the data. If the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. The namespace for this config map is openshift-config.
-                            type: object
-                            required:
-                              - name
-                            properties:
-                              name:
-                                description: name is the metadata.name of the referenced config map
-                                type: string
-                          challengeURL:
-                            description: challengeURL is a URL to redirect unauthenticated /authorize requests to Unauthenticated requests from OAuth clients which expect WWW-Authenticate challenges will be redirected here. ${url} is replaced with the current URL, escaped to be safe in a query parameter https://www.example.com/sso-login?then=${url} ${query} is replaced with the current query string https://www.example.com/auth-proxy/oauth/authorize?${query} Required when challenge is set to true.
-                            type: string
-                          clientCommonNames:
-                            description: clientCommonNames is an optional list of common names to require a match from. If empty, any client certificate validated against the clientCA bundle is considered authoritative.
-                            type: array
-                            items:
-                              type: string
-                          emailHeaders:
-                            description: emailHeaders is the set of headers to check for the email address
-                            type: array
-                            items:
-                              type: string
-                          headers:
-                            description: headers is the set of headers to check for identity information
-                            type: array
-                            items:
-                              type: string
-                          loginURL:
-                            description: loginURL is a URL to redirect unauthenticated /authorize requests to Unauthenticated requests from OAuth clients which expect interactive logins will be redirected here ${url} is replaced with the current URL, escaped to be safe in a query parameter https://www.example.com/sso-login?then=${url} ${query} is replaced with the current query string https://www.example.com/auth-proxy/oauth/authorize?${query} Required when login is set to true.
-                            type: string
-                          nameHeaders:
-                            description: nameHeaders is the set of headers to check for the display name
-                            type: array
-                            items:
-                              type: string
-                          preferredUsernameHeaders:
-                            description: preferredUsernameHeaders is the set of headers to check for the preferred username
-                            type: array
-                            items:
-                              type: string
-                      type:
-                        description: type identifies the identity provider type for this entry.
-                        type: string
-                  x-kubernetes-list-type: atomic
-                templates:
-                  description: templates allow you to customize pages like the login page.
-                  type: object
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "OAuth holds cluster-wide information about OAuth.  The canonical
+          name is `cluster`. It is used to configure the integrated OAuth server.
+          This configuration is only honored when the top level Authentication config
+          has type set to IntegratedOAuth. \n Compatibility level 1: Stable within
+          a major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              identityProviders:
+                description: identityProviders is an ordered list of ways for a user
+                  to identify themselves. When this list is empty, no identities are
+                  provisioned for users.
+                items:
+                  description: IdentityProvider provides identities for users authenticating
+                    using credentials
                   properties:
-                    error:
-                      description: error is the name of a secret that specifies a go template to use to render error pages during the authentication or grant flow. The key "errors.html" is used to locate the template data. If specified and the secret or expected key is not found, the default error page is used. If the specified template is not valid, the default error page is used. If unspecified, the default error page is used. The namespace for this secret is openshift-config.
-                      type: object
-                      required:
-                        - name
+                    basicAuth:
+                      description: basicAuth contains configuration options for the
+                        BasicAuth IdP
                       properties:
-                        name:
-                          description: name is the metadata.name of the referenced secret
+                        ca:
+                          description: ca is an optional reference to a config map
+                            by name containing the PEM-encoded CA bundle. It is used
+                            as a trust anchor to validate the TLS certificate presented
+                            by the remote server. The key "ca.crt" is used to locate
+                            the data. If specified and the config map or expected
+                            key is not found, the identity provider is not honored.
+                            If the specified ca data is not valid, the identity provider
+                            is not honored. If empty, the default system roots are
+                            used. The namespace for this config map is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        tlsClientCert:
+                          description: tlsClientCert is an optional reference to a
+                            secret by name that contains the PEM-encoded TLS client
+                            certificate to present when connecting to the server.
+                            The key "tls.crt" is used to locate the data. If specified
+                            and the secret or expected key is not found, the identity
+                            provider is not honored. If the specified certificate
+                            data is not valid, the identity provider is not honored.
+                            The namespace for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        tlsClientKey:
+                          description: tlsClientKey is an optional reference to a
+                            secret by name that contains the PEM-encoded TLS private
+                            key for the client certificate referenced in tlsClientCert.
+                            The key "tls.key" is used to locate the data. If specified
+                            and the secret or expected key is not found, the identity
+                            provider is not honored. If the specified certificate
+                            data is not valid, the identity provider is not honored.
+                            The namespace for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        url:
+                          description: url is the remote URL to connect to
                           type: string
-                    login:
-                      description: login is the name of a secret that specifies a go template to use to render the login page. The key "login.html" is used to locate the template data. If specified and the secret or expected key is not found, the default login page is used. If the specified template is not valid, the default login page is used. If unspecified, the default login page is used. The namespace for this secret is openshift-config.
                       type: object
-                      required:
-                        - name
+                    github:
+                      description: github enables user authentication using GitHub
+                        credentials
                       properties:
-                        name:
-                          description: name is the metadata.name of the referenced secret
+                        ca:
+                          description: ca is an optional reference to a config map
+                            by name containing the PEM-encoded CA bundle. It is used
+                            as a trust anchor to validate the TLS certificate presented
+                            by the remote server. The key "ca.crt" is used to locate
+                            the data. If specified and the config map or expected
+                            key is not found, the identity provider is not honored.
+                            If the specified ca data is not valid, the identity provider
+                            is not honored. If empty, the default system roots are
+                            used. This can only be configured when hostname is set
+                            to a non-empty value. The namespace for this config map
+                            is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        clientID:
+                          description: clientID is the oauth client ID
                           type: string
-                    providerSelection:
-                      description: providerSelection is the name of a secret that specifies a go template to use to render the provider selection page. The key "providers.html" is used to locate the template data. If specified and the secret or expected key is not found, the default provider selection page is used. If the specified template is not valid, the default provider selection page is used. If unspecified, the default provider selection page is used. The namespace for this secret is openshift-config.
+                        clientSecret:
+                          description: clientSecret is a required reference to the
+                            secret by name containing the oauth client secret. The
+                            key "clientSecret" is used to locate the data. If the
+                            secret or expected key is not found, the identity provider
+                            is not honored. The namespace for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        hostname:
+                          description: hostname is the optional domain (e.g. "mycompany.com")
+                            for use with a hosted instance of GitHub Enterprise. It
+                            must match the GitHub Enterprise settings value configured
+                            at /setup/settings#hostname.
+                          type: string
+                        organizations:
+                          description: organizations optionally restricts which organizations
+                            are allowed to log in
+                          items:
+                            type: string
+                          type: array
+                        teams:
+                          description: teams optionally restricts which teams are
+                            allowed to log in. Format is <org>/<team>.
+                          items:
+                            type: string
+                          type: array
                       type: object
-                      required:
-                        - name
+                    gitlab:
+                      description: gitlab enables user authentication using GitLab
+                        credentials
                       properties:
-                        name:
-                          description: name is the metadata.name of the referenced secret
+                        ca:
+                          description: ca is an optional reference to a config map
+                            by name containing the PEM-encoded CA bundle. It is used
+                            as a trust anchor to validate the TLS certificate presented
+                            by the remote server. The key "ca.crt" is used to locate
+                            the data. If specified and the config map or expected
+                            key is not found, the identity provider is not honored.
+                            If the specified ca data is not valid, the identity provider
+                            is not honored. If empty, the default system roots are
+                            used. The namespace for this config map is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        clientID:
+                          description: clientID is the oauth client ID
                           type: string
-                tokenConfig:
-                  description: tokenConfig contains options for authorization and access tokens
-                  type: object
-                  properties:
-                    accessTokenInactivityTimeout:
-                      description: "accessTokenInactivityTimeout defines the token inactivity timeout for tokens granted by any client. The value represents the maximum amount of time that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. The user will need to acquire a new token to regain access once a token times out. Takes valid time duration string such as \"5m\", \"1.5h\" or \"2h45m\". The minimum allowed value for duration is 300s (5 minutes). If the timeout is configured per client, then that value takes precedence. If the timeout value is not specified and the client does not override the value, then tokens are valid until their lifetime. \n WARNING: existing tokens' timeout will not be affected (lowered) by changing this value"
+                        clientSecret:
+                          description: clientSecret is a required reference to the
+                            secret by name containing the oauth client secret. The
+                            key "clientSecret" is used to locate the data. If the
+                            secret or expected key is not found, the identity provider
+                            is not honored. The namespace for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        url:
+                          description: url is the oauth server base URL
+                          type: string
+                      type: object
+                    google:
+                      description: google enables user authentication using Google
+                        credentials
+                      properties:
+                        clientID:
+                          description: clientID is the oauth client ID
+                          type: string
+                        clientSecret:
+                          description: clientSecret is a required reference to the
+                            secret by name containing the oauth client secret. The
+                            key "clientSecret" is used to locate the data. If the
+                            secret or expected key is not found, the identity provider
+                            is not honored. The namespace for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        hostedDomain:
+                          description: hostedDomain is the optional Google App domain
+                            (e.g. "mycompany.com") to restrict logins to
+                          type: string
+                      type: object
+                    htpasswd:
+                      description: htpasswd enables user authentication using an HTPasswd
+                        file to validate credentials
+                      properties:
+                        fileData:
+                          description: fileData is a required reference to a secret
+                            by name containing the data to use as the htpasswd file.
+                            The key "htpasswd" is used to locate the data. If the
+                            secret or expected key is not found, the identity provider
+                            is not honored. If the specified htpasswd data is not
+                            valid, the identity provider is not honored. The namespace
+                            for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      type: object
+                    keystone:
+                      description: keystone enables user authentication using keystone
+                        password credentials
+                      properties:
+                        ca:
+                          description: ca is an optional reference to a config map
+                            by name containing the PEM-encoded CA bundle. It is used
+                            as a trust anchor to validate the TLS certificate presented
+                            by the remote server. The key "ca.crt" is used to locate
+                            the data. If specified and the config map or expected
+                            key is not found, the identity provider is not honored.
+                            If the specified ca data is not valid, the identity provider
+                            is not honored. If empty, the default system roots are
+                            used. The namespace for this config map is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        domainName:
+                          description: domainName is required for keystone v3
+                          type: string
+                        tlsClientCert:
+                          description: tlsClientCert is an optional reference to a
+                            secret by name that contains the PEM-encoded TLS client
+                            certificate to present when connecting to the server.
+                            The key "tls.crt" is used to locate the data. If specified
+                            and the secret or expected key is not found, the identity
+                            provider is not honored. If the specified certificate
+                            data is not valid, the identity provider is not honored.
+                            The namespace for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        tlsClientKey:
+                          description: tlsClientKey is an optional reference to a
+                            secret by name that contains the PEM-encoded TLS private
+                            key for the client certificate referenced in tlsClientCert.
+                            The key "tls.key" is used to locate the data. If specified
+                            and the secret or expected key is not found, the identity
+                            provider is not honored. If the specified certificate
+                            data is not valid, the identity provider is not honored.
+                            The namespace for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        url:
+                          description: url is the remote URL to connect to
+                          type: string
+                      type: object
+                    ldap:
+                      description: ldap enables user authentication using LDAP credentials
+                      properties:
+                        attributes:
+                          description: attributes maps LDAP attributes to identities
+                          properties:
+                            email:
+                              description: email is the list of attributes whose values
+                                should be used as the email address. Optional. If
+                                unspecified, no email is set for the identity
+                              items:
+                                type: string
+                              type: array
+                            id:
+                              description: id is the list of attributes whose values
+                                should be used as the user ID. Required. First non-empty
+                                attribute is used. At least one attribute is required.
+                                If none of the listed attribute have a value, authentication
+                                fails. LDAP standard identity attribute is "dn"
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: name is the list of attributes whose values
+                                should be used as the display name. Optional. If unspecified,
+                                no display name is set for the identity LDAP standard
+                                display name attribute is "cn"
+                              items:
+                                type: string
+                              type: array
+                            preferredUsername:
+                              description: preferredUsername is the list of attributes
+                                whose values should be used as the preferred username.
+                                LDAP standard login attribute is "uid"
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        bindDN:
+                          description: bindDN is an optional DN to bind with during
+                            the search phase.
+                          type: string
+                        bindPassword:
+                          description: bindPassword is an optional reference to a
+                            secret by name containing a password to bind with during
+                            the search phase. The key "bindPassword" is used to locate
+                            the data. If specified and the secret or expected key
+                            is not found, the identity provider is not honored. The
+                            namespace for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        ca:
+                          description: ca is an optional reference to a config map
+                            by name containing the PEM-encoded CA bundle. It is used
+                            as a trust anchor to validate the TLS certificate presented
+                            by the remote server. The key "ca.crt" is used to locate
+                            the data. If specified and the config map or expected
+                            key is not found, the identity provider is not honored.
+                            If the specified ca data is not valid, the identity provider
+                            is not honored. If empty, the default system roots are
+                            used. The namespace for this config map is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        insecure:
+                          description: 'insecure, if true, indicates the connection
+                            should not use TLS WARNING: Should not be set to `true`
+                            with the URL scheme "ldaps://" as "ldaps://" URLs always
+                            attempt to connect using TLS, even when `insecure` is
+                            set to `true` When `true`, "ldap://" URLS connect insecurely.
+                            When `false`, "ldap://" URLs are upgraded to a TLS connection
+                            using StartTLS as specified in https://tools.ietf.org/html/rfc2830.'
+                          type: boolean
+                        url:
+                          description: 'url is an RFC 2255 URL which specifies the
+                            LDAP search parameters to use. The syntax of the URL is:
+                            ldap://host:port/basedn?attribute?scope?filter'
+                          type: string
+                      type: object
+                    mappingMethod:
+                      description: mappingMethod determines how identities from this
+                        provider are mapped to users Defaults to "claim"
                       type: string
-                    accessTokenInactivityTimeoutSeconds:
-                      description: 'accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.'
-                      type: integer
-                      format: int32
-                    accessTokenMaxAgeSeconds:
-                      description: accessTokenMaxAgeSeconds defines the maximum age of access tokens
-                      type: integer
-                      format: int32
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    name:
+                      description: 'name is used to qualify the identities returned
+                        by this provider. - It MUST be unique and not shared by any
+                        other identity provider used - It MUST be a valid path segment:
+                        name cannot equal "." or ".." or contain "/" or "%" or ":"
+                        Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName'
+                      type: string
+                    openID:
+                      description: openID enables user authentication using OpenID
+                        credentials
+                      properties:
+                        ca:
+                          description: ca is an optional reference to a config map
+                            by name containing the PEM-encoded CA bundle. It is used
+                            as a trust anchor to validate the TLS certificate presented
+                            by the remote server. The key "ca.crt" is used to locate
+                            the data. If specified and the config map or expected
+                            key is not found, the identity provider is not honored.
+                            If the specified ca data is not valid, the identity provider
+                            is not honored. If empty, the default system roots are
+                            used. The namespace for this config map is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        claims:
+                          description: claims mappings
+                          properties:
+                            email:
+                              description: email is the list of claims whose values
+                                should be used as the email address. Optional. If
+                                unspecified, no email is set for the identity
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            groups:
+                              description: groups is the list of claims value of which
+                                should be used to synchronize groups from the OIDC
+                                provider to OpenShift for the user. If multiple claims
+                                are specified, the first one with a non-empty value
+                                is used.
+                              items:
+                                description: OpenIDClaim represents a claim retrieved
+                                  from an OpenID provider's tokens or userInfo responses
+                                minLength: 1
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              description: name is the list of claims whose values
+                                should be used as the display name. Optional. If unspecified,
+                                no display name is set for the identity
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            preferredUsername:
+                              description: preferredUsername is the list of claims
+                                whose values should be used as the preferred username.
+                                If unspecified, the preferred username is determined
+                                from the value of the sub claim
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        clientID:
+                          description: clientID is the oauth client ID
+                          type: string
+                        clientSecret:
+                          description: clientSecret is a required reference to the
+                            secret by name containing the oauth client secret. The
+                            key "clientSecret" is used to locate the data. If the
+                            secret or expected key is not found, the identity provider
+                            is not honored. The namespace for this secret is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        extraAuthorizeParameters:
+                          additionalProperties:
+                            type: string
+                          description: extraAuthorizeParameters are any custom parameters
+                            to add to the authorize request.
+                          type: object
+                        extraScopes:
+                          description: extraScopes are any scopes to request in addition
+                            to the standard "openid" scope.
+                          items:
+                            type: string
+                          type: array
+                        issuer:
+                          description: issuer is the URL that the OpenID Provider
+                            asserts as its Issuer Identifier. It must use the https
+                            scheme with no query or fragment component.
+                          type: string
+                      type: object
+                    requestHeader:
+                      description: requestHeader enables user authentication using
+                        request header credentials
+                      properties:
+                        ca:
+                          description: ca is a required reference to a config map
+                            by name containing the PEM-encoded CA bundle. It is used
+                            as a trust anchor to validate the TLS certificate presented
+                            by the remote server. Specifically, it allows verification
+                            of incoming requests to prevent header spoofing. The key
+                            "ca.crt" is used to locate the data. If the config map
+                            or expected key is not found, the identity provider is
+                            not honored. If the specified ca data is not valid, the
+                            identity provider is not honored. The namespace for this
+                            config map is openshift-config.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        challengeURL:
+                          description: challengeURL is a URL to redirect unauthenticated
+                            /authorize requests to Unauthenticated requests from OAuth
+                            clients which expect WWW-Authenticate challenges will
+                            be redirected here. ${url} is replaced with the current
+                            URL, escaped to be safe in a query parameter https://www.example.com/sso-login?then=${url}
+                            ${query} is replaced with the current query string https://www.example.com/auth-proxy/oauth/authorize?${query}
+                            Required when challenge is set to true.
+                          type: string
+                        clientCommonNames:
+                          description: clientCommonNames is an optional list of common
+                            names to require a match from. If empty, any client certificate
+                            validated against the clientCA bundle is considered authoritative.
+                          items:
+                            type: string
+                          type: array
+                        emailHeaders:
+                          description: emailHeaders is the set of headers to check
+                            for the email address
+                          items:
+                            type: string
+                          type: array
+                        headers:
+                          description: headers is the set of headers to check for
+                            identity information
+                          items:
+                            type: string
+                          type: array
+                        loginURL:
+                          description: loginURL is a URL to redirect unauthenticated
+                            /authorize requests to Unauthenticated requests from OAuth
+                            clients which expect interactive logins will be redirected
+                            here ${url} is replaced with the current URL, escaped
+                            to be safe in a query parameter https://www.example.com/sso-login?then=${url}
+                            ${query} is replaced with the current query string https://www.example.com/auth-proxy/oauth/authorize?${query}
+                            Required when login is set to true.
+                          type: string
+                        nameHeaders:
+                          description: nameHeaders is the set of headers to check
+                            for the display name
+                          items:
+                            type: string
+                          type: array
+                        preferredUsernameHeaders:
+                          description: preferredUsernameHeaders is the set of headers
+                            to check for the preferred username
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    type:
+                      description: type identifies the identity provider type for
+                        this entry.
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              templates:
+                description: templates allow you to customize pages like the login
+                  page.
+                properties:
+                  error:
+                    description: error is the name of a secret that specifies a go
+                      template to use to render error pages during the authentication
+                      or grant flow. The key "errors.html" is used to locate the template
+                      data. If specified and the secret or expected key is not found,
+                      the default error page is used. If the specified template is
+                      not valid, the default error page is used. If unspecified, the
+                      default error page is used. The namespace for this secret is
+                      openshift-config.
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  login:
+                    description: login is the name of a secret that specifies a go
+                      template to use to render the login page. The key "login.html"
+                      is used to locate the template data. If specified and the secret
+                      or expected key is not found, the default login page is used.
+                      If the specified template is not valid, the default login page
+                      is used. If unspecified, the default login page is used. The
+                      namespace for this secret is openshift-config.
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  providerSelection:
+                    description: providerSelection is the name of a secret that specifies
+                      a go template to use to render the provider selection page.
+                      The key "providers.html" is used to locate the template data.
+                      If specified and the secret or expected key is not found, the
+                      default provider selection page is used. If the specified template
+                      is not valid, the default provider selection page is used. If
+                      unspecified, the default provider selection page is used. The
+                      namespace for this secret is openshift-config.
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              tokenConfig:
+                description: tokenConfig contains options for authorization and access
+                  tokens
+                properties:
+                  accessTokenInactivityTimeout:
+                    description: "accessTokenInactivityTimeout defines the token inactivity
+                      timeout for tokens granted by any client. The value represents
+                      the maximum amount of time that can occur between consecutive
+                      uses of the token. Tokens become invalid if they are not used
+                      within this temporal window. The user will need to acquire a
+                      new token to regain access once a token times out. Takes valid
+                      time duration string such as \"5m\", \"1.5h\" or \"2h45m\".
+                      The minimum allowed value for duration is 300s (5 minutes).
+                      If the timeout is configured per client, then that value takes
+                      precedence. If the timeout value is not specified and the client
+                      does not override the value, then tokens are valid until their
+                      lifetime. \n WARNING: existing tokens' timeout will not be affected
+                      (lowered) by changing this value"
+                    type: string
+                  accessTokenInactivityTimeoutSeconds:
+                    description: 'accessTokenInactivityTimeoutSeconds - DEPRECATED:
+                      setting this field has no effect.'
+                    format: int32
+                    type: integer
+                  accessTokenMaxAgeSeconds:
+                    description: accessTokenMaxAgeSeconds defines the maximum age
+                      of access tokens
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_project.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_project.crd.yaml
@@ -16,40 +16,53 @@ spec:
     singular: project
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Project holds cluster-wide information about Project.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                projectRequestMessage:
-                  description: projectRequestMessage is the string presented to a user if they are unable to request a project via the projectrequest api endpoint
-                  type: string
-                projectRequestTemplate:
-                  description: projectRequestTemplate is the template to use for creating projects in response to projectrequest. This must point to a template in 'openshift-config' namespace. It is optional. If it is not specified, a default template is used.
-                  type: object
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced project request template
-                      type: string
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Project holds cluster-wide information about Project.  The canonical
+          name is `cluster` \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              projectRequestMessage:
+                description: projectRequestMessage is the string presented to a user
+                  if they are unable to request a project via the projectrequest api
+                  endpoint
+                type: string
+              projectRequestTemplate:
+                description: projectRequestTemplate is the template to use for creating
+                  projects in response to projectrequest. This must point to a template
+                  in 'openshift-config' namespace. It is optional. If it is not specified,
+                  a default template is used.
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced project
+                      request template
+                    type: string
+                type: object
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/0000_10_config-operator_01_scheduler.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_scheduler.crd.yaml
@@ -16,53 +16,93 @@ spec:
     singular: scheduler
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Scheduler holds cluster-wide config information to run the Kubernetes Scheduler and influence its placement decisions. The canonical name for this config is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                defaultNodeSelector:
-                  description: 'defaultNodeSelector helps set the cluster-wide default node selector to restrict pod placement to specific nodes. This is applied to the pods created in all namespaces and creates an intersection with any existing nodeSelectors already set on a pod, additionally constraining that pod''s selector. For example, defaultNodeSelector: "type=user-node,region=east" would set nodeSelector field in pod spec to "type=user-node,region=east" to all pods created in all namespaces. Namespaces having project-wide node selectors won''t be impacted even if this field is set. This adds an annotation section to the namespace. For example, if a new namespace is created with node-selector=''type=user-node,region=east'', the annotation openshift.io/node-selector: type=user-node,region=east gets added to the project. When the openshift.io/node-selector annotation is set on the project the value is used in preference to the value we are setting for defaultNodeSelector field. For instance, openshift.io/node-selector: "type=user-node,region=west" means that the default of "type=user-node,region=east" set in defaultNodeSelector would not be applied.'
-                  type: string
-                mastersSchedulable:
-                  description: 'MastersSchedulable allows masters nodes to be schedulable. When this flag is turned on, all the master nodes in the cluster will be made schedulable, so that workload pods can run on them. The default value for this field is false, meaning none of the master nodes are schedulable. Important Note: Once the workload pods start running on the master nodes, extreme care must be taken to ensure that cluster-critical control plane components are not impacted. Please turn on this field after doing due diligence.'
-                  type: boolean
-                policy:
-                  description: 'DEPRECATED: the scheduler Policy API has been deprecated and will be removed in a future release. policy is a reference to a ConfigMap containing scheduler policy which has user specified predicates and priorities. If this ConfigMap is not available scheduler will default to use DefaultAlgorithmProvider. The namespace for this configmap is openshift-config.'
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced config map
-                      type: string
-                profile:
-                  description: "profile sets which scheduling profile should be set in order to configure scheduling decisions for new pods. \n Valid values are \"LowNodeUtilization\", \"HighNodeUtilization\", \"NoScoring\" Defaults to \"LowNodeUtilization\""
-                  type: string
-                  enum:
-                    - ""
-                    - LowNodeUtilization
-                    - HighNodeUtilization
-                    - NoScoring
-            status:
-              description: status holds observed values from the cluster. They may not be overridden.
-              type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Scheduler holds cluster-wide config information to run the Kubernetes
+          Scheduler and influence its placement decisions. The canonical name for
+          this config is `cluster`. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              defaultNodeSelector:
+                description: 'defaultNodeSelector helps set the cluster-wide default
+                  node selector to restrict pod placement to specific nodes. This
+                  is applied to the pods created in all namespaces and creates an
+                  intersection with any existing nodeSelectors already set on a pod,
+                  additionally constraining that pod''s selector. For example, defaultNodeSelector:
+                  "type=user-node,region=east" would set nodeSelector field in pod
+                  spec to "type=user-node,region=east" to all pods created in all
+                  namespaces. Namespaces having project-wide node selectors won''t
+                  be impacted even if this field is set. This adds an annotation section
+                  to the namespace. For example, if a new namespace is created with
+                  node-selector=''type=user-node,region=east'', the annotation openshift.io/node-selector:
+                  type=user-node,region=east gets added to the project. When the openshift.io/node-selector
+                  annotation is set on the project the value is used in preference
+                  to the value we are setting for defaultNodeSelector field. For instance,
+                  openshift.io/node-selector: "type=user-node,region=west" means that
+                  the default of "type=user-node,region=east" set in defaultNodeSelector
+                  would not be applied.'
+                type: string
+              mastersSchedulable:
+                description: 'MastersSchedulable allows masters nodes to be schedulable.
+                  When this flag is turned on, all the master nodes in the cluster
+                  will be made schedulable, so that workload pods can run on them.
+                  The default value for this field is false, meaning none of the master
+                  nodes are schedulable. Important Note: Once the workload pods start
+                  running on the master nodes, extreme care must be taken to ensure
+                  that cluster-critical control plane components are not impacted.
+                  Please turn on this field after doing due diligence.'
+                type: boolean
+              policy:
+                description: 'DEPRECATED: the scheduler Policy API has been deprecated
+                  and will be removed in a future release. policy is a reference to
+                  a ConfigMap containing scheduler policy which has user specified
+                  predicates and priorities. If this ConfigMap is not available scheduler
+                  will default to use DefaultAlgorithmProvider. The namespace for
+                  this configmap is openshift-config.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              profile:
+                description: "profile sets which scheduling profile should be set
+                  in order to configure scheduling decisions for new pods. \n Valid
+                  values are \"LowNodeUtilization\", \"HighNodeUtilization\", \"NoScoring\"
+                  Defaults to \"LowNodeUtilization\""
+                enum:
+                - ""
+                - LowNodeUtilization
+                - HighNodeUtilization
+                - NoScoring
+                type: string
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consoleclidownload.crd.yaml
+++ b/console/v1/0000_10_consoleclidownload.crd.yaml
@@ -3,12 +3,13 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/481
-    description: Extension for configuring openshift web console command line interface (CLI) downloads.
+    capability.openshift.io/name: Console
+    description: Extension for configuring openshift web console command line interface
+      (CLI) downloads.
     displayName: ConsoleCLIDownload
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
   name: consoleclidownloads.console.openshift.io
 spec:
   group: console.openshift.io
@@ -19,59 +20,69 @@ spec:
     singular: consoleclidownload
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.displayName
-          name: Display name
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ConsoleCLIDownload is an extension for configuring openshift web console command line interface (CLI) downloads. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConsoleCLIDownloadSpec is the desired cli download configuration.
-              type: object
-              required:
-                - description
-                - displayName
-                - links
-              properties:
-                description:
-                  description: description is the description of the CLI download (can include markdown).
-                  type: string
-                displayName:
-                  description: displayName is the display name of the CLI download.
-                  type: string
-                links:
-                  description: links is a list of objects that provide CLI download link details.
-                  type: array
-                  items:
-                    type: object
-                    required:
-                      - href
-                    properties:
-                      href:
-                        description: href is the absolute secure URL for the link (must use https)
-                        type: string
-                        pattern: ^https://
-                      text:
-                        description: text is the display text for the link
-                        type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.displayName
+      name: Display name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ConsoleCLIDownload is an extension for configuring openshift
+          web console command line interface (CLI) downloads. \n Compatibility level
+          2: Stable within a major release for a minimum of 9 months or 3 minor releases
+          (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleCLIDownloadSpec is the desired cli download configuration.
+            properties:
+              description:
+                description: description is the description of the CLI download (can
+                  include markdown).
+                type: string
+              displayName:
+                description: displayName is the display name of the CLI download.
+                type: string
+              links:
+                description: links is a list of objects that provide CLI download
+                  link details.
+                items:
+                  properties:
+                    href:
+                      description: href is the absolute secure URL for the link (must
+                        use https)
+                      pattern: ^https://
+                      type: string
+                    text:
+                      description: text is the display text for the link
+                      type: string
+                  required:
+                  - href
+                  type: object
+                type: array
+            required:
+            - description
+            - displayName
+            - links
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consoleexternalloglink.crd.yaml
+++ b/console/v1/0000_10_consoleexternalloglink.crd.yaml
@@ -3,12 +3,13 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/481
-    description: ConsoleExternalLogLink is an extension for customizing OpenShift web console log links.
+    capability.openshift.io/name: Console
+    description: ConsoleExternalLogLink is an extension for customizing OpenShift
+      web console log links.
     displayName: ConsoleExternalLogLinks
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
   name: consoleexternalloglinks.console.openshift.io
 spec:
   group: console.openshift.io
@@ -19,50 +20,73 @@ spec:
     singular: consoleexternalloglink
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.text
-          name: Text
-          type: string
-        - jsonPath: .spec.hrefTemplate
-          name: HrefTemplate
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ConsoleExternalLogLink is an extension for customizing OpenShift web console log links. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConsoleExternalLogLinkSpec is the desired log link configuration. The log link will appear on the logs tab of the pod details page.
-              type: object
-              required:
-                - hrefTemplate
-                - text
-              properties:
-                hrefTemplate:
-                  description: "hrefTemplate is an absolute secure URL (must use https) for the log link including variables to be replaced. Variables are specified in the URL with the format ${variableName}, for instance, ${containerName} and will be replaced with the corresponding values from the resource. Resource is a pod. Supported variables are: - ${resourceName} - name of the resource which containes the logs - ${resourceUID} - UID of the resource which contains the logs - e.g. `11111111-2222-3333-4444-555555555555` - ${containerName} - name of the resource's container that contains the logs - ${resourceNamespace} - namespace of the resource that contains the logs - ${resourceNamespaceUID} - namespace UID of the resource that contains the logs - ${podLabels} - JSON representation of labels matching the pod with the logs - e.g. `{\"key1\":\"value1\",\"key2\":\"value2\"}` \n e.g., https://example.com/logs?resourceName=${resourceName}&containerName=${containerName}&resourceNamespace=${resourceNamespace}&podLabels=${podLabels}"
-                  type: string
-                  pattern: ^https://
-                namespaceFilter:
-                  description: namespaceFilter is a regular expression used to restrict a log link to a matching set of namespaces (e.g., `^openshift-`). The string is converted into a regular expression using the JavaScript RegExp constructor. If not specified, links will be displayed for all the namespaces.
-                  type: string
-                text:
-                  description: text is the display text for the link
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.text
+      name: Text
+      type: string
+    - jsonPath: .spec.hrefTemplate
+      name: HrefTemplate
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ConsoleExternalLogLink is an extension for customizing OpenShift
+          web console log links. \n Compatibility level 2: Stable within a major release
+          for a minimum of 9 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleExternalLogLinkSpec is the desired log link configuration.
+              The log link will appear on the logs tab of the pod details page.
+            properties:
+              hrefTemplate:
+                description: "hrefTemplate is an absolute secure URL (must use https)
+                  for the log link including variables to be replaced. Variables are
+                  specified in the URL with the format ${variableName}, for instance,
+                  ${containerName} and will be replaced with the corresponding values
+                  from the resource. Resource is a pod. Supported variables are: -
+                  ${resourceName} - name of the resource which containes the logs
+                  - ${resourceUID} - UID of the resource which contains the logs -
+                  e.g. `11111111-2222-3333-4444-555555555555` - ${containerName} -
+                  name of the resource's container that contains the logs - ${resourceNamespace}
+                  - namespace of the resource that contains the logs - ${resourceNamespaceUID}
+                  - namespace UID of the resource that contains the logs - ${podLabels}
+                  - JSON representation of labels matching the pod with the logs -
+                  e.g. `{\"key1\":\"value1\",\"key2\":\"value2\"}` \n e.g., https://example.com/logs?resourceName=${resourceName}&containerName=${containerName}&resourceNamespace=${resourceNamespace}&podLabels=${podLabels}"
+                pattern: ^https://
+                type: string
+              namespaceFilter:
+                description: namespaceFilter is a regular expression used to restrict
+                  a log link to a matching set of namespaces (e.g., `^openshift-`).
+                  The string is converted into a regular expression using the JavaScript
+                  RegExp constructor. If not specified, links will be displayed for
+                  all the namespaces.
+                type: string
+              text:
+                description: text is the display text for the link
+                type: string
+            required:
+            - hrefTemplate
+            - text
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consolelink.crd.yaml
+++ b/console/v1/0000_10_consolelink.crd.yaml
@@ -3,12 +3,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/481
+    capability.openshift.io/name: Console
     description: Extension for customizing OpenShift web console links
     displayName: ConsoleLinks
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
   name: consolelinks.console.openshift.io
 spec:
   group: console.openshift.io
@@ -19,107 +19,144 @@ spec:
     singular: consolelink
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.text
-          name: Text
-          type: string
-        - jsonPath: .spec.href
-          name: URL
-          type: string
-        - jsonPath: .spec.menu
-          name: Menu
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ConsoleLink is an extension for customizing OpenShift web console links. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConsoleLinkSpec is the desired console link configuration.
-              type: object
-              required:
-                - href
-                - location
-                - text
-              properties:
-                applicationMenu:
-                  description: applicationMenu holds information about section and icon used for the link in the application menu, and it is applicable only when location is set to ApplicationMenu.
-                  type: object
-                  required:
-                    - section
-                  properties:
-                    imageURL:
-                      description: imageUrl is the URL for the icon used in front of the link in the application menu. The URL must be an HTTPS URL or a Data URI. The image should be square and will be shown at 24x24 pixels.
-                      type: string
-                    section:
-                      description: section is the section of the application menu in which the link should appear. This can be any text that will appear as a subheading in the application menu dropdown. A new section will be created if the text does not match text of an existing section.
-                      type: string
-                href:
-                  description: href is the absolute secure URL for the link (must use https)
-                  type: string
-                  pattern: ^https://
-                location:
-                  description: location determines which location in the console the link will be appended to (ApplicationMenu, HelpMenu, UserMenu, NamespaceDashboard).
-                  type: string
-                  pattern: ^(ApplicationMenu|HelpMenu|UserMenu|NamespaceDashboard)$
-                namespaceDashboard:
-                  description: namespaceDashboard holds information about namespaces in which the dashboard link should appear, and it is applicable only when location is set to NamespaceDashboard. If not specified, the link will appear in all namespaces.
-                  type: object
-                  properties:
-                    namespaceSelector:
-                      description: namespaceSelector is used to select the Namespaces that should contain dashboard link by label. If the namespace labels match, dashboard link will be shown for the namespaces.
-                      type: object
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                          type: array
-                          items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                            type: object
-                            required:
-                              - key
-                              - operator
-                            properties:
-                              key:
-                                description: key is the label key that the selector applies to.
+  - additionalPrinterColumns:
+    - jsonPath: .spec.text
+      name: Text
+      type: string
+    - jsonPath: .spec.href
+      name: URL
+      type: string
+    - jsonPath: .spec.menu
+      name: Menu
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ConsoleLink is an extension for customizing OpenShift web console
+          links. \n Compatibility level 2: Stable within a major release for a minimum
+          of 9 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleLinkSpec is the desired console link configuration.
+            properties:
+              applicationMenu:
+                description: applicationMenu holds information about section and icon
+                  used for the link in the application menu, and it is applicable
+                  only when location is set to ApplicationMenu.
+                properties:
+                  imageURL:
+                    description: imageUrl is the URL for the icon used in front of
+                      the link in the application menu. The URL must be an HTTPS URL
+                      or a Data URI. The image should be square and will be shown
+                      at 24x24 pixels.
+                    type: string
+                  section:
+                    description: section is the section of the application menu in
+                      which the link should appear. This can be any text that will
+                      appear as a subheading in the application menu dropdown. A new
+                      section will be created if the text does not match text of an
+                      existing section.
+                    type: string
+                required:
+                - section
+                type: object
+              href:
+                description: href is the absolute secure URL for the link (must use
+                  https)
+                pattern: ^https://
+                type: string
+              location:
+                description: location determines which location in the console the
+                  link will be appended to (ApplicationMenu, HelpMenu, UserMenu, NamespaceDashboard).
+                pattern: ^(ApplicationMenu|HelpMenu|UserMenu|NamespaceDashboard)$
+                type: string
+              namespaceDashboard:
+                description: namespaceDashboard holds information about namespaces
+                  in which the dashboard link should appear, and it is applicable
+                  only when location is set to NamespaceDashboard. If not specified,
+                  the link will appear in all namespaces.
+                properties:
+                  namespaceSelector:
+                    description: namespaceSelector is used to select the Namespaces
+                      that should contain dashboard link by label. If the namespace
+                      labels match, dashboard link will be shown for the namespaces.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
                                 type: string
-                              operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                type: array
-                                items:
-                                  type: string
-                        matchLabels:
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: array
+                          required:
+                          - key
+                          - operator
                           type: object
-                          additionalProperties:
-                            type: string
-                      x-kubernetes-map-type: atomic
-                    namespaces:
-                      description: namespaces is an array of namespace names in which the dashboard link should appear.
-                      type: array
-                      items:
-                        type: string
-                text:
-                  description: text is the display text for the link
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  namespaces:
+                    description: namespaces is an array of namespace names in which
+                      the dashboard link should appear.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              text:
+                description: text is the display text for the link
+                type: string
+            required:
+            - href
+            - location
+            - text
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consolenotification.crd.yaml
+++ b/console/v1/0000_10_consolenotification.crd.yaml
@@ -3,12 +3,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/481
+    capability.openshift.io/name: Console
     description: Extension for configuring openshift web console notifications.
     displayName: ConsoleNotification
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
   name: consolenotifications.console.openshift.io
 spec:
   group: console.openshift.io
@@ -19,66 +19,77 @@ spec:
     singular: consolenotification
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .spec.text
-          name: Text
-          type: string
-        - jsonPath: .spec.location
-          name: Location
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ConsoleNotification is the extension for configuring openshift web console notifications. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConsoleNotificationSpec is the desired console notification configuration.
-              type: object
-              required:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.text
+      name: Text
+      type: string
+    - jsonPath: .spec.location
+      name: Location
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ConsoleNotification is the extension for configuring openshift
+          web console notifications. \n Compatibility level 2: Stable within a major
+          release for a minimum of 9 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleNotificationSpec is the desired console notification
+              configuration.
+            properties:
+              backgroundColor:
+                description: backgroundColor is the color of the background for the
+                  notification as CSS data type color.
+                type: string
+              color:
+                description: color is the color of the text for the notification as
+                  CSS data type color.
+                type: string
+              link:
+                description: link is an object that holds notification link details.
+                properties:
+                  href:
+                    description: href is the absolute secure URL for the link (must
+                      use https)
+                    pattern: ^https://
+                    type: string
+                  text:
+                    description: text is the display text for the link
+                    type: string
+                required:
+                - href
                 - text
-              properties:
-                backgroundColor:
-                  description: backgroundColor is the color of the background for the notification as CSS data type color.
-                  type: string
-                color:
-                  description: color is the color of the text for the notification as CSS data type color.
-                  type: string
-                link:
-                  description: link is an object that holds notification link details.
-                  type: object
-                  required:
-                    - href
-                    - text
-                  properties:
-                    href:
-                      description: href is the absolute secure URL for the link (must use https)
-                      type: string
-                      pattern: ^https://
-                    text:
-                      description: text is the display text for the link
-                      type: string
-                location:
-                  description: 'location is the location of the notification in the console. Valid values are: "BannerTop", "BannerBottom", "BannerTopBottom".'
-                  type: string
-                  pattern: ^(BannerTop|BannerBottom|BannerTopBottom)$
-                text:
-                  description: text is the visible text of the notification.
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+              location:
+                description: 'location is the location of the notification in the
+                  console. Valid values are: "BannerTop", "BannerBottom", "BannerTopBottom".'
+                pattern: ^(BannerTop|BannerBottom|BannerTopBottom)$
+                type: string
+              text:
+                description: text is the visible text of the notification.
+                type: string
+            required:
+            - text
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/console/v1/0000_10_consolequickstart.crd.yaml
+++ b/console/v1/0000_10_consolequickstart.crd.yaml
@@ -3,12 +3,13 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/750
-    description: Extension for guiding user through various workflows in the OpenShift web console.
+    capability.openshift.io/name: Console
+    description: Extension for guiding user through various workflows in the OpenShift
+      web console.
     displayName: ConsoleQuickStart
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
   name: consolequickstarts.console.openshift.io
 spec:
   group: console.openshift.io
@@ -19,147 +20,188 @@ spec:
     singular: consolequickstart
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ConsoleQuickStart is an extension for guiding user through various workflows in the OpenShift web console. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConsoleQuickStartSpec is the desired quick start configuration.
-              type: object
-              required:
-                - description
-                - displayName
-                - durationMinutes
-                - introduction
-                - tasks
-              properties:
-                accessReviewResources:
-                  description: accessReviewResources contains a list of resources that the user's access will be reviewed against in order for the user to complete the Quick Start. The Quick Start will be hidden if any of the access reviews fail.
-                  type: array
-                  items:
-                    description: ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface
-                    type: object
-                    properties:
-                      group:
-                        description: Group is the API Group of the Resource.  "*" means all.
-                        type: string
-                      name:
-                        description: Name is the name of the resource being requested for a "get" or deleted for a "delete". "" (empty) means all.
-                        type: string
-                      namespace:
-                        description: Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces "" (empty) is defaulted for LocalSubjectAccessReviews "" (empty) is empty for cluster-scoped resources "" (empty) means "all" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview
-                        type: string
-                      resource:
-                        description: Resource is one of the existing resource types.  "*" means all.
-                        type: string
-                      subresource:
-                        description: Subresource is one of the existing resource types.  "" means none.
-                        type: string
-                      verb:
-                        description: 'Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.'
-                        type: string
-                      version:
-                        description: Version is the API Version of the Resource.  "*" means all.
-                        type: string
-                conclusion:
-                  description: conclusion sums up the Quick Start and suggests the possible next steps. (includes markdown)
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ConsoleQuickStart is an extension for guiding user through various
+          workflows in the OpenShift web console. \n Compatibility level 2: Stable
+          within a major release for a minimum of 9 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleQuickStartSpec is the desired quick start configuration.
+            properties:
+              accessReviewResources:
+                description: accessReviewResources contains a list of resources that
+                  the user's access will be reviewed against in order for the user
+                  to complete the Quick Start. The Quick Start will be hidden if any
+                  of the access reviews fail.
+                items:
+                  description: ResourceAttributes includes the authorization attributes
+                    available for resource requests to the Authorizer interface
+                  properties:
+                    group:
+                      description: Group is the API Group of the Resource.  "*" means
+                        all.
+                      type: string
+                    name:
+                      description: Name is the name of the resource being requested
+                        for a "get" or deleted for a "delete". "" (empty) means all.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the action being
+                        requested.  Currently, there is no distinction between no
+                        namespace and all namespaces "" (empty) is defaulted for LocalSubjectAccessReviews
+                        "" (empty) is empty for cluster-scoped resources "" (empty)
+                        means "all" for namespace scoped resources from a SubjectAccessReview
+                        or SelfSubjectAccessReview
+                      type: string
+                    resource:
+                      description: Resource is one of the existing resource types.  "*"
+                        means all.
+                      type: string
+                    subresource:
+                      description: Subresource is one of the existing resource types.  ""
+                        means none.
+                      type: string
+                    verb:
+                      description: 'Verb is a kubernetes resource API verb, like:
+                        get, list, watch, create, update, delete, proxy.  "*" means
+                        all.'
+                      type: string
+                    version:
+                      description: Version is the API Version of the Resource.  "*"
+                        means all.
+                      type: string
+                  type: object
+                type: array
+              conclusion:
+                description: conclusion sums up the Quick Start and suggests the possible
+                  next steps. (includes markdown)
+                type: string
+              description:
+                description: description is the description of the Quick Start. (includes
+                  markdown)
+                maxLength: 256
+                minLength: 1
+                type: string
+              displayName:
+                description: displayName is the display name of the Quick Start.
+                minLength: 1
+                type: string
+              durationMinutes:
+                description: durationMinutes describes approximately how many minutes
+                  it will take to complete the Quick Start.
+                minimum: 1
+                type: integer
+              icon:
+                description: icon is a base64 encoded image that will be displayed
+                  beside the Quick Start display name. The icon should be an vector
+                  image for easy scaling. The size of the icon should be 40x40.
+                type: string
+              introduction:
+                description: introduction describes the purpose of the Quick Start.
+                  (includes markdown)
+                minLength: 1
+                type: string
+              nextQuickStart:
+                description: nextQuickStart is a list of the following Quick Starts,
+                  suggested for the user to try.
+                items:
                   type: string
-                description:
-                  description: description is the description of the Quick Start. (includes markdown)
+                type: array
+              prerequisites:
+                description: prerequisites contains all prerequisites that need to
+                  be met before taking a Quick Start. (includes markdown)
+                items:
                   type: string
-                  maxLength: 256
-                  minLength: 1
-                displayName:
-                  description: displayName is the display name of the Quick Start.
+                type: array
+              tags:
+                description: tags is a list of strings that describe the Quick Start.
+                items:
                   type: string
-                  minLength: 1
-                durationMinutes:
-                  description: durationMinutes describes approximately how many minutes it will take to complete the Quick Start.
-                  type: integer
-                  minimum: 1
-                icon:
-                  description: icon is a base64 encoded image that will be displayed beside the Quick Start display name. The icon should be an vector image for easy scaling. The size of the icon should be 40x40.
-                  type: string
-                introduction:
-                  description: introduction describes the purpose of the Quick Start. (includes markdown)
-                  type: string
-                  minLength: 1
-                nextQuickStart:
-                  description: nextQuickStart is a list of the following Quick Starts, suggested for the user to try.
-                  type: array
-                  items:
-                    type: string
-                prerequisites:
-                  description: prerequisites contains all prerequisites that need to be met before taking a Quick Start. (includes markdown)
-                  type: array
-                  items:
-                    type: string
-                tags:
-                  description: tags is a list of strings that describe the Quick Start.
-                  type: array
-                  items:
-                    type: string
-                tasks:
-                  description: tasks is the list of steps the user has to perform to complete the Quick Start.
-                  type: array
-                  minItems: 1
-                  items:
-                    description: ConsoleQuickStartTask is a single step in a Quick Start.
-                    type: object
-                    required:
-                      - description
-                      - title
-                    properties:
-                      description:
-                        description: description describes the steps needed to complete the task. (includes markdown)
-                        type: string
-                        minLength: 1
-                      review:
-                        description: review contains instructions to validate the task is complete. The user will select 'Yes' or 'No'. using a radio button, which indicates whether the step was completed successfully.
-                        type: object
-                        required:
-                          - failedTaskHelp
-                          - instructions
-                        properties:
-                          failedTaskHelp:
-                            description: failedTaskHelp contains suggestions for a failed task review and is shown at the end of task. (includes markdown)
-                            type: string
-                            minLength: 1
-                          instructions:
-                            description: instructions contains steps that user needs to take in order to validate his work after going through a task. (includes markdown)
-                            type: string
-                            minLength: 1
-                      summary:
-                        description: summary contains information about the passed step.
-                        type: object
-                        required:
-                          - failed
-                          - success
-                        properties:
-                          failed:
-                            description: failed briefly describes the unsuccessfully passed task. (includes markdown)
-                            type: string
-                            maxLength: 128
-                            minLength: 1
-                          success:
-                            description: success describes the succesfully passed task.
-                            type: string
-                            minLength: 1
-                      title:
-                        description: title describes the task and is displayed as a step heading.
-                        type: string
-                        minLength: 1
-      served: true
-      storage: true
+                type: array
+              tasks:
+                description: tasks is the list of steps the user has to perform to
+                  complete the Quick Start.
+                items:
+                  description: ConsoleQuickStartTask is a single step in a Quick Start.
+                  properties:
+                    description:
+                      description: description describes the steps needed to complete
+                        the task. (includes markdown)
+                      minLength: 1
+                      type: string
+                    review:
+                      description: review contains instructions to validate the task
+                        is complete. The user will select 'Yes' or 'No'. using a radio
+                        button, which indicates whether the step was completed successfully.
+                      properties:
+                        failedTaskHelp:
+                          description: failedTaskHelp contains suggestions for a failed
+                            task review and is shown at the end of task. (includes
+                            markdown)
+                          minLength: 1
+                          type: string
+                        instructions:
+                          description: instructions contains steps that user needs
+                            to take in order to validate his work after going through
+                            a task. (includes markdown)
+                          minLength: 1
+                          type: string
+                      required:
+                      - failedTaskHelp
+                      - instructions
+                      type: object
+                    summary:
+                      description: summary contains information about the passed step.
+                      properties:
+                        failed:
+                          description: failed briefly describes the unsuccessfully
+                            passed task. (includes markdown)
+                          maxLength: 128
+                          minLength: 1
+                          type: string
+                        success:
+                          description: success describes the succesfully passed task.
+                          minLength: 1
+                          type: string
+                      required:
+                      - failed
+                      - success
+                      type: object
+                    title:
+                      description: title describes the task and is displayed as a
+                        step heading.
+                      minLength: 1
+                      type: string
+                  required:
+                  - description
+                  - title
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - description
+            - displayName
+            - durationMinutes
+            - introduction
+            - tasks
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/console/v1/0000_10_consoleyamlsample.crd.yaml
+++ b/console/v1/0000_10_consoleyamlsample.crd.yaml
@@ -3,12 +3,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/481
+    capability.openshift.io/name: Console
     description: Extension for configuring openshift web console YAML samples.
     displayName: ConsoleYAMLSample
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
   name: consoleyamlsamples.console.openshift.io
 spec:
   group: console.openshift.io
@@ -19,56 +19,73 @@ spec:
     singular: consoleyamlsample
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ConsoleYAMLSample is an extension for customizing OpenShift web console YAML samples. \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - metadata
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConsoleYAMLSampleSpec is the desired YAML sample configuration. Samples will appear with their descriptions in a samples sidebar when creating a resources in the web console.
-              type: object
-              required:
-                - description
-                - targetResource
-                - title
-                - yaml
-              properties:
-                description:
-                  description: description of the YAML sample.
-                  type: string
-                  pattern: ^(.|\s)*\S(.|\s)*$
-                snippet:
-                  description: snippet indicates that the YAML sample is not the full YAML resource definition, but a fragment that can be inserted into the existing YAML document at the user's cursor.
-                  type: boolean
-                targetResource:
-                  description: targetResource contains apiVersion and kind of the resource YAML sample is representating.
-                  type: object
-                  properties:
-                    apiVersion:
-                      description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                      type: string
-                    kind:
-                      description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                title:
-                  description: title of the YAML sample.
-                  type: string
-                  pattern: ^(.|\s)*\S(.|\s)*$
-                yaml:
-                  description: yaml is the YAML sample to display.
-                  type: string
-                  pattern: ^(.|\s)*\S(.|\s)*$
-      served: true
-      storage: true
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ConsoleYAMLSample is an extension for customizing OpenShift
+          web console YAML samples. \n Compatibility level 2: Stable within a major
+          release for a minimum of 9 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleYAMLSampleSpec is the desired YAML sample configuration.
+              Samples will appear with their descriptions in a samples sidebar when
+              creating a resources in the web console.
+            properties:
+              description:
+                description: description of the YAML sample.
+                pattern: ^(.|\s)*\S(.|\s)*$
+                type: string
+              snippet:
+                description: snippet indicates that the YAML sample is not the full
+                  YAML resource definition, but a fragment that can be inserted into
+                  the existing YAML document at the user's cursor.
+                type: boolean
+              targetResource:
+                description: targetResource contains apiVersion and kind of the resource
+                  YAML sample is representating.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                type: object
+              title:
+                description: title of the YAML sample.
+                pattern: ^(.|\s)*\S(.|\s)*$
+                type: string
+              yaml:
+                description: yaml is the YAML sample to display.
+                pattern: ^(.|\s)*\S(.|\s)*$
+                type: string
+            required:
+            - description
+            - targetResource
+            - title
+            - yaml
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/console/v1alpha1/0000_10_consoleplugin.crd.yaml
+++ b/console/v1alpha1/0000_10_consoleplugin.crd.yaml
@@ -3,12 +3,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/764
+    capability.openshift.io/name: Console
     description: Extension for configuring openshift web console plugins.
     displayName: ConsolePlugin
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
   name: consoleplugins.console.openshift.io
 spec:
   group: console.openshift.io
@@ -19,115 +19,151 @@ spec:
     singular: consoleplugin
   scope: Cluster
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: "ConsolePlugin is an extension for customizing OpenShift web console by dynamically loading code from another service running on the cluster. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support."
-          type: object
-          required:
-            - metadata
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConsolePluginSpec is the desired plugin configuration.
-              type: object
-              required:
-                - service
-              properties:
-                displayName:
-                  description: displayName is the display name of the plugin.
-                  type: string
-                  minLength: 1
-                proxy:
-                  description: proxy is a list of proxies that describe various service type to which the plugin needs to connect to.
-                  type: array
-                  items:
-                    description: ConsolePluginProxy holds information on various service types to which console's backend will proxy the plugin's requests.
-                    type: object
-                    required:
-                      - alias
-                      - type
-                    properties:
-                      alias:
-                        description: "alias is a proxy name that identifies the plugin's proxy. An alias name should be unique per plugin. The console backend exposes following proxy endpoint: \n /api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>?<optional-query-parameters> \n Request example path: \n /api/proxy/plugin/acm/search/pods?namespace=openshift-apiserver"
-                        type: string
-                        maxLength: 128
-                        minLength: 1
-                        pattern: ^[A-Za-z0-9-_]+$
-                      authorize:
-                        description: "authorize indicates if the proxied request should contain the logged-in user's OpenShift access token in the \"Authorization\" request header. For example: \n Authorization: Bearer sha256~kV46hPnEYhCWFnB85r5NrprAxggzgb6GOeLbgcKNsH0 \n By default the access token is not part of the proxied request."
-                        type: boolean
-                        default: false
-                      caCertificate:
-                        description: caCertificate provides the cert authority certificate contents, in case the proxied Service is using custom service CA. By default, the service CA bundle provided by the service-ca operator is used.
-                        type: string
-                        pattern: ^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$
-                      service:
-                        description: 'service is an in-cluster Service that the plugin will connect to. The Service must use HTTPS. The console backend exposes an endpoint in order to proxy communication between the plugin and the Service. Note: service field is required for now, since currently only "Service" type is supported.'
-                        type: object
-                        required:
-                          - name
-                          - namespace
-                          - port
-                        properties:
-                          name:
-                            description: name of Service that the plugin needs to connect to.
-                            type: string
-                            maxLength: 128
-                            minLength: 1
-                          namespace:
-                            description: namespace of Service that the plugin needs to connect to
-                            type: string
-                            maxLength: 128
-                            minLength: 1
-                          port:
-                            description: port on which the Service that the plugin needs to connect to is listening on.
-                            type: integer
-                            format: int32
-                            maximum: 65535
-                            minimum: 1
-                      type:
-                        description: type is the type of the console plugin's proxy. Currently only "Service" is supported.
-                        type: string
-                        pattern: ^(Service)$
-                service:
-                  description: service is a Kubernetes Service that exposes the plugin using a deployment with an HTTP server. The Service must use HTTPS and Service serving certificate. The console backend will proxy the plugins assets from the Service using the service CA bundle.
-                  type: object
-                  required:
-                    - basePath
-                    - name
-                    - namespace
-                    - port
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "ConsolePlugin is an extension for customizing OpenShift web
+          console by dynamically loading code from another service running on the
+          cluster. \n Compatibility level 4: No compatibility is provided, the API
+          can change at any point for any reason. These capabilities should not be
+          used by applications needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsolePluginSpec is the desired plugin configuration.
+            properties:
+              displayName:
+                description: displayName is the display name of the plugin.
+                minLength: 1
+                type: string
+              proxy:
+                description: proxy is a list of proxies that describe various service
+                  type to which the plugin needs to connect to.
+                items:
+                  description: ConsolePluginProxy holds information on various service
+                    types to which console's backend will proxy the plugin's requests.
                   properties:
-                    basePath:
-                      description: basePath is the path to the plugin's assets. The primary asset it the manifest file called `plugin-manifest.json`, which is a JSON document that contains metadata about the plugin and the extensions.
-                      type: string
-                      default: /
-                      minLength: 1
-                      pattern: ^/
-                    name:
-                      description: name of Service that is serving the plugin assets.
-                      type: string
+                    alias:
+                      description: "alias is a proxy name that identifies the plugin's
+                        proxy. An alias name should be unique per plugin. The console
+                        backend exposes following proxy endpoint: \n /api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>?<optional-query-parameters>
+                        \n Request example path: \n /api/proxy/plugin/acm/search/pods?namespace=openshift-apiserver"
                       maxLength: 128
                       minLength: 1
-                    namespace:
-                      description: namespace of Service that is serving the plugin assets.
+                      pattern: ^[A-Za-z0-9-_]+$
                       type: string
-                      maxLength: 128
-                      minLength: 1
-                    port:
-                      description: port on which the Service that is serving the plugin is listening to.
-                      type: integer
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-      served: true
-      storage: true
+                    authorize:
+                      default: false
+                      description: "authorize indicates if the proxied request should
+                        contain the logged-in user's OpenShift access token in the
+                        \"Authorization\" request header. For example: \n Authorization:
+                        Bearer sha256~kV46hPnEYhCWFnB85r5NrprAxggzgb6GOeLbgcKNsH0
+                        \n By default the access token is not part of the proxied
+                        request."
+                      type: boolean
+                    caCertificate:
+                      description: caCertificate provides the cert authority certificate
+                        contents, in case the proxied Service is using custom service
+                        CA. By default, the service CA bundle provided by the service-ca
+                        operator is used.
+                      pattern: ^-----BEGIN CERTIFICATE-----([\s\S]*)-----END CERTIFICATE-----\s?$
+                      type: string
+                    service:
+                      description: 'service is an in-cluster Service that the plugin
+                        will connect to. The Service must use HTTPS. The console backend
+                        exposes an endpoint in order to proxy communication between
+                        the plugin and the Service. Note: service field is required
+                        for now, since currently only "Service" type is supported.'
+                      properties:
+                        name:
+                          description: name of Service that the plugin needs to connect
+                            to.
+                          maxLength: 128
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: namespace of Service that the plugin needs
+                            to connect to
+                          maxLength: 128
+                          minLength: 1
+                          type: string
+                        port:
+                          description: port on which the Service that the plugin needs
+                            to connect to is listening on.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - name
+                      - namespace
+                      - port
+                      type: object
+                    type:
+                      description: type is the type of the console plugin's proxy.
+                        Currently only "Service" is supported.
+                      pattern: ^(Service)$
+                      type: string
+                  required:
+                  - alias
+                  - type
+                  type: object
+                type: array
+              service:
+                description: service is a Kubernetes Service that exposes the plugin
+                  using a deployment with an HTTP server. The Service must use HTTPS
+                  and Service serving certificate. The console backend will proxy
+                  the plugins assets from the Service using the service CA bundle.
+                properties:
+                  basePath:
+                    default: /
+                    description: basePath is the path to the plugin's assets. The
+                      primary asset it the manifest file called `plugin-manifest.json`,
+                      which is a JSON document that contains metadata about the plugin
+                      and the extensions.
+                    minLength: 1
+                    pattern: ^/
+                    type: string
+                  name:
+                    description: name of Service that is serving the plugin assets.
+                    maxLength: 128
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: namespace of Service that is serving the plugin assets.
+                    maxLength: 128
+                    minLength: 1
+                    type: string
+                  port:
+                    description: port on which the Service that is serving the plugin
+                      is listening to.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                required:
+                - basePath
+                - name
+                - namespace
+                - port
+                type: object
+            required:
+            - service
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/example/v1/0000_50_stabletype-default.crd.yaml
+++ b/example/v1/0000_50_stabletype-default.crd.yaml
@@ -3,13 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/xxx
-    # this CRD manifest will not be created on TechPreview clusters, so you almost always have a techpreview.crd.yaml variant
-    # with this value set to TechPreviewNoUpgrade.  If you're just "normal", without any TechPreview fields, then you
-    # simply exclude this annotation.
-    release.openshift.io/feature-set: Default
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
   name: stableconfigtypes.example.openshift.io
 spec:
   group: example.openshift.io
@@ -20,75 +17,111 @@ spec:
     singular: stableconfigtype
   scope: Cluster
   versions:
-    - name: v1
-      "schema":
-        "openAPIV3Schema":
-          description: "StableConfigType is a stable config type that may include TechPreviewNoUpgrade fields. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec is the specification of the desired behavior of the StableConfigType.
-              type: object
-              properties:
-                stableField:
-                  description: "stableField is a field that is present on default clusters and on tech preview clusters \n If empty, the platform will choose a good default, which may change over time without notice."
-                  type: string
-            status:
-              description: status is the most recently observed status of the StableConfigType.
-              type: object
-              properties:
-                conditions:
-                  description: 'Represents the observations of a foo''s current state. Known .status.conditions.type are: "Available", "Progressing", and "Degraded"'
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "StableConfigType is a stable config type that may include TechPreviewNoUpgrade
+          fields. \n Compatibility level 1: Stable within a major release for a minimum
+          of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              StableConfigType.
+            properties:
+              stableField:
+                description: "stableField is a field that is present on default clusters
+                  and on tech preview clusters \n If empty, the platform will choose
+                  a good default, which may change over time without notice."
+                type: string
+            type: object
+          status:
+            description: status is the most recently observed status of the StableConfigType.
+            properties:
+              conditions:
+                description: 'Represents the observations of a foo''s current state.
+                  Known .status.conditions.type are: "Available", "Progressing", and
+                  "Degraded"'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object

--- a/example/v1/0000_50_stabletype-techpreview.crd.yaml
+++ b/example/v1/0000_50_stabletype-techpreview.crd.yaml
@@ -3,10 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/xxx
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: stableconfigtypes.example.openshift.io
 spec:
   group: example.openshift.io
@@ -17,78 +17,115 @@ spec:
     singular: stableconfigtype
   scope: Cluster
   versions:
-    - name: v1
-      "schema":
-        "openAPIV3Schema":
-          description: "StableConfigType is a stable config type that may include TechPreviewNoUpgrade fields. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec is the specification of the desired behavior of the StableConfigType.
-              type: object
-              properties:
-                coolNewField:
-                  description: coolNewField is a field that is for tech preview only.  On normal clusters this shouldn't be present
-                  type: string
-                stableField:
-                  description: "stableField is a field that is present on default clusters and on tech preview clusters \n If empty, the platform will choose a good default, which may change over time without notice."
-                  type: string
-            status:
-              description: status is the most recently observed status of the StableConfigType.
-              type: object
-              properties:
-                conditions:
-                  description: 'Represents the observations of a foo''s current state. Known .status.conditions.type are: "Available", "Progressing", and "Degraded"'
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "StableConfigType is a stable config type that may include TechPreviewNoUpgrade
+          fields. \n Compatibility level 1: Stable within a major release for a minimum
+          of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              StableConfigType.
+            properties:
+              coolNewField:
+                description: coolNewField is a field that is for tech preview only.  On
+                  normal clusters this shouldn't be present
+                type: string
+              stableField:
+                description: "stableField is a field that is present on default clusters
+                  and on tech preview clusters \n If empty, the platform will choose
+                  a good default, which may change over time without notice."
+                type: string
+            type: object
+          status:
+            description: status is the most recently observed status of the StableConfigType.
+            properties:
+              conditions:
+                description: 'Represents the observations of a foo''s current state.
+                  Known .status.conditions.type are: "Available", "Progressing", and
+                  "Degraded"'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object

--- a/example/v1alpha1/0000_50_notstabletype-techpreview.crd.yaml
+++ b/example/v1alpha1/0000_50_notstabletype-techpreview.crd.yaml
@@ -3,10 +3,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/xxx
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: notstableconfigtypes.example.openshift.io
 spec:
   group: example.openshift.io
@@ -17,77 +17,113 @@ spec:
     singular: notstableconfigtype
   scope: Cluster
   versions:
-    - name: v1alpha1
-      "schema":
-        "openAPIV3Schema":
-          description: "NotStableConfigType is a stable config type that is TechPreviewNoUpgrade only. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support."
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec is the specification of the desired behavior of the NotStableConfigType.
-              type: object
-              required:
-                - newField
-              properties:
-                newField:
-                  description: newField is a field that is tech preview, but because the entire type is gated, there is no marker on the field.
-                  type: string
-            status:
-              description: status is the most recently observed status of the NotStableConfigType.
-              type: object
-              properties:
-                conditions:
-                  description: 'Represents the observations of a foo''s current state. Known .status.conditions.type are: "Available", "Progressing", and "Degraded"'
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "NotStableConfigType is a stable config type that is TechPreviewNoUpgrade
+          only. \n Compatibility level 4: No compatibility is provided, the API can
+          change at any point for any reason. These capabilities should not be used
+          by applications needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              NotStableConfigType.
+            properties:
+              newField:
+                description: newField is a field that is tech preview, but because
+                  the entire type is gated, there is no marker on the field.
+                type: string
+            required:
+            - newField
+            type: object
+          status:
+            description: status is the most recently observed status of the NotStableConfigType.
+            properties:
+              conditions:
+                description: 'Represents the observations of a foo''s current state.
+                  Known .status.conditions.type are: "Available", "Progressing", and
+                  "Degraded"'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dave/dst v0.26.2
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.6
-	github.com/openshift/build-machinery-go v0.0.0-20220909124648-e003344f49e8
+	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/tools v0.1.12
 	k8s.io/api v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/openshift/build-machinery-go v0.0.0-20220909124648-e003344f49e8 h1:zKrRxzzgBNhHvT46esSG3brtEeTrR1MyQ8QUEO4NVlA=
-github.com/openshift/build-machinery-go v0.0.0-20220909124648-e003344f49e8/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=
+github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
+++ b/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml
@@ -16,115 +16,159 @@ spec:
     singular: helmchartrepository
   scope: Cluster
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: "HelmChartRepository holds cluster-wide configuration for proxied Helm chart repository \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                connectionConfig:
-                  description: Required configuration for connecting to the chart repo
-                  type: object
-                  properties:
-                    ca:
-                      description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca-bundle.crt" is used to locate the data. If empty, the default system roots are used. The namespace for this config map is openshift-config.
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        name:
-                          description: name is the metadata.name of the referenced config map
-                          type: string
-                    tlsClientConfig:
-                      description: tlsClientConfig is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate and private key to present when connecting to the server. The key "tls.crt" is used to locate the client certificate. The key "tls.key" is used to locate the private key. The namespace for this secret is openshift-config.
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        name:
-                          description: name is the metadata.name of the referenced secret
-                          type: string
-                    url:
-                      description: Chart repository URL
-                      type: string
-                      maxLength: 2048
-                      pattern: ^https?:\/\/
-                description:
-                  description: Optional human readable repository description, it can be used by UI for displaying purposes
-                  type: string
-                  maxLength: 2048
-                  minLength: 1
-                disabled:
-                  description: If set to true, disable the repo usage in the cluster/namespace
-                  type: boolean
-                name:
-                  description: Optional associated human readable repository name, it can be used by UI for displaying purposes
-                  type: string
-                  maxLength: 100
-                  minLength: 1
-            status:
-              description: Observed status of the repository within the cluster..
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their statuses
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: "HelmChartRepository holds cluster-wide configuration for proxied
+          Helm chart repository \n Compatibility level 2: Stable within a major release
+          for a minimum of 9 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              connectionConfig:
+                description: Required configuration for connecting to the chart repo
+                properties:
+                  ca:
+                    description: ca is an optional reference to a config map by name
+                      containing the PEM-encoded CA bundle. It is used as a trust
+                      anchor to validate the TLS certificate presented by the remote
+                      server. The key "ca-bundle.crt" is used to locate the data.
+                      If empty, the default system roots are used. The namespace for
+                      this config map is openshift-config.
                     properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      name:
+                        description: name is the metadata.name of the referenced config
+                          map
                         type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                    required:
+                    - name
+                    type: object
+                  tlsClientConfig:
+                    description: tlsClientConfig is an optional reference to a secret
+                      by name that contains the PEM-encoded TLS client certificate
+                      and private key to present when connecting to the server. The
+                      key "tls.crt" is used to locate the client certificate. The
+                      key "tls.key" is used to locate the private key. The namespace
+                      for this secret is openshift-config.
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
                         type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    required:
+                    - name
+                    type: object
+                  url:
+                    description: Chart repository URL
+                    maxLength: 2048
+                    pattern: ^https?:\/\/
+                    type: string
+                type: object
+              description:
+                description: Optional human readable repository description, it can
+                  be used by UI for displaying purposes
+                maxLength: 2048
+                minLength: 1
+                type: string
+              disabled:
+                description: If set to true, disable the repo usage in the cluster/namespace
+                type: boolean
+              name:
+                description: Optional associated human readable repository name, it
+                  can be used by UI for displaying purposes
+                maxLength: 100
+                minLength: 1
+                type: string
+            type: object
+          status:
+            description: Observed status of the repository within the cluster..
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their statuses
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/v1beta1/0000_10-project-helm-chart-repository.crd.yaml
+++ b/helm/v1beta1/0000_10-project-helm-chart-repository.crd.yaml
@@ -16,124 +16,177 @@ spec:
     singular: projecthelmchartrepository
   scope: Namespaced
   versions:
-    - name: v1beta1
-      served: true
-      storage: true
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          description: "ProjectHelmChartRepository holds namespace-wide configuration for proxied Helm chart repository \n Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                connectionConfig:
-                  description: Required configuration for connecting to the chart repo
-                  type: object
-                  properties:
-                    basicAuthConfig:
-                      description: basicAuthConfig is an optional reference to a secret by name that contains the basic authentication credentials to present when connecting to the server. The key "username" is used locate the username. The key "password" is used to locate the password. The namespace for this secret must be same as the namespace where the project helm chart repository is getting instantiated.
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        name:
-                          description: name is the metadata.name of the referenced secret
-                          type: string
-                    ca:
-                      description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca-bundle.crt" is used to locate the data. If empty, the default system roots are used. The namespace for this configmap must be same as the namespace where the project helm chart repository is getting instantiated.
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        name:
-                          description: name is the metadata.name of the referenced config map
-                          type: string
-                    tlsClientConfig:
-                      description: tlsClientConfig is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate and private key to present when connecting to the server. The key "tls.crt" is used to locate the client certificate. The key "tls.key" is used to locate the private key. The namespace for this secret must be same as the namespace where the project helm chart repository is getting instantiated.
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        name:
-                          description: name is the metadata.name of the referenced secret
-                          type: string
-                    url:
-                      description: Chart repository URL
-                      type: string
-                      maxLength: 2048
-                      pattern: ^https?:\/\/
-                description:
-                  description: Optional human readable repository description, it can be used by UI for displaying purposes
-                  type: string
-                  maxLength: 2048
-                  minLength: 1
-                disabled:
-                  description: If set to true, disable the repo usage in the namespace
-                  type: boolean
-                name:
-                  description: Optional associated human readable repository name, it can be used by UI for displaying purposes
-                  type: string
-                  maxLength: 100
-                  minLength: 1
-            status:
-              description: Observed status of the repository within the namespace..
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their statuses
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: "ProjectHelmChartRepository holds namespace-wide configuration
+          for proxied Helm chart repository \n Compatibility level 2: Stable within
+          a major release for a minimum of 9 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              connectionConfig:
+                description: Required configuration for connecting to the chart repo
+                properties:
+                  basicAuthConfig:
+                    description: basicAuthConfig is an optional reference to a secret
+                      by name that contains the basic authentication credentials to
+                      present when connecting to the server. The key "username" is
+                      used locate the username. The key "password" is used to locate
+                      the password. The namespace for this secret must be same as
+                      the namespace where the project helm chart repository is getting
+                      instantiated.
                     properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      name:
+                        description: name is the metadata.name of the referenced secret
                         type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                    required:
+                    - name
+                    type: object
+                  ca:
+                    description: ca is an optional reference to a config map by name
+                      containing the PEM-encoded CA bundle. It is used as a trust
+                      anchor to validate the TLS certificate presented by the remote
+                      server. The key "ca-bundle.crt" is used to locate the data.
+                      If empty, the default system roots are used. The namespace for
+                      this configmap must be same as the namespace where the project
+                      helm chart repository is getting instantiated.
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced config
+                          map
                         type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                    required:
+                    - name
+                    type: object
+                  tlsClientConfig:
+                    description: tlsClientConfig is an optional reference to a secret
+                      by name that contains the PEM-encoded TLS client certificate
+                      and private key to present when connecting to the server. The
+                      key "tls.crt" is used to locate the client certificate. The
+                      key "tls.key" is used to locate the private key. The namespace
+                      for this secret must be same as the namespace where the project
+                      helm chart repository is getting instantiated.
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
                         type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                    required:
+                    - name
+                    type: object
+                  url:
+                    description: Chart repository URL
+                    maxLength: 2048
+                    pattern: ^https?:\/\/
+                    type: string
+                type: object
+              description:
+                description: Optional human readable repository description, it can
+                  be used by UI for displaying purposes
+                maxLength: 2048
+                minLength: 1
+                type: string
+              disabled:
+                description: If set to true, disable the repo usage in the namespace
+                type: boolean
+              name:
+                description: Optional associated human readable repository name, it
+                  can be used by UI for displaying purposes
+                maxLength: 100
+                minLength: 1
+                type: string
+            type: object
+          status:
+            description: Observed status of the repository within the namespace..
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their statuses
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/imageregistry/v1/01_imagepruner.crd.yaml
+++ b/imageregistry/v1/01_imagepruner.crd.yaml
@@ -16,614 +16,1019 @@ spec:
     singular: imagepruner
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ImagePruner is the configuration object for an image registry pruner managed by the registry operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - metadata
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ImagePrunerSpec defines the specs for the running image pruner.
-              type: object
-              properties:
-                affinity:
-                  description: affinity is a group of node affinity scheduling rules for the image pruner pod.
-                  type: object
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the pod.
-                      type: object
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
-                          type: array
-                          items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                            type: object
-                            required:
-                              - preference
-                              - weight
-                            properties:
-                              preference:
-                                description: A node selector term, associated with the corresponding weight.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
-                                    type: array
-                                    items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                        - key
-                                        - operator
-                                      properties:
-                                        key:
-                                          description: The label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchFields:
-                                    description: A list of node selector requirements by node's fields.
-                                    type: array
-                                    items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                        - key
-                                        - operator
-                                      properties:
-                                        key:
-                                          description: The label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                x-kubernetes-map-type: atomic
-                              weight:
-                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-                                type: integer
-                                format: int32
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
-                          type: object
-                          required:
-                            - nodeSelectorTerms
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ImagePruner is the configuration object for an image registry
+          pruner managed by the registry operator. \n Compatibility level 1: Stable
+          within a major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImagePrunerSpec defines the specs for the running image pruner.
+            properties:
+              affinity:
+                description: affinity is a group of node affinity scheduling rules
+                  for the image pruner pod.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
                           properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms. The terms are ORed.
-                              type: array
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
                               items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
-                                    type: array
-                                    items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                        - key
-                                        - operator
-                                      properties:
-                                        key:
-                                          description: The label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchFields:
-                                    description: A list of node selector requirements by node's fields.
-                                    type: array
-                                    items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                        - key
-                                        - operator
-                                      properties:
-                                        key:
-                                          description: The label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                x-kubernetes-map-type: atomic
-                          x-kubernetes-map-type: atomic
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-                      type: object
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
-                          type: array
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                            type: object
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
-                                type: object
-                                required:
-                                  - topologyKey
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        type: array
-                                        items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                          type: object
-                                          required:
-                                            - key
-                                            - operator
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                              type: array
-                                              items:
-                                                type: string
-                                      matchLabels:
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                    x-kubernetes-map-type: atomic
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        type: array
-                                        items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                          type: object
-                                          required:
-                                            - key
-                                            - operator
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                              type: array
-                                              items:
-                                                type: string
-                                      matchLabels:
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                    x-kubernetes-map-type: atomic
-                                  namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                    type: array
-                                    items:
-                                      type: string
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                              weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-                                type: integer
-                                format: int32
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                          type: array
-                          items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
-                            type: object
-                            required:
-                              - topologyKey
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources, in this case pods.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    type: array
-                                    items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                        - key
-                                        - operator
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchLabels:
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                                x-kubernetes-map-type: atomic
-                              namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    type: array
-                                    items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                        - key
-                                        - operator
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchLabels:
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                                x-kubernetes-map-type: atomic
-                              namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                type: array
-                                items:
-                                  type: string
-                              topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                 type: string
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-                      type: object
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
-                          type: array
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                            type: object
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
-                                type: object
-                                required:
-                                  - topologyKey
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        type: array
-                                        items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                          type: object
-                                          required:
-                                            - key
-                                            - operator
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
                                               type: string
-                                            operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                              type: array
-                                              items:
-                                                type: string
-                                      matchLabels:
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
                                         type: object
-                                        additionalProperties:
-                                          type: string
-                                    x-kubernetes-map-type: atomic
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
-                                    type: object
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        type: array
-                                        items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                          type: object
-                                          required:
-                                            - key
-                                            - operator
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
                                               type: string
-                                            operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                              type: array
-                                              items:
-                                                type: string
-                                      matchLabels:
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
                                         type: object
-                                        additionalProperties:
-                                          type: string
-                                    x-kubernetes-map-type: atomic
-                                  namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                    type: array
-                                    items:
-                                      type: string
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
                                     type: string
-                              weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-                                type: integer
-                                format: int32
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                          type: array
-                          items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
-                            type: object
-                            required:
-                              - topologyKey
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources, in this case pods.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    type: array
-                                    items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                        - key
-                                        - operator
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchLabels:
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                                x-kubernetes-map-type: atomic
-                              namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
-                                type: object
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    type: array
-                                    items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      type: object
-                                      required:
-                                        - key
-                                        - operator
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                          type: array
-                                          items:
-                                            type: string
-                                  matchLabels:
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                    additionalProperties:
-                                      type: string
-                                x-kubernetes-map-type: atomic
-                              namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
-                                type: array
-                                items:
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
                                   type: string
-                              topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
                                 type: string
-                failedJobsHistoryLimit:
-                  description: failedJobsHistoryLimit specifies how many failed image pruner jobs to retain. Defaults to 3 if not set.
-                  type: integer
-                  format: int32
-                ignoreInvalidImageReferences:
-                  description: ignoreInvalidImageReferences indicates whether the pruner can ignore errors while parsing image references.
-                  type: boolean
-                keepTagRevisions:
-                  description: keepTagRevisions specifies the number of image revisions for a tag in an image stream that will be preserved. Defaults to 3.
-                  type: integer
-                keepYoungerThan:
-                  description: 'keepYoungerThan specifies the minimum age in nanoseconds of an image and its referrers for it to be considered a candidate for pruning. DEPRECATED: This field is deprecated in favor of keepYoungerThanDuration. If both are set, this field is ignored and keepYoungerThanDuration takes precedence.'
-                  type: integer
-                  format: int64
-                keepYoungerThanDuration:
-                  description: keepYoungerThanDuration specifies the minimum age of an image and its referrers for it to be considered a candidate for pruning. Defaults to 60m (60 minutes).
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              failedJobsHistoryLimit:
+                description: failedJobsHistoryLimit specifies how many failed image
+                  pruner jobs to retain. Defaults to 3 if not set.
+                format: int32
+                type: integer
+              ignoreInvalidImageReferences:
+                description: ignoreInvalidImageReferences indicates whether the pruner
+                  can ignore errors while parsing image references.
+                type: boolean
+              keepTagRevisions:
+                description: keepTagRevisions specifies the number of image revisions
+                  for a tag in an image stream that will be preserved. Defaults to
+                  3.
+                type: integer
+              keepYoungerThan:
+                description: 'keepYoungerThan specifies the minimum age in nanoseconds
+                  of an image and its referrers for it to be considered a candidate
+                  for pruning. DEPRECATED: This field is deprecated in favor of keepYoungerThanDuration.
+                  If both are set, this field is ignored and keepYoungerThanDuration
+                  takes precedence.'
+                format: int64
+                type: integer
+              keepYoungerThanDuration:
+                description: keepYoungerThanDuration specifies the minimum age of
+                  an image and its referrers for it to be considered a candidate for
+                  pruning. Defaults to 60m (60 minutes).
+                format: duration
+                type: string
+              logLevel:
+                default: Normal
+                description: "logLevel sets the level of log output for the pruner
+                  job. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\".
+                  Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              nodeSelector:
+                additionalProperties:
                   type: string
-                  format: duration
-                logLevel:
-                  description: "logLevel sets the level of log output for the pruner job. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                nodeSelector:
-                  description: nodeSelector defines the node selection constraints for the image pruner pod.
-                  type: object
-                  additionalProperties:
-                    type: string
-                resources:
-                  description: resources defines the resource requests and limits for the image pruner pod.
-                  type: object
+                description: nodeSelector defines the node selection constraints for
+                  the image pruner pod.
+                type: object
+              resources:
+                description: resources defines the resource requests and limits for
+                  the image pruner pod.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              schedule:
+                description: 'schedule specifies when to execute the job using standard
+                  cronjob syntax: https://wikipedia.org/wiki/Cron. Defaults to `0
+                  0 * * *`.'
+                type: string
+              successfulJobsHistoryLimit:
+                description: successfulJobsHistoryLimit specifies how many successful
+                  image pruner jobs to retain. Defaults to 3 if not set.
+                format: int32
+                type: integer
+              suspend:
+                description: suspend specifies whether or not to suspend subsequent
+                  executions of this cronjob. Defaults to false.
+                type: boolean
+              tolerations:
+                description: tolerations defines the node tolerations for the image
+                  pruner pod.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
                   properties:
-                    limits:
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                      type: object
-                      additionalProperties:
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        x-kubernetes-int-or-string: true
-                    requests:
-                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                      type: object
-                      additionalProperties:
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        x-kubernetes-int-or-string: true
-                schedule:
-                  description: 'schedule specifies when to execute the job using standard cronjob syntax: https://wikipedia.org/wiki/Cron. Defaults to `0 0 * * *`.'
-                  type: string
-                successfulJobsHistoryLimit:
-                  description: successfulJobsHistoryLimit specifies how many successful image pruner jobs to retain. Defaults to 3 if not set.
-                  type: integer
-                  format: int32
-                suspend:
-                  description: suspend specifies whether or not to suspend subsequent executions of this cronjob. Defaults to false.
-                  type: boolean
-                tolerations:
-                  description: tolerations defines the node tolerations for the image pruner pod.
-                  type: array
-                  items:
-                    description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
-                    type: object
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-                        type: integer
-                        format: int64
-                      value:
-                        description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-                        type: string
-            status:
-              description: ImagePrunerStatus reports image pruner operational status.
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status.
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                observedGeneration:
-                  description: observedGeneration is the last generation change that has been applied.
-                  type: integer
-                  format: int64
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: ImagePrunerStatus reports image pruner operational status.
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status.
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change that
+                  has been applied.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -2,9 +2,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1112
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1112
   creationTimestamp: null
   name: controlplanemachinesets.machine.openshift.io
 spec:
@@ -16,476 +16,727 @@ spec:
     singular: controlplanemachineset
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: Desired Replicas
-          jsonPath: .spec.replicas
-          name: Desired
-          type: integer
-        - description: Current Replicas
-          jsonPath: .status.replicas
-          name: Current
-          type: integer
-        - description: Ready Replicas
-          jsonPath: .status.readyReplicas
-          name: Ready
-          type: integer
-        - description: Updated Replicas
-          jsonPath: .status.updatedReplicas
-          name: Updated
-          type: integer
-        - description: Observed number of unavailable replicas
-          jsonPath: .status.unavailableReplicas
-          name: Unavailable
-          type: integer
-        - description: ControlPlaneMachineSet age
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: 'ControlPlaneMachineSet ensures that a specified number of control plane machine replicas are running at any given time. Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).'
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ControlPlaneMachineSet represents the configuration of the ControlPlaneMachineSet.
-              type: object
-              required:
-                - replicas
-                - selector
-                - template
-              properties:
-                replicas:
-                  description: Replicas defines how many Control Plane Machines should be created by this ControlPlaneMachineSet. This field is immutable and cannot be changed after cluster installation. The ControlPlaneMachineSet only operates with 3 or 5 node control planes, 3 and 5 are the only valid values for this field.
-                  type: integer
-                  format: int32
-                  default: 3
-                  enum:
-                    - 3
-                    - 5
-                selector:
-                  description: Label selector for Machines. Existing Machines selected by this selector will be the ones affected by this ControlPlaneMachineSet. It must match the template's labels. This field is considered immutable after creation of the resource.
-                  type: object
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                      type: array
-                      items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                        type: object
-                        required:
-                          - key
-                          - operator
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                            type: array
-                            items:
-                              type: string
-                    matchLabels:
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                      additionalProperties:
-                        type: string
-                  x-kubernetes-map-type: atomic
-                strategy:
-                  description: Strategy defines how the ControlPlaneMachineSet will update Machines when it detects a change to the ProviderSpec.
-                  type: object
-                  default:
-                    type: RollingUpdate
-                  properties:
-                    type:
-                      description: Type defines the type of update strategy that should be used when updating Machines owned by the ControlPlaneMachineSet. Valid values are "RollingUpdate" and "OnDelete". The current default value is "RollingUpdate".
-                      type: string
-                      default: RollingUpdate
-                      enum:
-                        - RollingUpdate
-                        - OnDelete
-                template:
-                  description: Template describes the Control Plane Machines that will be created by this ControlPlaneMachineSet.
-                  type: object
-                  required:
-                    - machineType
-                    - machines_v1beta1_machine_openshift_io
-                  properties:
-                    machineType:
-                      description: MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet. Currently, the only valid value is machines_v1beta1_machine_openshift_io.
-                      type: string
-                      enum:
-                        - machines_v1beta1_machine_openshift_io
-                    machines_v1beta1_machine_openshift_io:
-                      description: OpenShiftMachineV1Beta1Machine defines the template for creating Machines from the v1beta1.machine.openshift.io API group.
-                      type: object
-                      required:
-                        - metadata
-                        - spec
+  - additionalPrinterColumns:
+    - description: Desired Replicas
+      jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - description: Current Replicas
+      jsonPath: .status.replicas
+      name: Current
+      type: integer
+    - description: Ready Replicas
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Updated Replicas
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Observed number of unavailable replicas
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: ControlPlaneMachineSet age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: 'ControlPlaneMachineSet ensures that a specified number of control
+          plane machine replicas are running at any given time. Compatibility level
+          1: Stable within a major release for a minimum of 12 months or 3 minor releases
+          (whichever is longer).'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ControlPlaneMachineSet represents the configuration of the
+              ControlPlaneMachineSet.
+            properties:
+              replicas:
+                default: 3
+                description: Replicas defines how many Control Plane Machines should
+                  be created by this ControlPlaneMachineSet. This field is immutable
+                  and cannot be changed after cluster installation. The ControlPlaneMachineSet
+                  only operates with 3 or 5 node control planes, 3 and 5 are the only
+                  valid values for this field.
+                enum:
+                - 3
+                - 5
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for Machines. Existing Machines selected
+                  by this selector will be the ones affected by this ControlPlaneMachineSet.
+                  It must match the template's labels. This field is considered immutable
+                  after creation of the resource.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
-                        failureDomains:
-                          description: FailureDomains is the list of failure domains (sometimes called availability zones) in which the ControlPlaneMachineSet should balance the Control Plane Machines. This will be merged into the ProviderSpec given in the template. This field is optional on platforms that do not require placement information.
-                          type: object
-                          required:
-                            - platform
-                          properties:
-                            aws:
-                              description: AWS configures failure domain information for the AWS platform.
-                              type: array
-                              items:
-                                description: AWSFailureDomain configures failure domain information for the AWS platform.
-                                type: object
-                                minProperties: 1
-                                properties:
-                                  placement:
-                                    description: Placement configures the placement information for this instance.
-                                    type: object
-                                    required:
-                                      - availabilityZone
-                                    properties:
-                                      availabilityZone:
-                                        description: AvailabilityZone is the availability zone of the instance.
-                                        type: string
-                                  subnet:
-                                    description: Subnet is a reference to the subnet to use for this instance.
-                                    type: object
-                                    required:
-                                      - type
-                                    properties:
-                                      arn:
-                                        description: ARN of resource.
-                                        type: string
-                                      filters:
-                                        description: Filters is a set of filters used to identify a resource.
-                                        type: array
-                                        items:
-                                          description: AWSResourceFilter is a filter used to identify an AWS resource
-                                          type: object
-                                          required:
-                                            - name
-                                          properties:
-                                            name:
-                                              description: Name of the filter. Filter names are case-sensitive.
-                                              type: string
-                                            values:
-                                              description: Values includes one or more filter values. Filter values are case-sensitive.
-                                              type: array
-                                              items:
-                                                type: string
-                                      id:
-                                        description: ID of resource.
-                                        type: string
-                                      type:
-                                        description: Type determines how the reference will fetch the AWS resource.
-                                        type: string
-                                        enum:
-                                          - ID
-                                          - ARN
-                                          - Filters
-                            azure:
-                              description: Azure configures failure domain information for the Azure platform.
-                              type: array
-                              items:
-                                description: AzureFailureDomain configures failure domain information for the Azure platform.
-                                type: object
-                                required:
-                                  - zone
-                                properties:
-                                  zone:
-                                    description: Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone.
-                                    type: string
-                            gcp:
-                              description: GCP configures failure domain information for the GCP platform.
-                              type: array
-                              items:
-                                description: GCPFailureDomain configures failure domain information for the GCP platform
-                                type: object
-                                required:
-                                  - zone
-                                properties:
-                                  zone:
-                                    description: Zone is the zone in which the GCP machine provider will create the VM.
-                                    type: string
-                            openstack:
-                              description: OpenStack configures failure domain information for the OpenStack platform.
-                              type: array
-                              items:
-                                description: OpenStackFailureDomain configures failure domain information for the OpenStack platform
-                                type: object
-                                required:
-                                  - availabilityZone
-                                properties:
-                                  availabilityZone:
-                                    description: The availability zone from which to launch the server.
-                                    type: string
-                            platform:
-                              description: Platform identifies the platform for which the FailureDomain represents. Currently supported values are AWS, Azure, GCP and OpenStack.
-                              type: string
-                              enum:
-                                - ""
-                                - AWS
-                                - Azure
-                                - BareMetal
-                                - GCP
-                                - Libvirt
-                                - OpenStack
-                                - None
-                                - VSphere
-                                - oVirt
-                                - IBMCloud
-                                - KubeVirt
-                                - EquinixMetal
-                                - PowerVS
-                                - AlibabaCloud
-                                - Nutanix
-                        metadata:
-                          description: 'ObjectMeta is the standard object metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata Labels are required to match the ControlPlaneMachineSet selector.'
-                          type: object
-                          properties:
-                            annotations:
-                              description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-                              type: object
-                              additionalProperties:
-                                type: string
-                            labels:
-                              description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
-                              type: object
-                              additionalProperties:
-                                type: string
-                        spec:
-                          description: Spec contains the desired configuration of the Control Plane Machines. The ProviderSpec within contains platform specific details for creating the Control Plane Machines. The ProviderSe should be complete apart from the platform specific failure domain field. This will be overriden when the Machines are created based on the FailureDomains field.
-                          type: object
-                          properties:
-                            lifecycleHooks:
-                              description: LifecycleHooks allow users to pause operations on the machine at certain predefined points within the machine lifecycle.
-                              type: object
-                              properties:
-                                preDrain:
-                                  description: PreDrain hooks prevent the machine from being drained. This also blocks further lifecycle events, such as termination.
-                                  type: array
-                                  items:
-                                    description: LifecycleHook represents a single instance of a lifecycle hook
-                                    type: object
-                                    required:
-                                      - name
-                                      - owner
-                                    properties:
-                                      name:
-                                        description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
-                                        type: string
-                                        maxLength: 256
-                                        minLength: 3
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                      owner:
-                                        description: Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.
-                                        type: string
-                                        maxLength: 512
-                                        minLength: 3
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                                preTerminate:
-                                  description: PreTerminate hooks prevent the machine from being terminated. PreTerminate hooks be actioned after the Machine has been drained.
-                                  type: array
-                                  items:
-                                    description: LifecycleHook represents a single instance of a lifecycle hook
-                                    type: object
-                                    required:
-                                      - name
-                                      - owner
-                                    properties:
-                                      name:
-                                        description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
-                                        type: string
-                                        maxLength: 256
-                                        minLength: 3
-                                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                      owner:
-                                        description: Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.
-                                        type: string
-                                        maxLength: 512
-                                        minLength: 3
-                                  x-kubernetes-list-map-keys:
-                                    - name
-                                  x-kubernetes-list-type: map
-                            metadata:
-                              description: ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.
-                              type: object
-                              properties:
-                                annotations:
-                                  description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                generateName:
-                                  description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
-                                  type: string
-                                labels:
-                                  description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                name:
-                                  description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                  type: string
-                                namespace:
-                                  description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces"
-                                  type: string
-                                ownerReferences:
-                                  description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
-                                  type: array
-                                  items:
-                                    description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
-                                    type: object
-                                    required:
-                                      - apiVersion
-                                      - kind
-                                      - name
-                                      - uid
-                                    properties:
-                                      apiVersion:
-                                        description: API version of the referent.
-                                        type: string
-                                      blockOwnerDeletion:
-                                        description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
-                                        type: boolean
-                                      controller:
-                                        description: If true, this reference points to the managing controller.
-                                        type: boolean
-                                      kind:
-                                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                        type: string
-                                      uid:
-                                        description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
-                                        type: string
-                                    x-kubernetes-map-type: atomic
-                            providerID:
-                              description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
-                              type: string
-                            providerSpec:
-                              description: ProviderSpec details Provider-specific configuration to use during node creation.
-                              type: object
-                              properties:
-                                value:
-                                  description: Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.
-                                  type: object
-                                  x-kubernetes-preserve-unknown-fields: true
-                            taints:
-                              description: The list of the taints to be applied to the corresponding Node in additive manner. This list will not overwrite any other taints added to the Node on an ongoing basis by other entities. These taints should be actively reconciled e.g. if you ask the machine controller to apply a taint and then manually remove the taint the machine controller will put it back) but not have the machine controller remove any taints
-                              type: array
-                              items:
-                                description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
-                                type: object
-                                required:
-                                  - effect
-                                  - key
-                                properties:
-                                  effect:
-                                    description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                                    type: string
-                                  key:
-                                    description: Required. The taint key to be applied to a node.
-                                    type: string
-                                  timeAdded:
-                                    description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
-                                    type: string
-                                    format: date-time
-                                  value:
-                                    description: The taint value corresponding to the taint key.
-                                    type: string
-            status:
-              description: ControlPlaneMachineSetStatus represents the status of the ControlPlaneMachineSet CRD.
-              type: object
-              properties:
-                conditions:
-                  description: 'Conditions represents the observations of the ControlPlaneMachineSet''s current state. Known .status.conditions.type are: Available, Degraded and Progressing.'
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
                     type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                default:
+                  type: RollingUpdate
+                description: Strategy defines how the ControlPlaneMachineSet will
+                  update Machines when it detects a change to the ProviderSpec.
+                properties:
+                  type:
+                    default: RollingUpdate
+                    description: Type defines the type of update strategy that should
+                      be used when updating Machines owned by the ControlPlaneMachineSet.
+                      Valid values are "RollingUpdate" and "OnDelete". The current
+                      default value is "RollingUpdate".
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: Template describes the Control Plane Machines that will
+                  be created by this ControlPlaneMachineSet.
+                properties:
+                  machineType:
+                    description: MachineType determines the type of Machines that
+                      should be managed by the ControlPlaneMachineSet. Currently,
+                      the only valid value is machines_v1beta1_machine_openshift_io.
+                    enum:
+                    - machines_v1beta1_machine_openshift_io
+                    type: string
+                  machines_v1beta1_machine_openshift_io:
+                    description: OpenShiftMachineV1Beta1Machine defines the template
+                      for creating Machines from the v1beta1.machine.openshift.io
+                      API group.
                     properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed for this ControlPlaneMachineSet. It corresponds to the ControlPlaneMachineSets's generation, which is updated on mutation by the API Server.
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: ReadyReplicas is the number of Control Plane Machines created by the ControlPlaneMachineSet controller which are ready. Note that this value may be higher than the desired number of replicas while rolling updates are in-progress.
-                  type: integer
-                  format: int32
-                replicas:
-                  description: Replicas is the number of Control Plane Machines created by the ControlPlaneMachineSet controller. Note that during update operations this value may differ from the desired replica count.
-                  type: integer
-                  format: int32
-                unavailableReplicas:
-                  description: UnavailableReplicas is the number of Control Plane Machines that are still required before the ControlPlaneMachineSet reaches the desired available capacity. When this value is non-zero, the number of ReadyReplicas is less than the desired Replicas.
-                  type: integer
-                  format: int32
-                updatedReplicas:
-                  description: UpdatedReplicas is the number of non-terminated Control Plane Machines created by the ControlPlaneMachineSet controller that have the desired provider spec and are ready. This value is set to 0 when a change is detected to the desired spec. When the update strategy is RollingUpdate, this will also coincide with starting the process of updating the Machines. When the update strategy is OnDelete, this value will remain at 0 until a user deletes an existing replica and its replacement has become ready.
-                  type: integer
-                  format: int32
-      served: true
-      storage: true
-      subresources:
-        scale:
-          labelSelectorPath: .status.labelSelector
-          specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.replicas
-        status: {}
+                      failureDomains:
+                        description: FailureDomains is the list of failure domains
+                          (sometimes called availability zones) in which the ControlPlaneMachineSet
+                          should balance the Control Plane Machines. This will be
+                          merged into the ProviderSpec given in the template. This
+                          field is optional on platforms that do not require placement
+                          information.
+                        properties:
+                          aws:
+                            description: AWS configures failure domain information
+                              for the AWS platform.
+                            items:
+                              description: AWSFailureDomain configures failure domain
+                                information for the AWS platform.
+                              minProperties: 1
+                              properties:
+                                placement:
+                                  description: Placement configures the placement
+                                    information for this instance.
+                                  properties:
+                                    availabilityZone:
+                                      description: AvailabilityZone is the availability
+                                        zone of the instance.
+                                      type: string
+                                  required:
+                                  - availabilityZone
+                                  type: object
+                                subnet:
+                                  description: Subnet is a reference to the subnet
+                                    to use for this instance.
+                                  properties:
+                                    arn:
+                                      description: ARN of resource.
+                                      type: string
+                                    filters:
+                                      description: Filters is a set of filters used
+                                        to identify a resource.
+                                      items:
+                                        description: AWSResourceFilter is a filter
+                                          used to identify an AWS resource
+                                        properties:
+                                          name:
+                                            description: Name of the filter. Filter
+                                              names are case-sensitive.
+                                            type: string
+                                          values:
+                                            description: Values includes one or more
+                                              filter values. Filter values are case-sensitive.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    id:
+                                      description: ID of resource.
+                                      type: string
+                                    type:
+                                      description: Type determines how the reference
+                                        will fetch the AWS resource.
+                                      enum:
+                                      - ID
+                                      - ARN
+                                      - Filters
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                              type: object
+                            type: array
+                          azure:
+                            description: Azure configures failure domain information
+                              for the Azure platform.
+                            items:
+                              description: AzureFailureDomain configures failure domain
+                                information for the Azure platform.
+                              properties:
+                                zone:
+                                  description: Availability Zone for the virtual machine.
+                                    If nil, the virtual machine should be deployed
+                                    to no zone.
+                                  type: string
+                              required:
+                              - zone
+                              type: object
+                            type: array
+                          gcp:
+                            description: GCP configures failure domain information
+                              for the GCP platform.
+                            items:
+                              description: GCPFailureDomain configures failure domain
+                                information for the GCP platform
+                              properties:
+                                zone:
+                                  description: Zone is the zone in which the GCP machine
+                                    provider will create the VM.
+                                  type: string
+                              required:
+                              - zone
+                              type: object
+                            type: array
+                          openstack:
+                            description: OpenStack configures failure domain information
+                              for the OpenStack platform.
+                            items:
+                              description: OpenStackFailureDomain configures failure
+                                domain information for the OpenStack platform
+                              properties:
+                                availabilityZone:
+                                  description: The availability zone from which to
+                                    launch the server.
+                                  type: string
+                              required:
+                              - availabilityZone
+                              type: object
+                            type: array
+                          platform:
+                            description: Platform identifies the platform for which
+                              the FailureDomain represents. Currently supported values
+                              are AWS, Azure, GCP and OpenStack.
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            type: string
+                        required:
+                        - platform
+                        type: object
+                      metadata:
+                        description: 'ObjectMeta is the standard object metadata More
+                          info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                          Labels are required to match the ControlPlaneMachineSet
+                          selector.'
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'Annotations is an unstructured key value
+                              map stored with a resource that may be set by external
+                              tools to store and retrieve arbitrary metadata. They
+                              are not queryable and should be preserved when modifying
+                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Map of string keys and values that can be
+                              used to organize and categorize (scope and select) objects.
+                              May match selectors of replication controllers and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels'
+                            type: object
+                        type: object
+                      spec:
+                        description: Spec contains the desired configuration of the
+                          Control Plane Machines. The ProviderSpec within contains
+                          platform specific details for creating the Control Plane
+                          Machines. The ProviderSe should be complete apart from the
+                          platform specific failure domain field. This will be overriden
+                          when the Machines are created based on the FailureDomains
+                          field.
+                        properties:
+                          lifecycleHooks:
+                            description: LifecycleHooks allow users to pause operations
+                              on the machine at certain predefined points within the
+                              machine lifecycle.
+                            properties:
+                              preDrain:
+                                description: PreDrain hooks prevent the machine from
+                                  being drained. This also blocks further lifecycle
+                                  events, such as termination.
+                                items:
+                                  description: LifecycleHook represents a single instance
+                                    of a lifecycle hook
+                                  properties:
+                                    name:
+                                      description: Name defines a unique name for
+                                        the lifcycle hook. The name should be unique
+                                        and descriptive, ideally 1-3 words, in CamelCase
+                                        or it may be namespaced, eg. foo.example.com/CamelCase.
+                                        Names must be unique and should only be managed
+                                        by a single entity.
+                                      maxLength: 256
+                                      minLength: 3
+                                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                      type: string
+                                    owner:
+                                      description: Owner defines the owner of the
+                                        lifecycle hook. This should be descriptive
+                                        enough so that users can identify who/what
+                                        is responsible for blocking the lifecycle.
+                                        This could be the name of a controller (e.g.
+                                        clusteroperator/etcd) or an administrator
+                                        managing the hook.
+                                      maxLength: 512
+                                      minLength: 3
+                                      type: string
+                                  required:
+                                  - name
+                                  - owner
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              preTerminate:
+                                description: PreTerminate hooks prevent the machine
+                                  from being terminated. PreTerminate hooks be actioned
+                                  after the Machine has been drained.
+                                items:
+                                  description: LifecycleHook represents a single instance
+                                    of a lifecycle hook
+                                  properties:
+                                    name:
+                                      description: Name defines a unique name for
+                                        the lifcycle hook. The name should be unique
+                                        and descriptive, ideally 1-3 words, in CamelCase
+                                        or it may be namespaced, eg. foo.example.com/CamelCase.
+                                        Names must be unique and should only be managed
+                                        by a single entity.
+                                      maxLength: 256
+                                      minLength: 3
+                                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                      type: string
+                                    owner:
+                                      description: Owner defines the owner of the
+                                        lifecycle hook. This should be descriptive
+                                        enough so that users can identify who/what
+                                        is responsible for blocking the lifecycle.
+                                        This could be the name of a controller (e.g.
+                                        clusteroperator/etcd) or an administrator
+                                        managing the hook.
+                                      maxLength: 512
+                                      minLength: 3
+                                      type: string
+                                  required:
+                                  - name
+                                  - owner
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          metadata:
+                            description: ObjectMeta will autopopulate the Node created.
+                              Use this to indicate what labels, annotations, name
+                              prefix, etc., should be used when creating the Node.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: 'Annotations is an unstructured key value
+                                  map stored with a resource that may be set by external
+                                  tools to store and retrieve arbitrary metadata.
+                                  They are not queryable and should be preserved when
+                                  modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                              generateName:
+                                description: "GenerateName is an optional prefix,
+                                  used by the server, to generate a unique name ONLY
+                                  IF the Name field has not been provided. If this
+                                  field is used, the name returned to the client will
+                                  be different than the name passed. This value will
+                                  also be combined with a unique suffix. The provided
+                                  value has the same validation rules as the Name
+                                  field, and may be truncated by the length of the
+                                  suffix required to make the value unique on the
+                                  server. \n If this field is specified and the generated
+                                  name exists, the server will NOT return a 409 -
+                                  instead, it will either return 201 Created or 500
+                                  with Reason ServerTimeout indicating a unique name
+                                  could not be found in the time allotted, and the
+                                  client should retry (optionally after the time indicated
+                                  in the Retry-After header). \n Applied only if Name
+                                  is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: 'Map of string keys and values that can
+                                  be used to organize and categorize (scope and select)
+                                  objects. May match selectors of replication controllers
+                                  and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                type: object
+                              name:
+                                description: 'Name must be unique within a namespace.
+                                  Is required when creating resources, although some
+                                  resources may allow a client to request the generation
+                                  of an appropriate name automatically. Name is primarily
+                                  intended for creation idempotence and configuration
+                                  definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                type: string
+                              namespace:
+                                description: "Namespace defines the space within each
+                                  name must be unique. An empty namespace is equivalent
+                                  to the \"default\" namespace, but \"default\" is
+                                  the canonical representation. Not all objects are
+                                  required to be scoped to a namespace - the value
+                                  of this field for those objects will be empty. \n
+                                  Must be a DNS_LABEL. Cannot be updated. More info:
+                                  http://kubernetes.io/docs/user-guide/namespaces"
+                                type: string
+                              ownerReferences:
+                                description: List of objects depended by this object.
+                                  If ALL objects in the list have been deleted, this
+                                  object will be garbage collected. If this object
+                                  is managed by a controller, then an entry in this
+                                  list will point to this controller, with the controller
+                                  field set to true. There cannot be more than one
+                                  managing controller.
+                                items:
+                                  description: OwnerReference contains enough information
+                                    to let you identify an owning object. An owning
+                                    object must be in the same namespace as the dependent,
+                                    or be cluster-scoped, so there is no namespace
+                                    field.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    blockOwnerDeletion:
+                                      description: If true, AND if the owner has the
+                                        "foregroundDeletion" finalizer, then the owner
+                                        cannot be deleted from the key-value store
+                                        until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                        for how the garbage collector interacts with
+                                        this field and enforces the foreground deletion.
+                                        Defaults to false. To set this field, a user
+                                        needs "delete" permission of the owner, otherwise
+                                        422 (Unprocessable Entity) will be returned.
+                                      type: boolean
+                                    controller:
+                                      description: If true, this reference points
+                                        to the managing controller.
+                                      type: boolean
+                                    kind:
+                                      description: 'Kind of the referent. More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        http://kubernetes.io/docs/user-guide/identifiers#names'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info:
+                                        http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                  required:
+                                  - apiVersion
+                                  - kind
+                                  - name
+                                  - uid
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            type: object
+                          providerID:
+                            description: ProviderID is the identification ID of the
+                              machine provided by the provider. This field must match
+                              the provider ID as seen on the node object corresponding
+                              to this machine. This field is required by higher level
+                              consumers of cluster-api. Example use case is cluster
+                              autoscaler with cluster-api as provider. Clean-up logic
+                              in the autoscaler compares machines to nodes to find
+                              out machines at provider which could not get registered
+                              as Kubernetes nodes. With cluster-api as a generic out-of-tree
+                              provider for autoscaler, this field is required by autoscaler
+                              to be able to have a provider view of the list of machines.
+                              Another list of nodes is queried from the k8s apiserver
+                              and then a comparison is done to find out unregistered
+                              machines and are marked for delete. This field will
+                              be set by the actuators and consumed by higher level
+                              entities like autoscaler that will be interfacing with
+                              cluster-api as generic provider.
+                            type: string
+                          providerSpec:
+                            description: ProviderSpec details Provider-specific configuration
+                              to use during node creation.
+                            properties:
+                              value:
+                                description: Value is an inlined, serialized representation
+                                  of the resource configuration. It is recommended
+                                  that providers maintain their own versioned API
+                                  types that should be serialized/deserialized from
+                                  this field, akin to component config.
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                            type: object
+                          taints:
+                            description: The list of the taints to be applied to the
+                              corresponding Node in additive manner. This list will
+                              not overwrite any other taints added to the Node on
+                              an ongoing basis by other entities. These taints should
+                              be actively reconciled e.g. if you ask the machine controller
+                              to apply a taint and then manually remove the taint
+                              the machine controller will put it back) but not have
+                              the machine controller remove any taints
+                            items:
+                              description: The node this Taint is attached to has
+                                the "effect" on any pod that does not tolerate the
+                                Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on
+                                    pods that do not tolerate the taint. Valid effects
+                                    are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which
+                                    the taint was added. It is only written for NoExecute
+                                    taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    required:
+                    - metadata
+                    - spec
+                    type: object
+                required:
+                - machineType
+                - machines_v1beta1_machine_openshift_io
+                type: object
+            required:
+            - replicas
+            - selector
+            - template
+            type: object
+          status:
+            description: ControlPlaneMachineSetStatus represents the status of the
+              ControlPlaneMachineSet CRD.
+            properties:
+              conditions:
+                description: 'Conditions represents the observations of the ControlPlaneMachineSet''s
+                  current state. Known .status.conditions.type are: Available, Degraded
+                  and Progressing.'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this ControlPlaneMachineSet. It corresponds to the ControlPlaneMachineSets's
+                  generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: ReadyReplicas is the number of Control Plane Machines
+                  created by the ControlPlaneMachineSet controller which are ready.
+                  Note that this value may be higher than the desired number of replicas
+                  while rolling updates are in-progress.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the number of Control Plane Machines created
+                  by the ControlPlaneMachineSet controller. Note that during update
+                  operations this value may differ from the desired replica count.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: UnavailableReplicas is the number of Control Plane Machines
+                  that are still required before the ControlPlaneMachineSet reaches
+                  the desired available capacity. When this value is non-zero, the
+                  number of ReadyReplicas is less than the desired Replicas.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: UpdatedReplicas is the number of non-terminated Control
+                  Plane Machines created by the ControlPlaneMachineSet controller
+                  that have the desired provider spec and are ready. This value is
+                  set to 0 when a change is detected to the desired spec. When the
+                  update strategy is RollingUpdate, this will also coincide with starting
+                  the process of updating the Machines. When the update strategy is
+                  OnDelete, this value will remain at 0 until a user deletes an existing
+                  replica and its replacement has become ready.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.labelSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/machine/v1beta1/0000_10_machine.crd.yaml
+++ b/machine/v1beta1/0000_10_machine.crd.yaml
@@ -2,10 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/948
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    api-approved.openshift.io: https://github.com/openshift/api/pull/948
   name: machines.machine.openshift.io
 spec:
   group: machine.openshift.io
@@ -16,310 +16,473 @@ spec:
     singular: machine
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: Phase of machine
-          jsonPath: .status.phase
-          name: Phase
-          type: string
-        - description: Type of instance
-          jsonPath: .metadata.labels['machine\.openshift\.io/instance-type']
-          name: Type
-          type: string
-        - description: Region associated with machine
-          jsonPath: .metadata.labels['machine\.openshift\.io/region']
-          name: Region
-          type: string
-        - description: Zone associated with machine
-          jsonPath: .metadata.labels['machine\.openshift\.io/zone']
-          name: Zone
-          type: string
-        - description: Machine age
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-        - description: Node associated with machine
-          jsonPath: .status.nodeRef.name
-          name: Node
-          priority: 1
-          type: string
-        - description: Provider ID of machine created in cloud provider
-          jsonPath: .spec.providerID
-          name: ProviderID
-          priority: 1
-          type: string
-        - description: State of instance
-          jsonPath: .metadata.annotations['machine\.openshift\.io/instance-state']
-          name: State
-          priority: 1
-          type: string
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: 'Machine is the Schema for the machines API Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).'
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: MachineSpec defines the desired state of Machine
-              type: object
-              properties:
-                lifecycleHooks:
-                  description: LifecycleHooks allow users to pause operations on the machine at certain predefined points within the machine lifecycle.
-                  type: object
-                  properties:
-                    preDrain:
-                      description: PreDrain hooks prevent the machine from being drained. This also blocks further lifecycle events, such as termination.
-                      type: array
-                      items:
-                        description: LifecycleHook represents a single instance of a lifecycle hook
-                        type: object
-                        required:
-                          - name
-                          - owner
-                        properties:
-                          name:
-                            description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
-                            type: string
-                            maxLength: 256
-                            minLength: 3
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                          owner:
-                            description: Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.
-                            type: string
-                            maxLength: 512
-                            minLength: 3
-                      x-kubernetes-list-map-keys:
-                        - name
-                      x-kubernetes-list-type: map
-                    preTerminate:
-                      description: PreTerminate hooks prevent the machine from being terminated. PreTerminate hooks be actioned after the Machine has been drained.
-                      type: array
-                      items:
-                        description: LifecycleHook represents a single instance of a lifecycle hook
-                        type: object
-                        required:
-                          - name
-                          - owner
-                        properties:
-                          name:
-                            description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
-                            type: string
-                            maxLength: 256
-                            minLength: 3
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                          owner:
-                            description: Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.
-                            type: string
-                            maxLength: 512
-                            minLength: 3
-                      x-kubernetes-list-map-keys:
-                        - name
-                      x-kubernetes-list-type: map
-                metadata:
-                  description: ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.
-                  type: object
-                  properties:
-                    annotations:
-                      description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+  - additionalPrinterColumns:
+    - description: Phase of machine
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Type of instance
+      jsonPath: .metadata.labels['machine\.openshift\.io/instance-type']
+      name: Type
+      type: string
+    - description: Region associated with machine
+      jsonPath: .metadata.labels['machine\.openshift\.io/region']
+      name: Region
+      type: string
+    - description: Zone associated with machine
+      jsonPath: .metadata.labels['machine\.openshift\.io/zone']
+      name: Zone
+      type: string
+    - description: Machine age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Node associated with machine
+      jsonPath: .status.nodeRef.name
+      name: Node
+      priority: 1
+      type: string
+    - description: Provider ID of machine created in cloud provider
+      jsonPath: .spec.providerID
+      name: ProviderID
+      priority: 1
+      type: string
+    - description: State of instance
+      jsonPath: .metadata.annotations['machine\.openshift\.io/instance-state']
+      name: State
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: 'Machine is the Schema for the machines API Compatibility level
+          2: Stable within a major release for a minimum of 9 months or 3 minor releases
+          (whichever is longer).'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine
+            properties:
+              lifecycleHooks:
+                description: LifecycleHooks allow users to pause operations on the
+                  machine at certain predefined points within the machine lifecycle.
+                properties:
+                  preDrain:
+                    description: PreDrain hooks prevent the machine from being drained.
+                      This also blocks further lifecycle events, such as termination.
+                    items:
+                      description: LifecycleHook represents a single instance of a
+                        lifecycle hook
+                      properties:
+                        name:
+                          description: Name defines a unique name for the lifcycle
+                            hook. The name should be unique and descriptive, ideally
+                            1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase.
+                            Names must be unique and should only be managed by a single
+                            entity.
+                          maxLength: 256
+                          minLength: 3
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                        owner:
+                          description: Owner defines the owner of the lifecycle hook.
+                            This should be descriptive enough so that users can identify
+                            who/what is responsible for blocking the lifecycle. This
+                            could be the name of a controller (e.g. clusteroperator/etcd)
+                            or an administrator managing the hook.
+                          maxLength: 512
+                          minLength: 3
+                          type: string
+                      required:
+                      - name
+                      - owner
                       type: object
-                      additionalProperties:
-                        type: string
-                    generateName:
-                      description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
-                      type: string
-                    labels:
-                      description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  preTerminate:
+                    description: PreTerminate hooks prevent the machine from being
+                      terminated. PreTerminate hooks be actioned after the Machine
+                      has been drained.
+                    items:
+                      description: LifecycleHook represents a single instance of a
+                        lifecycle hook
+                      properties:
+                        name:
+                          description: Name defines a unique name for the lifcycle
+                            hook. The name should be unique and descriptive, ideally
+                            1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase.
+                            Names must be unique and should only be managed by a single
+                            entity.
+                          maxLength: 256
+                          minLength: 3
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                        owner:
+                          description: Owner defines the owner of the lifecycle hook.
+                            This should be descriptive enough so that users can identify
+                            who/what is responsible for blocking the lifecycle. This
+                            could be the name of a controller (e.g. clusteroperator/etcd)
+                            or an administrator managing the hook.
+                          maxLength: 512
+                          minLength: 3
+                          type: string
+                      required:
+                      - name
+                      - owner
                       type: object
-                      additionalProperties:
-                        type: string
-                    name:
-                      description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                type: object
+              metadata:
+                description: ObjectMeta will autopopulate the Node created. Use this
+                  to indicate what labels, annotations, name prefix, etc., should
+                  be used when creating the Node.
+                properties:
+                  annotations:
+                    additionalProperties:
                       type: string
-                    namespace:
-                      description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces"
+                    description: 'Annotations is an unstructured key value map stored
+                      with a resource that may be set by external tools to store and
+                      retrieve arbitrary metadata. They are not queryable and should
+                      be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                    type: object
+                  generateName:
+                    description: "GenerateName is an optional prefix, used by the
+                      server, to generate a unique name ONLY IF the Name field has
+                      not been provided. If this field is used, the name returned
+                      to the client will be different than the name passed. This value
+                      will also be combined with a unique suffix. The provided value
+                      has the same validation rules as the Name field, and may be
+                      truncated by the length of the suffix required to make the value
+                      unique on the server. \n If this field is specified and the
+                      generated name exists, the server will NOT return a 409 - instead,
+                      it will either return 201 Created or 500 with Reason ServerTimeout
+                      indicating a unique name could not be found in the time allotted,
+                      and the client should retry (optionally after the time indicated
+                      in the Retry-After header). \n Applied only if Name is not specified.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
+                    type: string
+                  labels:
+                    additionalProperties:
                       type: string
-                    ownerReferences:
-                      description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
-                      type: array
-                      items:
-                        description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
-                        type: object
-                        required:
-                          - apiVersion
-                          - kind
-                          - name
-                          - uid
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          blockOwnerDeletion:
-                            description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
-                            type: boolean
-                          controller:
-                            description: If true, this reference points to the managing controller.
-                            type: boolean
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
-                            type: string
-                        x-kubernetes-map-type: atomic
-                providerID:
-                  description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
-                  type: string
-                providerSpec:
-                  description: ProviderSpec details Provider-specific configuration to use during node creation.
-                  type: object
-                  properties:
-                    value:
-                      description: Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.
+                    description: 'Map of string keys and values that can be used to
+                      organize and categorize (scope and select) objects. May match
+                      selectors of replication controllers and services. More info:
+                      http://kubernetes.io/docs/user-guide/labels'
+                    type: object
+                  name:
+                    description: 'Name must be unique within a namespace. Is required
+                      when creating resources, although some resources may allow a
+                      client to request the generation of an appropriate name automatically.
+                      Name is primarily intended for creation idempotence and configuration
+                      definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                  namespace:
+                    description: "Namespace defines the space within each name must
+                      be unique. An empty namespace is equivalent to the \"default\"
+                      namespace, but \"default\" is the canonical representation.
+                      Not all objects are required to be scoped to a namespace - the
+                      value of this field for those objects will be empty. \n Must
+                      be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces"
+                    type: string
+                  ownerReferences:
+                    description: List of objects depended by this object. If ALL objects
+                      in the list have been deleted, this object will be garbage collected.
+                      If this object is managed by a controller, then an entry in
+                      this list will point to this controller, with the controller
+                      field set to true. There cannot be more than one managing controller.
+                    items:
+                      description: OwnerReference contains enough information to let
+                        you identify an owning object. An owning object must be in
+                        the same namespace as the dependent, or be cluster-scoped,
+                        so there is no namespace field.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        blockOwnerDeletion:
+                          description: If true, AND if the owner has the "foregroundDeletion"
+                            finalizer, then the owner cannot be deleted from the key-value
+                            store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                            for how the garbage collector interacts with this field
+                            and enforces the foreground deletion. Defaults to false.
+                            To set this field, a user needs "delete" permission of
+                            the owner, otherwise 422 (Unprocessable Entity) will be
+                            returned.
+                          type: boolean
+                        controller:
+                          description: If true, this reference points to the managing
+                            controller.
+                          type: boolean
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
+                      required:
+                      - apiVersion
+                      - kind
+                      - name
+                      - uid
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                taints:
-                  description: The list of the taints to be applied to the corresponding Node in additive manner. This list will not overwrite any other taints added to the Node on an ongoing basis by other entities. These taints should be actively reconciled e.g. if you ask the machine controller to apply a taint and then manually remove the taint the machine controller will put it back) but not have the machine controller remove any taints
-                  type: array
-                  items:
-                    description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+              providerID:
+                description: ProviderID is the identification ID of the machine provided
+                  by the provider. This field must match the provider ID as seen on
+                  the node object corresponding to this machine. This field is required
+                  by higher level consumers of cluster-api. Example use case is cluster
+                  autoscaler with cluster-api as provider. Clean-up logic in the autoscaler
+                  compares machines to nodes to find out machines at provider which
+                  could not get registered as Kubernetes nodes. With cluster-api as
+                  a generic out-of-tree provider for autoscaler, this field is required
+                  by autoscaler to be able to have a provider view of the list of
+                  machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines
+                  and are marked for delete. This field will be set by the actuators
+                  and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                type: string
+              providerSpec:
+                description: ProviderSpec details Provider-specific configuration
+                  to use during node creation.
+                properties:
+                  value:
+                    description: Value is an inlined, serialized representation of
+                      the resource configuration. It is recommended that providers
+                      maintain their own versioned API types that should be serialized/deserialized
+                      from this field, akin to component config.
                     type: object
-                    required:
-                      - effect
-                      - key
-                    properties:
-                      effect:
-                        description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Required. The taint key to be applied to a node.
-                        type: string
-                      timeAdded:
-                        description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
-                        type: string
-                        format: date-time
-                      value:
-                        description: The taint value corresponding to the taint key.
-                        type: string
-            status:
-              description: MachineStatus defines the observed state of Machine
-              type: object
-              properties:
-                addresses:
-                  description: Addresses is a list of addresses assigned to the machine. Queried from cloud provider, if available.
-                  type: array
-                  items:
-                    description: NodeAddress contains information for the node's address.
-                    type: object
-                    required:
-                      - address
-                      - type
-                    properties:
-                      address:
-                        description: The node address.
-                        type: string
-                      type:
-                        description: Node address type, one of Hostname, ExternalIP or InternalIP.
-                        type: string
-                conditions:
-                  description: Conditions defines the current state of the Machine
-                  type: array
-                  items:
-                    description: Condition defines an observation of a Machine API resource operational state.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: A human readable message indicating details about the transition. This field may be empty.
-                        type: string
-                      reason:
-                        description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
-                        type: string
-                      severity:
-                        description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
-                        type: string
-                      status:
-                        description: Status of the condition, one of True, False, Unknown.
-                        type: string
-                      type:
-                        description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
-                        type: string
-                errorMessage:
-                  description: "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
-                  type: string
-                errorReason:
-                  description: "ErrorReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
-                  type: string
-                lastOperation:
-                  description: LastOperation describes the last-operation performed by the machine-controller. This API should be useful as a history in terms of the latest operation performed on the specific machine. It should also convey the state of the latest-operation for example if it is still on-going, failed or completed successfully.
-                  type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              taints:
+                description: The list of the taints to be applied to the corresponding
+                  Node in additive manner. This list will not overwrite any other
+                  taints added to the Node on an ongoing basis by other entities.
+                  These taints should be actively reconciled e.g. if you ask the machine
+                  controller to apply a taint and then manually remove the taint the
+                  machine controller will put it back) but not have the machine controller
+                  remove any taints
+                items:
+                  description: The node this Taint is attached to has the "effect"
+                    on any pod that does not tolerate the Taint.
                   properties:
-                    description:
-                      description: Description is the human-readable description of the last operation.
+                    effect:
+                      description: Required. The effect of the taint on pods that
+                        do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule
+                        and NoExecute.
                       type: string
-                    lastUpdated:
-                      description: LastUpdated is the timestamp at which LastOperation API was last-updated.
+                    key:
+                      description: Required. The taint key to be applied to a node.
                       type: string
+                    timeAdded:
+                      description: TimeAdded represents the time at which the taint
+                        was added. It is only written for NoExecute taints.
                       format: date-time
-                    state:
-                      description: State is the current status of the last performed operation. E.g. Processing, Failed, Successful etc
+                      type: string
+                    value:
+                      description: The taint value corresponding to the taint key.
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                type: array
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine
+            properties:
+              addresses:
+                description: Addresses is a list of addresses assigned to the machine.
+                  Queried from cloud provider, if available.
+                items:
+                  description: NodeAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The node address.
                       type: string
                     type:
-                      description: Type is the type of operation which was last performed. E.g. Create, Delete, Update etc
+                      description: Node address type, one of Hostname, ExternalIP
+                        or InternalIP.
                       type: string
-                lastUpdated:
-                  description: LastUpdated identifies when this status was last observed.
-                  type: string
-                  format: date-time
-                nodeRef:
-                  description: NodeRef will point to the corresponding Node if it exists.
+                  required:
+                  - address
+                  - type
                   type: object
+                type: array
+              conditions:
+                description: Conditions defines the current state of the Machine
+                items:
+                  description: Condition defines an observation of a Machine API resource
+                    operational state.
                   properties:
-                    apiVersion:
-                      description: API version of the referent.
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another. This should be when the underlying condition changed.
+                        If that is not known, then using the time when the API field
+                        changed is acceptable.
+                      format: date-time
                       type: string
-                    fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    message:
+                      description: A human readable message indicating details about
+                        the transition. This field may be empty.
                       type: string
-                    kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    reason:
+                      description: The reason for the condition's last transition
+                        in CamelCase. The specific API may choose whether or not this
+                        field is considered a guaranteed API. This field may not be
+                        empty.
                       type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    severity:
+                      description: Severity provides an explicit classification of
+                        Reason code, so the users or machines can immediately understand
+                        the current situation and act accordingly. The Severity field
+                        MUST be set only when Status=False.
                       type: string
-                    namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
                       type: string
-                    resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important.
                       type: string
-                    uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                      type: string
-                  x-kubernetes-map-type: atomic
-                phase:
-                  description: 'Phase represents the current phase of machine actuation. One of: Failed, Provisioning, Provisioned, Running, Deleting'
-                  type: string
-                providerStatus:
-                  description: ProviderStatus details a Provider-specific status. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field.
                   type: object
-                  x-kubernetes-preserve-unknown-fields: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              errorMessage:
+                description: "ErrorMessage will be set in the event that there is
+                  a terminal problem reconciling the Machine and will contain a more
+                  verbose string suitable for logging and human consumption. \n This
+                  field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over time (like
+                  service outages), but instead indicate that something is fundamentally
+                  wrong with the Machine's spec or the configuration of the controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the controller, or the responsible controller
+                  itself being critically misconfigured. \n Any transient errors that
+                  occur during the reconciliation of Machines can be added as events
+                  to the Machine object and/or logged in the controller's output."
+                type: string
+              errorReason:
+                description: "ErrorReason will be set in the event that there is a
+                  terminal problem reconciling the Machine and will contain a succinct
+                  value suitable for machine interpretation. \n This field should
+                  not be set for transitive errors that a controller faces that are
+                  expected to be fixed automatically over time (like service outages),
+                  but instead indicate that something is fundamentally wrong with
+                  the Machine's spec or the configuration of the controller, and that
+                  manual intervention is required. Examples of terminal errors would
+                  be invalid combinations of settings in the spec, values that are
+                  unsupported by the controller, or the responsible controller itself
+                  being critically misconfigured. \n Any transient errors that occur
+                  during the reconciliation of Machines can be added as events to
+                  the Machine object and/or logged in the controller's output."
+                type: string
+              lastOperation:
+                description: LastOperation describes the last-operation performed
+                  by the machine-controller. This API should be useful as a history
+                  in terms of the latest operation performed on the specific machine.
+                  It should also convey the state of the latest-operation for example
+                  if it is still on-going, failed or completed successfully.
+                properties:
+                  description:
+                    description: Description is the human-readable description of
+                      the last operation.
+                    type: string
+                  lastUpdated:
+                    description: LastUpdated is the timestamp at which LastOperation
+                      API was last-updated.
+                    format: date-time
+                    type: string
+                  state:
+                    description: State is the current status of the last performed
+                      operation. E.g. Processing, Failed, Successful etc
+                    type: string
+                  type:
+                    description: Type is the type of operation which was last performed.
+                      E.g. Create, Delete, Update etc
+                    type: string
+                type: object
+              lastUpdated:
+                description: LastUpdated identifies when this status was last observed.
+                format: date-time
+                type: string
+              nodeRef:
+                description: NodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              phase:
+                description: 'Phase represents the current phase of machine actuation.
+                  One of: Failed, Provisioning, Provisioned, Running, Deleting'
+                type: string
+              providerStatus:
+                description: ProviderStatus details a Provider-specific status. It
+                  is recommended that providers maintain their own versioned API types
+                  that should be serialized/deserialized from this field.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/machine/v1beta1/0000_10_machineset.crd.yaml
+++ b/machine/v1beta1/0000_10_machineset.crd.yaml
@@ -2,10 +2,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1032
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1032
   creationTimestamp: null
   name: machinesets.machine.openshift.io
 spec:
@@ -17,331 +17,542 @@ spec:
     singular: machineset
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - description: Desired Replicas
-          jsonPath: .spec.replicas
-          name: Desired
-          type: integer
-        - description: Current Replicas
-          jsonPath: .status.replicas
-          name: Current
-          type: integer
-        - description: Ready Replicas
-          jsonPath: .status.readyReplicas
-          name: Ready
-          type: integer
-        - description: Observed number of available replicas
-          jsonPath: .status.availableReplicas
-          name: Available
-          type: string
-        - description: Machineset age
-          jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: 'MachineSet ensures that a specified number of machines replicas are running at any given time. Compatibility level 2: Stable within a major release for a minimum of 9 months or 3 minor releases (whichever is longer).'
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: MachineSetSpec defines the desired state of MachineSet
-              type: object
-              properties:
-                deletePolicy:
-                  description: DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
-                  type: string
-                  enum:
-                    - Random
-                    - Newest
-                    - Oldest
-                minReadySeconds:
-                  description: MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
-                  type: integer
-                  format: int32
-                replicas:
-                  description: Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.
-                  type: integer
-                  format: int32
-                  default: 1
-                selector:
-                  description: 'Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
-                  type: object
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                      type: array
-                      items:
-                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                        type: object
-                        required:
-                          - key
-                          - operator
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                            type: array
-                            items:
-                              type: string
-                    matchLabels:
-                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                      type: object
-                      additionalProperties:
-                        type: string
-                  x-kubernetes-map-type: atomic
-                template:
-                  description: Template is the object that describes the machine that will be created if insufficient replicas are detected.
-                  type: object
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
+  - additionalPrinterColumns:
+    - description: Desired Replicas
+      jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - description: Current Replicas
+      jsonPath: .status.replicas
+      name: Current
+      type: integer
+    - description: Ready Replicas
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Observed number of available replicas
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: string
+    - description: Machineset age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineSet ensures that a specified number of machines replicas
+          are running at any given time. Compatibility level 2: Stable within a major
+          release for a minimum of 9 months or 3 minor releases (whichever is longer).'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet
+            properties:
+              deletePolicy:
+                description: DeletePolicy defines the policy used to identify nodes
+                  to delete when downscaling. Defaults to "Random".  Valid values
+                  are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: MinReadySeconds is the minimum number of seconds for
+                  which a newly created machine should be ready. Defaults to 0 (machine
+                  will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Replicas is the number of desired replicas. This is a
+                  pointer to distinguish between explicit zero and unspecified. Defaults
+                  to 1.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over machines that should
+                  match the replica count. Label keys and values that must match in
+                  order to be controlled by this MachineSet. It must match the machine
+                  template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
-                        annotations:
-                          description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-                          type: object
-                          additionalProperties:
-                            type: string
-                        generateName:
-                          description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
-                        labels:
-                          description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
-                          type: object
-                          additionalProperties:
-                            type: string
-                        name:
-                          description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
                           type: string
-                        namespace:
-                          description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces"
-                          type: string
-                        ownerReferences:
-                          description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
-                          type: array
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
                           items:
-                            description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: Template is the object that describes the machine that
+                  will be created if insufficient replicas are detected.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map
+                          stored with a resource that may be set by external tools
+                          to store and retrieve arbitrary metadata. They are not queryable
+                          and should be preserved when modifying objects. More info:
+                          http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by
+                          the server, to generate a unique name ONLY IF the Name field
+                          has not been provided. If this field is used, the name returned
+                          to the client will be different than the name passed. This
+                          value will also be combined with a unique suffix. The provided
+                          value has the same validation rules as the Name field, and
+                          may be truncated by the length of the suffix required to
+                          make the value unique on the server. \n If this field is
+                          specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created
+                          or 500 with Reason ServerTimeout indicating a unique name
+                          could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the
+                          Retry-After header). \n Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used
+                          to organize and categorize (scope and select) objects. May
+                          match selectors of replication controllers and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: 'Name must be unique within a namespace. Is required
+                          when creating resources, although some resources may allow
+                          a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence
+                          and configuration definition. Cannot be updated. More info:
+                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name
+                          must be unique. An empty namespace is equivalent to the
+                          \"default\" namespace, but \"default\" is the canonical
+                          representation. Not all objects are required to be scoped
+                          to a namespace - the value of this field for those objects
+                          will be empty. \n Must be a DNS_LABEL. Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces"
+                        type: string
+                      ownerReferences:
+                        description: List of objects depended by this object. If ALL
+                          objects in the list have been deleted, this object will
+                          be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller,
+                          with the controller field set to true. There cannot be more
+                          than one managing controller.
+                        items:
+                          description: OwnerReference contains enough information
+                            to let you identify an owning object. An owning object
+                            must be in the same namespace as the dependent, or be
+                            cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion"
+                                finalizer, then the owner cannot be deleted from the
+                                key-value store until this reference is removed. See
+                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this
+                                field and enforces the foreground deletion. Defaults
+                                to false. To set this field, a user needs "delete"
+                                permission of the owner, otherwise 422 (Unprocessable
+                                Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      lifecycleHooks:
+                        description: LifecycleHooks allow users to pause operations
+                          on the machine at certain predefined points within the machine
+                          lifecycle.
+                        properties:
+                          preDrain:
+                            description: PreDrain hooks prevent the machine from being
+                              drained. This also blocks further lifecycle events,
+                              such as termination.
+                            items:
+                              description: LifecycleHook represents a single instance
+                                of a lifecycle hook
+                              properties:
+                                name:
+                                  description: Name defines a unique name for the
+                                    lifcycle hook. The name should be unique and descriptive,
+                                    ideally 1-3 words, in CamelCase or it may be namespaced,
+                                    eg. foo.example.com/CamelCase. Names must be unique
+                                    and should only be managed by a single entity.
+                                  maxLength: 256
+                                  minLength: 3
+                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                  type: string
+                                owner:
+                                  description: Owner defines the owner of the lifecycle
+                                    hook. This should be descriptive enough so that
+                                    users can identify who/what is responsible for
+                                    blocking the lifecycle. This could be the name
+                                    of a controller (e.g. clusteroperator/etcd) or
+                                    an administrator managing the hook.
+                                  maxLength: 512
+                                  minLength: 3
+                                  type: string
+                              required:
+                              - name
+                              - owner
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          preTerminate:
+                            description: PreTerminate hooks prevent the machine from
+                              being terminated. PreTerminate hooks be actioned after
+                              the Machine has been drained.
+                            items:
+                              description: LifecycleHook represents a single instance
+                                of a lifecycle hook
+                              properties:
+                                name:
+                                  description: Name defines a unique name for the
+                                    lifcycle hook. The name should be unique and descriptive,
+                                    ideally 1-3 words, in CamelCase or it may be namespaced,
+                                    eg. foo.example.com/CamelCase. Names must be unique
+                                    and should only be managed by a single entity.
+                                  maxLength: 256
+                                  minLength: 3
+                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                  type: string
+                                owner:
+                                  description: Owner defines the owner of the lifecycle
+                                    hook. This should be descriptive enough so that
+                                    users can identify who/what is responsible for
+                                    blocking the lifecycle. This could be the name
+                                    of a controller (e.g. clusteroperator/etcd) or
+                                    an administrator managing the hook.
+                                  maxLength: 512
+                                  minLength: 3
+                                  type: string
+                              required:
+                              - name
+                              - owner
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                      metadata:
+                        description: ObjectMeta will autopopulate the Node created.
+                          Use this to indicate what labels, annotations, name prefix,
+                          etc., should be used when creating the Node.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'Annotations is an unstructured key value
+                              map stored with a resource that may be set by external
+                              tools to store and retrieve arbitrary metadata. They
+                              are not queryable and should be preserved when modifying
+                              objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                             type: object
-                            required:
+                          generateName:
+                            description: "GenerateName is an optional prefix, used
+                              by the server, to generate a unique name ONLY IF the
+                              Name field has not been provided. If this field is used,
+                              the name returned to the client will be different than
+                              the name passed. This value will also be combined with
+                              a unique suffix. The provided value has the same validation
+                              rules as the Name field, and may be truncated by the
+                              length of the suffix required to make the value unique
+                              on the server. \n If this field is specified and the
+                              generated name exists, the server will NOT return a
+                              409 - instead, it will either return 201 Created or
+                              500 with Reason ServerTimeout indicating a unique name
+                              could not be found in the time allotted, and the client
+                              should retry (optionally after the time indicated in
+                              the Retry-After header). \n Applied only if Name is
+                              not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Map of string keys and values that can be
+                              used to organize and categorize (scope and select) objects.
+                              May match selectors of replication controllers and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels'
+                            type: object
+                          name:
+                            description: 'Name must be unique within a namespace.
+                              Is required when creating resources, although some resources
+                              may allow a client to request the generation of an appropriate
+                              name automatically. Name is primarily intended for creation
+                              idempotence and configuration definition. Cannot be
+                              updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                            type: string
+                          namespace:
+                            description: "Namespace defines the space within each
+                              name must be unique. An empty namespace is equivalent
+                              to the \"default\" namespace, but \"default\" is the
+                              canonical representation. Not all objects are required
+                              to be scoped to a namespace - the value of this field
+                              for those objects will be empty. \n Must be a DNS_LABEL.
+                              Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces"
+                            type: string
+                          ownerReferences:
+                            description: List of objects depended by this object.
+                              If ALL objects in the list have been deleted, this object
+                              will be garbage collected. If this object is managed
+                              by a controller, then an entry in this list will point
+                              to this controller, with the controller field set to
+                              true. There cannot be more than one managing controller.
+                            items:
+                              description: OwnerReference contains enough information
+                                to let you identify an owning object. An owning object
+                                must be in the same namespace as the dependent, or
+                                be cluster-scoped, so there is no namespace field.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                blockOwnerDeletion:
+                                  description: If true, AND if the owner has the "foregroundDeletion"
+                                    finalizer, then the owner cannot be deleted from
+                                    the key-value store until this reference is removed.
+                                    See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                    for how the garbage collector interacts with this
+                                    field and enforces the foreground deletion. Defaults
+                                    to false. To set this field, a user needs "delete"
+                                    permission of the owner, otherwise 422 (Unprocessable
+                                    Entity) will be returned.
+                                  type: boolean
+                                controller:
+                                  description: If true, this reference points to the
+                                    managing controller.
+                                  type: boolean
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                  type: string
+                                uid:
+                                  description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                  type: string
+                              required:
                               - apiVersion
                               - kind
                               - name
                               - uid
-                            properties:
-                              apiVersion:
-                                description: API version of the referent.
-                                type: string
-                              blockOwnerDeletion:
-                                description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
-                                type: boolean
-                              controller:
-                                description: If true, this reference points to the managing controller.
-                                type: boolean
-                              kind:
-                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                type: string
-                              uid:
-                                description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
-                                type: string
-                            x-kubernetes-map-type: atomic
-                    spec:
-                      description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-                      type: object
-                      properties:
-                        lifecycleHooks:
-                          description: LifecycleHooks allow users to pause operations on the machine at certain predefined points within the machine lifecycle.
-                          type: object
-                          properties:
-                            preDrain:
-                              description: PreDrain hooks prevent the machine from being drained. This also blocks further lifecycle events, such as termination.
-                              type: array
-                              items:
-                                description: LifecycleHook represents a single instance of a lifecycle hook
-                                type: object
-                                required:
-                                  - name
-                                  - owner
-                                properties:
-                                  name:
-                                    description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
-                                    type: string
-                                    maxLength: 256
-                                    minLength: 3
-                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                  owner:
-                                    description: Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.
-                                    type: string
-                                    maxLength: 512
-                                    minLength: 3
-                              x-kubernetes-list-map-keys:
-                                - name
-                              x-kubernetes-list-type: map
-                            preTerminate:
-                              description: PreTerminate hooks prevent the machine from being terminated. PreTerminate hooks be actioned after the Machine has been drained.
-                              type: array
-                              items:
-                                description: LifecycleHook represents a single instance of a lifecycle hook
-                                type: object
-                                required:
-                                  - name
-                                  - owner
-                                properties:
-                                  name:
-                                    description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
-                                    type: string
-                                    maxLength: 256
-                                    minLength: 3
-                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                  owner:
-                                    description: Owner defines the owner of the lifecycle hook. This should be descriptive enough so that users can identify who/what is responsible for blocking the lifecycle. This could be the name of a controller (e.g. clusteroperator/etcd) or an administrator managing the hook.
-                                    type: string
-                                    maxLength: 512
-                                    minLength: 3
-                              x-kubernetes-list-map-keys:
-                                - name
-                              x-kubernetes-list-type: map
-                        metadata:
-                          description: ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.
-                          type: object
-                          properties:
-                            annotations:
-                              description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
                               type: object
-                              additionalProperties:
-                                type: string
-                            generateName:
-                              description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency"
-                              type: string
-                            labels:
-                              description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
-                              type: object
-                              additionalProperties:
-                                type: string
-                            name:
-                              description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                              type: string
-                            namespace:
-                              description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces"
-                              type: string
-                            ownerReferences:
-                              description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
-                              type: array
-                              items:
-                                description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
-                                type: object
-                                required:
-                                  - apiVersion
-                                  - kind
-                                  - name
-                                  - uid
-                                properties:
-                                  apiVersion:
-                                    description: API version of the referent.
-                                    type: string
-                                  blockOwnerDeletion:
-                                    description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
-                                    type: boolean
-                                  controller:
-                                    description: If true, this reference points to the managing controller.
-                                    type: boolean
-                                  kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                    type: string
-                                  uid:
-                                    description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
-                                    type: string
-                                x-kubernetes-map-type: atomic
-                        providerID:
-                          description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
-                          type: string
-                        providerSpec:
-                          description: ProviderSpec details Provider-specific configuration to use during node creation.
-                          type: object
-                          properties:
-                            value:
-                              description: Value is an inlined, serialized representation of the resource configuration. It is recommended that providers maintain their own versioned API types that should be serialized/deserialized from this field, akin to component config.
-                              type: object
-                              x-kubernetes-preserve-unknown-fields: true
-                        taints:
-                          description: The list of the taints to be applied to the corresponding Node in additive manner. This list will not overwrite any other taints added to the Node on an ongoing basis by other entities. These taints should be actively reconciled e.g. if you ask the machine controller to apply a taint and then manually remove the taint the machine controller will put it back) but not have the machine controller remove any taints
-                          type: array
-                          items:
-                            description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              x-kubernetes-map-type: atomic
+                            type: array
+                        type: object
+                      providerID:
+                        description: ProviderID is the identification ID of the machine
+                          provided by the provider. This field must match the provider
+                          ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api.
+                          Example use case is cluster autoscaler with cluster-api
+                          as provider. Clean-up logic in the autoscaler compares machines
+                          to nodes to find out machines at provider which could not
+                          get registered as Kubernetes nodes. With cluster-api as
+                          a generic out-of-tree provider for autoscaler, this field
+                          is required by autoscaler to be able to have a provider
+                          view of the list of machines. Another list of nodes is queried
+                          from the k8s apiserver and then a comparison is done to
+                          find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by
+                          higher level entities like autoscaler that will be interfacing
+                          with cluster-api as generic provider.
+                        type: string
+                      providerSpec:
+                        description: ProviderSpec details Provider-specific configuration
+                          to use during node creation.
+                        properties:
+                          value:
+                            description: Value is an inlined, serialized representation
+                              of the resource configuration. It is recommended that
+                              providers maintain their own versioned API types that
+                              should be serialized/deserialized from this field, akin
+                              to component config.
                             type: object
-                            required:
-                              - effect
-                              - key
-                            properties:
-                              effect:
-                                description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                                type: string
-                              key:
-                                description: Required. The taint key to be applied to a node.
-                                type: string
-                              timeAdded:
-                                description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
-                                type: string
-                                format: date-time
-                              value:
-                                description: The taint value corresponding to the taint key.
-                                type: string
-            status:
-              description: MachineSetStatus defines the observed state of MachineSet
-              type: object
-              properties:
-                availableReplicas:
-                  description: The number of available replicas (ready for at least minReadySeconds) for this MachineSet.
-                  type: integer
-                  format: int32
-                errorMessage:
-                  type: string
-                errorReason:
-                  description: "In the event that there is a terminal problem reconciling the replicas, both ErrorReason and ErrorMessage will be set. ErrorReason will be populated with a succinct value suitable for machine interpretation, while ErrorMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output."
-                  type: string
-                fullyLabeledReplicas:
-                  description: The number of replicas that have labels matching the labels of the machine template of the MachineSet.
-                  type: integer
-                  format: int32
-                observedGeneration:
-                  description: ObservedGeneration reflects the generation of the most recently observed MachineSet.
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is "Ready".
-                  type: integer
-                  format: int32
-                replicas:
-                  description: Replicas is the most recently observed number of replicas.
-                  type: integer
-                  format: int32
-      served: true
-      storage: true
-      subresources:
-        scale:
-          labelSelectorPath: .status.labelSelector
-          specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.replicas
-        status: {}
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
+                      taints:
+                        description: The list of the taints to be applied to the corresponding
+                          Node in additive manner. This list will not overwrite any
+                          other taints added to the Node on an ongoing basis by other
+                          entities. These taints should be actively reconciled e.g.
+                          if you ask the machine controller to apply a taint and then
+                          manually remove the taint the machine controller will put
+                          it back) but not have the machine controller remove any
+                          taints
+                        items:
+                          description: The node this Taint is attached to has the
+                            "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods
+                                that do not tolerate the taint. Valid effects are
+                                NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which
+                                the taint was added. It is only written for NoExecute
+                                taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              errorMessage:
+                type: string
+              errorReason:
+                description: "In the event that there is a terminal problem reconciling
+                  the replicas, both ErrorReason and ErrorMessage will be set. ErrorReason
+                  will be populated with a succinct value suitable for machine interpretation,
+                  while ErrorMessage will contain a more verbose string suitable for
+                  logging and human consumption. \n These fields should not be set
+                  for transitive errors that a controller faces that are expected
+                  to be fixed automatically over time (like service outages), but
+                  instead indicate that something is fundamentally wrong with the
+                  MachineTemplate's spec or the configuration of the machine controller,
+                  and that manual intervention is required. Examples of terminal errors
+                  would be invalid combinations of settings in the spec, values that
+                  are unsupported by the machine controller, or the responsible machine
+                  controller itself being critically misconfigured. \n Any transient
+                  errors that occur during the reconciliation of Machines can be added
+                  as events to the MachineSet object and/or logged in the controller's
+                  output."
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the
+                  labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine
+                  is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.labelSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/monitoring/v1alpha1/0000_50_monitoring_01_alertingrules.crd.yaml
+++ b/monitoring/v1alpha1/0000_50_monitoring_01_alertingrules.crd.yaml
@@ -3,8 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1179
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
     description: OpenShift Monitoring alerting rules
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: alertingrules.monitoring.openshift.io
 spec:
   group: monitoring.openshift.io
@@ -15,105 +15,188 @@ spec:
     singular: alertingrule
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: "AlertingRule represents a set of user-defined Prometheus rule groups containing alerting rules.  This resource is the supported method for cluster admins to create alerts based on metrics recorded by the platform monitoring stack in OpenShift, i.e. the Prometheus instance deployed to the openshift-monitoring namespace.  You might use this to create custom alerting rules not shipped with OpenShift based on metrics from components such as the node_exporter, which provides machine-level metrics such as CPU usage, or kube-state-metrics, which provides metrics on Kubernetes usage. \n The API is mostly compatible with the upstream PrometheusRule type from the prometheus-operator.  The primary difference being that recording rules are not allowed here -- only alerting rules.  For each AlertingRule resource created, a corresponding PrometheusRule will be created in the openshift-monitoring namespace.  OpenShift requires admins to use the AlertingRule resource rather than the upstream type in order to allow better OpenShift specific defaulting and validation, while not modifying the upstream APIs directly. \n You can find upstream API documentation for PrometheusRule resources here: \n https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec describes the desired state of this AlertingRule object.
-              type: object
-              required:
-                - groups
-              properties:
-                groups:
-                  description: "groups is a list of grouped alerting rules.  Rule groups are the unit at which Prometheus parallelizes rule processing.  All rules in a single group share a configured evaluation interval.  All rules in the group will be processed together on this interval, sequentially, and all rules will be processed. \n It's common to group related alerting rules into a single AlertingRule resources, and within that resource, closely related alerts, or simply alerts with the same interval, into individual groups.  You are also free to create AlertingRule resources with only a single rule group, but be aware that this can have a performance impact on Prometheus if the group is extremely large or has very complex query expressions to evaluate. Spreading very complex rules across multiple groups to allow them to be processed in parallel is also a common use-case."
-                  type: array
-                  minItems: 1
-                  items:
-                    description: RuleGroup is a list of sequentially evaluated alerting rules.
-                    type: object
-                    required:
-                      - name
-                      - rules
-                    properties:
-                      interval:
-                        description: "interval is how often rules in the group are evaluated.  If not specified, it defaults to the global.evaluation_interval configured in Prometheus, which itself defaults to 30 seconds.  You can check if this value has been modified from the default on your cluster by inspecting the platform Prometheus configuration: \n $ oc -n openshift-monitoring describe prometheus k8s \n The relevant field in that resource is: spec.evaluationInterval \n This is represented as a Prometheus duration, e.g. 1d, 1h30m, 5m, 10s.  You can find the upstream documentation here: \n https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration"
-                        type: string
-                        pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
-                      name:
-                        description: name is the name of the group.
-                        type: string
-                      rules:
-                        description: rules is a list of sequentially evaluated alerting rules.  Prometheus may process rule groups in parallel, but rules within a single group are always processed sequentially, and all rules are processed.
-                        type: array
-                        minItems: 1
-                        items:
-                          description: 'Rule describes an alerting rule. See Prometheus documentation: - https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules'
-                          type: object
-                          required:
-                            - alert
-                            - expr
-                          properties:
-                            alert:
-                              description: alert is the name of the alert. Must be a valid label value, i.e. only contain ASCII letters, numbers, and underscores.
-                              type: string
-                              pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
-                            annotations:
-                              description: "annotations to add to each alert.  These are values that can be used to store longer additional information that you won't query on, such as alert descriptions or runbook links, e.g.: \n annotations: summary: HAProxy reload failure description: | This alert fires when HAProxy fails to reload its configuration, which will result in the router not picking up recently created or modified routes."
-                              type: object
-                              additionalProperties:
-                                type: string
-                            expr:
-                              description: "expr is the PromQL expression to evaluate. Every evaluation cycle this is evaluated at the current time, and all resultant time series become pending or firing alerts.  This is most often a string representing a PromQL expression, e.g.: \n mapi_current_pending_csr > mapi_max_pending_csr \n In rare cases this could be a simple integer, e.g. a simple \"1\" if the intent is to create an alert that is always firing.  This is sometimes used to create an always-firing \"Watchdog\" alert in order to ensure the alerting pipeline is functional."
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              x-kubernetes-int-or-string: true
-                            for:
-                              description: 'for is the time period after which alerts are considered firing after first returning results.  Alerts which have not yet fired for long enough are considered pending. This is represented as a Prometheus duration, for details on the format see: - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration'
-                              type: string
-                              pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
-                            labels:
-                              description: "labels to add or overwrite for each alert.  The results of the PromQL expression for the alert will result in an existing set of labels for the alert, after evaluating the expression, for any label specified here with the same name as a label in that set, the label here wins and overwrites the previous value.  These should typically be short identifying values that may be useful to query against.  A common example is the alert severity: \n labels: severity: warning"
-                              type: object
-                              additionalProperties:
-                                type: string
-                  x-kubernetes-list-map-keys:
-                    - name
-                  x-kubernetes-list-type: map
-            status:
-              description: status describes the current state of this AlertOverrides object.
-              type: object
-              properties:
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with.
-                  type: integer
-                  format: int64
-                prometheusRule:
-                  description: prometheusRule is the generated PrometheusRule for this AlertingRule.  Each AlertingRule instance results in a generated PrometheusRule object in the same namespace, which is always the openshift-monitoring namespace.
-                  type: object
-                  required:
-                    - name
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "AlertingRule represents a set of user-defined Prometheus rule
+          groups containing alerting rules.  This resource is the supported method
+          for cluster admins to create alerts based on metrics recorded by the platform
+          monitoring stack in OpenShift, i.e. the Prometheus instance deployed to
+          the openshift-monitoring namespace.  You might use this to create custom
+          alerting rules not shipped with OpenShift based on metrics from components
+          such as the node_exporter, which provides machine-level metrics such as
+          CPU usage, or kube-state-metrics, which provides metrics on Kubernetes usage.
+          \n The API is mostly compatible with the upstream PrometheusRule type from
+          the prometheus-operator.  The primary difference being that recording rules
+          are not allowed here -- only alerting rules.  For each AlertingRule resource
+          created, a corresponding PrometheusRule will be created in the openshift-monitoring
+          namespace.  OpenShift requires admins to use the AlertingRule resource rather
+          than the upstream type in order to allow better OpenShift specific defaulting
+          and validation, while not modifying the upstream APIs directly. \n You can
+          find upstream API documentation for PrometheusRule resources here: \n https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md
+          \n Compatibility level 4: No compatibility is provided, the API can change
+          at any point for any reason. These capabilities should not be used by applications
+          needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the desired state of this AlertingRule object.
+            properties:
+              groups:
+                description: "groups is a list of grouped alerting rules.  Rule groups
+                  are the unit at which Prometheus parallelizes rule processing.  All
+                  rules in a single group share a configured evaluation interval.
+                  \ All rules in the group will be processed together on this interval,
+                  sequentially, and all rules will be processed. \n It's common to
+                  group related alerting rules into a single AlertingRule resources,
+                  and within that resource, closely related alerts, or simply alerts
+                  with the same interval, into individual groups.  You are also free
+                  to create AlertingRule resources with only a single rule group,
+                  but be aware that this can have a performance impact on Prometheus
+                  if the group is extremely large or has very complex query expressions
+                  to evaluate. Spreading very complex rules across multiple groups
+                  to allow them to be processed in parallel is also a common use-case."
+                items:
+                  description: RuleGroup is a list of sequentially evaluated alerting
+                    rules.
                   properties:
-                    name:
-                      description: name of the referenced PrometheusRule.
+                    interval:
+                      description: "interval is how often rules in the group are evaluated.
+                        \ If not specified, it defaults to the global.evaluation_interval
+                        configured in Prometheus, which itself defaults to 30 seconds.
+                        \ You can check if this value has been modified from the default
+                        on your cluster by inspecting the platform Prometheus configuration:
+                        \n $ oc -n openshift-monitoring describe prometheus k8s \n
+                        The relevant field in that resource is: spec.evaluationInterval
+                        \n This is represented as a Prometheus duration, e.g. 1d,
+                        1h30m, 5m, 10s.  You can find the upstream documentation here:
+                        \n https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration"
+                      pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
                       type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    name:
+                      description: name is the name of the group.
+                      type: string
+                    rules:
+                      description: rules is a list of sequentially evaluated alerting
+                        rules.  Prometheus may process rule groups in parallel, but
+                        rules within a single group are always processed sequentially,
+                        and all rules are processed.
+                      items:
+                        description: 'Rule describes an alerting rule. See Prometheus
+                          documentation: - https://www.prometheus.io/docs/prometheus/latest/configuration/alerting_rules'
+                        properties:
+                          alert:
+                            description: alert is the name of the alert. Must be a
+                              valid label value, i.e. only contain ASCII letters,
+                              numbers, and underscores.
+                            pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                            type: string
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: "annotations to add to each alert.  These
+                              are values that can be used to store longer additional
+                              information that you won't query on, such as alert descriptions
+                              or runbook links, e.g.: \n annotations: summary: HAProxy
+                              reload failure description: | This alert fires when
+                              HAProxy fails to reload its configuration, which will
+                              result in the router not picking up recently created
+                              or modified routes."
+                            type: object
+                          expr:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: "expr is the PromQL expression to evaluate.
+                              Every evaluation cycle this is evaluated at the current
+                              time, and all resultant time series become pending or
+                              firing alerts.  This is most often a string representing
+                              a PromQL expression, e.g.: \n mapi_current_pending_csr
+                              > mapi_max_pending_csr \n In rare cases this could be
+                              a simple integer, e.g. a simple \"1\" if the intent
+                              is to create an alert that is always firing.  This is
+                              sometimes used to create an always-firing \"Watchdog\"
+                              alert in order to ensure the alerting pipeline is functional."
+                            x-kubernetes-int-or-string: true
+                          for:
+                            description: 'for is the time period after which alerts
+                              are considered firing after first returning results.  Alerts
+                              which have not yet fired for long enough are considered
+                              pending. This is represented as a Prometheus duration,
+                              for details on the format see: - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration'
+                            pattern: ^(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?$
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: "labels to add or overwrite for each alert.
+                              \ The results of the PromQL expression for the alert
+                              will result in an existing set of labels for the alert,
+                              after evaluating the expression, for any label specified
+                              here with the same name as a label in that set, the
+                              label here wins and overwrites the previous value.  These
+                              should typically be short identifying values that may
+                              be useful to query against.  A common example is the
+                              alert severity: \n labels: severity: warning"
+                            type: object
+                        required:
+                        - alert
+                        - expr
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - name
+                  - rules
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - groups
+            type: object
+          status:
+            description: status describes the current state of this AlertOverrides
+              object.
+            properties:
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with.
+                format: int64
+                type: integer
+              prometheusRule:
+                description: prometheusRule is the generated PrometheusRule for this
+                  AlertingRule.  Each AlertingRule instance results in a generated
+                  PrometheusRule object in the same namespace, which is always the
+                  openshift-monitoring namespace.
+                properties:
+                  name:
+                    description: name of the referenced PrometheusRule.
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/monitoring/v1alpha1/0000_50_monitoring_02_alertrelabelconfigs.crd.yaml
+++ b/monitoring/v1alpha1/0000_50_monitoring_02_alertrelabelconfigs.crd.yaml
@@ -3,8 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1179
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
     description: OpenShift Monitoring alert relabel configurations
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: alertrelabelconfigs.monitoring.openshift.io
 spec:
   group: monitoring.openshift.io
@@ -15,123 +15,178 @@ spec:
     singular: alertrelabelconfig
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: "AlertRelabelConfig defines a set of relabel configs for alerts. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec describes the desired state of this AlertRelabelConfig object.
-              type: object
-              required:
-                - configs
-              properties:
-                configs:
-                  description: configs is a list of sequentially evaluated alert relabel configs.
-                  type: array
-                  minItems: 1
-                  items:
-                    description: 'RelabelConfig allows dynamic rewriting of label sets for alerts. See Prometheus documentation: - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
-                    type: object
-                    properties:
-                      action:
-                        description: 'action to perform based on regex matching. Must be one of: Replace, Keep, Drop, HashMod, LabelMap, LabelDrop, or LabelKeep.  Default is: ''Replace'''
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "AlertRelabelConfig defines a set of relabel configs for alerts.
+          \n Compatibility level 4: No compatibility is provided, the API can change
+          at any point for any reason. These capabilities should not be used by applications
+          needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the desired state of this AlertRelabelConfig
+              object.
+            properties:
+              configs:
+                description: configs is a list of sequentially evaluated alert relabel
+                  configs.
+                items:
+                  description: 'RelabelConfig allows dynamic rewriting of label sets
+                    for alerts. See Prometheus documentation: - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs
+                    - https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                  properties:
+                    action:
+                      default: Replace
+                      description: 'action to perform based on regex matching. Must
+                        be one of: Replace, Keep, Drop, HashMod, LabelMap, LabelDrop,
+                        or LabelKeep.  Default is: ''Replace'''
+                      enum:
+                      - Replace
+                      - Keep
+                      - Drop
+                      - HashMod
+                      - LabelMap
+                      - LabelDrop
+                      - LabelKeep
+                      type: string
+                    modulus:
+                      description: modulus to take of the hash of the source label
+                        values.  This can be combined with the 'HashMod' action to
+                        set 'target_label' to the 'modulus' of a hash of the concatenated
+                        'source_labels'.
+                      format: int64
+                      type: integer
+                    regex:
+                      description: 'regex against which the extracted value is matched.
+                        Default is: ''(.*)'''
+                      type: string
+                    replacement:
+                      description: 'replacement value against which a regex replace
+                        is performed if the regular expression matches. This is required
+                        if the action is ''Replace'' or ''LabelMap''. Regex capture
+                        groups are available. Default is: ''$1'''
+                      type: string
+                    separator:
+                      description: separator placed between concatenated source label
+                        values. When omitted, Prometheus will use its default value
+                        of ';'.
+                      type: string
+                    sourceLabels:
+                      description: sourceLabels select values from existing labels.
+                        Their content is concatenated using the configured separator
+                        and matched against the configured regular expression for
+                        the Replace, Keep, and Drop actions.
+                      items:
+                        description: LabelName is a valid Prometheus label name which
+                          may only contain ASCII letters, numbers, and underscores.
+                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
                         type: string
-                        default: Replace
-                        enum:
-                          - Replace
-                          - Keep
-                          - Drop
-                          - HashMod
-                          - LabelMap
-                          - LabelDrop
-                          - LabelKeep
-                      modulus:
-                        description: modulus to take of the hash of the source label values.  This can be combined with the 'HashMod' action to set 'target_label' to the 'modulus' of a hash of the concatenated 'source_labels'.
-                        type: integer
-                        format: int64
-                      regex:
-                        description: 'regex against which the extracted value is matched. Default is: ''(.*)'''
-                        type: string
-                      replacement:
-                        description: 'replacement value against which a regex replace is performed if the regular expression matches. This is required if the action is ''Replace'' or ''LabelMap''. Regex capture groups are available. Default is: ''$1'''
-                        type: string
-                      separator:
-                        description: separator placed between concatenated source label values. When omitted, Prometheus will use its default value of ';'.
-                        type: string
-                      sourceLabels:
-                        description: sourceLabels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the Replace, Keep, and Drop actions.
-                        type: array
-                        items:
-                          description: LabelName is a valid Prometheus label name which may only contain ASCII letters, numbers, and underscores.
-                          type: string
-                          pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
-                      targetLabel:
-                        description: targetLabel to which the resulting value is written in a 'Replace' action. It is mandatory for 'Replace' and 'HashMod' actions. Regex capture groups are available.
-                        type: string
-            status:
-              description: status describes the current state of this AlertRelabelConfig object.
-              type: object
-              properties:
-                conditions:
-                  description: conditions contains details on the state of the AlertRelabelConfig, may be empty.
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      type: array
+                    targetLabel:
+                      description: targetLabel to which the resulting value is written
+                        in a 'Replace' action. It is mandatory for 'Replace' and 'HashMod'
+                        actions. Regex capture groups are available.
+                      type: string
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - configs
+            type: object
+          status:
+            description: status describes the current state of this AlertRelabelConfig
+              object.
+            properties:
+              conditions:
+                description: conditions contains details on the state of the AlertRelabelConfig,
+                  may be empty.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/operator/v1/0000_10_config-operator_01_config.crd.yaml
+++ b/operator/v1/0000_10_config-operator_01_config.crd.yaml
@@ -11,126 +11,158 @@ spec:
   group: operator.openshift.io
   names:
     categories:
-      - coreoperators
+    - coreoperators
     kind: Config
     plural: configs
     singular: config
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Config specifies the behavior of the config operator which is responsible for creating the initial configuration of other components on the cluster.  The operator also handles installation, migration or synchronization of cloud configurations for AWS and Azure cloud based clusters \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec is the specification of the desired behavior of the Config Operator.
-              type: object
-              properties:
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Config specifies the behavior of the config operator which is
+          responsible for creating the initial configuration of other components on
+          the cluster.  The operator also handles installation, migration or synchronization
+          of cloud configurations for AWS and Azure cloud based clusters \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              Config Operator.
+            properties:
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: status defines the observed status of the Config Operator.
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                type: array
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              description: status defines the observed status of the Config Operator.
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
-                        type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
-                        type: string
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
+++ b/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
@@ -11,182 +11,230 @@ spec:
   group: operator.openshift.io
   names:
     categories:
-      - coreoperators
+    - coreoperators
     kind: Etcd
     plural: etcds
     singular: etcd
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Etcd provides information to configure an operator to manage etcd. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              type: object
-              properties:
-                failedRevisionLimit:
-                  description: failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)
-                  type: integer
-                  format: int32
-                forceRedeploymentReason:
-                  description: forceRedeploymentReason can be used to force the redeployment of the operand by providing a unique string. This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work this time instead of failing again on the same config.
-                  type: string
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Etcd provides information to configure an operator to manage
+          etcd. \n Compatibility level 1: Stable within a major release for a minimum
+          of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              failedRevisionLimit:
+                description: failedRevisionLimit is the number of failed static pod
+                  installer revisions to keep on disk and in the api -1 = unlimited,
+                  0 or unset = 5 (default)
+                format: int32
+                type: integer
+              forceRedeploymentReason:
+                description: forceRedeploymentReason can be used to force the redeployment
+                  of the operand by providing a unique string. This provides a mechanism
+                  to kick a previously failed deployment and provide a reason why
+                  you think it will work this time instead of failing again on the
+                  same config.
+                type: string
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              succeededRevisionLimit:
+                description: succeededRevisionLimit is the number of successful static
+                  pod installer revisions to keep on disk and in the api -1 = unlimited,
+                  0 or unset = 5 (default)
+                format: int32
+                type: integer
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                succeededRevisionLimit:
-                  description: succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)
-                  type: integer
-                  format: int32
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                type: array
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
+                type: array
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+              latestAvailableRevisionReason:
+                description: latestAvailableRevisionReason describe the detailed reason
+                  for the most recent deployment
+                type: string
+              nodeStatuses:
+                description: nodeStatuses track the deployment values and errors across
+                  individual nodes
+                items:
+                  description: NodeStatus provides information about the current state
+                    of a particular node managed by this operator.
+                  properties:
+                    currentRevision:
+                      description: currentRevision is the generation of the most recently
+                        successful deployment
+                      format: int32
+                      type: integer
+                    lastFailedCount:
+                      description: lastFailedCount is how often the installer pod
+                        of the last failed revision failed.
+                      type: integer
+                    lastFailedReason:
+                      description: lastFailedReason is a machine readable failure
+                        reason string.
+                      type: string
+                    lastFailedRevision:
+                      description: lastFailedRevision is the generation of the deployment
+                        we tried and failed to deploy.
+                      format: int32
+                      type: integer
+                    lastFailedRevisionErrors:
+                      description: lastFailedRevisionErrors is a list of human readable
+                        errors during the failed deployment referenced in lastFailedRevision.
+                      items:
                         type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
-                        type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
-                        type: string
-                latestAvailableRevision:
-                  description: latestAvailableRevision is the deploymentID of the most recent deployment
-                  type: integer
-                  format: int32
-                latestAvailableRevisionReason:
-                  description: latestAvailableRevisionReason describe the detailed reason for the most recent deployment
-                  type: string
-                nodeStatuses:
-                  description: nodeStatuses track the deployment values and errors across individual nodes
-                  type: array
-                  items:
-                    description: NodeStatus provides information about the current state of a particular node managed by this operator.
-                    type: object
-                    properties:
-                      currentRevision:
-                        description: currentRevision is the generation of the most recently successful deployment
-                        type: integer
-                        format: int32
-                      lastFailedCount:
-                        description: lastFailedCount is how often the installer pod of the last failed revision failed.
-                        type: integer
-                      lastFailedReason:
-                        description: lastFailedReason is a machine readable failure reason string.
-                        type: string
-                      lastFailedRevision:
-                        description: lastFailedRevision is the generation of the deployment we tried and failed to deploy.
-                        type: integer
-                        format: int32
-                      lastFailedRevisionErrors:
-                        description: lastFailedRevisionErrors is a list of human readable errors during the failed deployment referenced in lastFailedRevision.
-                        type: array
-                        items:
-                          type: string
-                      lastFailedTime:
-                        description: lastFailedTime is the time the last failed revision failed the last time.
-                        type: string
-                        format: date-time
-                      lastFallbackCount:
-                        description: lastFallbackCount is how often a fallback to a previous revision happened.
-                        type: integer
-                      nodeName:
-                        description: nodeName is the name of the node
-                        type: string
-                      targetRevision:
-                        description: targetRevision is the generation of the deployment we're trying to apply
-                        type: integer
-                        format: int32
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      type: array
+                    lastFailedTime:
+                      description: lastFailedTime is the time the last failed revision
+                        failed the last time.
+                      format: date-time
+                      type: string
+                    lastFallbackCount:
+                      description: lastFallbackCount is how often a fallback to a
+                        previous revision happened.
+                      type: integer
+                    nodeName:
+                      description: nodeName is the name of the node
+                      type: string
+                    targetRevision:
+                      description: targetRevision is the generation of the deployment
+                        we're trying to apply
+                      format: int32
+                      type: integer
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_30_openshift-apiserver-operator_01_config.crd.yaml
+++ b/operator/v1/0000_30_openshift-apiserver-operator_01_config.crd.yaml
@@ -11,131 +11,163 @@ spec:
   group: operator.openshift.io
   names:
     categories:
-      - coreoperators
+    - coreoperators
     kind: OpenShiftAPIServer
     plural: openshiftapiservers
     singular: openshiftapiserver
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "OpenShiftAPIServer provides information to configure an operator to manage openshift-apiserver. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec is the specification of the desired behavior of the OpenShift API Server.
-              type: object
-              properties:
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "OpenShiftAPIServer provides information to configure an operator
+          to manage openshift-apiserver. \n Compatibility level 1: Stable within a
+          major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              OpenShift API Server.
+            properties:
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: status defines the observed status of the OpenShift API Server.
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                type: array
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              description: status defines the observed status of the OpenShift API Server.
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
-                        type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
-                        type: string
-                latestAvailableRevision:
-                  description: latestAvailableRevision is the latest revision used as suffix of revisioned secrets like encryption-config. A new revision causes a new deployment of pods.
-                  type: integer
-                  format: int32
-                  minimum: 0
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              latestAvailableRevision:
+                description: latestAvailableRevision is the latest revision used as
+                  suffix of revisioned secrets like encryption-config. A new revision
+                  causes a new deployment of pods.
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
+++ b/operator/v1/0000_40_cloud-credential-operator_00_config.crd.yaml
@@ -15,128 +15,166 @@ spec:
     singular: cloudcredential
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "CloudCredential provides a means to configure an operator to manage CredentialsRequests. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: CloudCredentialSpec is the specification of the desired behavior of the cloud-credential-operator.
-              type: object
-              properties:
-                credentialsMode:
-                  description: 'CredentialsMode allows informing CCO that it should not attempt to dynamically determine the root cloud credentials capabilities, and it should just run in the specified mode. It also allows putting the operator into "manual" mode if desired. Leaving the field in default mode runs CCO so that the cluster''s cloud credentials will be dynamically probed for capabilities (on supported clouds/platforms). Supported modes: AWS/Azure/GCP: "" (Default), "Mint", "Passthrough", "Manual" Others: Do not set value as other platforms only support running in "Passthrough"'
-                  type: string
-                  enum:
-                    - ""
-                    - Manual
-                    - Mint
-                    - Passthrough
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "CloudCredential provides a means to configure an operator to
+          manage CredentialsRequests. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CloudCredentialSpec is the specification of the desired behavior
+              of the cloud-credential-operator.
+            properties:
+              credentialsMode:
+                description: 'CredentialsMode allows informing CCO that it should
+                  not attempt to dynamically determine the root cloud credentials
+                  capabilities, and it should just run in the specified mode. It also
+                  allows putting the operator into "manual" mode if desired. Leaving
+                  the field in default mode runs CCO so that the cluster''s cloud
+                  credentials will be dynamically probed for capabilities (on supported
+                  clouds/platforms). Supported modes: AWS/Azure/GCP: "" (Default),
+                  "Mint", "Passthrough", "Manual" Others: Do not set value as other
+                  platforms only support running in "Passthrough"'
+                enum:
+                - ""
+                - Manual
+                - Mint
+                - Passthrough
+                type: string
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: CloudCredentialStatus defines the observed status of the
+              cloud-credential-operator.
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                type: array
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              description: CloudCredentialStatus defines the observed status of the cloud-credential-operator.
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
-                        type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
-                        type: string
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_40_kube-storage-version-migrator-operator_00_config.crd.yaml
+++ b/operator/v1/0000_40_kube-storage-version-migrator-operator_00_config.crd.yaml
@@ -16,118 +16,147 @@ spec:
     singular: kubestorageversionmigrator
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "KubeStorageVersionMigrator provides information to configure an operator to manage kube-storage-version-migrator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              type: object
-              properties:
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "KubeStorageVersionMigrator provides information to configure
+          an operator to manage kube-storage-version-migrator. \n Compatibility level
+          1: Stable within a major release for a minimum of 12 months or 3 minor releases
+          (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                type: array
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
-                        type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
-                        type: string
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_50_cluster-authentication-operator_01_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-authentication-operator_01_config.crd.yaml
@@ -14,127 +14,157 @@ spec:
     singular: authentication
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Authentication provides information to configure an operator to manage authentication. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              type: object
-              properties:
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
-                        type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
-                        type: string
-                oauthAPIServer:
-                  description: OAuthAPIServer holds status specific only to oauth-apiserver
-                  type: object
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Authentication provides information to configure an operator
+          to manage authentication. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
                   properties:
-                    latestAvailableRevision:
-                      description: LatestAvailableRevision is the latest revision used as suffix of revisioned secrets like encryption-config. A new revision causes a new deployment of pods.
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
                       type: integer
-                      format: int32
-                      minimum: 0
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
+                  type: object
+                type: array
+              oauthAPIServer:
+                description: OAuthAPIServer holds status specific only to oauth-apiserver
+                properties:
+                  latestAvailableRevision:
+                    description: LatestAvailableRevision is the latest revision used
+                      as suffix of revisioned secrets like encryption-config. A new
+                      revision causes a new deployment of pods.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
@@ -11,124 +11,153 @@ spec:
   group: operator.openshift.io
   names:
     categories:
-      - coreoperators
+    - coreoperators
     kind: OpenShiftControllerManager
     plural: openshiftcontrollermanagers
     singular: openshiftcontrollermanager
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "OpenShiftControllerManager provides information to configure an operator to manage openshift-controller-manager. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              type: object
-              properties:
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "OpenShiftControllerManager provides information to configure
+          an operator to manage openshift-controller-manager. \n Compatibility level
+          1: Stable within a major release for a minimum of 12 months or 3 minor releases
+          (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                type: array
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
                   type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
-                        type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
-                        type: string
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1/0000_50_insights-operator_00-insightsoperator.crd.yaml
+++ b/operator/v1/0000_50_insights-operator_00-insightsoperator.crd.yaml
@@ -16,241 +16,324 @@ spec:
     singular: insightsoperator
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "InsightsOperator holds cluster-wide information about the Insights Operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec is the specification of the desired behavior of the Insights.
-              type: object
-              properties:
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              description: status is the most recently observed status of the Insights operator.
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                gatherStatus:
-                  description: gatherStatus provides basic information about the last Insights data gathering. When omitted, this means no data gathering has taken place yet.
-                  type: object
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "InsightsOperator holds cluster-wide information about the Insights
+          Operator. \n Compatibility level 1: Stable within a major release for a
+          minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              Insights.
+            properties:
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: status is the most recently observed status of the Insights
+              operator.
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
                   properties:
-                    gatherers:
-                      description: gatherers is a list of active gatherers (and their statuses) in the last gathering.
-                      type: array
-                      items:
-                        description: gathererStatus represents information about a particular data gatherer.
-                        type: object
-                        required:
-                          - conditions
-                          - lastGatherDuration
-                          - name
-                        properties:
-                          conditions:
-                            description: conditions provide details on the status of each gatherer.
-                            type: array
-                            minItems: 1
-                            items:
-                              description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                              type: object
-                              required:
-                                - lastTransitionTime
-                                - message
-                                - reason
-                                - status
-                                - type
-                              properties:
-                                lastTransitionTime:
-                                  description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                                  type: string
-                                  format: date-time
-                                message:
-                                  description: message is a human readable message indicating details about the transition. This may be an empty string.
-                                  type: string
-                                  maxLength: 32768
-                                observedGeneration:
-                                  description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                                  type: integer
-                                  format: int64
-                                  minimum: 0
-                                reason:
-                                  description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                                  type: string
-                                  maxLength: 1024
-                                  minLength: 1
-                                  pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                                status:
-                                  description: status of the condition, one of True, False, Unknown.
-                                  type: string
-                                  enum:
-                                    - "True"
-                                    - "False"
-                                    - Unknown
-                                type:
-                                  description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                                  type: string
-                                  maxLength: 316
-                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            x-kubernetes-list-type: atomic
-                          lastGatherDuration:
-                            description: lastGatherDuration represents the time spent gathering.
-                            type: string
-                            pattern: ^([1-9][0-9]*(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                          name:
-                            description: name is the name of the gatherer.
-                            type: string
-                            maxLength: 256
-                            minLength: 5
-                      x-kubernetes-list-type: atomic
-                    lastGatherDuration:
-                      description: lastGatherDuration is the total time taken to process all gatherers during the last gather event.
-                      type: string
-                      pattern: ^0|([1-9][0-9]*(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
-                    lastGatherTime:
-                      description: lastGatherTime is the last time when Insights data gathering finished. An empty value means that no data has been gathered yet.
-                      type: string
+                    lastTransitionTime:
                       format: date-time
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
-                        type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
-                        type: string
-                insightsReport:
-                  description: insightsReport provides general Insights analysis results. When omitted, this means no data gathering has taken place yet.
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
                   type: object
+                type: array
+              gatherStatus:
+                description: gatherStatus provides basic information about the last
+                  Insights data gathering. When omitted, this means no data gathering
+                  has taken place yet.
+                properties:
+                  gatherers:
+                    description: gatherers is a list of active gatherers (and their
+                      statuses) in the last gathering.
+                    items:
+                      description: gathererStatus represents information about a particular
+                        data gatherer.
+                      properties:
+                        conditions:
+                          description: conditions provide details on the status of
+                            each gatherer.
+                          items:
+                            description: "Condition contains details for one aspect
+                              of the current state of this API Resource. --- This
+                              struct is intended for direct use as an array at the
+                              field path .status.conditions.  For example, \n type
+                              FooStatus struct{ // Represents the observations of
+                              a foo's current state. // Known .status.conditions.type
+                              are: \"Available\", \"Progressing\", and \"Degraded\"
+                              // +patchMergeKey=type // +patchStrategy=merge // +listType=map
+                              // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                              patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                              \n // other fields }"
+                            properties:
+                              lastTransitionTime:
+                                description: lastTransitionTime is the last time the
+                                  condition transitioned from one status to another.
+                                  This should be when the underlying condition changed.  If
+                                  that is not known, then using the time when the
+                                  API field changed is acceptable.
+                                format: date-time
+                                type: string
+                              message:
+                                description: message is a human readable message indicating
+                                  details about the transition. This may be an empty
+                                  string.
+                                maxLength: 32768
+                                type: string
+                              observedGeneration:
+                                description: observedGeneration represents the .metadata.generation
+                                  that the condition was set based upon. For instance,
+                                  if .metadata.generation is currently 12, but the
+                                  .status.conditions[x].observedGeneration is 9, the
+                                  condition is out of date with respect to the current
+                                  state of the instance.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                              reason:
+                                description: reason contains a programmatic identifier
+                                  indicating the reason for the condition's last transition.
+                                  Producers of specific condition types may define
+                                  expected values and meanings for this field, and
+                                  whether the values are considered a guaranteed API.
+                                  The value should be a CamelCase string. This field
+                                  may not be empty.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                type: string
+                              status:
+                                description: status of the condition, one of True,
+                                  False, Unknown.
+                                enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                                type: string
+                              type:
+                                description: type of condition in CamelCase or in
+                                  foo.example.com/CamelCase. --- Many .condition.type
+                                  values are consistent across resources like Available,
+                                  but because arbitrary conditions can be useful (see
+                                  .node.status.conditions), the ability to deconflict
+                                  is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                            required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                            type: object
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        lastGatherDuration:
+                          description: lastGatherDuration represents the time spent
+                            gathering.
+                          pattern: ^([1-9][0-9]*(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                          type: string
+                        name:
+                          description: name is the name of the gatherer.
+                          maxLength: 256
+                          minLength: 5
+                          type: string
+                      required:
+                      - conditions
+                      - lastGatherDuration
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  lastGatherDuration:
+                    description: lastGatherDuration is the total time taken to process
+                      all gatherers during the last gather event.
+                    pattern: ^0|([1-9][0-9]*(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                    type: string
+                  lastGatherTime:
+                    description: lastGatherTime is the last time when Insights data
+                      gathering finished. An empty value means that no data has been
+                      gathered yet.
+                    format: date-time
+                    type: string
+                type: object
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
                   properties:
-                    healthChecks:
-                      description: healthChecks provides basic information about active Insights health checks in a cluster.
-                      type: array
-                      items:
-                        description: healthCheck represents an Insights health check attributes.
-                        type: object
-                        required:
-                          - advisorURI
-                          - description
-                          - state
-                          - totalRisk
-                        properties:
-                          advisorURI:
-                            description: advisorURI provides the URL link to the Insights Advisor.
-                            type: string
-                            pattern: ^https:\/\/\S+
-                          description:
-                            description: description provides basic description of the healtcheck.
-                            type: string
-                            maxLength: 2048
-                            minLength: 10
-                          state:
-                            description: state determines what the current state of the health check is. Health check is enabled by default and can be disabled by the user in the Insights advisor user interface.
-                            type: string
-                            enum:
-                              - Enabled
-                              - Disabled
-                          totalRisk:
-                            description: totalRisk of the healthcheck. Indicator of the total risk posed by the detected issue; combination of impact and likelihood. The values can be from 1 to 4, and the higher the number, the more important the issue.
-                            type: integer
-                            format: int32
-                            maximum: 4
-                            minimum: 1
-                      x-kubernetes-list-type: atomic
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
-                  type: string
-      served: true
-      storage: true
-      subresources:
-        scale:
-          labelSelectorPath: .status.selector
-          specReplicasPath: .spec.replicas
-          statusReplicasPath: .status.availableReplicas
-        status: {}
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
+                  type: object
+                type: array
+              insightsReport:
+                description: insightsReport provides general Insights analysis results.
+                  When omitted, this means no data gathering has taken place yet.
+                properties:
+                  healthChecks:
+                    description: healthChecks provides basic information about active
+                      Insights health checks in a cluster.
+                    items:
+                      description: healthCheck represents an Insights health check
+                        attributes.
+                      properties:
+                        advisorURI:
+                          description: advisorURI provides the URL link to the Insights
+                            Advisor.
+                          pattern: ^https:\/\/\S+
+                          type: string
+                        description:
+                          description: description provides basic description of the
+                            healtcheck.
+                          maxLength: 2048
+                          minLength: 10
+                          type: string
+                        state:
+                          description: state determines what the current state of
+                            the health check is. Health check is enabled by default
+                            and can be disabled by the user in the Insights advisor
+                            user interface.
+                          enum:
+                          - Enabled
+                          - Disabled
+                          type: string
+                        totalRisk:
+                          description: totalRisk of the healthcheck. Indicator of
+                            the total risk posed by the detected issue; combination
+                            of impact and likelihood. The values can be from 1 to
+                            4, and the higher the number, the more important the issue.
+                          format: int32
+                          maximum: 4
+                          minimum: 1
+                          type: integer
+                      required:
+                      - advisorURI
+                      - description
+                      - state
+                      - totalRisk
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.availableReplicas
+      status: {}

--- a/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
@@ -15,501 +15,743 @@ spec:
     singular: network
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Network describes the cluster's desired network configuration. It is consumed by the cluster-network-operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: NetworkSpec is the top-level network configuration object.
-              type: object
-              properties:
-                additionalNetworks:
-                  description: additionalNetworks is a list of extra networks to make available to pods when multiple networks are enabled.
-                  type: array
-                  items:
-                    description: AdditionalNetworkDefinition configures an extra network that is available but not created by default. Instead, pods must request them by name. type must be specified, along with exactly one "Config" that matches the type.
-                    type: object
-                    properties:
-                      name:
-                        description: name is the name of the network. This will be populated in the resulting CRD This must be unique.
-                        type: string
-                      namespace:
-                        description: namespace is the namespace of the network. This will be populated in the resulting CRD If not given the network will be created in the default namespace.
-                        type: string
-                      rawCNIConfig:
-                        description: rawCNIConfig is the raw CNI configuration json to create in the NetworkAttachmentDefinition CRD
-                        type: string
-                      simpleMacvlanConfig:
-                        description: SimpleMacvlanConfig configures the macvlan interface in case of type:NetworkTypeSimpleMacvlan
-                        type: object
-                        properties:
-                          ipamConfig:
-                            description: IPAMConfig configures IPAM module will be used for IP Address Management (IPAM).
-                            type: object
-                            properties:
-                              staticIPAMConfig:
-                                description: StaticIPAMConfig configures the static IP address in case of type:IPAMTypeStatic
-                                type: object
-                                properties:
-                                  addresses:
-                                    description: Addresses configures IP address for the interface
-                                    type: array
-                                    items:
-                                      description: StaticIPAMAddresses provides IP address and Gateway for static IPAM addresses
-                                      type: object
-                                      properties:
-                                        address:
-                                          description: Address is the IP address in CIDR format
-                                          type: string
-                                        gateway:
-                                          description: Gateway is IP inside of subnet to designate as the gateway
-                                          type: string
-                                  dns:
-                                    description: DNS configures DNS for the interface
-                                    type: object
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Network describes the cluster's desired network configuration.
+          It is consumed by the cluster-network-operator. \n Compatibility level 1:
+          Stable within a major release for a minimum of 12 months or 3 minor releases
+          (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkSpec is the top-level network configuration object.
+            properties:
+              additionalNetworks:
+                description: additionalNetworks is a list of extra networks to make
+                  available to pods when multiple networks are enabled.
+                items:
+                  description: AdditionalNetworkDefinition configures an extra network
+                    that is available but not created by default. Instead, pods must
+                    request them by name. type must be specified, along with exactly
+                    one "Config" that matches the type.
+                  properties:
+                    name:
+                      description: name is the name of the network. This will be populated
+                        in the resulting CRD This must be unique.
+                      type: string
+                    namespace:
+                      description: namespace is the namespace of the network. This
+                        will be populated in the resulting CRD If not given the network
+                        will be created in the default namespace.
+                      type: string
+                    rawCNIConfig:
+                      description: rawCNIConfig is the raw CNI configuration json
+                        to create in the NetworkAttachmentDefinition CRD
+                      type: string
+                    simpleMacvlanConfig:
+                      description: SimpleMacvlanConfig configures the macvlan interface
+                        in case of type:NetworkTypeSimpleMacvlan
+                      properties:
+                        ipamConfig:
+                          description: IPAMConfig configures IPAM module will be used
+                            for IP Address Management (IPAM).
+                          properties:
+                            staticIPAMConfig:
+                              description: StaticIPAMConfig configures the static
+                                IP address in case of type:IPAMTypeStatic
+                              properties:
+                                addresses:
+                                  description: Addresses configures IP address for
+                                    the interface
+                                  items:
+                                    description: StaticIPAMAddresses provides IP address
+                                      and Gateway for static IPAM addresses
                                     properties:
-                                      domain:
-                                        description: Domain configures the domainname the local domain used for short hostname lookups
+                                      address:
+                                        description: Address is the IP address in
+                                          CIDR format
                                         type: string
-                                      nameservers:
-                                        description: Nameservers points DNS servers for IP lookup
-                                        type: array
-                                        items:
-                                          type: string
-                                      search:
-                                        description: Search configures priority ordered search domains for short hostname lookups
-                                        type: array
-                                        items:
-                                          type: string
-                                  routes:
-                                    description: Routes configures IP routes for the interface
-                                    type: array
-                                    items:
-                                      description: StaticIPAMRoutes provides Destination/Gateway pairs for static IPAM routes
-                                      type: object
-                                      properties:
-                                        destination:
-                                          description: Destination points the IP route destination
-                                          type: string
-                                        gateway:
-                                          description: Gateway is the route's next-hop IP address If unset, a default gateway is assumed (as determined by the CNI plugin).
-                                          type: string
-                              type:
-                                description: Type is the type of IPAM module will be used for IP Address Management(IPAM). The supported values are IPAMTypeDHCP, IPAMTypeStatic
-                                type: string
-                          master:
-                            description: master is the host interface to create the macvlan interface from. If not specified, it will be default route interface
-                            type: string
-                          mode:
-                            description: 'mode is the macvlan mode: bridge, private, vepa, passthru. The default is bridge'
-                            type: string
-                          mtu:
-                            description: mtu is the mtu to use for the macvlan interface. if unset, host's kernel will select the value.
-                            type: integer
-                            format: int32
-                            minimum: 0
-                      type:
-                        description: type is the type of network The supported values are NetworkTypeRaw, NetworkTypeSimpleMacvlan
-                        type: string
-                clusterNetwork:
-                  description: clusterNetwork is the IP address pool to use for pod IPs. Some network providers, e.g. OpenShift SDN, support multiple ClusterNetworks. Others only support one. This is equivalent to the cluster-cidr.
-                  type: array
-                  items:
-                    description: ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks
-                    type: object
+                                      gateway:
+                                        description: Gateway is IP inside of subnet
+                                          to designate as the gateway
+                                        type: string
+                                    type: object
+                                  type: array
+                                dns:
+                                  description: DNS configures DNS for the interface
+                                  properties:
+                                    domain:
+                                      description: Domain configures the domainname
+                                        the local domain used for short hostname lookups
+                                      type: string
+                                    nameservers:
+                                      description: Nameservers points DNS servers
+                                        for IP lookup
+                                      items:
+                                        type: string
+                                      type: array
+                                    search:
+                                      description: Search configures priority ordered
+                                        search domains for short hostname lookups
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                routes:
+                                  description: Routes configures IP routes for the
+                                    interface
+                                  items:
+                                    description: StaticIPAMRoutes provides Destination/Gateway
+                                      pairs for static IPAM routes
+                                    properties:
+                                      destination:
+                                        description: Destination points the IP route
+                                          destination
+                                        type: string
+                                      gateway:
+                                        description: Gateway is the route's next-hop
+                                          IP address If unset, a default gateway is
+                                          assumed (as determined by the CNI plugin).
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            type:
+                              description: Type is the type of IPAM module will be
+                                used for IP Address Management(IPAM). The supported
+                                values are IPAMTypeDHCP, IPAMTypeStatic
+                              type: string
+                          type: object
+                        master:
+                          description: master is the host interface to create the
+                            macvlan interface from. If not specified, it will be default
+                            route interface
+                          type: string
+                        mode:
+                          description: 'mode is the macvlan mode: bridge, private,
+                            vepa, passthru. The default is bridge'
+                          type: string
+                        mtu:
+                          description: mtu is the mtu to use for the macvlan interface.
+                            if unset, host's kernel will select the value.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                      type: object
+                    type:
+                      description: type is the type of network The supported values
+                        are NetworkTypeRaw, NetworkTypeSimpleMacvlan
+                      type: string
+                  type: object
+                type: array
+              clusterNetwork:
+                description: clusterNetwork is the IP address pool to use for pod
+                  IPs. Some network providers, e.g. OpenShift SDN, support multiple
+                  ClusterNetworks. Others only support one. This is equivalent to
+                  the cluster-cidr.
+                items:
+                  description: ClusterNetworkEntry is a subnet from which to allocate
+                    PodIPs. A network of size HostPrefix (in CIDR notation) will be
+                    allocated when nodes join the cluster. If the HostPrefix field
+                    is not used by the plugin, it can be left unset. Not all network
+                    providers support multiple ClusterNetworks
+                  properties:
+                    cidr:
+                      type: string
+                    hostPrefix:
+                      format: int32
+                      minimum: 0
+                      type: integer
+                  type: object
+                type: array
+              defaultNetwork:
+                description: defaultNetwork is the "default" network that all pods
+                  will receive
+                properties:
+                  kuryrConfig:
+                    description: KuryrConfig configures the kuryr plugin
                     properties:
-                      cidr:
-                        type: string
-                      hostPrefix:
-                        type: integer
+                      controllerProbesPort:
+                        description: The port kuryr-controller will listen for readiness
+                          and liveness requests.
                         format: int32
                         minimum: 0
-                defaultNetwork:
-                  description: defaultNetwork is the "default" network that all pods will receive
-                  type: object
-                  properties:
-                    kuryrConfig:
-                      description: KuryrConfig configures the kuryr plugin
-                      type: object
-                      properties:
-                        controllerProbesPort:
-                          description: The port kuryr-controller will listen for readiness and liveness requests.
-                          type: integer
-                          format: int32
-                          minimum: 0
-                        daemonProbesPort:
-                          description: The port kuryr-daemon will listen for readiness and liveness requests.
-                          type: integer
-                          format: int32
-                          minimum: 0
-                        enablePortPoolsPrepopulation:
-                          description: enablePortPoolsPrepopulation when true will make Kuryr prepopulate each newly created port pool with a minimum number of ports. Kuryr uses Neutron port pooling to fight the fact that it takes a significant amount of time to create one. It creates a number of ports when the first pod that is configured to use the dedicated network for pods is created in a namespace, and keeps them ready to be attached to pods. Port prepopulation is disabled by default.
-                          type: boolean
-                        mtu:
-                          description: mtu is the MTU that Kuryr should use when creating pod networks in Neutron. The value has to be lower or equal to the MTU of the nodes network and Neutron has to allow creation of tenant networks with such MTU. If unset Pod networks will be created with the same MTU as the nodes network has.
-                          type: integer
-                          format: int32
-                          minimum: 0
-                        openStackServiceNetwork:
-                          description: openStackServiceNetwork contains the CIDR of network from which to allocate IPs for OpenStack Octavia's Amphora VMs. Please note that with Amphora driver Octavia uses two IPs from that network for each loadbalancer - one given by OpenShift and second for VRRP connections. As the first one is managed by OpenShift's and second by Neutron's IPAMs, those need to come from different pools. Therefore `openStackServiceNetwork` needs to be at least twice the size of `serviceNetwork`, and whole `serviceNetwork` must be overlapping with `openStackServiceNetwork`. cluster-network-operator will then make sure VRRP IPs are taken from the ranges inside `openStackServiceNetwork` that are not overlapping with `serviceNetwork`, effectivly preventing conflicts. If not set cluster-network-operator will use `serviceNetwork` expanded by decrementing the prefix size by 1.
-                          type: string
-                        poolBatchPorts:
-                          description: poolBatchPorts sets a number of ports that should be created in a single batch request to extend the port pool. The default is 3. For more information about port pools see enablePortPoolsPrepopulation setting.
-                          type: integer
-                          minimum: 0
-                        poolMaxPorts:
-                          description: poolMaxPorts sets a maximum number of free ports that are being kept in a port pool. If the number of ports exceeds this setting, free ports will get deleted. Setting 0 will disable this upper bound, effectively preventing pools from shrinking and this is the default value. For more information about port pools see enablePortPoolsPrepopulation setting.
-                          type: integer
-                          minimum: 0
-                        poolMinPorts:
-                          description: poolMinPorts sets a minimum number of free ports that should be kept in a port pool. If the number of ports is lower than this setting, new ports will get created and added to pool. The default is 1. For more information about port pools see enablePortPoolsPrepopulation setting.
-                          type: integer
-                          minimum: 1
-                    openshiftSDNConfig:
-                      description: openShiftSDNConfig configures the openshift-sdn plugin
-                      type: object
-                      properties:
-                        enableUnidling:
-                          description: enableUnidling controls whether or not the service proxy will support idling and unidling of services. By default, unidling is enabled.
-                          type: boolean
-                        mode:
-                          description: mode is one of "Multitenant", "Subnet", or "NetworkPolicy"
-                          type: string
-                        mtu:
-                          description: mtu is the mtu to use for the tunnel interface. Defaults to 1450 if unset. This must be 50 bytes smaller than the machine's uplink.
-                          type: integer
-                          format: int32
-                          minimum: 0
-                        useExternalOpenvswitch:
-                          description: 'useExternalOpenvswitch used to control whether the operator would deploy an OVS DaemonSet itself or expect someone else to start OVS. As of 4.6, OVS is always run as a system service, and this flag is ignored. DEPRECATED: non-functional as of 4.6'
-                          type: boolean
-                        vxlanPort:
-                          description: vxlanPort is the port to use for all vxlan packets. The default is 4789.
-                          type: integer
-                          format: int32
-                          minimum: 0
-                    ovnKubernetesConfig:
-                      description: ovnKubernetesConfig configures the ovn-kubernetes plugin.
-                      type: object
-                      properties:
-                        egressIPConfig:
-                          description: egressIPConfig holds the configuration for EgressIP options.
-                          type: object
-                          properties:
-                            reachabilityTotalTimeoutSeconds:
-                              description: reachabilityTotalTimeout configures the EgressIP node reachability check total timeout in seconds. If the EgressIP node cannot be reached within this timeout, the node is declared down. Setting a large value may cause the EgressIP feature to react slowly to node changes. In particular, it may react slowly for EgressIP nodes that really have a genuine problem and are unreachable. When omitted, this means the user has no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is 1 second. A value of 0 disables the EgressIP node's reachability check.
-                              type: integer
-                              format: int32
-                              maximum: 60
-                              minimum: 0
-                        gatewayConfig:
-                          description: gatewayConfig holds the configuration for node gateway options.
-                          type: object
-                          properties:
-                            routingViaHost:
-                              description: RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.
-                              type: boolean
-                              default: false
-                        genevePort:
-                          description: geneve port is the UDP port to be used by geneve encapulation. Default is 6081
-                          type: integer
-                          format: int32
-                          minimum: 1
-                        hybridOverlayConfig:
-                          description: HybridOverlayConfig configures an additional overlay network for peers that are not using OVN.
-                          type: object
-                          properties:
-                            hybridClusterNetwork:
-                              description: HybridClusterNetwork defines a network space given to nodes on an additional overlay network.
-                              type: array
-                              items:
-                                description: ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks
-                                type: object
-                                properties:
-                                  cidr:
-                                    type: string
-                                  hostPrefix:
-                                    type: integer
-                                    format: int32
-                                    minimum: 0
-                            hybridOverlayVXLANPort:
-                              description: HybridOverlayVXLANPort defines the VXLAN port number to be used by the additional overlay network. Default is 4789
-                              type: integer
-                              format: int32
-                        ipsecConfig:
-                          description: ipsecConfig enables and configures IPsec for pods on the pod network within the cluster.
-                          type: object
-                        mtu:
-                          description: mtu is the MTU to use for the tunnel interface. This must be 100 bytes smaller than the uplink mtu. Default is 1400
-                          type: integer
-                          format: int32
-                          minimum: 0
-                        policyAuditConfig:
-                          description: policyAuditConfig is the configuration for network policy audit events. If unset, reported defaults are used.
-                          type: object
-                          properties:
-                            destination:
-                              description: 'destination is the location for policy log messages. Regardless of this config, persistent logs will always be dumped to the host at /var/log/ovn/ however Additionally syslog output may be configured as follows. Valid values are: - "libc" -> to use the libc syslog() function of the host node''s journdald process - "udp:host:port" -> for sending syslog over UDP - "unix:file" -> for using the UNIX domain socket directly - "null" -> to discard all messages logged to syslog The default is "null"'
-                              type: string
-                              default: "null"
-                            maxFileSize:
-                              description: maxFilesSize is the max size an ACL_audit log file is allowed to reach before rotation occurs Units are in MB and the Default is 50MB
-                              type: integer
-                              format: int32
-                              default: 50
-                              minimum: 1
-                            rateLimit:
-                              description: rateLimit is the approximate maximum number of messages to generate per-second per-node. If unset the default of 20 msg/sec is used.
-                              type: integer
-                              format: int32
-                              default: 20
-                              minimum: 1
-                            syslogFacility:
-                              description: syslogFacility the RFC5424 facility for generated messages, e.g. "kern". Default is "local0"
-                              type: string
-                              default: local0
-                        v4InternalSubnet:
-                          description: v4InternalSubnet is a v4 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is 100.64.0.0/16
-                          type: string
-                        v6InternalSubnet:
-                          description: v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is fd98::/48
-                          type: string
-                    type:
-                      description: type is the type of network All NetworkTypes are supported except for NetworkTypeRaw
-                      type: string
-                deployKubeProxy:
-                  description: deployKubeProxy specifies whether or not a standalone kube-proxy should be deployed by the operator. Some network providers include kube-proxy or similar functionality. If unset, the plugin will attempt to select the correct value, which is false when OpenShift SDN and ovn-kubernetes are used and true otherwise.
-                  type: boolean
-                disableMultiNetwork:
-                  description: disableMultiNetwork specifies whether or not multiple pod network support should be disabled. If unset, this property defaults to 'false' and multiple network support is enabled.
-                  type: boolean
-                disableNetworkDiagnostics:
-                  description: disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck CRs from a test pod to every node, apiserver and LB should be disabled or not. If unset, this property defaults to 'false' and network diagnostics is enabled. Setting this to 'true' would reduce the additional load of the pods performing the checks.
-                  type: boolean
-                  default: false
-                exportNetworkFlows:
-                  description: exportNetworkFlows enables and configures the export of network flow metadata from the pod network by using protocols NetFlow, SFlow or IPFIX. Currently only supported on OVN-Kubernetes plugin. If unset, flows will not be exported to any collector.
-                  type: object
-                  properties:
-                    ipfix:
-                      description: ipfix defines IPFIX configuration.
-                      type: object
-                      properties:
-                        collectors:
-                          description: ipfixCollectors is list of strings formatted as ip:port with a maximum of ten items
-                          type: array
-                          maxItems: 10
-                          minItems: 1
-                          items:
-                            type: string
-                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-                    netFlow:
-                      description: netFlow defines the NetFlow configuration.
-                      type: object
-                      properties:
-                        collectors:
-                          description: netFlow defines the NetFlow collectors that will consume the flow data exported from OVS. It is a list of strings formatted as ip:port with a maximum of ten items
-                          type: array
-                          maxItems: 10
-                          minItems: 1
-                          items:
-                            type: string
-                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-                    sFlow:
-                      description: sFlow defines the SFlow configuration.
-                      type: object
-                      properties:
-                        collectors:
-                          description: sFlowCollectors is list of strings formatted as ip:port with a maximum of ten items
-                          type: array
-                          maxItems: 10
-                          minItems: 1
-                          items:
-                            type: string
-                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
-                kubeProxyConfig:
-                  description: kubeProxyConfig lets us configure desired proxy configuration. If not specified, sensible defaults will be chosen by OpenShift directly. Not consumed by all network providers - currently only openshift-sdn.
-                  type: object
-                  properties:
-                    bindAddress:
-                      description: The address to "bind" on Defaults to 0.0.0.0
-                      type: string
-                    iptablesSyncPeriod:
-                      description: 'An internal kube-proxy parameter. In older releases of OCP, this sometimes needed to be adjusted in large clusters for performance reasons, but this is no longer necessary, and there is no reason to change this from the default value. Default: 30s'
-                      type: string
-                    proxyArguments:
-                      description: Any additional arguments to pass to the kubeproxy process
-                      type: object
-                      additionalProperties:
-                        description: ProxyArgumentList is a list of arguments to pass to the kubeproxy process
-                        type: array
-                        items:
-                          type: string
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                migration:
-                  description: migration enables and configures the cluster network migration. The migration procedure allows to change the network type and the MTU.
-                  type: object
-                  properties:
-                    features:
-                      description: features contains the features migration configuration. Set this to migrate feature configuration when changing the cluster default network provider. if unset, the default operation is to migrate all the configuration of supported features.
-                      type: object
-                      properties:
-                        egressFirewall:
-                          description: egressFirewall specifies whether or not the Egress Firewall configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and Egress Firewall configure is migrated.
-                          type: boolean
-                          default: true
-                        egressIP:
-                          description: egressIP specifies whether or not the Egress IP configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and Egress IP configure is migrated.
-                          type: boolean
-                          default: true
-                        multicast:
-                          description: multicast specifies whether or not the multicast configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and multicast configure is migrated.
-                          type: boolean
-                          default: true
-                    mtu:
-                      description: mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.
-                      type: object
-                      properties:
-                        machine:
-                          description: machine contains MTU migration configuration for the machine's uplink. Needs to be migrated along with the default network MTU unless the current uplink MTU already accommodates the default network MTU.
-                          type: object
-                          properties:
-                            from:
-                              description: from is the MTU to migrate from.
-                              type: integer
-                              format: int32
-                              minimum: 0
-                            to:
-                              description: to is the MTU to migrate to.
-                              type: integer
-                              format: int32
-                              minimum: 0
-                        network:
-                          description: network contains information about MTU migration for the default network. Migrations are only allowed to MTU values lower than the machine's uplink MTU by the minimum appropriate offset.
-                          type: object
-                          properties:
-                            from:
-                              description: from is the MTU to migrate from.
-                              type: integer
-                              format: int32
-                              minimum: 0
-                            to:
-                              description: to is the MTU to migrate to.
-                              type: integer
-                              format: int32
-                              minimum: 0
-                    networkType:
-                      description: networkType is the target type of network migration. Set this to the target network type to allow changing the default network. If unset, the operation of changing cluster default network plugin will be rejected. The supported values are OpenShiftSDN, OVNKubernetes
-                      type: string
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                serviceNetwork:
-                  description: serviceNetwork is the ip address pool to use for Service IPs Currently, all existing network providers only support a single value here, but this is an array to allow for growth.
-                  type: array
-                  items:
-                    type: string
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                useMultiNetworkPolicy:
-                  description: useMultiNetworkPolicy enables a controller which allows for MultiNetworkPolicy objects to be used on additional networks as created by Multus CNI. MultiNetworkPolicy are similar to NetworkPolicy objects, but NetworkPolicy objects only apply to the primary interface. With MultiNetworkPolicy, you can control the traffic that a pod can receive over the secondary interfaces. If unset, this property defaults to 'false' and MultiNetworkPolicy objects are ignored. If 'disableMultiNetwork' is 'true' then the value of this field is ignored.
-                  type: boolean
-            status:
-              description: NetworkStatus is detailed operator status, which is distilled up to the Network clusteroperator object.
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
-                    properties:
-                      lastTransitionTime:
-                        type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
                         type: integer
-                        format: int64
-                      name:
-                        description: name is the name of the thing you're tracking
+                      daemonProbesPort:
+                        description: The port kuryr-daemon will listen for readiness
+                          and liveness requests.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      enablePortPoolsPrepopulation:
+                        description: enablePortPoolsPrepopulation when true will make
+                          Kuryr prepopulate each newly created port pool with a minimum
+                          number of ports. Kuryr uses Neutron port pooling to fight
+                          the fact that it takes a significant amount of time to create
+                          one. It creates a number of ports when the first pod that
+                          is configured to use the dedicated network for pods is created
+                          in a namespace, and keeps them ready to be attached to pods.
+                          Port prepopulation is disabled by default.
+                        type: boolean
+                      mtu:
+                        description: mtu is the MTU that Kuryr should use when creating
+                          pod networks in Neutron. The value has to be lower or equal
+                          to the MTU of the nodes network and Neutron has to allow
+                          creation of tenant networks with such MTU. If unset Pod
+                          networks will be created with the same MTU as the nodes
+                          network has.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      openStackServiceNetwork:
+                        description: openStackServiceNetwork contains the CIDR of
+                          network from which to allocate IPs for OpenStack Octavia's
+                          Amphora VMs. Please note that with Amphora driver Octavia
+                          uses two IPs from that network for each loadbalancer - one
+                          given by OpenShift and second for VRRP connections. As the
+                          first one is managed by OpenShift's and second by Neutron's
+                          IPAMs, those need to come from different pools. Therefore
+                          `openStackServiceNetwork` needs to be at least twice the
+                          size of `serviceNetwork`, and whole `serviceNetwork` must
+                          be overlapping with `openStackServiceNetwork`. cluster-network-operator
+                          will then make sure VRRP IPs are taken from the ranges inside
+                          `openStackServiceNetwork` that are not overlapping with
+                          `serviceNetwork`, effectivly preventing conflicts. If not
+                          set cluster-network-operator will use `serviceNetwork` expanded
+                          by decrementing the prefix size by 1.
                         type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
+                      poolBatchPorts:
+                        description: poolBatchPorts sets a number of ports that should
+                          be created in a single batch request to extend the port
+                          pool. The default is 3. For more information about port
+                          pools see enablePortPoolsPrepopulation setting.
+                        minimum: 0
+                        type: integer
+                      poolMaxPorts:
+                        description: poolMaxPorts sets a maximum number of free ports
+                          that are being kept in a port pool. If the number of ports
+                          exceeds this setting, free ports will get deleted. Setting
+                          0 will disable this upper bound, effectively preventing
+                          pools from shrinking and this is the default value. For
+                          more information about port pools see enablePortPoolsPrepopulation
+                          setting.
+                        minimum: 0
+                        type: integer
+                      poolMinPorts:
+                        description: poolMinPorts sets a minimum number of free ports
+                          that should be kept in a port pool. If the number of ports
+                          is lower than this setting, new ports will get created and
+                          added to pool. The default is 1. For more information about
+                          port pools see enablePortPoolsPrepopulation setting.
+                        minimum: 1
+                        type: integer
+                    type: object
+                  openshiftSDNConfig:
+                    description: openShiftSDNConfig configures the openshift-sdn plugin
+                    properties:
+                      enableUnidling:
+                        description: enableUnidling controls whether or not the service
+                          proxy will support idling and unidling of services. By default,
+                          unidling is enabled.
+                        type: boolean
+                      mode:
+                        description: mode is one of "Multitenant", "Subnet", or "NetworkPolicy"
                         type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
+                      mtu:
+                        description: mtu is the mtu to use for the tunnel interface.
+                          Defaults to 1450 if unset. This must be 50 bytes smaller
+                          than the machine's uplink.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      useExternalOpenvswitch:
+                        description: 'useExternalOpenvswitch used to control whether
+                          the operator would deploy an OVS DaemonSet itself or expect
+                          someone else to start OVS. As of 4.6, OVS is always run
+                          as a system service, and this flag is ignored. DEPRECATED:
+                          non-functional as of 4.6'
+                        type: boolean
+                      vxlanPort:
+                        description: vxlanPort is the port to use for all vxlan packets.
+                          The default is 4789.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                    type: object
+                  ovnKubernetesConfig:
+                    description: ovnKubernetesConfig configures the ovn-kubernetes
+                      plugin.
+                    properties:
+                      egressIPConfig:
+                        description: egressIPConfig holds the configuration for EgressIP
+                          options.
+                        properties:
+                          reachabilityTotalTimeoutSeconds:
+                            description: reachabilityTotalTimeout configures the EgressIP
+                              node reachability check total timeout in seconds. If
+                              the EgressIP node cannot be reached within this timeout,
+                              the node is declared down. Setting a large value may
+                              cause the EgressIP feature to react slowly to node changes.
+                              In particular, it may react slowly for EgressIP nodes
+                              that really have a genuine problem and are unreachable.
+                              When omitted, this means the user has no opinion and
+                              the platform is left to choose a reasonable default,
+                              which is subject to change over time. The current default
+                              is 1 second. A value of 0 disables the EgressIP node's
+                              reachability check.
+                            format: int32
+                            maximum: 60
+                            minimum: 0
+                            type: integer
+                        type: object
+                      gatewayConfig:
+                        description: gatewayConfig holds the configuration for node
+                          gateway options.
+                        properties:
+                          routingViaHost:
+                            default: false
+                            description: RoutingViaHost allows pod egress traffic
+                              to exit via the ovn-k8s-mp0 management port into the
+                              host before sending it out. If this is not set, traffic
+                              will always egress directly from OVN to outside without
+                              touching the host stack. Setting this to true means
+                              hardware offload will not be supported. Default is false
+                              if GatewayConfig is specified.
+                            type: boolean
+                        type: object
+                      genevePort:
+                        description: geneve port is the UDP port to be used by geneve
+                          encapulation. Default is 6081
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      hybridOverlayConfig:
+                        description: HybridOverlayConfig configures an additional
+                          overlay network for peers that are not using OVN.
+                        properties:
+                          hybridClusterNetwork:
+                            description: HybridClusterNetwork defines a network space
+                              given to nodes on an additional overlay network.
+                            items:
+                              description: ClusterNetworkEntry is a subnet from which
+                                to allocate PodIPs. A network of size HostPrefix (in
+                                CIDR notation) will be allocated when nodes join the
+                                cluster. If the HostPrefix field is not used by the
+                                plugin, it can be left unset. Not all network providers
+                                support multiple ClusterNetworks
+                              properties:
+                                cidr:
+                                  type: string
+                                hostPrefix:
+                                  format: int32
+                                  minimum: 0
+                                  type: integer
+                              type: object
+                            type: array
+                          hybridOverlayVXLANPort:
+                            description: HybridOverlayVXLANPort defines the VXLAN
+                              port number to be used by the additional overlay network.
+                              Default is 4789
+                            format: int32
+                            type: integer
+                        type: object
+                      ipsecConfig:
+                        description: ipsecConfig enables and configures IPsec for
+                          pods on the pod network within the cluster.
+                        type: object
+                      mtu:
+                        description: mtu is the MTU to use for the tunnel interface.
+                          This must be 100 bytes smaller than the uplink mtu. Default
+                          is 1400
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      policyAuditConfig:
+                        description: policyAuditConfig is the configuration for network
+                          policy audit events. If unset, reported defaults are used.
+                        properties:
+                          destination:
+                            default: "null"
+                            description: 'destination is the location for policy log
+                              messages. Regardless of this config, persistent logs
+                              will always be dumped to the host at /var/log/ovn/ however
+                              Additionally syslog output may be configured as follows.
+                              Valid values are: - "libc" -> to use the libc syslog()
+                              function of the host node''s journdald process - "udp:host:port"
+                              -> for sending syslog over UDP - "unix:file" -> for
+                              using the UNIX domain socket directly - "null" -> to
+                              discard all messages logged to syslog The default is
+                              "null"'
+                            type: string
+                          maxFileSize:
+                            default: 50
+                            description: maxFilesSize is the max size an ACL_audit
+                              log file is allowed to reach before rotation occurs
+                              Units are in MB and the Default is 50MB
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          rateLimit:
+                            default: 20
+                            description: rateLimit is the approximate maximum number
+                              of messages to generate per-second per-node. If unset
+                              the default of 20 msg/sec is used.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          syslogFacility:
+                            default: local0
+                            description: syslogFacility the RFC5424 facility for generated
+                              messages, e.g. "kern". Default is "local0"
+                            type: string
+                        type: object
+                      v4InternalSubnet:
+                        description: v4InternalSubnet is a v4 subnet used internally
+                          by ovn-kubernetes in case the default one is being already
+                          used by something else. It must not overlap with any other
+                          subnet being used by OpenShift or by the node network. The
+                          size of the subnet must be larger than the number of nodes.
+                          The value cannot be changed after installation. Default
+                          is 100.64.0.0/16
                         type: string
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
+                      v6InternalSubnet:
+                        description: v6InternalSubnet is a v6 subnet used internally
+                          by ovn-kubernetes in case the default one is being already
+                          used by something else. It must not overlap with any other
+                          subnet being used by OpenShift or by the node network. The
+                          size of the subnet must be larger than the number of nodes.
+                          The value cannot be changed after installation. Default
+                          is fd98::/48
+                        type: string
+                    type: object
+                  type:
+                    description: type is the type of network All NetworkTypes are
+                      supported except for NetworkTypeRaw
+                    type: string
+                type: object
+              deployKubeProxy:
+                description: deployKubeProxy specifies whether or not a standalone
+                  kube-proxy should be deployed by the operator. Some network providers
+                  include kube-proxy or similar functionality. If unset, the plugin
+                  will attempt to select the correct value, which is false when OpenShift
+                  SDN and ovn-kubernetes are used and true otherwise.
+                type: boolean
+              disableMultiNetwork:
+                description: disableMultiNetwork specifies whether or not multiple
+                  pod network support should be disabled. If unset, this property
+                  defaults to 'false' and multiple network support is enabled.
+                type: boolean
+              disableNetworkDiagnostics:
+                default: false
+                description: disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck
+                  CRs from a test pod to every node, apiserver and LB should be disabled
+                  or not. If unset, this property defaults to 'false' and network
+                  diagnostics is enabled. Setting this to 'true' would reduce the
+                  additional load of the pods performing the checks.
+                type: boolean
+              exportNetworkFlows:
+                description: exportNetworkFlows enables and configures the export
+                  of network flow metadata from the pod network by using protocols
+                  NetFlow, SFlow or IPFIX. Currently only supported on OVN-Kubernetes
+                  plugin. If unset, flows will not be exported to any collector.
+                properties:
+                  ipfix:
+                    description: ipfix defines IPFIX configuration.
+                    properties:
+                      collectors:
+                        description: ipfixCollectors is list of strings formatted
+                          as ip:port with a maximum of ten items
+                        items:
+                          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                          type: string
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                    type: object
+                  netFlow:
+                    description: netFlow defines the NetFlow configuration.
+                    properties:
+                      collectors:
+                        description: netFlow defines the NetFlow collectors that will
+                          consume the flow data exported from OVS. It is a list of
+                          strings formatted as ip:port with a maximum of ten items
+                        items:
+                          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                          type: string
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                    type: object
+                  sFlow:
+                    description: sFlow defines the SFlow configuration.
+                    properties:
+                      collectors:
+                        description: sFlowCollectors is list of strings formatted
+                          as ip:port with a maximum of ten items
+                        items:
+                          pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                          type: string
+                        maxItems: 10
+                        minItems: 1
+                        type: array
+                    type: object
+                type: object
+              kubeProxyConfig:
+                description: kubeProxyConfig lets us configure desired proxy configuration.
+                  If not specified, sensible defaults will be chosen by OpenShift
+                  directly. Not consumed by all network providers - currently only
+                  openshift-sdn.
+                properties:
+                  bindAddress:
+                    description: The address to "bind" on Defaults to 0.0.0.0
+                    type: string
+                  iptablesSyncPeriod:
+                    description: 'An internal kube-proxy parameter. In older releases
+                      of OCP, this sometimes needed to be adjusted in large clusters
+                      for performance reasons, but this is no longer necessary, and
+                      there is no reason to change this from the default value. Default:
+                      30s'
+                    type: string
+                  proxyArguments:
+                    additionalProperties:
+                      description: ProxyArgumentList is a list of arguments to pass
+                        to the kubeproxy process
+                      items:
+                        type: string
+                      type: array
+                    description: Any additional arguments to pass to the kubeproxy
+                      process
+                    type: object
+                type: object
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              migration:
+                description: migration enables and configures the cluster network
+                  migration. The migration procedure allows to change the network
+                  type and the MTU.
+                properties:
+                  features:
+                    description: features contains the features migration configuration.
+                      Set this to migrate feature configuration when changing the
+                      cluster default network provider. if unset, the default operation
+                      is to migrate all the configuration of supported features.
+                    properties:
+                      egressFirewall:
+                        default: true
+                        description: egressFirewall specifies whether or not the Egress
+                          Firewall configuration is migrated automatically when changing
+                          the cluster default network provider. If unset, this property
+                          defaults to 'true' and Egress Firewall configure is migrated.
+                        type: boolean
+                      egressIP:
+                        default: true
+                        description: egressIP specifies whether or not the Egress
+                          IP configuration is migrated automatically when changing
+                          the cluster default network provider. If unset, this property
+                          defaults to 'true' and Egress IP configure is migrated.
+                        type: boolean
+                      multicast:
+                        default: true
+                        description: multicast specifies whether or not the multicast
+                          configuration is migrated automatically when changing the
+                          cluster default network provider. If unset, this property
+                          defaults to 'true' and multicast configure is migrated.
+                        type: boolean
+                    type: object
+                  mtu:
+                    description: mtu contains the MTU migration configuration. Set
+                      this to allow changing the MTU values for the default network.
+                      If unset, the operation of changing the MTU for the default
+                      network will be rejected.
+                    properties:
+                      machine:
+                        description: machine contains MTU migration configuration
+                          for the machine's uplink. Needs to be migrated along with
+                          the default network MTU unless the current uplink MTU already
+                          accommodates the default network MTU.
+                        properties:
+                          from:
+                            description: from is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: to is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      network:
+                        description: network contains information about MTU migration
+                          for the default network. Migrations are only allowed to
+                          MTU values lower than the machine's uplink MTU by the minimum
+                          appropriate offset.
+                        properties:
+                          from:
+                            description: from is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: to is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  networkType:
+                    description: networkType is the target type of network migration.
+                      Set this to the target network type to allow changing the default
+                      network. If unset, the operation of changing cluster default
+                      network plugin will be rejected. The supported values are OpenShiftSDN,
+                      OVNKubernetes
+                    type: string
+                type: object
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              serviceNetwork:
+                description: serviceNetwork is the ip address pool to use for Service
+                  IPs Currently, all existing network providers only support a single
+                  value here, but this is an array to allow for growth.
+                items:
                   type: string
-      served: true
-      storage: true
+                type: array
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              useMultiNetworkPolicy:
+                description: useMultiNetworkPolicy enables a controller which allows
+                  for MultiNetworkPolicy objects to be used on additional networks
+                  as created by Multus CNI. MultiNetworkPolicy are similar to NetworkPolicy
+                  objects, but NetworkPolicy objects only apply to the primary interface.
+                  With MultiNetworkPolicy, you can control the traffic that a pod
+                  can receive over the secondary interfaces. If unset, this property
+                  defaults to 'false' and MultiNetworkPolicy objects are ignored.
+                  If 'disableMultiNetwork' is 'true' then the value of this field
+                  is ignored.
+                type: boolean
+            type: object
+          status:
+            description: NetworkStatus is detailed operator status, which is distilled
+              up to the Network clusteroperator object.
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/operator/v1/0000_70_console-operator.crd.yaml
+++ b/operator/v1/0000_70_console-operator.crd.yaml
@@ -16,260 +16,356 @@ spec:
     singular: console
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Console provides a means to configure an operator to manage the console. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConsoleSpec is the specification of the desired behavior of the Console.
-              type: object
-              properties:
-                customization:
-                  description: customization is used to optionally provide a small set of customization options to the web console.
-                  type: object
-                  properties:
-                    addPage:
-                      description: addPage allows customizing actions on the Add page in developer perspective.
-                      type: object
-                      properties:
-                        disabledActions:
-                          description: disabledActions is a list of actions that are not shown to users. Each action in the list is represented by its ID.
-                          type: array
-                          minItems: 1
-                          items:
-                            type: string
-                    brand:
-                      description: brand is the default branding of the web console which can be overridden by providing the brand field.  There is a limited set of specific brand options. This field controls elements of the console such as the logo. Invalid value will prevent a console rollout.
-                      type: string
-                      pattern: ^$|^(ocp|origin|okd|dedicated|online|azure)$
-                    customLogoFile:
-                      description: 'customLogoFile replaces the default OpenShift logo in the masthead and about dialog. It is a reference to a ConfigMap in the openshift-config namespace. This can be created with a command like ''oc create configmap custom-logo --from-file=/path/to/file -n openshift-config''. Image size must be less than 1 MB due to constraints on the ConfigMap size. The ConfigMap key should include a file extension so that the console serves the file with the correct MIME type. Recommended logo specifications: Dimensions: Max height of 68px and max width of 200px SVG format preferred'
-                      type: object
-                      properties:
-                        key:
-                          description: Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Console provides a means to configure an operator to manage
+          the console. \n Compatibility level 1: Stable within a major release for
+          a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConsoleSpec is the specification of the desired behavior
+              of the Console.
+            properties:
+              customization:
+                description: customization is used to optionally provide a small set
+                  of customization options to the web console.
+                properties:
+                  addPage:
+                    description: addPage allows customizing actions on the Add page
+                      in developer perspective.
+                    properties:
+                      disabledActions:
+                        description: disabledActions is a list of actions that are
+                          not shown to users. Each action in the list is represented
+                          by its ID.
+                        items:
                           type: string
-                        name:
-                          type: string
-                    customProductName:
-                      description: customProductName is the name that will be displayed in page titles, logo alt text, and the about dialog instead of the normal OpenShift product name.
-                      type: string
-                    developerCatalog:
-                      description: developerCatalog allows to configure the shown developer catalog categories.
-                      type: object
-                      properties:
-                        categories:
-                          description: categories which are shown in the developer catalog.
-                          type: array
-                          items:
-                            description: DeveloperConsoleCatalogCategory for the developer console catalog.
-                            type: object
-                            required:
-                              - id
-                              - label
-                            properties:
-                              id:
-                                description: ID is an identifier used in the URL to enable deep linking in console. ID is required and must have 1-32 URL safe (A-Z, a-z, 0-9, - and _) characters.
-                                type: string
-                                maxLength: 32
-                                minLength: 1
-                                pattern: ^[A-Za-z0-9-_]+$
-                              label:
-                                description: label defines a category display label. It is required and must have 1-64 characters.
-                                type: string
-                                maxLength: 64
-                                minLength: 1
-                              subcategories:
-                                description: subcategories defines a list of child categories.
-                                type: array
-                                items:
-                                  description: DeveloperConsoleCatalogCategoryMeta are the key identifiers of a developer catalog category.
-                                  type: object
-                                  required:
-                                    - id
-                                    - label
-                                  properties:
-                                    id:
-                                      description: ID is an identifier used in the URL to enable deep linking in console. ID is required and must have 1-32 URL safe (A-Z, a-z, 0-9, - and _) characters.
-                                      type: string
-                                      maxLength: 32
-                                      minLength: 1
-                                      pattern: ^[A-Za-z0-9-_]+$
-                                    label:
-                                      description: label defines a category display label. It is required and must have 1-64 characters.
-                                      type: string
-                                      maxLength: 64
-                                      minLength: 1
-                                    tags:
-                                      description: tags is a list of strings that will match the category. A selected category show all items which has at least one overlapping tag between category and item.
-                                      type: array
-                                      items:
-                                        type: string
-                              tags:
-                                description: tags is a list of strings that will match the category. A selected category show all items which has at least one overlapping tag between category and item.
-                                type: array
-                                items:
-                                  type: string
-                    documentationBaseURL:
-                      description: documentationBaseURL links to external documentation are shown in various sections of the web console.  Providing documentationBaseURL will override the default documentation URL. Invalid value will prevent a console rollout.
-                      type: string
-                      pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))\/$
-                    projectAccess:
-                      description: projectAccess allows customizing the available list of ClusterRoles in the Developer perspective Project access page which can be used by a project admin to specify roles to other users and restrict access within the project. If set, the list will replace the default ClusterRole options.
-                      type: object
-                      properties:
-                        availableClusterRoles:
-                          description: availableClusterRoles is the list of ClusterRole names that are assignable to users through the project access tab.
-                          type: array
-                          items:
-                            type: string
-                    quickStarts:
-                      description: quickStarts allows customization of available ConsoleQuickStart resources in console.
-                      type: object
-                      properties:
-                        disabled:
-                          description: disabled is a list of ConsoleQuickStart resource names that are not shown to users.
-                          type: array
-                          items:
-                            type: string
-                logLevel:
-                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                managementState:
-                  description: managementState indicates whether and how the operator should manage the component
-                  type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                observedConfig:
-                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
-                  type: string
-                  default: Normal
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                plugins:
-                  description: plugins defines a list of enabled console plugin names.
-                  type: array
-                  items:
+                        minItems: 1
+                        type: array
+                    type: object
+                  brand:
+                    description: brand is the default branding of the web console
+                      which can be overridden by providing the brand field.  There
+                      is a limited set of specific brand options. This field controls
+                      elements of the console such as the logo. Invalid value will
+                      prevent a console rollout.
+                    pattern: ^$|^(ocp|origin|okd|dedicated|online|azure)$
                     type: string
-                providers:
-                  description: providers contains configuration for using specific service providers.
-                  type: object
-                  properties:
-                    statuspage:
-                      description: statuspage contains ID for statuspage.io page that provides status info about.
-                      type: object
-                      properties:
-                        pageID:
-                          description: pageID is the unique ID assigned by Statuspage for your page. This must be a public page.
-                          type: string
-                route:
-                  description: route contains hostname and secret reference that contains the serving certificate. If a custom route is specified, a new route will be created with the provided hostname, under which console will be available. In case of custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed. In case of custom hostname points to an arbitrary domain, manual DNS configurations steps are necessary. The default console route will be maintained to reserve the default hostname for console if the custom route is removed. If not specified, default route will be used. DEPRECATED
-                  type: object
-                  properties:
-                    hostname:
-                      description: hostname is the desired custom domain under which console will be available.
-                      type: string
-                    secret:
-                      description: 'secret points to secret in the openshift-config namespace that contains custom certificate and key and needs to be created manually by the cluster admin. Referenced Secret is required to contain following key value pairs: - "tls.crt" - to specifies custom certificate - "tls.key" - to specifies private key of the custom certificate If the custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed.'
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        name:
-                          description: name is the metadata.name of the referenced secret
-                          type: string
-                unsupportedConfigOverrides:
-                  description: 'unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
-                  type: object
-                  nullable: true
-                  x-kubernetes-preserve-unknown-fields: true
-            status:
-              description: ConsoleStatus defines the observed status of the Console.
-              type: object
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  type: array
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    type: object
+                  customLogoFile:
+                    description: 'customLogoFile replaces the default OpenShift logo
+                      in the masthead and about dialog. It is a reference to a ConfigMap
+                      in the openshift-config namespace. This can be created with
+                      a command like ''oc create configmap custom-logo --from-file=/path/to/file
+                      -n openshift-config''. Image size must be less than 1 MB due
+                      to constraints on the ConfigMap size. The ConfigMap key should
+                      include a file extension so that the console serves the file
+                      with the correct MIME type. Recommended logo specifications:
+                      Dimensions: Max height of 68px and max width of 200px SVG format
+                      preferred'
                     properties:
-                      lastTransitionTime:
+                      key:
+                        description: Key allows pointing to a specific key/value inside
+                          of the configmap.  This is useful for logical file references.
                         type: string
-                        format: date-time
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        type: string
-                      type:
-                        type: string
-                generations:
-                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-                  type: array
-                  items:
-                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
-                    type: object
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload controller involved
-                        type: integer
-                        format: int64
                       name:
-                        description: name is the name of the thing you're tracking
                         type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're tracking
-                        type: string
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've dealt with
-                  type: integer
-                  format: int64
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and at the desired state
-                  type: integer
-                  format: int32
-                version:
-                  description: version is the level this availability applies to
+                    type: object
+                  customProductName:
+                    description: customProductName is the name that will be displayed
+                      in page titles, logo alt text, and the about dialog instead
+                      of the normal OpenShift product name.
+                    type: string
+                  developerCatalog:
+                    description: developerCatalog allows to configure the shown developer
+                      catalog categories.
+                    properties:
+                      categories:
+                        description: categories which are shown in the developer catalog.
+                        items:
+                          description: DeveloperConsoleCatalogCategory for the developer
+                            console catalog.
+                          properties:
+                            id:
+                              description: ID is an identifier used in the URL to
+                                enable deep linking in console. ID is required and
+                                must have 1-32 URL safe (A-Z, a-z, 0-9, - and _) characters.
+                              maxLength: 32
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9-_]+$
+                              type: string
+                            label:
+                              description: label defines a category display label.
+                                It is required and must have 1-64 characters.
+                              maxLength: 64
+                              minLength: 1
+                              type: string
+                            subcategories:
+                              description: subcategories defines a list of child categories.
+                              items:
+                                description: DeveloperConsoleCatalogCategoryMeta are
+                                  the key identifiers of a developer catalog category.
+                                properties:
+                                  id:
+                                    description: ID is an identifier used in the URL
+                                      to enable deep linking in console. ID is required
+                                      and must have 1-32 URL safe (A-Z, a-z, 0-9,
+                                      - and _) characters.
+                                    maxLength: 32
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9-_]+$
+                                    type: string
+                                  label:
+                                    description: label defines a category display
+                                      label. It is required and must have 1-64 characters.
+                                    maxLength: 64
+                                    minLength: 1
+                                    type: string
+                                  tags:
+                                    description: tags is a list of strings that will
+                                      match the category. A selected category show
+                                      all items which has at least one overlapping
+                                      tag between category and item.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - id
+                                - label
+                                type: object
+                              type: array
+                            tags:
+                              description: tags is a list of strings that will match
+                                the category. A selected category show all items which
+                                has at least one overlapping tag between category
+                                and item.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - id
+                          - label
+                          type: object
+                        type: array
+                    type: object
+                  documentationBaseURL:
+                    description: documentationBaseURL links to external documentation
+                      are shown in various sections of the web console.  Providing
+                      documentationBaseURL will override the default documentation
+                      URL. Invalid value will prevent a console rollout.
+                    pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))\/$
+                    type: string
+                  projectAccess:
+                    description: projectAccess allows customizing the available list
+                      of ClusterRoles in the Developer perspective Project access
+                      page which can be used by a project admin to specify roles to
+                      other users and restrict access within the project. If set,
+                      the list will replace the default ClusterRole options.
+                    properties:
+                      availableClusterRoles:
+                        description: availableClusterRoles is the list of ClusterRole
+                          names that are assignable to users through the project access
+                          tab.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  quickStarts:
+                    description: quickStarts allows customization of available ConsoleQuickStart
+                      resources in console.
+                    properties:
+                      disabled:
+                        description: disabled is a list of ConsoleQuickStart resource
+                          names that are not shown to users.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              plugins:
+                description: plugins defines a list of enabled console plugin names.
+                items:
                   type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              providers:
+                description: providers contains configuration for using specific service
+                  providers.
+                properties:
+                  statuspage:
+                    description: statuspage contains ID for statuspage.io page that
+                      provides status info about.
+                    properties:
+                      pageID:
+                        description: pageID is the unique ID assigned by Statuspage
+                          for your page. This must be a public page.
+                        type: string
+                    type: object
+                type: object
+              route:
+                description: route contains hostname and secret reference that contains
+                  the serving certificate. If a custom route is specified, a new route
+                  will be created with the provided hostname, under which console
+                  will be available. In case of custom hostname uses the default routing
+                  suffix of the cluster, the Secret specification for a serving certificate
+                  will not be needed. In case of custom hostname points to an arbitrary
+                  domain, manual DNS configurations steps are necessary. The default
+                  console route will be maintained to reserve the default hostname
+                  for console if the custom route is removed. If not specified, default
+                  route will be used. DEPRECATED
+                properties:
+                  hostname:
+                    description: hostname is the desired custom domain under which
+                      console will be available.
+                    type: string
+                  secret:
+                    description: 'secret points to secret in the openshift-config
+                      namespace that contains custom certificate and key and needs
+                      to be created manually by the cluster admin. Referenced Secret
+                      is required to contain following key value pairs: - "tls.crt"
+                      - to specifies custom certificate - "tls.key" - to specifies
+                      private key of the custom certificate If the custom hostname
+                      uses the default routing suffix of the cluster, the Secret specification
+                      for a serving certificate will not be needed.'
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              unsupportedConfigOverrides:
+                description: 'unsupportedConfigOverrides holds a sparse config that
+                  will override any previously set options.  It only needs to be the
+                  fields to override it will end up overlaying in the following order:
+                  1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: ConsoleStatus defines the observed status of the Console.
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
+++ b/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
@@ -16,44 +16,82 @@ spec:
     singular: imagecontentsourcepolicy
   scope: Cluster
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: "ImageContentSourcePolicy holds cluster-wide information about how to handle registry mirror rules. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              type: object
-              properties:
-                repositoryDigestMirrors:
-                  description: "repositoryDigestMirrors allows images referenced by image digests in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in RepositoryDigestMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. Only image pull specifications that have an image digest will have this behavior applied to them - tags will continue to be pulled from the specified repository in the pull spec. \n Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified."
-                  type: array
-                  items:
-                    description: 'RepositoryDigestMirrors holds cluster-wide information about how to handle mirros in the registries config. Note: the mirrors only work when pulling the images that are referenced by their digests.'
-                    type: object
-                    required:
-                      - source
-                    properties:
-                      mirrors:
-                        description: mirrors is one or more repositories that may also contain the same images. The order of mirrors in this list is treated as the user's desired priority, while source is by default considered lower priority than all mirrors. Other cluster configuration, including (but not limited to) other repositoryDigestMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering.
-                        type: array
-                        items:
-                          type: string
-                      source:
-                        description: source is the repository that users refer to, e.g. in image pull specifications.
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "ImageContentSourcePolicy holds cluster-wide information about
+          how to handle registry mirror rules. When multiple policies are defined,
+          the outcome of the behavior is defined on each field. \n Compatibility level
+          4: No compatibility is provided, the API can change at any point for any
+          reason. These capabilities should not be used by applications needing long
+          term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              repositoryDigestMirrors:
+                description: "repositoryDigestMirrors allows images referenced by
+                  image digests in pods to be pulled from alternative mirrored repository
+                  locations. The image pull specification provided to the pod will
+                  be compared to the source locations described in RepositoryDigestMirrors
+                  and the image may be pulled down from any of the mirrors in the
+                  list instead of the specified repository allowing administrators
+                  to choose a potentially faster mirror. Only image pull specifications
+                  that have an image digest will have this behavior applied to them
+                  - tags will continue to be pulled from the specified repository
+                  in the pull spec. \n Each “source” repository is treated independently;
+                  configurations for different “source” repositories don’t interact.
+                  \n When multiple policies are defined for the same “source” repository,
+                  the sets of defined mirrors will be merged together, preserving
+                  the relative order of the mirrors, if possible. For example, if
+                  policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`,
+                  the mirrors will be used in the order `a, b, c, d, e`.  If the orders
+                  of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration
+                  is not rejected but the resulting order is unspecified."
+                items:
+                  description: 'RepositoryDigestMirrors holds cluster-wide information
+                    about how to handle mirros in the registries config. Note: the
+                    mirrors only work when pulling the images that are referenced
+                    by their digests.'
+                  properties:
+                    mirrors:
+                      description: mirrors is one or more repositories that may also
+                        contain the same images. The order of mirrors in this list
+                        is treated as the user's desired priority, while source is
+                        by default considered lower priority than all mirrors. Other
+                        cluster configuration, including (but not limited to) other
+                        repositoryDigestMirrors objects, may impact the exact order
+                        mirrors are contacted in, or some mirrors may be contacted
+                        in parallel, so this should be considered a preference rather
+                        than a guarantee of ordering.
+                      items:
                         type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                      type: array
+                    source:
+                      description: source is the repository that users refer to, e.g.
+                        in image pull specifications.
+                      type: string
+                  required:
+                  - source
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
+++ b/operatorcontrolplane/v1alpha1/0000_10-pod-network-connectivity-check.crd.yaml
@@ -15,213 +15,248 @@ spec:
     singular: podnetworkconnectivitycheck
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: "PodNetworkConnectivityCheck \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec defines the source and target of the connectivity check
-              type: object
-              required:
-                - sourcePod
-                - targetEndpoint
-              properties:
-                sourcePod:
-                  description: SourcePod names the pod from which the condition will be checked
-                  type: string
-                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                targetEndpoint:
-                  description: EndpointAddress to check. A TCP address of the form host:port. Note that if host is a DNS name, then the check would fail if the DNS name cannot be resolved. Specify an IP address for host to bypass DNS name lookup.
-                  type: string
-                  pattern: ^\S+:\d*$
-                tlsClientCert:
-                  description: TLSClientCert, if specified, references a kubernetes.io/tls type secret with 'tls.crt' and 'tls.key' entries containing an optional TLS client certificate and key to be used when checking endpoints that require a client certificate in order to gracefully preform the scan without causing excessive logging in the endpoint process. The secret must exist in the same namespace as this resource.
-                  type: object
-                  required:
-                    - name
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "PodNetworkConnectivityCheck \n Compatibility level 4: No compatibility
+          is provided, the API can change at any point for any reason. These capabilities
+          should not be used by applications needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the source and target of the connectivity check
+            properties:
+              sourcePod:
+                description: SourcePod names the pod from which the condition will
+                  be checked
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
+              targetEndpoint:
+                description: EndpointAddress to check. A TCP address of the form host:port.
+                  Note that if host is a DNS name, then the check would fail if the
+                  DNS name cannot be resolved. Specify an IP address for host to bypass
+                  DNS name lookup.
+                pattern: ^\S+:\d*$
+                type: string
+              tlsClientCert:
+                description: TLSClientCert, if specified, references a kubernetes.io/tls
+                  type secret with 'tls.crt' and 'tls.key' entries containing an optional
+                  TLS client certificate and key to be used when checking endpoints
+                  that require a client certificate in order to gracefully preform
+                  the scan without causing excessive logging in the endpoint process.
+                  The secret must exist in the same namespace as this resource.
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced secret
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - sourcePod
+            - targetEndpoint
+            type: object
+          status:
+            description: Status contains the observed status of the connectivity check
+            properties:
+              conditions:
+                description: Conditions summarize the status of the check
+                items:
+                  description: PodNetworkConnectivityCheckCondition represents the
+                    overall status of the pod network connectivity.
                   properties:
-                    name:
-                      description: name is the metadata.name of the referenced secret
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      nullable: true
                       type: string
-            status:
-              description: Status contains the observed status of the connectivity check
-              type: object
-              properties:
-                conditions:
-                  description: Conditions summarize the status of the check
-                  type: array
-                  items:
-                    description: PodNetworkConnectivityCheckCondition represents the overall status of the pod network connectivity.
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one status to another.
-                        type: string
-                        format: date-time
-                        nullable: true
-                      message:
-                        description: Message indicating details about last transition in a human readable format.
-                        type: string
-                      reason:
-                        description: Reason for the condition's last status transition in a machine readable format.
-                        type: string
-                      status:
-                        description: Status of the condition
-                        type: string
-                      type:
-                        description: Type of the condition
-                        type: string
-                failures:
-                  description: Failures contains logs of unsuccessful check actions
-                  type: array
-                  items:
-                    description: LogEntry records events
-                    type: object
-                    required:
-                      - success
-                      - time
-                    properties:
-                      latency:
-                        description: Latency records how long the action mentioned in the entry took.
-                        type: string
-                        nullable: true
-                      message:
-                        description: Message explaining status in a human readable format.
-                        type: string
-                      reason:
-                        description: Reason for status in a machine readable format.
-                        type: string
-                      success:
-                        description: Success indicates if the log entry indicates a success or failure.
-                        type: boolean
-                      time:
-                        description: Start time of check action.
-                        type: string
-                        format: date-time
-                        nullable: true
-                outages:
-                  description: Outages contains logs of time periods of outages
-                  type: array
-                  items:
-                    description: OutageEntry records time period of an outage
-                    type: object
-                    required:
-                      - start
-                    properties:
-                      end:
-                        description: End of outage detected
-                        type: string
-                        format: date-time
-                        nullable: true
-                      endLogs:
-                        description: EndLogs contains log entries related to the end of this outage. Should contain the success entry that resolved the outage and possibly a few of the failure log entries that preceded it.
-                        type: array
-                        items:
-                          description: LogEntry records events
-                          type: object
-                          required:
-                            - success
-                            - time
-                          properties:
-                            latency:
-                              description: Latency records how long the action mentioned in the entry took.
-                              type: string
-                              nullable: true
-                            message:
-                              description: Message explaining status in a human readable format.
-                              type: string
-                            reason:
-                              description: Reason for status in a machine readable format.
-                              type: string
-                            success:
-                              description: Success indicates if the log entry indicates a success or failure.
-                              type: boolean
-                            time:
-                              description: Start time of check action.
-                              type: string
-                              format: date-time
-                              nullable: true
-                      message:
-                        description: Message summarizes outage details in a human readable format.
-                        type: string
-                      start:
-                        description: Start of outage detected
-                        type: string
-                        format: date-time
-                        nullable: true
-                      startLogs:
-                        description: StartLogs contains log entries related to the start of this outage. Should contain the original failure, any entries where the failure mode changed.
-                        type: array
-                        items:
-                          description: LogEntry records events
-                          type: object
-                          required:
-                            - success
-                            - time
-                          properties:
-                            latency:
-                              description: Latency records how long the action mentioned in the entry took.
-                              type: string
-                              nullable: true
-                            message:
-                              description: Message explaining status in a human readable format.
-                              type: string
-                            reason:
-                              description: Reason for status in a machine readable format.
-                              type: string
-                            success:
-                              description: Success indicates if the log entry indicates a success or failure.
-                              type: boolean
-                            time:
-                              description: Start time of check action.
-                              type: string
-                              format: date-time
-                              nullable: true
-                successes:
-                  description: Successes contains logs successful check actions
-                  type: array
-                  items:
-                    description: LogEntry records events
-                    type: object
-                    required:
-                      - success
-                      - time
-                    properties:
-                      latency:
-                        description: Latency records how long the action mentioned in the entry took.
-                        type: string
-                        nullable: true
-                      message:
-                        description: Message explaining status in a human readable format.
-                        type: string
-                      reason:
-                        description: Reason for status in a machine readable format.
-                        type: string
-                      success:
-                        description: Success indicates if the log entry indicates a success or failure.
-                        type: boolean
-                      time:
-                        description: Start time of check action.
-                        type: string
-                        format: date-time
-                        nullable: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                    message:
+                      description: Message indicating details about last transition
+                        in a human readable format.
+                      type: string
+                    reason:
+                      description: Reason for the condition's last status transition
+                        in a machine readable format.
+                      type: string
+                    status:
+                      description: Status of the condition
+                      type: string
+                    type:
+                      description: Type of the condition
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failures:
+                description: Failures contains logs of unsuccessful check actions
+                items:
+                  description: LogEntry records events
+                  properties:
+                    latency:
+                      description: Latency records how long the action mentioned in
+                        the entry took.
+                      nullable: true
+                      type: string
+                    message:
+                      description: Message explaining status in a human readable format.
+                      type: string
+                    reason:
+                      description: Reason for status in a machine readable format.
+                      type: string
+                    success:
+                      description: Success indicates if the log entry indicates a
+                        success or failure.
+                      type: boolean
+                    time:
+                      description: Start time of check action.
+                      format: date-time
+                      nullable: true
+                      type: string
+                  required:
+                  - success
+                  - time
+                  type: object
+                type: array
+              outages:
+                description: Outages contains logs of time periods of outages
+                items:
+                  description: OutageEntry records time period of an outage
+                  properties:
+                    end:
+                      description: End of outage detected
+                      format: date-time
+                      nullable: true
+                      type: string
+                    endLogs:
+                      description: EndLogs contains log entries related to the end
+                        of this outage. Should contain the success entry that resolved
+                        the outage and possibly a few of the failure log entries that
+                        preceded it.
+                      items:
+                        description: LogEntry records events
+                        properties:
+                          latency:
+                            description: Latency records how long the action mentioned
+                              in the entry took.
+                            nullable: true
+                            type: string
+                          message:
+                            description: Message explaining status in a human readable
+                              format.
+                            type: string
+                          reason:
+                            description: Reason for status in a machine readable format.
+                            type: string
+                          success:
+                            description: Success indicates if the log entry indicates
+                              a success or failure.
+                            type: boolean
+                          time:
+                            description: Start time of check action.
+                            format: date-time
+                            nullable: true
+                            type: string
+                        required:
+                        - success
+                        - time
+                        type: object
+                      type: array
+                    message:
+                      description: Message summarizes outage details in a human readable
+                        format.
+                      type: string
+                    start:
+                      description: Start of outage detected
+                      format: date-time
+                      nullable: true
+                      type: string
+                    startLogs:
+                      description: StartLogs contains log entries related to the start
+                        of this outage. Should contain the original failure, any entries
+                        where the failure mode changed.
+                      items:
+                        description: LogEntry records events
+                        properties:
+                          latency:
+                            description: Latency records how long the action mentioned
+                              in the entry took.
+                            nullable: true
+                            type: string
+                          message:
+                            description: Message explaining status in a human readable
+                              format.
+                            type: string
+                          reason:
+                            description: Reason for status in a machine readable format.
+                            type: string
+                          success:
+                            description: Success indicates if the log entry indicates
+                              a success or failure.
+                            type: boolean
+                          time:
+                            description: Start time of check action.
+                            format: date-time
+                            nullable: true
+                            type: string
+                        required:
+                        - success
+                        - time
+                        type: object
+                      type: array
+                  required:
+                  - start
+                  type: object
+                type: array
+              successes:
+                description: Successes contains logs successful check actions
+                items:
+                  description: LogEntry records events
+                  properties:
+                    latency:
+                      description: Latency records how long the action mentioned in
+                        the entry took.
+                      nullable: true
+                      type: string
+                    message:
+                      description: Message explaining status in a human readable format.
+                      type: string
+                    reason:
+                      description: Reason for status in a machine readable format.
+                      type: string
+                    success:
+                      description: Success indicates if the log entry indicates a
+                        success or failure.
+                      type: boolean
+                    time:
+                      description: Start time of check action.
+                      format: date-time
+                      nullable: true
+                      type: string
+                  required:
+                  - success
+                  - time
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/platform/v1alpha1/platformoperators.crd.yaml
+++ b/platform/v1alpha1/platformoperators.crd.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
     api-approved.openshift.io: https://github.com/openshift/api/pull/1234
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   creationTimestamp: null
   name: platformoperators.platform.openshift.io
 spec:
@@ -15,100 +15,143 @@ spec:
     singular: platformoperator
   scope: Cluster
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: "PlatformOperator is the Schema for the PlatformOperators API. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support."
-          type: object
-          required:
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: PlatformOperatorSpec defines the desired state of PlatformOperator.
-              type: object
-              required:
-                - package
-              properties:
-                package:
-                  description: package contains the desired package and its configuration for this PlatformOperator.
-                  type: object
-                  required:
-                    - name
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "PlatformOperator is the Schema for the PlatformOperators API.
+          \n Compatibility level 4: No compatibility is provided, the API can change
+          at any point for any reason. These capabilities should not be used by applications
+          needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PlatformOperatorSpec defines the desired state of PlatformOperator.
+            properties:
+              package:
+                description: package contains the desired package and its configuration
+                  for this PlatformOperator.
+                properties:
+                  name:
+                    description: "name contains the desired OLM-based Operator package
+                      name that is defined in an existing CatalogSource resource in
+                      the cluster. \n This configured package will be managed with
+                      the cluster's lifecycle. In the current implementation, it will
+                      be retrieving this name from a list of supported operators out
+                      of the catalogs included with OpenShift. \n ---"
+                    maxLength: 56
+                    pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - package
+            type: object
+          status:
+            description: PlatformOperatorStatus defines the observed state of PlatformOperator
+            properties:
+              activeBundleDeployment:
+                description: activeBundleDeployment is the reference to the BundleDeployment
+                  resource that's being managed by this PO resource. If this field
+                  is not populated in the status then it means the PlatformOperator
+                  has either not been installed yet or is failing to install.
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced BundleDeployment
+                      object.
+                    type: string
+                required:
+                - name
+                type: object
+              conditions:
+                description: conditions represent the latest available observations
+                  of a platform operator's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
-                    name:
-                      description: "name contains the desired OLM-based Operator package name that is defined in an existing CatalogSource resource in the cluster. \n This configured package will be managed with the cluster's lifecycle. In the current implementation, it will be retrieving this name from a list of supported operators out of the catalogs included with OpenShift. \n ---"
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
                       type: string
-                      maxLength: 56
-                      pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
-            status:
-              description: PlatformOperatorStatus defines the observed state of PlatformOperator
-              type: object
-              properties:
-                activeBundleDeployment:
-                  description: activeBundleDeployment is the reference to the BundleDeployment resource that's being managed by this PO resource. If this field is not populated in the status then it means the PlatformOperator has either not been installed yet or is failing to install.
-                  type: object
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
                   required:
-                    - name
-                  properties:
-                    name:
-                      description: name is the metadata.name of the referenced BundleDeployment object.
-                      type: string
-                conditions:
-                  description: conditions represent the latest available observations of a platform operator's current state.
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/quota/v1/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
+++ b/quota/v1/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
@@ -16,182 +16,237 @@ spec:
     singular: clusterresourcequota
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "ClusterResourceQuota mirrors ResourceQuota at a cluster scope.  This object is easily convertible to synthetic ResourceQuota object to allow quota evaluation re-use. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - metadata
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec defines the desired quota
-              type: object
-              required:
-                - quota
-                - selector
-              properties:
-                quota:
-                  description: Quota defines the desired quota
-                  type: object
-                  properties:
-                    hard:
-                      description: 'hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
-                      type: object
-                      additionalProperties:
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        x-kubernetes-int-or-string: true
-                    scopeSelector:
-                      description: scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
-                      type: object
-                      properties:
-                        matchExpressions:
-                          description: A list of scope selector requirements by scope of the resources.
-                          type: array
-                          items:
-                            description: A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
-                            type: object
-                            required:
-                              - operator
-                              - scopeName
-                            properties:
-                              operator:
-                                description: Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
-                                type: string
-                              scopeName:
-                                description: The name of the scope that the selector applies to.
-                                type: string
-                              values:
-                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                type: array
-                                items:
-                                  type: string
-                      x-kubernetes-map-type: atomic
-                    scopes:
-                      description: A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
-                      type: array
-                      items:
-                        description: A ResourceQuotaScope defines a filter that must match each object tracked by a quota
-                        type: string
-                selector:
-                  description: Selector is the selector used to match projects. It should only select active projects on the scale of dozens (though it can select many more less active projects).  These projects will contend on object creation through this resource.
-                  type: object
-                  properties:
-                    annotations:
-                      description: AnnotationSelector is used to select projects by annotation.
-                      type: object
-                      additionalProperties:
-                        type: string
-                      nullable: true
-                    labels:
-                      description: LabelSelector is used to select projects by label.
-                      type: object
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                          type: array
-                          items:
-                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                            type: object
-                            required:
-                              - key
-                              - operator
-                            properties:
-                              key:
-                                description: key is the label key that the selector applies to.
-                                type: string
-                              operator:
-                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                type: array
-                                items:
-                                  type: string
-                        matchLabels:
-                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                          type: object
-                          additionalProperties:
-                            type: string
-                      nullable: true
-                      x-kubernetes-map-type: atomic
-            status:
-              description: Status defines the actual enforced quota and its current usage
-              type: object
-              required:
-                - total
-              properties:
-                namespaces:
-                  description: Namespaces slices the usage by project.  This division allows for quick resolution of deletion reconciliation inside of a single project without requiring a recalculation across all projects.  This can be used to pull the deltas for a given project.
-                  type: array
-                  items:
-                    description: ResourceQuotaStatusByNamespace gives status for a particular project
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterResourceQuota mirrors ResourceQuota at a cluster scope.
+          \ This object is easily convertible to synthetic ResourceQuota object to
+          allow quota evaluation re-use. \n Compatibility level 1: Stable within a
+          major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired quota
+            properties:
+              quota:
+                description: Quota defines the desired quota
+                properties:
+                  hard:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'hard is the set of desired hard limits for each
+                      named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
                     type: object
-                    required:
-                      - namespace
-                      - status
+                  scopeSelector:
+                    description: scopeSelector is also a collection of filters like
+                      scopes that must match each object tracked by a quota but expressed
+                      using ScopeSelectorOperator in combination with possible values.
+                      For a resource to match, both scopes AND scopeSelector (if specified
+                      in spec), must be matched.
                     properties:
-                      namespace:
-                        description: Namespace the project this status applies to
-                        type: string
-                      status:
-                        description: Status indicates how many resources have been consumed by this project
+                      matchExpressions:
+                        description: A list of scope selector requirements by scope
+                          of the resources.
+                        items:
+                          description: A scoped-resource selector requirement is a
+                            selector that contains values, a scope name, and an operator
+                            that relates the scope name and values.
+                          properties:
+                            operator:
+                              description: Represents a scope's relationship to a
+                                set of values. Valid operators are In, NotIn, Exists,
+                                DoesNotExist.
+                              type: string
+                            scopeName:
+                              description: The name of the scope that the selector
+                                applies to.
+                              type: string
+                            values:
+                              description: An array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty.
+                                If the operator is Exists or DoesNotExist, the values
+                                array must be empty. This array is replaced during
+                                a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - operator
+                          - scopeName
+                          type: object
+                        type: array
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  scopes:
+                    description: A collection of filters that must match each object
+                      tracked by a quota. If not specified, the quota matches all
+                      objects.
+                    items:
+                      description: A ResourceQuotaScope defines a filter that must
+                        match each object tracked by a quota
+                      type: string
+                    type: array
+                type: object
+              selector:
+                description: Selector is the selector used to match projects. It should
+                  only select active projects on the scale of dozens (though it can
+                  select many more less active projects).  These projects will contend
+                  on object creation through this resource.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: AnnotationSelector is used to select projects by
+                      annotation.
+                    nullable: true
+                    type: object
+                  labels:
+                    description: LabelSelector is used to select projects by label.
+                    nullable: true
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
                         type: object
-                        properties:
-                          hard:
-                            description: 'Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
-                            type: object
-                            additionalProperties:
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              x-kubernetes-int-or-string: true
-                          used:
-                            description: Used is the current observed total usage of the resource in the namespace.
-                            type: object
-                            additionalProperties:
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              x-kubernetes-int-or-string: true
-                  nullable: true
-                total:
-                  description: Total defines the actual enforced quota and its current usage across all projects
-                  type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+            required:
+            - quota
+            - selector
+            type: object
+          status:
+            description: Status defines the actual enforced quota and its current
+              usage
+            properties:
+              namespaces:
+                description: Namespaces slices the usage by project.  This division
+                  allows for quick resolution of deletion reconciliation inside of
+                  a single project without requiring a recalculation across all projects.  This
+                  can be used to pull the deltas for a given project.
+                items:
+                  description: ResourceQuotaStatusByNamespace gives status for a particular
+                    project
                   properties:
-                    hard:
-                      description: 'Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                    namespace:
+                      description: Namespace the project this status applies to
+                      type: string
+                    status:
+                      description: Status indicates how many resources have been consumed
+                        by this project
+                      properties:
+                        hard:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Hard is the set of enforced hard limits for
+                            each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                          type: object
+                        used:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Used is the current observed total usage of
+                            the resource in the namespace.
+                          type: object
                       type: object
-                      additionalProperties:
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        x-kubernetes-int-or-string: true
-                    used:
-                      description: Used is the current observed total usage of the resource in the namespace.
-                      type: object
-                      additionalProperties:
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        x-kubernetes-int-or-string: true
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  required:
+                  - namespace
+                  - status
+                  type: object
+                nullable: true
+                type: array
+              total:
+                description: Total defines the actual enforced quota and its current
+                  usage across all projects
+                properties:
+                  hard:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Hard is the set of enforced hard limits for each
+                      named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                    type: object
+                  used:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: Used is the current observed total usage of the resource
+                      in the namespace.
+                    type: object
+                type: object
+            required:
+            - total
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/samples/v1/0000_10_samplesconfig.crd.yaml
+++ b/samples/v1/0000_10_samplesconfig.crd.yaml
@@ -19,109 +19,162 @@ spec:
   preserveUnknownFields: false
   scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: "Config contains the configuration and detailed condition status for the Samples Operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - metadata
-            - spec
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ConfigSpec contains the desired configuration and state for the Samples Operator, controlling various behavior around the imagestreams and templates it creates/updates in the openshift namespace.
-              type: object
-              properties:
-                architectures:
-                  description: architectures determine which hardware architecture(s) to install, where x86_64, ppc64le, and s390x are the only supported choices currently.
-                  type: array
-                  items:
-                    type: string
-                managementState:
-                  description: managementState is top level on/off type of switch for all operators. When "Managed", this operator processes config and manipulates the samples accordingly. When "Unmanaged", this operator ignores any updates to the resources it watches. When "Removed", it reacts that same wasy as it does if the Config object is deleted, meaning any ImageStreams or Templates it manages (i.e. it honors the skipped lists) and the registry secret are deleted, along with the ConfigMap in the operator's namespace that represents the last config used to manipulate the samples,
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Config contains the configuration and detailed condition status
+          for the Samples Operator. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ConfigSpec contains the desired configuration and state for
+              the Samples Operator, controlling various behavior around the imagestreams
+              and templates it creates/updates in the openshift namespace.
+            properties:
+              architectures:
+                description: architectures determine which hardware architecture(s)
+                  to install, where x86_64, ppc64le, and s390x are the only supported
+                  choices currently.
+                items:
                   type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                samplesRegistry:
-                  description: samplesRegistry allows for the specification of which registry is accessed by the ImageStreams for their image content.  Defaults on the content in https://github.com/openshift/library that are pulled into this github repository, but based on our pulling only ocp content it typically defaults to registry.redhat.io.
+                type: array
+              managementState:
+                description: managementState is top level on/off type of switch for
+                  all operators. When "Managed", this operator processes config and
+                  manipulates the samples accordingly. When "Unmanaged", this operator
+                  ignores any updates to the resources it watches. When "Removed",
+                  it reacts that same wasy as it does if the Config object is deleted,
+                  meaning any ImageStreams or Templates it manages (i.e. it honors
+                  the skipped lists) and the registry secret are deleted, along with
+                  the ConfigMap in the operator's namespace that represents the last
+                  config used to manipulate the samples,
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              samplesRegistry:
+                description: samplesRegistry allows for the specification of which
+                  registry is accessed by the ImageStreams for their image content.  Defaults
+                  on the content in https://github.com/openshift/library that are
+                  pulled into this github repository, but based on our pulling only
+                  ocp content it typically defaults to registry.redhat.io.
+                type: string
+              skippedImagestreams:
+                description: skippedImagestreams specifies names of image streams
+                  that should NOT be created/updated.  Admins can use this to allow
+                  them to delete content they don’t want.  They will still have to
+                  manually delete the content but the operator will not recreate(or
+                  update) anything listed here.
+                items:
                   type: string
-                skippedImagestreams:
-                  description: skippedImagestreams specifies names of image streams that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.
-                  type: array
-                  items:
-                    type: string
-                skippedTemplates:
-                  description: skippedTemplates specifies names of templates that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.
-                  type: array
-                  items:
-                    type: string
-            status:
-              description: ConfigStatus contains the actual configuration in effect, as well as various details that describe the state of the Samples Operator.
-              type: object
-              properties:
-                architectures:
-                  description: architectures determine which hardware architecture(s) to install, where x86_64 and ppc64le are the supported choices.
-                  type: array
-                  items:
-                    type: string
-                conditions:
-                  description: conditions represents the available maintenance status of the sample imagestreams and templates.
-                  type: array
-                  items:
-                    description: ConfigCondition captures various conditions of the Config as entries are processed.
-                    type: object
-                    required:
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another.
-                        type: string
-                        format: date-time
-                      lastUpdateTime:
-                        description: lastUpdateTime is the last time this condition was updated.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition.
-                        type: string
-                      reason:
-                        description: reason is what caused the condition's last transition.
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                      type:
-                        description: type of condition.
-                        type: string
-                managementState:
-                  description: managementState reflects the current operational status of the on/off switch for the operator.  This operator compares the ManagementState as part of determining that we are turning the operator back on (i.e. "Managed") when it was previously "Unmanaged".
+                type: array
+              skippedTemplates:
+                description: skippedTemplates specifies names of templates that should
+                  NOT be created/updated.  Admins can use this to allow them to delete
+                  content they don’t want.  They will still have to manually delete
+                  the content but the operator will not recreate(or update) anything
+                  listed here.
+                items:
                   type: string
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                samplesRegistry:
-                  description: samplesRegistry allows for the specification of which registry is accessed by the ImageStreams for their image content.  Defaults on the content in https://github.com/openshift/library that are pulled into this github repository, but based on our pulling only ocp content it typically defaults to registry.redhat.io.
+                type: array
+            type: object
+          status:
+            description: ConfigStatus contains the actual configuration in effect,
+              as well as various details that describe the state of the Samples Operator.
+            properties:
+              architectures:
+                description: architectures determine which hardware architecture(s)
+                  to install, where x86_64 and ppc64le are the supported choices.
+                items:
                   type: string
-                skippedImagestreams:
-                  description: skippedImagestreams specifies names of image streams that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.
-                  type: array
-                  items:
-                    type: string
-                skippedTemplates:
-                  description: skippedTemplates specifies names of templates that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.
-                  type: array
-                  items:
-                    type: string
-                version:
-                  description: version is the value of the operator's payload based version indicator when it was last successfully processed
+                type: array
+              conditions:
+                description: conditions represents the available maintenance status
+                  of the sample imagestreams and templates.
+                items:
+                  description: ConfigCondition captures various conditions of the
+                    Config as entries are processed.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: lastUpdateTime is the last time this condition
+                        was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition.
+                      type: string
+                    reason:
+                      description: reason is what caused the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              managementState:
+                description: managementState reflects the current operational status
+                  of the on/off switch for the operator.  This operator compares the
+                  ManagementState as part of determining that we are turning the operator
+                  back on (i.e. "Managed") when it was previously "Unmanaged".
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              samplesRegistry:
+                description: samplesRegistry allows for the specification of which
+                  registry is accessed by the ImageStreams for their image content.  Defaults
+                  on the content in https://github.com/openshift/library that are
+                  pulled into this github repository, but based on our pulling only
+                  ocp content it typically defaults to registry.redhat.io.
+                type: string
+              skippedImagestreams:
+                description: skippedImagestreams specifies names of image streams
+                  that should NOT be created/updated.  Admins can use this to allow
+                  them to delete content they don’t want.  They will still have to
+                  manually delete the content but the operator will not recreate(or
+                  update) anything listed here.
+                items:
                   type: string
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+              skippedTemplates:
+                description: skippedTemplates specifies names of templates that should
+                  NOT be created/updated.  Admins can use this to allow them to delete
+                  content they don’t want.  They will still have to manually delete
+                  the content but the operator will not recreate(or update) anything
+                  listed here.
+                items:
+                  type: string
+                type: array
+              version:
+                description: version is the value of the operator's payload based
+                  version indicator when it was last successfully processed
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/security/v1/0000_03_security-openshift_01_scc.crd.yaml
+++ b/security/v1/0000_03_security-openshift_01_scc.crd.yaml
@@ -16,264 +16,350 @@ spec:
     singular: securitycontextconstraints
   scope: Cluster
   versions:
-    - additionalPrinterColumns:
-        - description: Determines if a container can request to be run as privileged
-          jsonPath: .allowPrivilegedContainer
-          name: Priv
-          type: string
-        - description: A list of capabilities that can be requested to add to the container
-          jsonPath: .allowedCapabilities
-          name: Caps
-          type: string
-        - description: Strategy that will dictate what labels will be set in the SecurityContext
-          jsonPath: .seLinuxContext.type
-          name: SELinux
-          type: string
-        - description: Strategy that will dictate what RunAsUser is used in the SecurityContext
-          jsonPath: .runAsUser.type
-          name: RunAsUser
-          type: string
-        - description: Strategy that will dictate what fs group is used by the SecurityContext
-          jsonPath: .fsGroup.type
-          name: FSGroup
-          type: string
-        - description: Strategy that will dictate what supplemental groups are used by the SecurityContext
-          jsonPath: .supplementalGroups.type
-          name: SupGroup
-          type: string
-        - description: Sort order of SCCs
-          jsonPath: .priority
-          name: Priority
-          type: string
-        - description: Force containers to run with a read only root file system
-          jsonPath: .readOnlyRootFilesystem
-          name: ReadOnlyRootFS
-          type: string
-        - description: White list of allowed volume plugins
-          jsonPath: .volumes
-          name: Volumes
-          type: string
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description: "SecurityContextConstraints governs the ability to make requests that affect the SecurityContext that will be applied to a container. For historical reasons SCC was exposed under the core Kubernetes API group. That exposure is deprecated and will be removed in a future release - users should instead use the security.openshift.io group to manage SecurityContextConstraints. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-          type: object
-          required:
-            - allowHostDirVolumePlugin
-            - allowHostIPC
-            - allowHostNetwork
-            - allowHostPID
-            - allowHostPorts
-            - allowPrivilegedContainer
-            - allowedCapabilities
-            - defaultAddCapabilities
-            - priority
-            - readOnlyRootFilesystem
-            - requiredDropCapabilities
-            - volumes
-          properties:
-            allowHostDirVolumePlugin:
-              description: AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
-              type: boolean
-            allowHostIPC:
-              description: AllowHostIPC determines if the policy allows host ipc in the containers.
-              type: boolean
-            allowHostNetwork:
-              description: AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
-              type: boolean
-            allowHostPID:
-              description: AllowHostPID determines if the policy allows host pid in the containers.
-              type: boolean
-            allowHostPorts:
-              description: AllowHostPorts determines if the policy allows host ports in the containers.
-              type: boolean
-            allowPrivilegeEscalation:
-              description: AllowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.
-              type: boolean
-              nullable: true
-            allowPrivilegedContainer:
-              description: AllowPrivilegedContainer determines if a container can request to be run as privileged.
-              type: boolean
-            allowedCapabilities:
-              description: AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field maybe added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities. To allow all capabilities you may use '*'.
-              type: array
-              items:
-                description: Capability represent POSIX capabilities type
-                type: string
-              nullable: true
-            allowedFlexVolumes:
-              description: AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the "Volumes" field.
-              type: array
-              items:
-                description: AllowedFlexVolume represents a single Flexvolume that is allowed to be used.
-                type: object
-                required:
-                  - driver
-                properties:
-                  driver:
-                    description: Driver is the name of the Flexvolume driver.
-                    type: string
-              nullable: true
-            allowedUnsafeSysctls:
-              description: "AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection. \n Examples: e.g. \"foo/*\" allows \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" allows \"foo.bar\", \"foo.baz\", etc."
-              type: array
-              items:
-                type: string
-              nullable: true
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+  - additionalPrinterColumns:
+    - description: Determines if a container can request to be run as privileged
+      jsonPath: .allowPrivilegedContainer
+      name: Priv
+      type: string
+    - description: A list of capabilities that can be requested to add to the container
+      jsonPath: .allowedCapabilities
+      name: Caps
+      type: string
+    - description: Strategy that will dictate what labels will be set in the SecurityContext
+      jsonPath: .seLinuxContext.type
+      name: SELinux
+      type: string
+    - description: Strategy that will dictate what RunAsUser is used in the SecurityContext
+      jsonPath: .runAsUser.type
+      name: RunAsUser
+      type: string
+    - description: Strategy that will dictate what fs group is used by the SecurityContext
+      jsonPath: .fsGroup.type
+      name: FSGroup
+      type: string
+    - description: Strategy that will dictate what supplemental groups are used by
+        the SecurityContext
+      jsonPath: .supplementalGroups.type
+      name: SupGroup
+      type: string
+    - description: Sort order of SCCs
+      jsonPath: .priority
+      name: Priority
+      type: string
+    - description: Force containers to run with a read only root file system
+      jsonPath: .readOnlyRootFilesystem
+      name: ReadOnlyRootFS
+      type: string
+    - description: White list of allowed volume plugins
+      jsonPath: .volumes
+      name: Volumes
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "SecurityContextConstraints governs the ability to make requests
+          that affect the SecurityContext that will be applied to a container. For
+          historical reasons SCC was exposed under the core Kubernetes API group.
+          That exposure is deprecated and will be removed in a future release - users
+          should instead use the security.openshift.io group to manage SecurityContextConstraints.
+          \n Compatibility level 1: Stable within a major release for a minimum of
+          12 months or 3 minor releases (whichever is longer)."
+        properties:
+          allowHostDirVolumePlugin:
+            description: AllowHostDirVolumePlugin determines if the policy allow containers
+              to use the HostDir volume plugin
+            type: boolean
+          allowHostIPC:
+            description: AllowHostIPC determines if the policy allows host ipc in
+              the containers.
+            type: boolean
+          allowHostNetwork:
+            description: AllowHostNetwork determines if the policy allows the use
+              of HostNetwork in the pod spec.
+            type: boolean
+          allowHostPID:
+            description: AllowHostPID determines if the policy allows host pid in
+              the containers.
+            type: boolean
+          allowHostPorts:
+            description: AllowHostPorts determines if the policy allows host ports
+              in the containers.
+            type: boolean
+          allowPrivilegeEscalation:
+            description: AllowPrivilegeEscalation determines if a pod can request
+              to allow privilege escalation. If unspecified, defaults to true.
+            nullable: true
+            type: boolean
+          allowPrivilegedContainer:
+            description: AllowPrivilegedContainer determines if a container can request
+              to be run as privileged.
+            type: boolean
+          allowedCapabilities:
+            description: AllowedCapabilities is a list of capabilities that can be
+              requested to add to the container. Capabilities in this field maybe
+              added at the pod author's discretion. You must not list a capability
+              in both AllowedCapabilities and RequiredDropCapabilities. To allow all
+              capabilities you may use '*'.
+            items:
+              description: Capability represent POSIX capabilities type
               type: string
-            defaultAddCapabilities:
-              description: DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.
-              type: array
-              items:
-                description: Capability represent POSIX capabilities type
-                type: string
-              nullable: true
-            defaultAllowPrivilegeEscalation:
-              description: DefaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.
-              type: boolean
-              nullable: true
-            forbiddenSysctls:
-              description: "ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden. \n Examples: e.g. \"foo/*\" forbids \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" forbids \"foo.bar\", \"foo.baz\", etc."
-              type: array
-              items:
-                type: string
-              nullable: true
-            fsGroup:
-              description: FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.
-              type: object
+            nullable: true
+            type: array
+          allowedFlexVolumes:
+            description: AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty
+              or nil indicates that all Flexvolumes may be used.  This parameter is
+              effective only when the usage of the Flexvolumes is allowed in the "Volumes"
+              field.
+            items:
+              description: AllowedFlexVolume represents a single Flexvolume that is
+                allowed to be used.
               properties:
-                ranges:
-                  description: Ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.
-                  type: array
-                  items:
-                    description: 'IDRange provides a min/max of an allowed range of IDs. TODO: this could be reused for UIDs.'
-                    type: object
-                    properties:
-                      max:
-                        description: Max is the end of the range, inclusive.
-                        type: integer
-                        format: int64
-                      min:
-                        description: Min is the start of the range, inclusive.
-                        type: integer
-                        format: int64
-                type:
-                  description: Type is the strategy that will dictate what FSGroup is used in the SecurityContext.
+                driver:
+                  description: Driver is the name of the Flexvolume driver.
                   type: string
-              nullable: true
-            groups:
-              description: The groups that have permission to use this security context constraints
-              type: array
-              items:
-                type: string
-              nullable: true
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              required:
+              - driver
+              type: object
+            nullable: true
+            type: array
+          allowedUnsafeSysctls:
+            description: "AllowedUnsafeSysctls is a list of explicitly allowed unsafe
+              sysctls, defaults to none. Each entry is either a plain sysctl name
+              or ends in \"*\" in which case it is considered as a prefix of allowed
+              sysctls. Single * means all unsafe sysctls are allowed. Kubelet has
+              to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+              \n Examples: e.g. \"foo/*\" allows \"foo/bar\", \"foo/baz\", etc. e.g.
+              \"foo.*\" allows \"foo.bar\", \"foo.baz\", etc."
+            items:
               type: string
-            metadata:
-              type: object
-            priority:
-              description: Priority influences the sort order of SCCs when evaluating which SCCs to try first for a given pod request based on access in the Users and Groups fields.  The higher the int, the higher priority. An unset value is considered a 0 priority. If scores for multiple SCCs are equal they will be sorted from most restrictive to least restrictive. If both priorities and restrictions are equal the SCCs will be sorted by name.
-              type: integer
-              format: int32
-              nullable: true
-            readOnlyRootFilesystem:
-              description: ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the SCC should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.
-              type: boolean
-            requiredDropCapabilities:
-              description: RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.
-              type: array
-              items:
-                description: Capability represent POSIX capabilities type
-                type: string
-              nullable: true
-            runAsUser:
-              description: RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
-              type: object
-              properties:
-                type:
-                  description: Type is the strategy that will dictate what RunAsUser is used in the SecurityContext.
-                  type: string
-                uid:
-                  description: UID is the user id that containers must run as.  Required for the MustRunAs strategy if not using namespace/service account allocated uids.
-                  type: integer
-                  format: int64
-                uidRangeMax:
-                  description: UIDRangeMax defines the max value for a strategy that allocates by range.
-                  type: integer
-                  format: int64
-                uidRangeMin:
-                  description: UIDRangeMin defines the min value for a strategy that allocates by range.
-                  type: integer
-                  format: int64
-              nullable: true
-            seLinuxContext:
-              description: SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
-              type: object
-              properties:
-                seLinuxOptions:
-                  description: seLinuxOptions required to run as; required for MustRunAs
-                  type: object
+            nullable: true
+            type: array
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          defaultAddCapabilities:
+            description: DefaultAddCapabilities is the default set of capabilities
+              that will be added to the container unless the pod spec specifically
+              drops the capability.  You may not list a capabiility in both DefaultAddCapabilities
+              and RequiredDropCapabilities.
+            items:
+              description: Capability represent POSIX capabilities type
+              type: string
+            nullable: true
+            type: array
+          defaultAllowPrivilegeEscalation:
+            description: DefaultAllowPrivilegeEscalation controls the default setting
+              for whether a process can gain more privileges than its parent process.
+            nullable: true
+            type: boolean
+          forbiddenSysctls:
+            description: "ForbiddenSysctls is a list of explicitly forbidden sysctls,
+              defaults to none. Each entry is either a plain sysctl name or ends in
+              \"*\" in which case it is considered as a prefix of forbidden sysctls.
+              Single * means all sysctls are forbidden. \n Examples: e.g. \"foo/*\"
+              forbids \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" forbids \"foo.bar\",
+              \"foo.baz\", etc."
+            items:
+              type: string
+            nullable: true
+            type: array
+          fsGroup:
+            description: FSGroup is the strategy that will dictate what fs group is
+              used by the SecurityContext.
+            nullable: true
+            properties:
+              ranges:
+                description: Ranges are the allowed ranges of fs groups.  If you would
+                  like to force a single fs group then supply a single range with
+                  the same start and end.
+                items:
+                  description: 'IDRange provides a min/max of an allowed range of
+                    IDs. TODO: this could be reused for UIDs.'
                   properties:
-                    level:
-                      description: Level is SELinux level label that applies to the container.
-                      type: string
-                    role:
-                      description: Role is a SELinux role label that applies to the container.
-                      type: string
-                    type:
-                      description: Type is a SELinux type label that applies to the container.
-                      type: string
-                    user:
-                      description: User is a SELinux user label that applies to the container.
-                      type: string
-                type:
-                  description: Type is the strategy that will dictate what SELinux context is used in the SecurityContext.
-                  type: string
-              nullable: true
-            seccompProfiles:
-              description: "SeccompProfiles lists the allowed profiles that may be set for the pod or container's seccomp annotations.  An unset (nil) or empty value means that no profiles may be specifid by the pod or container.\tThe wildcard '*' may be used to allow all profiles.  When used to generate a value for a pod the first non-wildcard profile will be used as the default."
-              type: array
-              items:
+                    max:
+                      description: Max is the end of the range, inclusive.
+                      format: int64
+                      type: integer
+                    min:
+                      description: Min is the start of the range, inclusive.
+                      format: int64
+                      type: integer
+                  type: object
+                type: array
+              type:
+                description: Type is the strategy that will dictate what FSGroup is
+                  used in the SecurityContext.
                 type: string
-              nullable: true
-            supplementalGroups:
-              description: SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
-              type: object
-              properties:
-                ranges:
-                  description: Ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.
-                  type: array
-                  items:
-                    description: 'IDRange provides a min/max of an allowed range of IDs. TODO: this could be reused for UIDs.'
-                    type: object
-                    properties:
-                      max:
-                        description: Max is the end of the range, inclusive.
-                        type: integer
-                        format: int64
-                      min:
-                        description: Min is the start of the range, inclusive.
-                        type: integer
-                        format: int64
-                type:
-                  description: Type is the strategy that will dictate what supplemental groups is used in the SecurityContext.
-                  type: string
-              nullable: true
-            users:
-              description: The users who have permissions to use this security context constraints
-              type: array
-              items:
+            type: object
+          groups:
+            description: The groups that have permission to use this security context
+              constraints
+            items:
+              type: string
+            nullable: true
+            type: array
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          priority:
+            description: Priority influences the sort order of SCCs when evaluating
+              which SCCs to try first for a given pod request based on access in the
+              Users and Groups fields.  The higher the int, the higher priority. An
+              unset value is considered a 0 priority. If scores for multiple SCCs
+              are equal they will be sorted from most restrictive to least restrictive.
+              If both priorities and restrictions are equal the SCCs will be sorted
+              by name.
+            format: int32
+            nullable: true
+            type: integer
+          readOnlyRootFilesystem:
+            description: ReadOnlyRootFilesystem when set to true will force containers
+              to run with a read only root file system.  If the container specifically
+              requests to run with a non-read only root file system the SCC should
+              deny the pod. If set to false the container may run with a read only
+              root file system if it wishes but it will not be forced to.
+            type: boolean
+          requiredDropCapabilities:
+            description: RequiredDropCapabilities are the capabilities that will be
+              dropped from the container.  These are required to be dropped and cannot
+              be added.
+            items:
+              description: Capability represent POSIX capabilities type
+              type: string
+            nullable: true
+            type: array
+          runAsUser:
+            description: RunAsUser is the strategy that will dictate what RunAsUser
+              is used in the SecurityContext.
+            nullable: true
+            properties:
+              type:
+                description: Type is the strategy that will dictate what RunAsUser
+                  is used in the SecurityContext.
                 type: string
-              nullable: true
-            volumes:
-              description: Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*". To allow no volumes, set to ["none"].
-              type: array
-              items:
-                description: FS Type gives strong typing to different file systems that are used by volumes.
+              uid:
+                description: UID is the user id that containers must run as.  Required
+                  for the MustRunAs strategy if not using namespace/service account
+                  allocated uids.
+                format: int64
+                type: integer
+              uidRangeMax:
+                description: UIDRangeMax defines the max value for a strategy that
+                  allocates by range.
+                format: int64
+                type: integer
+              uidRangeMin:
+                description: UIDRangeMin defines the min value for a strategy that
+                  allocates by range.
+                format: int64
+                type: integer
+            type: object
+          seLinuxContext:
+            description: SELinuxContext is the strategy that will dictate what labels
+              will be set in the SecurityContext.
+            nullable: true
+            properties:
+              seLinuxOptions:
+                description: seLinuxOptions required to run as; required for MustRunAs
+                properties:
+                  level:
+                    description: Level is SELinux level label that applies to the
+                      container.
+                    type: string
+                  role:
+                    description: Role is a SELinux role label that applies to the
+                      container.
+                    type: string
+                  type:
+                    description: Type is a SELinux type label that applies to the
+                      container.
+                    type: string
+                  user:
+                    description: User is a SELinux user label that applies to the
+                      container.
+                    type: string
+                type: object
+              type:
+                description: Type is the strategy that will dictate what SELinux context
+                  is used in the SecurityContext.
                 type: string
-              nullable: true
-      served: true
-      storage: true
+            type: object
+          seccompProfiles:
+            description: "SeccompProfiles lists the allowed profiles that may be set
+              for the pod or container's seccomp annotations.  An unset (nil) or empty
+              value means that no profiles may be specifid by the pod or container.\tThe
+              wildcard '*' may be used to allow all profiles.  When used to generate
+              a value for a pod the first non-wildcard profile will be used as the
+              default."
+            items:
+              type: string
+            nullable: true
+            type: array
+          supplementalGroups:
+            description: SupplementalGroups is the strategy that will dictate what
+              supplemental groups are used by the SecurityContext.
+            nullable: true
+            properties:
+              ranges:
+                description: Ranges are the allowed ranges of supplemental groups.  If
+                  you would like to force a single supplemental group then supply
+                  a single range with the same start and end.
+                items:
+                  description: 'IDRange provides a min/max of an allowed range of
+                    IDs. TODO: this could be reused for UIDs.'
+                  properties:
+                    max:
+                      description: Max is the end of the range, inclusive.
+                      format: int64
+                      type: integer
+                    min:
+                      description: Min is the start of the range, inclusive.
+                      format: int64
+                      type: integer
+                  type: object
+                type: array
+              type:
+                description: Type is the strategy that will dictate what supplemental
+                  groups is used in the SecurityContext.
+                type: string
+            type: object
+          users:
+            description: The users who have permissions to use this security context
+              constraints
+            items:
+              type: string
+            nullable: true
+            type: array
+          volumes:
+            description: Volumes is a white list of allowed volume plugins.  FSType
+              corresponds directly with the field names of a VolumeSource (azureFile,
+              configMap, emptyDir).  To allow all volumes you may use "*". To allow
+              no volumes, set to ["none"].
+            items:
+              description: FS Type gives strong typing to different file systems that
+                are used by volumes.
+              type: string
+            nullable: true
+            type: array
+        required:
+        - allowHostDirVolumePlugin
+        - allowHostIPC
+        - allowHostNetwork
+        - allowHostPID
+        - allowHostPorts
+        - allowPrivilegedContainer
+        - allowedCapabilities
+        - defaultAddCapabilities
+        - priority
+        - readOnlyRootFilesystem
+        - requiredDropCapabilities
+        - volumes
+        type: object
+    served: true
+    storage: true

--- a/sharedresource/v1alpha1/0000_10_sharedconfigmap.crd.yaml
+++ b/sharedresource/v1alpha1/0000_10_sharedconfigmap.crd.yaml
@@ -1,107 +1,155 @@
-# this is the boilerplate crd def that controller-gen reads and modifies with the
-# contents from shared_configmap_type.go
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sharedconfigmaps.sharedresource.openshift.io
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/979
-    displayName: SharedConfigMap
     description: Extension for sharing ConfigMaps across Namespaces
+    displayName: SharedConfigMap
+  name: sharedconfigmaps.sharedresource.openshift.io
 spec:
-  scope: Cluster
   group: sharedresource.openshift.io
   names:
-    plural: sharedconfigmaps
-    singular: sharedconfigmap
     kind: SharedConfigMap
     listKind: SharedConfigMapList
+    plural: sharedconfigmaps
+    singular: sharedconfigmap
+  scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      "schema":
-        "openAPIV3Schema":
-          description: "SharedConfigMap allows a ConfigMap to be shared across namespaces. Pods can mount the shared ConfigMap by adding a CSI volume to the pod specification using the \"csi.sharedresource.openshift.io\" CSI driver and a reference to the SharedConfigMap in the volume attributes: \n spec: volumes: - name: shared-configmap csi: driver: csi.sharedresource.openshift.io volumeAttributes: sharedConfigMap: my-share \n For the mount to be successful, the pod's service account must be granted permission to 'use' the named SharedConfigMap object within its namespace with an appropriate Role and RoleBinding. For compactness, here are example `oc` invocations for creating such Role and RoleBinding objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedconfigmaps.sharedresource.openshift.io --resource-name=my-share` `oc create rolebinding shared-resource-my-share --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n Shared resource objects, in this case ConfigMaps, have default permissions of list, get, and watch for system authenticated users. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support. These capabilities should not be used by applications needing long term support."
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec is the specification of the desired shared configmap
-              type: object
-              required:
-                - configMapRef
-              properties:
-                configMapRef:
-                  description: configMapRef is a reference to the ConfigMap to share
-                  type: object
-                  required:
-                    - name
-                    - namespace
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "SharedConfigMap allows a ConfigMap to be shared across namespaces.
+          Pods can mount the shared ConfigMap by adding a CSI volume to the pod specification
+          using the \"csi.sharedresource.openshift.io\" CSI driver and a reference
+          to the SharedConfigMap in the volume attributes: \n spec: volumes: - name:
+          shared-configmap csi: driver: csi.sharedresource.openshift.io volumeAttributes:
+          sharedConfigMap: my-share \n For the mount to be successful, the pod's service
+          account must be granted permission to 'use' the named SharedConfigMap object
+          within its namespace with an appropriate Role and RoleBinding. For compactness,
+          here are example `oc` invocations for creating such Role and RoleBinding
+          objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedconfigmaps.sharedresource.openshift.io
+          --resource-name=my-share` `oc create rolebinding shared-resource-my-share
+          --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n
+          Shared resource objects, in this case ConfigMaps, have default permissions
+          of list, get, and watch for system authenticated users. \n Compatibility
+          level 4: No compatibility is provided, the API can change at any point for
+          any reason. These capabilities should not be used by applications needing
+          long term support. These capabilities should not be used by applications
+          needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired shared configmap
+            properties:
+              configMapRef:
+                description: configMapRef is a reference to the ConfigMap to share
+                properties:
+                  name:
+                    description: name represents the name of the ConfigMap that is
+                      being referenced.
+                    type: string
+                  namespace:
+                    description: namespace represents the namespace where the referenced
+                      ConfigMap is located.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              description:
+                description: description is a user readable explanation of what the
+                  backing resource provides.
+                type: string
+            required:
+            - configMapRef
+            type: object
+          status:
+            description: status is the observed status of the shared configmap
+            properties:
+              conditions:
+                description: conditions represents any observations made on this particular
+                  shared resource by the underlying CSI driver or Share controller.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
-                    name:
-                      description: name represents the name of the ConfigMap that is being referenced.
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
                       type: string
-                    namespace:
-                      description: namespace represents the namespace where the referenced ConfigMap is located.
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
                       type: string
-                description:
-                  description: description is a user readable explanation of what the backing resource provides.
-                  type: string
-            status:
-              description: status is the observed status of the shared configmap
-              type: object
-              properties:
-                conditions:
-                  description: conditions represents any observations made on this particular shared resource by the underlying CSI driver or Share controller.
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-      subresources:
-        status: {}
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/sharedresource/v1alpha1/0000_10_sharedsecret.crd.yaml
+++ b/sharedresource/v1alpha1/0000_10_sharedsecret.crd.yaml
@@ -1,107 +1,155 @@
-# this is the boilerplate crd def that controller-gen reads and modifies with the
-# contents from shared_secret_type.go
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: sharedsecrets.sharedresource.openshift.io
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/979
-    displayName: SharedSecret
     description: Extension for sharing Secrets across Namespaces
+    displayName: SharedSecret
+  name: sharedsecrets.sharedresource.openshift.io
 spec:
-  scope: Cluster
   group: sharedresource.openshift.io
   names:
-    plural: sharedsecrets
-    singular: sharedsecret
     kind: SharedSecret
     listKind: SharedSecretList
+    plural: sharedsecrets
+    singular: sharedsecret
+  scope: Cluster
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      "schema":
-        "openAPIV3Schema":
-          description: "SharedSecret allows a Secret to be shared across namespaces. Pods can mount the shared Secret by adding a CSI volume to the pod specification using the \"csi.sharedresource.openshift.io\" CSI driver and a reference to the SharedSecret in the volume attributes: \n spec: volumes: - name: shared-secret csi: driver: csi.sharedresource.openshift.io volumeAttributes: sharedSecret: my-share \n For the mount to be successful, the pod's service account must be granted permission to 'use' the named SharedSecret object within its namespace with an appropriate Role and RoleBinding. For compactness, here are example `oc` invocations for creating such Role and RoleBinding objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedsecrets.sharedresource.openshift.io --resource-name=my-share` `oc create rolebinding shared-resource-my-share --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n Shared resource objects, in this case Secrets, have default permissions of list, get, and watch for system authenticated users. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support. These capabilities should not be used by applications needing long term support."
-          type: object
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec is the specification of the desired shared secret
-              type: object
-              required:
-                - secretRef
-              properties:
-                description:
-                  description: description is a user readable explanation of what the backing resource provides.
-                  type: string
-                secretRef:
-                  description: secretRef is a reference to the Secret to share
-                  type: object
-                  required:
-                    - name
-                    - namespace
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "SharedSecret allows a Secret to be shared across namespaces.
+          Pods can mount the shared Secret by adding a CSI volume to the pod specification
+          using the \"csi.sharedresource.openshift.io\" CSI driver and a reference
+          to the SharedSecret in the volume attributes: \n spec: volumes: - name:
+          shared-secret csi: driver: csi.sharedresource.openshift.io volumeAttributes:
+          sharedSecret: my-share \n For the mount to be successful, the pod's service
+          account must be granted permission to 'use' the named SharedSecret object
+          within its namespace with an appropriate Role and RoleBinding. For compactness,
+          here are example `oc` invocations for creating such Role and RoleBinding
+          objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedsecrets.sharedresource.openshift.io
+          --resource-name=my-share` `oc create rolebinding shared-resource-my-share
+          --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n
+          Shared resource objects, in this case Secrets, have default permissions
+          of list, get, and watch for system authenticated users. \n Compatibility
+          level 4: No compatibility is provided, the API can change at any point for
+          any reason. These capabilities should not be used by applications needing
+          long term support. These capabilities should not be used by applications
+          needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired shared secret
+            properties:
+              description:
+                description: description is a user readable explanation of what the
+                  backing resource provides.
+                type: string
+              secretRef:
+                description: secretRef is a reference to the Secret to share
+                properties:
+                  name:
+                    description: name represents the name of the Secret that is being
+                      referenced.
+                    type: string
+                  namespace:
+                    description: namespace represents the namespace where the referenced
+                      Secret is located.
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+            required:
+            - secretRef
+            type: object
+          status:
+            description: status is the observed status of the shared secret
+            properties:
+              conditions:
+                description: conditions represents any observations made on this particular
+                  shared resource by the underlying CSI driver or Share controller.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
-                    name:
-                      description: name represents the name of the Secret that is being referenced.
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
                       type: string
-                    namespace:
-                      description: namespace represents the namespace where the referenced Secret is located.
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
                       type: string
-            status:
-              description: status is the observed status of the shared secret
-              type: object
-              properties:
-                conditions:
-                  description: conditions represents any observations made on this particular shared resource by the underlying CSI driver or Share controller.
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-      subresources:
-        status: {}
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
@@ -14,6 +14,12 @@ define patch-crd-yq
 endef
 
 # $1 - crd file
+define format-yaml
+	cat '$(1)' | $(YQ) read - > t.yaml
+	mv t.yaml '$(1)'
+endef
+
+# $1 - crd file
 # $2 - patch file
 define patch-crd-yaml-patch
 	$(YAML_PATCH) -o '$(2)' < '$(1)' > '$(1).patched'
@@ -32,6 +38,7 @@ define run-crd-gen
 		'output:dir="$(2)"'
 	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-merge-patch),$$(call patch-crd-yq,$$(basename $$(p)).yaml,$$(p)))
 	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-patch),$$(call patch-crd-yaml-patch,$$(basename $$(p)).yaml,$$(p)))
+	$$(foreach p,$$(wildcard $(2)/*.crd.yaml),$$(call patch-crd-yq,$$(basename $$(p)).yaml,$$(p)))
 endef
 
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -99,7 +99,7 @@ github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.2
 ## explicit; go 1.12
 github.com/modern-go/reflect2
-# github.com/openshift/build-machinery-go v0.0.0-20220909124648-e003344f49e8
+# github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 ## explicit; go 1.13
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
it's really hard to see a diff from a yaml patch because it reformats the yaml.  This makes `yq` always reformat the files so that we can see the diff more clearly.

/hold  this requires a change to build-machinery-go

/assign @JoelSpeed 