### PR TITLE
Recognize the GO environment variable

### DIFF
--- a/hack/update-openapi.sh
+++ b/hack/update-openapi.sh
@@ -35,6 +35,6 @@ GOPATH= ${OPENAPI_GEN} \
          --go-header-file ${SCRIPT_ROOT}/hack/empty.txt \
          ${verify}
 
-go build github.com/openshift/api/openapi/cmd/models-schema
+${GO:-go} build github.com/openshift/api/openapi/cmd/models-schema
 
 ./models-schema  | jq '.' > ${output_package}/openapi.json

--- a/hack/update-swagger-docs.sh
+++ b/hack/update-swagger-docs.sh
@@ -30,7 +30,7 @@ kube::swagger::gen_types_swagger_doc() {
 // AUTO-GENERATED FUNCTIONS START HERE
 EOF
 
-  go run tools/genswaggertypedocs/swagger_type_docs.go -s \
+  ${GO:-go} run tools/genswaggertypedocs/swagger_type_docs.go -s \
     "${gv_dir}/types*.go" \
     -f - \
     >>  "$TMPFILE"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,10 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-ENVTEST = go run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest
+ifeq ($(GO),)
+GO := go
+endif
+ENVTEST = $(GO) run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest
 
 .PHONY: integration
 integration: verify-vendor test
@@ -12,9 +15,9 @@ test: ## Run only the tests.
 
 .PHONY: vendor
 vendor:
-	go mod tidy
-	go mod vendor
-	go mod verify
+	$(GO) mod tidy
+	$(GO) mod vendor
+	$(GO) mod verify
 
 .PHONY: verify-vendor
 verify-vendor: vendor

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,7 +1,10 @@
 # Detect go environment to build tools into env specific directories.
 # This is helpful for those running tools locally and within containers across different OS/architechture combinations.
-GOOS=$(shell go env GOOS)
-GOARCH=$(shell go env GOARCH)
+ifeq ($(GO),)
+GO := go
+endif
+GOOS=$(shell $(GO) env GOOS)
+GOARCH=$(shell $(GO) env GOARCH)
 TOOLS_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 OUTPUT_DIR=$(TOOLS_DIR)/_output/bin/$(GOOS)/$(GOARCH)
 
@@ -35,10 +38,10 @@ openapi-gen: $(OUTPUT_DIR)/openapi-gen
 #####################################
 
 $(OUTPUT_DIR)/deepcopy-gen:
-	go build -mod=vendor -o $(OUTPUT_DIR)/deepcopy-gen ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
+	$(GO) build -mod=vendor -o $(OUTPUT_DIR)/deepcopy-gen ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
 
 $(OUTPUT_DIR)/openapi-gen:
-	go build -mod=vendor -o $(OUTPUT_DIR)/openapi-gen ./vendor/k8s.io/code-generator/cmd/openapi-gen
+	$(GO) build -mod=vendor -o $(OUTPUT_DIR)/openapi-gen ./vendor/k8s.io/code-generator/cmd/openapi-gen
 
 ###################################
 #


### PR DESCRIPTION
If the `GO` environment variable is nonempty, use its value as the command for running Go.  Otherwise, use "go".

* `hack/update-openapi.sh`:
* `hack/update-swagger-docs.sh`:
* `tests/Makefile`:
* `tools/Makefile`: Use the `GO` environment variable if it is nonempty.