### PR TITLE
machine/v1alpha1: Expose GroupVersion

### DIFF
--- a/machine/v1alpha1/register.go
+++ b/machine/v1alpha1/register.go
@@ -25,7 +25,7 @@ import (
 const GroupName = "machine.openshift.io"
 
 var (
-	groupVersion  = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
+	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	// Install is a function which adds this version to a scheme
 	Install = schemeBuilder.AddToScheme
@@ -33,6 +33,6 @@ var (
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	metav1.AddToGroupVersion(scheme, groupVersion)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
 	return nil
 }


### PR DESCRIPTION
This commit does not change any exposed OpenShift API. Rather, it conveniently exposes `machine.openshift.io/v1alpha1`'s versioning information, consistently with the other versions of the same resource.