### PR TITLE
enable discovery aggregation

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -23,6 +23,16 @@ var (
 )
 
 var (
+	FeatureAggregatedDiscoveryEndpoint = FeatureGateName("AggregatedDiscoveryEndpoint")
+	aggregatedDiscoveryEndpoint        = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureAggregatedDiscoveryEndpoint,
+		},
+		OwningJiraComponent: "kube-apiserver",
+		ResponsiblePerson:   "deads2k",
+		OwningProduct:       kubernetes,
+	}
+
 	FeatureGateGatewayAPI = FeatureGateName("GatewayAPI")
 	gateGatewayAPI        = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -179,6 +179,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(azureWorkloadIdentity).
 		with(gateGatewayAPI).
 		with(maxUnavailableStatefulSet).
+		with(aggregatedDiscoveryEndpoint).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),


### PR DESCRIPTION
This will reduce discovery from 200 API requests to one.  The performance impact for us with so many CRDs will be significant for every client when they build rest mappings, like `oc` every 10 minutes.

Needs a proof PR in the kas-o to be sure we can do this early, but this feature needs the soaking.