### PR TITLE
Fix omitempty json tags

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -198,11 +198,11 @@ type StaticPodOperatorStatus struct {
 
 	// latestAvailableRevision is the deploymentID of the most recent deployment
 	// +optional
-	LatestAvailableRevision int32 `json:"latestAvailableRevision,omitEmpty"`
+	LatestAvailableRevision int32 `json:"latestAvailableRevision,omitempty"`
 
 	// latestAvailableRevisionReason describe the detailed reason for the most recent deployment
 	// +optional
-	LatestAvailableRevisionReason string `json:"latestAvailableRevisionReason,omitEmpty"`
+	LatestAvailableRevisionReason string `json:"latestAvailableRevisionReason,omitempty"`
 
 	// nodeStatuses track the deployment values and errors across individual nodes
 	// +optional


### PR DESCRIPTION
"omitEmpty" is an unknown JSON option and therefore it is ignored during encoding. This commit changes all occurances to the correct "omitempty" tag.