### PR TITLE
Updates to ControlPlaneMachineSet validation with CEL

### DIFF
--- a/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -338,8 +338,29 @@ spec:
                             description: 'Map of string keys and values that can be
                               used to organize and categorize (scope and select) objects.
                               May match selectors of replication controllers and services.
-                              More info: http://kubernetes.io/docs/user-guide/labels'
+                              More info: http://kubernetes.io/docs/user-guide/labels.
+                              This field must contain both the ''machine.openshift.io/cluster-api-machine-role''
+                              and ''machine.openshift.io/cluster-api-machine-type''
+                              labels, both with a value of ''master''. It must also
+                              contain a label with the key ''machine.openshift.io/cluster-api-cluster''.'
                             type: object
+                            x-kubernetes-validations:
+                            - message: label 'machine.openshift.io/cluster-api-machine-role'
+                                is required, and must have value 'master'
+                              rule: '''machine.openshift.io/cluster-api-machine-role''
+                                in self && self[''machine.openshift.io/cluster-api-machine-role'']
+                                == ''master'''
+                            - message: label 'machine.openshift.io/cluster-api-machine-type'
+                                is required, and must have value 'master'
+                              rule: '''machine.openshift.io/cluster-api-machine-type''
+                                in self && self[''machine.openshift.io/cluster-api-machine-type'']
+                                == ''master'''
+                            - message: label 'machine.openshift.io/cluster-api-cluster'
+                                is required
+                              rule: '''machine.openshift.io/cluster-api-cluster''
+                                in self'
+                        required:
+                        - labels
                         type: object
                       spec:
                         description: Spec contains the desired configuration of the

--- a/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -77,6 +77,9 @@ spec:
                 - 5
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: replicas is immutable
+                  rule: self == oldSelf
               selector:
                 description: Label selector for Machines. Existing Machines selected
                   by this selector will be the ones affected by this ControlPlaneMachineSet.
@@ -125,6 +128,9 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: selector is immutable
+                  rule: self == oldSelf
               strategy:
                 default:
                   type: RollingUpdate
@@ -227,6 +233,19 @@ spec:
                                   required:
                                   - type
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: id is required when type is ID, and forbidden
+                                      otherwise
+                                    rule: 'has(self.type) && self.type == ''ID'' ?  has(self.id)
+                                      : !has(self.id)'
+                                  - message: arn is required when type is ARN, and
+                                      forbidden otherwise
+                                    rule: 'has(self.type) && self.type == ''ARN''
+                                      ?  has(self.arn) : !has(self.arn)'
+                                  - message: filters is required when type is Filters,
+                                      and forbidden otherwise
+                                    rule: 'has(self.type) && self.type == ''Filters''
+                                      ?  has(self.filters) : !has(self.filters)'
                               type: object
                             type: array
                           azure:
@@ -285,6 +304,19 @@ spec:
                         required:
                         - platform
                         type: object
+                        x-kubernetes-validations:
+                        - message: aws configuration is required when platform is
+                            AWS, and forbidden otherwise
+                          rule: 'has(self.platform) && self.platform == ''AWS'' ?  has(self.aws)
+                            : !has(self.aws)'
+                        - message: azure configuration is required when platform is
+                            Azure, and forbidden otherwise
+                          rule: 'has(self.platform) && self.platform == ''Azure''
+                            ?  has(self.azure) : !has(self.azure)'
+                        - message: gcp configuration is required when platform is
+                            GCP, and forbidden otherwise
+                          rule: 'has(self.platform) && self.platform == ''GCP'' ?  has(self.gcp)
+                            : !has(self.gcp)'
                       metadata:
                         description: 'ObjectMeta is the standard object metadata More
                           info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
@@ -590,8 +622,13 @@ spec:
                     type: object
                 required:
                 - machineType
-                - machines_v1beta1_machine_openshift_io
                 type: object
+                x-kubernetes-validations:
+                - message: machines_v1beta1_machine_openshift_io configuration is
+                    required when machineType is machines_v1beta1_machine_openshift_io,
+                    and forbidden otherwise
+                  rule: 'has(self.machineType) && self.machineType == ''machines_v1beta1_machine_openshift_io''
+                    ?  has(self.machines_v1beta1_machine_openshift_io) : !has(self.machines_v1beta1_machine_openshift_io)'
             required:
             - replicas
             - selector

--- a/machine/v1/Makefile
+++ b/machine/v1/Makefile
@@ -1,0 +1,3 @@
+.PHONY: test
+test:
+	make -C ../../tests test GINKGO_EXTRA_ARGS=--focus="machine.openshift.io/v1"

--- a/machine/v1/control-plane-machine-set.aws.stable.testsuite.yaml
+++ b/machine/v1/control-plane-machine-set.aws.stable.testsuite.yaml
@@ -1,0 +1,351 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[Stable] ControlPlaneMachineSet (AWS)"
+crd: 0000_10_controlplanemachineset.crd.yaml
+tests:
+  onCreate:
+  - name: Should reject an AWS platform failure domain without any AWS config
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains: Invalid value: \"object\": aws configuration is required when platform is AWS"
+  - name: Should reject an AWS configured failure domain without a platform type
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              aws:
+              - placement:
+                  availabilityZone: foo
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform: Required value"
+  - name: Should reject an AWS configured failure domain with the wrong platform type
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: BareMetal
+              aws:
+              - placement:
+                  availabilityZone: foo
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains: Invalid value: \"object\": aws configuration is required when platform is AWS, and forbidden otherwise"
+  - name: Should reject an AWS failure domain with the subnet type omitted
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet: {}
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws[0].subnet.type: Required value, <nil>: Invalid value: \"null\""
+  - name: Should reject an AWS failure domain with the subnet type ID and no ID provided
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: ID
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws[0].subnet: Invalid value: \"object\": id is required when type is ID, and forbidden otherwise"
+  - name: Should accept an AWS failure domain with the subnet type ID and an ID provided
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: ID
+                  id: foo
+    expected: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: ID
+                  id: foo
+  - name: Should reject an AWS failure domain with the subnet type ID and an ARN provided
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: ID
+                  id: foo
+                  arn: foo
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws[0].subnet: Invalid value: \"object\": arn is required when type is ARN, and forbidden otherwise"
+  - name: Should reject an AWS failure domain with the subnet type ID and a Filter provided
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: ID
+                  id: foo
+                  filters:
+                  - name: foo
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws[0].subnet: Invalid value: \"object\": filters is required when type is Filters, and forbidden otherwise"
+  - name: Should accept an AWS failure domain with the subnet type ARN and an ARN provided
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: ARN
+                  arn: foo
+    expected: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: ARN
+                  arn: foo
+  - name: Should accept an AWS failure domain with the subnet type Filters and a Filter provided
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: Filters
+                  filters:
+                  - name: foo
+    expected: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: Filters
+                  filters:
+                  - name: foo
+  - name: Should reject an AWS failure domain with the subnet type ARN and an ID provided
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: AWS
+              aws:
+              - subnet:
+                  type: ARN
+                  id: foo
+                  arn: foo
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.aws[0].subnet: Invalid value: \"object\": id is required when type is ID, and forbidden otherwise"

--- a/machine/v1/control-plane-machine-set.aws.stable.testsuite.yaml
+++ b/machine/v1/control-plane-machine-set.aws.stable.testsuite.yaml
@@ -19,6 +19,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -40,6 +41,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -63,6 +65,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -87,6 +90,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -110,6 +114,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -134,6 +139,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -160,6 +166,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -184,6 +191,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -210,6 +218,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -237,6 +246,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -263,6 +273,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -287,6 +298,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -314,6 +326,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -339,6 +352,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:

--- a/machine/v1/control-plane-machine-set.azure.stable.testsuite.yaml
+++ b/machine/v1/control-plane-machine-set.azure.stable.testsuite.yaml
@@ -1,0 +1,71 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[Stable] ControlPlaneMachineSet"
+crd: 0000_10_controlplanemachineset.crd.yaml
+tests:
+  onCreate:
+  - name: Should reject an Azure platform failure domain without any Azure config
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: Azure
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains: Invalid value: \"object\": azure configuration is required when platform is Azure"
+  - name: Should reject an Azure configured failure domain without a platform type
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              azure:
+              - zone: foo
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform: Required value"
+  - name: Should reject an Azure configured failure domain with the wrong platform type
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: BareMetal
+              azure:
+              - zone: foo
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains: Invalid value: \"object\": azure configuration is required when platform is Azure, and forbidden otherwise"

--- a/machine/v1/control-plane-machine-set.azure.stable.testsuite.yaml
+++ b/machine/v1/control-plane-machine-set.azure.stable.testsuite.yaml
@@ -19,6 +19,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -40,6 +41,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -62,6 +64,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:

--- a/machine/v1/control-plane-machine-set.gcp.stable.testsuite.yaml
+++ b/machine/v1/control-plane-machine-set.gcp.stable.testsuite.yaml
@@ -1,0 +1,71 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[Stable] ControlPlaneMachineSet"
+crd: 0000_10_controlplanemachineset.crd.yaml
+tests:
+  onCreate:
+  - name: Should reject an GCP platform failure domain without any GCP config
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: GCP
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains: Invalid value: \"object\": gcp configuration is required when platform is GCP"
+  - name: Should reject an GCP configured failure domain without a platform type
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              aws:
+              - zone: foo
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform: Required value"
+  - name: Should reject an GCP configured failure domain with the wrong platform type
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: BareMetal
+              gcp:
+              - zone: foo
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains: Invalid value: \"object\": gcp configuration is required when platform is GCP, and forbidden otherwise"

--- a/machine/v1/control-plane-machine-set.gcp.stable.testsuite.yaml
+++ b/machine/v1/control-plane-machine-set.gcp.stable.testsuite.yaml
@@ -19,6 +19,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -40,6 +41,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:
@@ -62,6 +64,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
             failureDomains:

--- a/machine/v1/control-plane-machine-set.stable.testsuite.yaml
+++ b/machine/v1/control-plane-machine-set.stable.testsuite.yaml
@@ -1,0 +1,73 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[Stable] ControlPlaneMachineSet"
+crd: 0000_10_controlplanemachineset.crd.yaml
+tests:
+  onCreate:
+  - name: Should be able to create a minimal ControlPlaneMachineSet
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+    expected: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+  - name: Should reject a missing machineType
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+    expectedError: "spec.template.machineType: Required value"
+  - name: Should reject a missing machines_v1beta1_machine_openshift_io
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+    expectedError: "spec.template: Invalid value: \"object\": machines_v1beta1_machine_openshift_io configuration is required when machineType is machines_v1beta1_machine_openshift_io, and forbidden otherwise"

--- a/machine/v1/control-plane-machine-set.stable.testsuite.yaml
+++ b/machine/v1/control-plane-machine-set.stable.testsuite.yaml
@@ -71,3 +71,148 @@ tests:
         template:
           machineType: machines_v1beta1_machine_openshift_io
     expectedError: "spec.template: Invalid value: \"object\": machines_v1beta1_machine_openshift_io configuration is required when machineType is machines_v1beta1_machine_openshift_io, and forbidden otherwise"
+  onUpdate:
+  - name: Replicas should be immutable
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+    updated: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 5
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+    expectedError: "spec.replicas: Invalid value: \"integer\": replicas is immutable"
+  - name: Selector should be immutable
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+    updated: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+            foo: bar
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+    expectedError: "spec.selector: Invalid value: \"object\": selector is immutable"
+  - name: Should default the strategy when removed
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        strategy:
+          type: OnDelete
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+    updated: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+    expected: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}

--- a/machine/v1/control-plane-machine-set.stable.testsuite.yaml
+++ b/machine/v1/control-plane-machine-set.stable.testsuite.yaml
@@ -19,6 +19,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
     expected: |
@@ -39,6 +40,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
   - name: Should reject a missing machineType
@@ -56,6 +58,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
     expectedError: "spec.template.machineType: Required value"
@@ -71,6 +74,103 @@ tests:
         template:
           machineType: machines_v1beta1_machine_openshift_io
     expectedError: "spec.template: Invalid value: \"object\": machines_v1beta1_machine_openshift_io configuration is required when machineType is machines_v1beta1_machine_openshift_io, and forbidden otherwise"
+  - name: Should reject a worker role label
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: worker
+                machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
+            spec:
+              providerSpec: {}
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.metadata.labels: Invalid value: \"object\": label 'machine.openshift.io/cluster-api-machine-role' is required, and must have value 'master'"
+  - name: Should reject a missing role label
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
+            spec:
+              providerSpec: {}
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.metadata.labels: Invalid value: \"object\": label 'machine.openshift.io/cluster-api-machine-role' is required, and must have value 'master'"
+  - name: Should reject a worker type label
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: worker
+                machine.openshift.io/cluster-api-cluster: cluster
+            spec:
+              providerSpec: {}
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.metadata.labels: Invalid value: \"object\": label 'machine.openshift.io/cluster-api-machine-type' is required, and must have value 'master'"
+  - name: Should reject a missing type label
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-cluster: cluster
+            spec:
+              providerSpec: {}
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.metadata.labels: Invalid value: \"object\": label 'machine.openshift.io/cluster-api-machine-type' is required, and must have value 'master'"
+  - name: Should reject a missing cluster ID label
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+            spec:
+              providerSpec: {}
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.metadata.labels: Invalid value: \"object\": label 'machine.openshift.io/cluster-api-cluster' is required"
   onUpdate:
   - name: Replicas should be immutable
     initial: |
@@ -91,6 +191,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
     updated: |
@@ -111,6 +212,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
     expectedError: "spec.replicas: Invalid value: \"integer\": replicas is immutable"
@@ -133,6 +235,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
     updated: |
@@ -154,6 +257,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
     expectedError: "spec.selector: Invalid value: \"object\": selector is immutable"
@@ -176,6 +280,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
     updated: |
@@ -194,6 +299,7 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}
     expected: |
@@ -214,5 +320,6 @@ tests:
               labels:
                 machine.openshift.io/cluster-api-machine-role: master
                 machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
             spec:
               providerSpec: {}

--- a/machine/v1/types_aws.go
+++ b/machine/v1/types_aws.go
@@ -4,6 +4,9 @@ package v1
 // Only one of ID, ARN or Filters may be specified. Specifying more than one will result in
 // a validation error.
 // +union
+// +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'ID' ?  has(self.id) : !has(self.id)",message="id is required when type is ID, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'ARN' ?  has(self.arn) : !has(self.arn)",message="arn is required when type is ARN, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'Filters' ?  has(self.filters) : !has(self.filters)",message="filters is required when type is Filters, and forbidden otherwise"
 type AWSResourceReference struct {
 	// Type determines how the reference will fetch the AWS resource.
 	// +unionDiscriminator

--- a/machine/v1/types_controlplanemachineset.go
+++ b/machine/v1/types_controlplanemachineset.go
@@ -131,9 +131,14 @@ type ControlPlaneMachineSetTemplateObjectMeta struct {
 	// Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
-	// More info: http://kubernetes.io/docs/user-guide/labels
-	// +optional
-	Labels map[string]string `json:"labels,omitempty"`
+	// More info: http://kubernetes.io/docs/user-guide/labels.
+	// This field must contain both the 'machine.openshift.io/cluster-api-machine-role' and 'machine.openshift.io/cluster-api-machine-type' labels, both with a value of 'master'.
+	// It must also contain a label with the key 'machine.openshift.io/cluster-api-cluster'.
+	// +kubebuilder:validation:XValidation:rule="'machine.openshift.io/cluster-api-machine-role' in self && self['machine.openshift.io/cluster-api-machine-role'] == 'master'",message="label 'machine.openshift.io/cluster-api-machine-role' is required, and must have value 'master'"
+	// +kubebuilder:validation:XValidation:rule="'machine.openshift.io/cluster-api-machine-type' in self && self['machine.openshift.io/cluster-api-machine-type'] == 'master'",message="label 'machine.openshift.io/cluster-api-machine-type' is required, and must have value 'master'"
+	// +kubebuilder:validation:XValidation:rule="'machine.openshift.io/cluster-api-cluster' in self",message="label 'machine.openshift.io/cluster-api-cluster' is required"
+	// +kubebuilder:validation:Required
+	Labels map[string]string `json:"labels"`
 
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not

--- a/machine/v1/types_controlplanemachineset.go
+++ b/machine/v1/types_controlplanemachineset.go
@@ -40,6 +40,7 @@ type ControlPlaneMachineSetSpec struct {
 	// 3 and 5 are the only valid values for this field.
 	// +kubebuilder:validation:Enum:=3;5
 	// +kubebuilder:default:=3
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="replicas is immutable"
 	// +kubebuilder:validation:Required
 	Replicas *int32 `json:"replicas"`
 
@@ -53,6 +54,7 @@ type ControlPlaneMachineSetSpec struct {
 	// selector will be the ones affected by this ControlPlaneMachineSet.
 	// It must match the template's labels.
 	// This field is considered immutable after creation of the resource.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="selector is immutable"
 	// +kubebuilder:validation:Required
 	Selector metav1.LabelSelector `json:"selector"`
 
@@ -71,16 +73,17 @@ type ControlPlaneMachineSetSpec struct {
 // + For now, the only supported type is the OpenShift Machine API Machine, but in the future
 // + we plan to expand this to allow other Machine types such as Cluster API Machines or a
 // + future version of the Machine API Machine.
+// +kubebuilder:validation:XValidation:rule="has(self.machineType) && self.machineType == 'machines_v1beta1_machine_openshift_io' ?  has(self.machines_v1beta1_machine_openshift_io) : !has(self.machines_v1beta1_machine_openshift_io)",message="machines_v1beta1_machine_openshift_io configuration is required when machineType is machines_v1beta1_machine_openshift_io, and forbidden otherwise"
 type ControlPlaneMachineSetTemplate struct {
 	// MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet.
 	// Currently, the only valid value is machines_v1beta1_machine_openshift_io.
 	// +unionDiscriminator
 	// +kubebuilder:validation:Required
-	MachineType ControlPlaneMachineSetMachineType `json:"machineType"`
+	MachineType ControlPlaneMachineSetMachineType `json:"machineType,omitempty"`
 
 	// OpenShiftMachineV1Beta1Machine defines the template for creating Machines
 	// from the v1beta1.machine.openshift.io API group.
-	// +kubebuilder:validation:Required
+	// +optional
 	OpenShiftMachineV1Beta1Machine *OpenShiftMachineV1Beta1MachineTemplate `json:"machines_v1beta1_machine_openshift_io,omitempty"`
 }
 
@@ -148,6 +151,7 @@ type ControlPlaneMachineSetStrategy struct {
 	// Valid values are "RollingUpdate" and "OnDelete".
 	// The current default value is "RollingUpdate".
 	// +kubebuilder:default:="RollingUpdate"
+	// +default="RollingUpdate"
 	// +kubebuilder:validation:Enum:="RollingUpdate";"OnDelete"
 	// +optional
 	Type ControlPlaneMachineSetStrategyType `json:"type,omitempty"`
@@ -186,6 +190,9 @@ const (
 // FailureDomain represents the different configurations required to spread Machines
 // across failure domains on different platforms.
 // +union
+// +kubebuilder:validation:XValidation:rule="has(self.platform) && self.platform == 'AWS' ?  has(self.aws) : !has(self.aws)",message="aws configuration is required when platform is AWS, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.platform) && self.platform == 'Azure' ?  has(self.azure) : !has(self.azure)",message="azure configuration is required when platform is Azure, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.platform) && self.platform == 'GCP' ?  has(self.gcp) : !has(self.gcp)",message="gcp configuration is required when platform is GCP, and forbidden otherwise"
 type FailureDomains struct {
 	// Platform identifies the platform for which the FailureDomain represents.
 	// Currently supported values are AWS, Azure, and GCP.

--- a/machine/v1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1/zz_generated.swagger_doc_generated.go
@@ -227,7 +227,7 @@ func (ControlPlaneMachineSetTemplate) SwaggerDoc() map[string]string {
 
 var map_ControlPlaneMachineSetTemplateObjectMeta = map[string]string{
 	"":            "ControlPlaneMachineSetTemplateObjectMeta is a subset of the metav1.ObjectMeta struct. It allows users to specify labels and annotations that will be copied onto Machines created from this template.",
-	"labels":      "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+	"labels":      "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels. This field must contain both the 'machine.openshift.io/cluster-api-machine-role' and 'machine.openshift.io/cluster-api-machine-type' labels, both with a value of 'master'. It must also contain a label with the key 'machine.openshift.io/cluster-api-cluster'.",
 	"annotations": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
 }
 

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -27917,7 +27917,7 @@ func schema_openshift_api_machine_v1_ControlPlaneMachineSetTemplateObjectMeta(re
 				Properties: map[string]spec.Schema{
 					"labels": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+							Description: "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels. This field must contain both the 'machine.openshift.io/cluster-api-machine-role' and 'machine.openshift.io/cluster-api-machine-type' labels, both with a value of 'master'. It must also contain a label with the key 'machine.openshift.io/cluster-api-cluster'.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -27948,6 +27948,7 @@ func schema_openshift_api_machine_v1_ControlPlaneMachineSetTemplateObjectMeta(re
 						},
 					},
 				},
+				Required: []string{"labels"},
 			},
 		},
 	}

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -27857,6 +27857,7 @@ func schema_openshift_api_machine_v1_ControlPlaneMachineSetStrategy(ref common.R
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type defines the type of update strategy that should be used when updating Machines owned by the ControlPlaneMachineSet. Valid values are \"RollingUpdate\" and \"OnDelete\". The current default value is \"RollingUpdate\".",
+							Default:     "RollingUpdate",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -27877,7 +27878,6 @@ func schema_openshift_api_machine_v1_ControlPlaneMachineSetTemplate(ref common.R
 					"machineType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet. Currently, the only valid value is machines_v1beta1_machine_openshift_io.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -27889,7 +27889,6 @@ func schema_openshift_api_machine_v1_ControlPlaneMachineSetTemplate(ref common.R
 						},
 					},
 				},
-				Required: []string{"machineType"},
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -16147,21 +16147,18 @@
       "properties": {
         "type": {
           "description": "Type defines the type of update strategy that should be used when updating Machines owned by the ControlPlaneMachineSet. Valid values are \"RollingUpdate\" and \"OnDelete\". The current default value is \"RollingUpdate\".",
-          "type": "string"
+          "type": "string",
+          "default": "RollingUpdate"
         }
       }
     },
     "com.github.openshift.api.machine.v1.ControlPlaneMachineSetTemplate": {
       "description": "ControlPlaneMachineSetTemplate is a template used by the ControlPlaneMachineSet to create the Machines that it will manage in the future.",
       "type": "object",
-      "required": [
-        "machineType"
-      ],
       "properties": {
         "machineType": {
           "description": "MachineType determines the type of Machines that should be managed by the ControlPlaneMachineSet. Currently, the only valid value is machines_v1beta1_machine_openshift_io.",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "machines_v1beta1_machine_openshift_io": {
           "description": "OpenShiftMachineV1Beta1Machine defines the template for creating Machines from the v1beta1.machine.openshift.io API group.",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -16177,6 +16177,9 @@
     "com.github.openshift.api.machine.v1.ControlPlaneMachineSetTemplateObjectMeta": {
       "description": "ControlPlaneMachineSetTemplateObjectMeta is a subset of the metav1.ObjectMeta struct. It allows users to specify labels and annotations that will be copied onto Machines created from this template.",
       "type": "object",
+      "required": [
+        "labels"
+      ],
       "properties": {
         "annotations": {
           "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
@@ -16187,7 +16190,7 @@
           }
         },
         "labels": {
-          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels. This field must contain both the 'machine.openshift.io/cluster-api-machine-role' and 'machine.openshift.io/cluster-api-machine-type' labels, both with a value of 'master'. It must also contain a label with the key 'machine.openshift.io/cluster-api-cluster'.",
           "type": "object",
           "additionalProperties": {
             "type": "string",

--- a/tests/hack/test.sh
+++ b/tests/hack/test.sh
@@ -8,7 +8,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 ARTIFACT_DIR=${ARTIFACT_DIR:-""}
 GINKGO=${GINKGO:-"go run ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
-GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --randomize-all --randomize-suites --keep-going --timeout=2m"}
+GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --randomize-all --randomize-suites --keep-going --timeout=10m"}
 GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}
 
 # Ensure that some home var is set and that it's not the root.


### PR DESCRIPTION
/hold this needs the Kube 1.25 rebase to have landed before it will work

We have these validations already but they are currently maintained as a webhook. In an effort to reduce our code complexity and demonstrate the CEL usage for OpenShift, I've tried to replicate the validations here.

Eg. Today we validate the unions with https://github.com/openshift/cluster-control-plane-machine-set-operator/blob/1fa6ff25480e5eb4221a1f5d059dd7b416381e12/pkg/webhooks/controlplanemachineset/webhooks.go#L511-L570, which is complicated, using CEL would simplify this for us and others who are writing unions.

Q: Can users override this validation and persist objects that don't match the schema? Does this change allow us to delete the webhook code?