### PR TITLE
CORS-2385: IBMCloud: Add networkResourceGroupName to Status

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
@@ -424,6 +424,12 @@ spec:
                         location:
                           description: Location is where the cluster has been deployed
                           type: string
+                        networkResourceGroupName:
+                          description: networkResourceGroupName is the Resource Group for network resources like the VPC and Subnets used by the cluster. If empty, the value is same as ResourceGroupName. This field is immutable and cannot be changed after cluster installation.
+                          type: string
+                          x-kubernetes-validations:
+                            - rule: self == oldSelf
+                              message: NetworkResourceGroupName is immutable
                         providerType:
                           description: ProviderType indicates the type of cluster that was created
                           type: string

--- a/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
@@ -570,6 +570,12 @@ spec:
                         location:
                           description: Location is where the cluster has been deployed
                           type: string
+                        networkResourceGroupName:
+                          description: networkResourceGroupName is the Resource Group for network resources like the VPC and Subnets used by the cluster. If empty, the value is same as ResourceGroupName. This field is immutable and cannot be changed after cluster installation.
+                          type: string
+                          x-kubernetes-validations:
+                            - message: NetworkResourceGroupName is immutable
+                              rule: self == oldSelf
                         providerType:
                           description: ProviderType indicates the type of cluster that was created
                           type: string

--- a/config/v1/stable.infrastructure.testsuite.yaml
+++ b/config/v1/stable.infrastructure.testsuite.yaml
@@ -12,3 +12,48 @@ tests:
       apiVersion: config.openshift.io/v1
       kind: Infrastructure
       spec: {}
+  onUpdate:
+  - name: Should allow setting IBM Cloud NetworkResourceGroupName immutable status field
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        controlPlaneTopology: "HighlyAvailable"
+        infrastructureTopology: "HighlyAvailable"
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        platformStatus:
+          ibmcloud:
+            networkResourceGroupName: bar
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        controlPlaneTopology: "HighlyAvailable"
+        infrastructureTopology: "HighlyAvailable"
+        platformStatus:
+          ibmcloud:
+            networkResourceGroupName: bar
+  - name: Should not allow changing IBM Cloud NetworkResourceGroupName immutable status field
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        platformStatus:
+          ibmcloud:
+            networkResourceGroupName: foo
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        platformStatus:
+          ibmcloud:
+            networkResourceGroupName: bar
+    expectedStatusError: "status.platformStatus.ibmcloud.networkResourceGroupName: Invalid value: \"string\": NetworkResourceGroupName is immutable"

--- a/config/v1/techpreview.infrastructure.testsuite.yaml
+++ b/config/v1/techpreview.infrastructure.testsuite.yaml
@@ -12,3 +12,48 @@ tests:
       apiVersion: config.openshift.io/v1
       kind: Infrastructure
       spec: {}
+  onUpdate:
+  - name: Should allow setting IBM Cloud NetworkResourceGroupName immutable status field
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        controlPlaneTopology: "HighlyAvailable"
+        infrastructureTopology: "HighlyAvailable"
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        platformStatus:
+          ibmcloud:
+            networkResourceGroupName: bar
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        controlPlaneTopology: "HighlyAvailable"
+        infrastructureTopology: "HighlyAvailable"
+        platformStatus:
+          ibmcloud:
+            networkResourceGroupName: bar
+  - name: Should not allow changing IBM Cloud NetworkResourceGroupName immutable status field
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        platformStatus:
+          ibmcloud:
+            networkResourceGroupName: foo
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        platformStatus:
+          ibmcloud:
+            networkResourceGroupName: bar
+    expectedStatusError: "status.platformStatus.ibmcloud.networkResourceGroupName: Invalid value: \"string\": NetworkResourceGroupName is immutable"

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -853,6 +853,13 @@ type IBMCloudPlatformStatus struct {
 	// ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.
 	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 
+	// networkResourceGroupName is the Resource Group for network resources like the VPC and Subnets used by the cluster.
+	// If empty, the value is same as ResourceGroupName.
+	// This field is immutable and cannot be changed after cluster installation.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="NetworkResourceGroupName is immutable"
+	// +optional
+	NetworkResourceGroupName string `json:"networkResourceGroupName,omitempty"`
+
 	// ProviderType indicates the type of cluster that was created
 	ProviderType IBMCloudProviderType `json:"providerType,omitempty"`
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1135,12 +1135,13 @@ func (IBMCloudPlatformSpec) SwaggerDoc() map[string]string {
 }
 
 var map_IBMCloudPlatformStatus = map[string]string{
-	"":                  "IBMCloudPlatformStatus holds the current status of the IBMCloud infrastructure provider.",
-	"location":          "Location is where the cluster has been deployed",
-	"resourceGroupName": "ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.",
-	"providerType":      "ProviderType indicates the type of cluster that was created",
-	"cisInstanceCRN":    "CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain",
-	"dnsInstanceCRN":    "DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain",
+	"":                         "IBMCloudPlatformStatus holds the current status of the IBMCloud infrastructure provider.",
+	"location":                 "Location is where the cluster has been deployed",
+	"resourceGroupName":        "ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.",
+	"networkResourceGroupName": "networkResourceGroupName is the Resource Group for network resources like the VPC and Subnets used by the cluster. If empty, the value is same as ResourceGroupName. This field is immutable and cannot be changed after cluster installation.",
+	"providerType":             "ProviderType indicates the type of cluster that was created",
+	"cisInstanceCRN":           "CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain",
+	"dnsInstanceCRN":           "DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain",
 }
 
 func (IBMCloudPlatformStatus) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -11909,6 +11909,13 @@ func schema_openshift_api_config_v1_IBMCloudPlatformStatus(ref common.ReferenceC
 							Format:      "",
 						},
 					},
+					"networkResourceGroupName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "networkResourceGroupName is the Resource Group for network resources like the VPC and Subnets used by the cluster. If empty, the value is same as ResourceGroupName. This field is immutable and cannot be changed after cluster installation.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"providerType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ProviderType indicates the type of cluster that was created",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -6310,6 +6310,10 @@
           "description": "Location is where the cluster has been deployed",
           "type": "string"
         },
+        "networkResourceGroupName": {
+          "description": "networkResourceGroupName is the Resource Group for network resources like the VPC and Subnets used by the cluster. If empty, the value is same as ResourceGroupName. This field is immutable and cannot be changed after cluster installation.",
+          "type": "string"
+        },
         "providerType": {
           "description": "ProviderType indicates the type of cluster that was created",
           "type": "string"


### PR DESCRIPTION
Added the networkResourceGroupName for use with BYON support, to the IBM Cloud PlatformStatus configuration in Infrastructure.