### PR TITLE
Ensure integration tests can test status updates

### DIFF
--- a/example/v1/0000_50_stabletype-default.crd.yaml
+++ b/example/v1/0000_50_stabletype-default.crd.yaml
@@ -135,5 +135,11 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                immutableField:
+                  description: immutableField is a field that is immutable once the object has been created. It is required at all times.
+                  type: string
+                  x-kubernetes-validations:
+                    - rule: self == oldSelf
+                      message: immutableField is immutable
       served: true
       storage: true

--- a/example/v1/0000_50_stabletype-default.crd.yaml
+++ b/example/v1/0000_50_stabletype-default.crd.yaml
@@ -143,3 +143,5 @@ spec:
                       message: immutableField is immutable
       served: true
       storage: true
+      subresources:
+        status: {}

--- a/example/v1/0000_50_stabletype-techpreview.crd.yaml
+++ b/example/v1/0000_50_stabletype-techpreview.crd.yaml
@@ -147,3 +147,5 @@ spec:
                       message: immutableField is immutable
       served: true
       storage: true
+      subresources:
+        status: {}

--- a/example/v1/0000_50_stabletype-techpreview.crd.yaml
+++ b/example/v1/0000_50_stabletype-techpreview.crd.yaml
@@ -139,5 +139,11 @@ spec:
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map
+                immutableField:
+                  description: immutableField is a field that is immutable once the object has been created. It is required at all times.
+                  type: string
+                  x-kubernetes-validations:
+                    - rule: self == oldSelf
+                      message: immutableField is immutable
       served: true
       storage: true

--- a/example/v1/stable.stableconfigtype.testsuite.yaml
+++ b/example/v1/stable.stableconfigtype.testsuite.yaml
@@ -239,3 +239,29 @@ tests:
         immutableField: foo
         optionalImmutableField: bar
     expectedError: "spec.optionalImmutableField: Invalid value: \"string\": optionalImmutableField is immutable once set"
+  - name: Should allow setting an immutable status field
+    initial: |
+      apiVersion: example.openshift.io/v1
+      kind: StableConfigType
+    updated: |
+      apiVersion: example.openshift.io/v1
+      kind: StableConfigType
+      status:
+        immutableField: bar
+    expected: |
+      apiVersion: example.openshift.io/v1
+      kind: StableConfigType
+      status:
+        immutableField: bar
+  - name: Should not allow changing an immutable status field
+    initial: |
+      apiVersion: example.openshift.io/v1
+      kind: StableConfigType
+      status:
+        immutableField: foo
+    updated: |
+      apiVersion: example.openshift.io/v1
+      kind: StableConfigType
+      status:
+        immutableField: bar
+    expectedStatusError: "status.immutableField: Invalid value: \"string\": immutableField is immutable"

--- a/example/v1/types_stable.go
+++ b/example/v1/types_stable.go
@@ -124,6 +124,12 @@ type StableConfigTypeStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	// immutableField is a field that is immutable once the object has been created.
+	// It is required at all times.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="immutableField is immutable"
+	// +optional
+	ImmutableField string `json:"immutableField,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/example/v1/zz_generated.swagger_doc_generated.go
+++ b/example/v1/zz_generated.swagger_doc_generated.go
@@ -63,8 +63,9 @@ func (StableConfigTypeSpec) SwaggerDoc() map[string]string {
 }
 
 var map_StableConfigTypeStatus = map[string]string{
-	"":           "StableConfigTypeStatus defines the observed status of the StableConfigType.",
-	"conditions": "Represents the observations of a foo's current state. Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
+	"":               "StableConfigTypeStatus defines the observed status of the StableConfigType.",
+	"conditions":     "Represents the observations of a foo's current state. Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"",
+	"immutableField": "immutableField is a field that is immutable once the object has been created. It is required at all times.",
 }
 
 func (StableConfigTypeStatus) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -19538,6 +19538,13 @@ func schema_openshift_api_example_v1_StableConfigTypeStatus(ref common.Reference
 							},
 						},
 					},
+					"immutableField": {
+						SchemaProps: spec.SchemaProps{
+							Description: "immutableField is a field that is immutable once the object has been created. It is required at all times.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -10855,6 +10855,10 @@
           "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "type",
           "x-kubernetes-patch-strategy": "merge"
+        },
+        "immutableField": {
+          "description": "immutableField is a field that is immutable once the object has been created. It is required at all times.",
+          "type": "string"
         }
       }
     },

--- a/tests/generator.go
+++ b/tests/generator.go
@@ -213,17 +213,29 @@ func generateOnCreateTable(onCreateTests []OnCreateTestSpec) {
 // within the test suite test spec.
 func generateOnUpdateTable(onUpdateTests []OnUpdateTestSpec) {
 	type onUpdateTableInput struct {
-		initial       []byte
-		updated       []byte
-		expected      []byte
-		expectedError string
+		initial             []byte
+		updated             []byte
+		expected            []byte
+		expectedError       string
+		expectedStatusError string
 	}
 
 	var assertOnUpdate interface{} = func(in onUpdateTableInput) {
 		initialObj, err := newUnstructuredFrom(in.initial)
 		Expect(err).ToNot(HaveOccurred(), "initial data should be a valid Kubernetes YAML resource")
 
+		initialStatus, ok, err := unstructured.NestedFieldNoCopy(initialObj.Object, "status")
+		Expect(err).ToNot(HaveOccurred())
+		if ok {
+			Expect(initialStatus).ToNot(BeNil())
+		}
+
 		Expect(k8sClient.Create(ctx, initialObj)).ToNot(HaveOccurred(), "initial object should create successfully")
+
+		if initialStatus != nil {
+			Expect(unstructured.SetNestedField(initialObj.Object, initialStatus, "status")).To(Succeed(), "should be able to restore initial status")
+			Expect(k8sClient.Status().Update(ctx, initialObj)).ToNot(HaveOccurred(), "initial object status should update successfully")
+		}
 
 		// Fetch the object we just created from the API.
 		gotObj := newEmptyUnstructuredFrom(initialObj)
@@ -231,6 +243,12 @@ func generateOnUpdateTable(onUpdateTests []OnUpdateTestSpec) {
 
 		updatedObj, err := newUnstructuredFrom(in.updated)
 		Expect(err).ToNot(HaveOccurred(), "updated data should be a valid Kubernetes YAML resource")
+
+		updatedObjStatus, ok, err := unstructured.NestedFieldNoCopy(updatedObj.Object, "status")
+		Expect(err).ToNot(HaveOccurred())
+		if ok {
+			Expect(updatedObjStatus).ToNot(BeNil())
+		}
 
 		// The updated object needs the following fields copied over.
 		updatedObj.SetName(gotObj.GetName())
@@ -243,6 +261,17 @@ func generateOnUpdateTable(onUpdateTests []OnUpdateTestSpec) {
 			return
 		}
 		Expect(err).ToNot(HaveOccurred())
+
+		if updatedObjStatus != nil {
+			Expect(unstructured.SetNestedField(updatedObj.Object, updatedObjStatus, "status")).To(Succeed(), "should be able to restore updated status")
+
+			err := k8sClient.Status().Update(ctx, updatedObj)
+			if in.expectedStatusError != "" {
+				Expect(err).To(MatchError(ContainSubstring(in.expectedStatusError)))
+				return
+			}
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		Expect(k8sClient.Get(ctx, objectKey(initialObj), gotObj))
 
@@ -263,10 +292,11 @@ func generateOnUpdateTable(onUpdateTests []OnUpdateTestSpec) {
 	// Convert the test specs into table entries
 	for _, testEntry := range onUpdateTests {
 		tableEntries = append(tableEntries, Entry(testEntry.Name, onUpdateTableInput{
-			initial:       []byte(testEntry.Initial),
-			updated:       []byte(testEntry.Updated),
-			expected:      []byte(testEntry.Expected),
-			expectedError: testEntry.ExpectedError,
+			initial:             []byte(testEntry.Initial),
+			updated:             []byte(testEntry.Updated),
+			expected:            []byte(testEntry.Expected),
+			expectedError:       testEntry.ExpectedError,
+			expectedStatusError: testEntry.ExpectedStatusError,
 		}))
 	}
 

--- a/tests/generator.go
+++ b/tests/generator.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,7 +56,7 @@ func LoadTestSuiteSpecs(paths ...string) ([]SuiteSpec, error) {
 
 // loadSuiteFile loads an individual SuiteSpec from the given file name.
 func loadSuiteFile(path string) (SuiteSpec, error) {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return SuiteSpec{}, fmt.Errorf("could not read file %q: %w", path, err)
 	}
@@ -332,7 +331,7 @@ func objectKey(obj client.Object) client.ObjectKey {
 
 // loadCRD loads the CustomResourceDefinition defined in the suite spec.
 func loadCRD(suiteSpec SuiteSpec) (*apiextensionsv1.CustomResourceDefinition, error) {
-	raw, err := ioutil.ReadFile(suiteSpec.CRD)
+	raw, err := os.ReadFile(suiteSpec.CRD)
 	if err != nil {
 		return nil, fmt.Errorf("could not load CRD: %w", err)
 	}

--- a/tests/types.go
+++ b/tests/types.go
@@ -14,7 +14,7 @@ type SuiteSpec struct {
 	Version string `json:"version,omitempty"`
 
 	// Tests defines the test cases to run for this test suite.
-	Tests TestSpec `json:tests`
+	Tests TestSpec `json:"tests"`
 }
 
 // TestSpec defines the test specs for individual tests in this suite.

--- a/tests/types.go
+++ b/tests/types.go
@@ -65,9 +65,13 @@ type OnUpdateTestSpec struct {
 	// Typically this will vary in `spec` only test to test.
 	Updated string `json:"updated"`
 
-	// ExpectedError defines the error string that should be returned when the initial resourec is invalid.
+	// ExpectedError defines the error string that should be returned when the updated resource is invalid.
 	// This will be matched as a substring of the actual error when non-empty.
 	ExpectedError string `json:"expectedError"`
+
+	// ExpectedStatusError defines the error string that should be returned when the updated resource status is invalid.
+	// This will be matched as a substring of the actual error when non-empty.
+	ExpectedStatusError string `json:"expectedStatusError"`
 
 	// Expected is a literal string containing the expected YAML content that should be
 	// persisted when the resource is updated.


### PR DESCRIPTION
Previously, we weren't testing the status subresource. However, now that kubectl exposes subresources to end users, we will want to add validations to the status so that we can prevent them from changing things we don't want them to change.

This PR updates the test generator so that status can be added to the update tests, allowing users to check that status can added to objects and allowing them to test validations