### PR TITLE
Add versioning to codegen utility

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -11,6 +11,12 @@ OUTPUT_DIR=$(TOOLS_DIR)/_output/bin/$(GOOS)/$(GOARCH)
 # Append dirty if the current working tree is dirty for any of the relevant files.
 CODEGEN_VERSION=$(shell git log -n 1 --pretty=format:%H -- codegen vendor go.mod go.sum; git diff HEAD --quiet codegen vendor go.mod go.sum || echo -dirty)
 
+# The VENDOR_VERSION is set to the commit hash of the most recent commit that touched
+# the vendor folder or go.mod and go.sum files.
+# This should contain any file that may change the output of the build for vendor based tooling.
+# Append dirty if the current working tree is dirty for any of the relevant files.
+VENDOR_VERSION=$(shell git log -n 1 --pretty=format:%H -- vendor go.mod go.sum; git diff HEAD --quiet vendor go.mod go.sum || echo -dirty)
+
 # Tools builds all tools.
 tools: codegen controller-gen deepcopy-gen go-to-protobuf openapi-gen protoc-gen-gogo yq
 
@@ -20,15 +26,6 @@ clean:
 .PHONY: run-codegen
 run-codegen: codegen
 	$(OUTPUT_DIR)/codegen --base-dir $(BASE_DIR) --api-group-versions $(API_GROUP_VERSIONS) --required-feature-sets $(OPENSHIFT_REQUIRED_FEATURESETS)
-
-# If the codegen utility is built, and the version doesn't match the latest version,
-# Remove it so that it'll be rebuilt before being executed again.
-.PHONY: check-codegen-version
-check-codegen-version:
-	@ if [ -f $(OUTPUT_DIR)/codegen ] && [ "$(CODEGEN_VERSION)" != "$(shell $(OUTPUT_DIR)/codegen --version)" ]; then \
-		echo "codegen version mismatch, removing old codegen"; \
-		rm $(OUTPUT_DIR)/codegen; \
-	fi
 
 #############################################
 #
@@ -54,6 +51,9 @@ openapi-gen: $(OUTPUT_DIR)/openapi-gen
 .PHONY:protoc-gen-gogo
 protoc-gen-gogo: $(OUTPUT_DIR)/protoc-gen-gogo
 
+.PHONY:vendor-version
+vendor-version: $(OUTPUT_DIR)/vendor-version
+
 .PHONY:yq
 yq: $(OUTPUT_DIR)/yq
 
@@ -77,22 +77,22 @@ $(OUTPUT_DIR)/codegen: check-codegen-version
 		go build -mod=vendor -o $(OUTPUT_DIR)/codegen -ldflags="-X main.version=${CODEGEN_VERSION}" ./codegen/cmd; \
 	fi
 
-$(OUTPUT_DIR)/controller-gen:
+$(OUTPUT_DIR)/controller-gen: $(OUTPUT_DIR)/vendor-version
 	go build -mod=vendor -o $(OUTPUT_DIR)/controller-gen ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 
-$(OUTPUT_DIR)/deepcopy-gen:
+$(OUTPUT_DIR)/deepcopy-gen: $(OUTPUT_DIR)/vendor-version
 	go build -mod=vendor -o $(OUTPUT_DIR)/deepcopy-gen ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
 
-$(OUTPUT_DIR)/go-to-protobuf:
+$(OUTPUT_DIR)/go-to-protobuf: $(OUTPUT_DIR)/vendor-version
 	go build -mod=vendor -o $(OUTPUT_DIR)/go-to-protobuf ./vendor/k8s.io/code-generator/cmd/go-to-protobuf
 
-$(OUTPUT_DIR)/openapi-gen:
+$(OUTPUT_DIR)/openapi-gen: $(OUTPUT_DIR)/vendor-version
 	go build -mod=vendor -o $(OUTPUT_DIR)/openapi-gen ./vendor/k8s.io/code-generator/cmd/openapi-gen
 
-$(OUTPUT_DIR)/protoc-gen-gogo:
+$(OUTPUT_DIR)/protoc-gen-gogo: $(OUTPUT_DIR)/vendor-version
 	go build -mod=vendor -o $(OUTPUT_DIR)/protoc-gen-gogo ./vendor/k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo
 
-$(OUTPUT_DIR)/yq:
+$(OUTPUT_DIR)/yq: $(OUTPUT_DIR)/vendor-version
 	go build -mod=vendor -o $(OUTPUT_DIR)/yq ./vendor/github.com/mikefarah/yq/v4
 
 ###################################
@@ -100,3 +100,43 @@ $(OUTPUT_DIR)/yq:
 # END: Fully qualified tool targets
 #
 ###################################
+
+#################################
+#
+# BEGIN: version checking targets
+#
+#################################
+
+# If the vendor version has changed, remove all compiled utils.
+# This ensures that when dependencies are updated, the utils are rebuilt.
+.PHONY: check-vendor-version
+check-vendor-version:
+	@ if [ -f $(OUTPUT_DIR)/vendor-version ] && [ "$(VENDOR_VERSION)" != "$$(cat $(OUTPUT_DIR)/vendor-version)" ]; then \
+		echo "Tools vendor version mismatch, removing old utils"; \
+		rm $(OUTPUT_DIR)/*; \
+	fi
+
+# This writes the vendor version to disk so that we can track it over time.
+# If the version ever differs from what is written to disk we know the utils need to be rebuilt.
+$(OUTPUT_DIR)/vendor-version: check-vendor-version
+	@ if [ ! -f $(OUTPUT_DIR)/vendor-version ]; then \
+		echo "Writing tools vendor version ${VENDOR_VERSION}"; \
+		mkdir -p $(OUTPUT_DIR); \
+		echo "${VENDOR_VERSION}" > $(OUTPUT_DIR)/vendor-version; \
+	fi
+	
+
+# If the codegen utility is built, and the version doesn't match the latest version,
+# Remove it so that it'll be rebuilt before being executed again.
+.PHONY: check-codegen-version
+check-codegen-version: vendor-version
+	@ if [ -f $(OUTPUT_DIR)/codegen ] && [ "$(CODEGEN_VERSION)" != "$$($(OUTPUT_DIR)/codegen --version)" ]; then \
+		echo "codegen version mismatch, removing old codegen"; \
+		rm $(OUTPUT_DIR)/codegen; \
+	fi
+
+###############################
+#
+# END: version checking targets
+#
+###############################

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,6 +5,11 @@ GOARCH=$(shell go env GOARCH)
 TOOLS_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 OUTPUT_DIR=$(TOOLS_DIR)/_output/bin/$(GOOS)/$(GOARCH)
 
+# The CODEGEN_VERSION is set to the commit hash of the most recent commit that touched
+# the codegen folder, vendor folder or go.mod and go.sum files.
+# This should contain any file that may change the output of the build for codegen.
+# Append dirty if the current working tree is dirty for any of the relevant files.
+CODEGEN_VERSION=$(shell git log -n 1 --pretty=format:%H -- codegen vendor go.mod go.sum; git diff HEAD --quiet codegen vendor go.mod go.sum || echo -dirty)
 
 # Tools builds all tools.
 tools: codegen controller-gen deepcopy-gen go-to-protobuf openapi-gen protoc-gen-gogo yq
@@ -15,6 +20,15 @@ clean:
 .PHONY: run-codegen
 run-codegen: codegen
 	$(OUTPUT_DIR)/codegen --base-dir $(BASE_DIR) --api-group-versions $(API_GROUP_VERSIONS) --required-feature-sets $(OPENSHIFT_REQUIRED_FEATURESETS)
+
+# If the codegen utility is built, and the version doesn't match the latest version,
+# Remove it so that it'll be rebuilt before being executed again.
+.PHONY: check-codegen-version
+check-codegen-version:
+	@ if [ -f $(OUTPUT_DIR)/codegen ] && [ "$(CODEGEN_VERSION)" != "$(shell $(OUTPUT_DIR)/codegen --version)" ]; then \
+		echo "codegen version mismatch, removing old codegen"; \
+		rm $(OUTPUT_DIR)/codegen; \
+	fi
 
 #############################################
 #
@@ -55,8 +69,13 @@ yq: $(OUTPUT_DIR)/yq
 #
 #####################################
 
-$(OUTPUT_DIR)/codegen:
-	go build -mod=vendor -o $(OUTPUT_DIR)/codegen ./codegen/cmd
+# Because the codegen target relies on a phony, it becomes a phony itself.
+# We must check the presence of the file before rebuilding.
+$(OUTPUT_DIR)/codegen: check-codegen-version
+	@ if [ ! -f $(OUTPUT_DIR)/codegen ]; then \
+		echo "Building codegen version ${CODEGEN_VERSION}"; \
+		go build -mod=vendor -o $(OUTPUT_DIR)/codegen -ldflags="-X main.version=${CODEGEN_VERSION}" ./codegen/cmd; \
+	fi
 
 $(OUTPUT_DIR)/controller-gen:
 	go build -mod=vendor -o $(OUTPUT_DIR)/controller-gen ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/tools/codegen/cmd/root.go
+++ b/tools/codegen/cmd/root.go
@@ -15,6 +15,12 @@ var (
 	apiGroupVersions []string
 	baseDir          string
 	verify           bool
+
+	// version will be set by the makefile when the binary is built.
+	// It should be the git commit hash of the last commit that
+	// affected the code used to build this tool.
+	version      = "Unknown"
+	printVersion bool
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -23,6 +29,11 @@ var rootCmd = &cobra.Command{
 	Use:   "codegen",
 	Short: "Codegen runs code generators for the OpenShift API definitions",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if printVersion {
+			fmt.Printf("%s\n", version)
+			return nil
+		}
+
 		genCtx, err := generation.NewContext(generation.Options{
 			BaseDir:          baseDir,
 			APIGroupVersions: apiGroupVersions,
@@ -46,6 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVar(&apiGroupVersions, "api-group-versions", []string{}, "A list of API group versions in the form <group>/<version>. The group should be fully qualified, e.g. machine.openshift.io/v1. The generator will generate against all group versions found within the base directory when no specific group versions are provided.")
 	rootCmd.PersistentFlags().StringVar(&baseDir, "base-dir", ".", "Base directory to search for API group versions")
 	rootCmd.PersistentFlags().BoolVar(&verify, "verify", false, "Verifies the content of generated files are up to date.")
+	rootCmd.PersistentFlags().BoolVar(&printVersion, "version", false, "Print the version of the codegen tool and exit")
 
 	klog.InitFlags(flag.CommandLine)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)


### PR DESCRIPTION
A lot of people are going to use this utility, and over time we expect it to evolve with new features and bug fixes.
To ensure that our users have the most up to date version, this PR does the following:
* Grabs the last commit to change any file that would affect the codegen utility (anything from the codegen source, or go modules relating to it)
* Injects that as a version arg into the codegen build
* Adds a `--version` flag to codegen
* Updates the makefile with a target that compares the current and built versions and removes the binary if it's an old version

The upshot of this is that whenever someone runs the update scripts, if the codegen tool needs to be rebuilt, it will automatically, if it doesn't, then there's no point rebuilding it.