### PR TITLE
Add codegen configuration file support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 .PHONY: all
 
-update: update-codegen-crds update-codegen-Default-crds update-codegen-TechPreviewNoUpgrade-crds
+update: update-codegen-crds
 
 RUNTIME ?= podman
 RUNTIME_IMAGE_NAME ?= registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.18-openshift-4.12
@@ -21,29 +21,15 @@ test-unit:
 #          E.g. make update-codegen-crds-machine
 #        - Set API_GROUP_VERSIONS to a space separated list of <group>/<version>.
 #          E.g. API_GROUP_VERSIONS="apps/v1 build/v1" make update-codegen-crds.
-#        To generate for a FeatureSet (filter as above):
-#        - update-codegen-Default-crds
-#        - update-codegen-TechPreviewNoUpgrade-crds
+#        FeatureSet generation is controlled at the group level by the
+#        .codegen.yaml file.
 #
 ##################################################################################
 
 # Ensure update-scripts are run before crd-gen so updates to Godoc are included in CRDs.
 .PHONY: update-codegen-crds
-update-codegen-crds: update-scripts update-codegen-TechPreviewNoUpgrade-crds update-codegen-Default-crds
+update-codegen-crds: update-scripts
 	hack/update-codegen-crds.sh
-
-.PHONY: update-codegen-Default-crds
-update-codegen-Default-crds: update-scripts
-	OPENSHIFT_REQUIRED_FEATURESETS=Default hack/update-codegen-crds.sh
-
-.PHONY: update-codegen-TechPreviewNoUpgrade-crds
-update-codegen-TechPreviewNoUpgrade-crds: update-scripts
-	OPENSHIFT_REQUIRED_FEATURESETS=TechPreviewNoUpgrade hack/update-codegen-crds.sh
-
-# Aliases to make it easier to generate the feature set based CRDs.
-update-codegen-default-crds: update-codegen-Default-crds
-update-codegen-techpreview-crds: update-codegen-TechPreviewNoUpgrade-crds
-update-codegen-techpreviewnoupgrade-crds: update-codegen-TechPreviewNoUpgrade-crds
 
 #####################
 #
@@ -64,7 +50,7 @@ verify-scripts:
 	bash -x hack/verify-group-versions.sh
 
 .PHONY: verify
-verify: verify-scripts verify-codegen-crds verify-codegen-TechPreviewNoUpgrade-crds verify-codegen-Default-crds
+verify: verify-scripts verify-codegen-crds
 
 .PHONY: verify-codegen-crds
 verify-codegen-crds: verify-update-codegen-crds

--- a/config/.codegen.yaml
+++ b/config/.codegen.yaml
@@ -1,0 +1,5 @@
+schemapatch:
+  requiredFeatureSets:
+  - ""
+  - "Default"
+  - "TechPreviewNoUpgrade"

--- a/example/.codegen.yaml
+++ b/example/.codegen.yaml
@@ -1,0 +1,12 @@
+schemapatch:
+  disabled: false
+  requiredFeatureSets:
+  - ""
+  - "Default"
+  - "TechPreviewNoUpgrade"
+swaggerdocs:
+  disabled: false
+  enforceComments: false
+  outputFileName: zz_generated.swagger_doc_generated.go
+compatibility:
+  disabled: false

--- a/example/.codegen.yaml
+++ b/example/.codegen.yaml
@@ -6,7 +6,7 @@ schemapatch:
   - "TechPreviewNoUpgrade"
 swaggerdocs:
   disabled: false
-  enforceComments: false
+  commentPolicy: Warn
   outputFileName: zz_generated.swagger_doc_generated.go
 compatibility:
   disabled: false

--- a/monitoring/.codegen.yaml
+++ b/monitoring/.codegen.yaml
@@ -1,0 +1,3 @@
+schemapatch:
+  requiredFeatureSets:
+  - "TechPreviewNoUpgrade"

--- a/platform/.codegen.yaml
+++ b/platform/.codegen.yaml
@@ -1,0 +1,3 @@
+schemapatch:
+  requiredFeatureSets:
+  - "TechPreviewNoUpgrade"

--- a/tools/codegen/README.md
+++ b/tools/codegen/README.md
@@ -139,3 +139,35 @@ These additional arguments may be provided when using the `swaggerdocs` generato
   When omitted, defaults to `zz_generated.swagger_doc_generated.go`.
 - `--swagger:enforce-comments` - Defines whether the generator should enforce that all fields have a comment or not.
   Only effective when combined with `--verify`. When not specified, a warning will be emitted for each missing comment.
+
+## Using configuration files
+
+The `codegen` utility will search for a file called `.codegen.yaml` at the API group level.
+These files allow individual API groups to configure the generation of their paritcular API files.
+
+It also enables the enablement and disablement of generators with a goal that the usage of the generator
+should require only the `--base-dir` argument.
+
+The schema of the configuration file is outlined below, all fields are optional and default values will apply
+when they are omitted.
+
+Each generator option relates to a flag attached to the generator, review the [generators](#generators) section
+for more details on each option within the config file structure.
+
+```yaml
+# Configuration for the compatibility generator.
+compatibility:
+  disabled: false # Defaults to false, set to true to disable.
+# Configuration for the schemapatch generator.
+schemapatch:
+  disabled: false # Defaults to true, set to false to disable.
+  requiredFeatureSets: # Each entry will be matched against the value of the required feature set annotation.
+  - "" # This matches any manifest that does not have the required feature set annotation.
+  - "Default"
+  - "TechPreviewNoUpgrade"
+# Configuration for the swaggerdocs generator.
+swaggerdocs:
+  disabled: false # Defaults to false, set to true to disable.
+  enforceComments: false # Defaults to false, set to true to enforce comments when verifying.
+  outputFileName: zz_generated.swagger_doc_generated.go # Change this if you want to rename the output file.
+```

--- a/tools/codegen/README.md
+++ b/tools/codegen/README.md
@@ -9,26 +9,22 @@ easier.
 The tool can be compiled in the normal way using either `go build` or `make codegen` from the root of the tools module.
 When using make the tool will output to `$(TOOLS_MODULE)/_output/bin/$(GOOS)/$(GOARCH)/bin/codegen`.
 
-The function has the following arguments:
+The root command has the following arguments:
 - `--api-group-versions` - A comma separated list of group versions to generate, all groups must be fully qualified.
   e.g. apps.openshift.io/v1,machine.openshift.io/v1,machine.openshift.io/v1beta1.
 - `--base-dir` - The path to the root of the API folders, this directory will be recursively searched to find the group
   versions specified in `--api-group-versions`. When no group versions are specified, all discovered group versions
   will be generated.
-- `--controller-gen` - optionally use a particular controller-gen binary. When not specified, the tool will use the
-  built in generator.
-  Note, you must use a `controller-gen` built from the [OpenShift fork](https://github.com/openshift/kubernetes-sigs-controller-tools) of controller-tools.
-- `--required-feature-sets` - optionally generate based on the OpenShift feature sets annotations.
-  This will update only CRDs with a matching value for the `release.openshift.io/feature-set` annotation.
+- `--verify` - Rather than updating existing files, the generators will verify that the existing files are up to date.
+  The generator will exit with a non-zero exit code if any file needs to be regenerated.
+- `--versions` - Prints the version of the utility and exits.
+
+When using the root command nakedly, all default generators will be executed on the API groups unless a configuration file
+is found which disables a particular generator.
 
 As a full example, from the root of the OpenShift API repository, you may run:
 ```
 codegen --base-dir /go/src/github.com/openshift/api --api-group-versions apps.openshift.io/v1,config.openshift.io/v1,operator.openshift.io/v1
-```
-
-And to generate only TechPreviewNoUpgrade versions of CRDs:
-```
-codegen-crds --base-dir /go/src/github.com/openshift/api --api-group-versions apps.openshift.io/v1,config.openshift.io/v1,operator.openshift.io/v1 --require-feature-sets TechPreviewNoUpgrade
 ```
 
 ## Inclusion in other repositories
@@ -78,3 +74,68 @@ update-codegen-crds:
 
 You may also want to add the `_output` directory to your `.gitignore` to avoid checking in compiled binaries created
 by this make target.
+
+## Generators
+
+The following section describes the individual generators included within the `codegen` utility.
+
+The generators enabled by default are:
+- [Compatibility](#compatibility)
+- [Schemapatch](#schemapatch)
+- [Swaggerdocs](#swaggerdocs)
+
+### Compatibility
+
+To generate API compatibility comments, use the `compatibility` subcommand.
+
+The `compatibility` subcommand generates a compatibility level comment for each API defintion.
+The generation is controlled by a marker applied to the CRD struct defintiion.
+For example, this annotation would be `+openshift:compatibility-gen:level=1` for a level 1 API.
+	
+Valid API levels are 1, 2, 3 and 4. Version 1 is required for all stable APIs.
+Version 2 should be used for beta level APIs. Levels 3 and 4 may be used for alpha APIs.
+
+### Schemapatch
+
+To generate CRD schemas, use the `schemapatch` subcommand.
+
+The schemapatch subcommand uses the [controller-tools][controller-tools] project to generate CRD schemas.
+It requires a stub CRD to exist before the schema will be generated. Copying an existing OpenShift CRD
+and updating the metadata is the easiest way to generate a stub.
+
+In addition to generating schemas, it also allows patches to be applied to the schema post generation.
+The [yaml-patch][yaml-patch] library accepts RFC-6092-ish patches in a YAML format and applies them to
+the CRD.
+YAML patch files must be named identically to the CRD they apply to, but with a `yaml-patch` extension
+instead of the standard `yaml` extension.
+
+These additional arguments may be provided when using the `schemapatch` generator:
+- `--controller-gen` - optionally use a particular controller-gen binary. When not specified, the tool will use the
+  built in generator.
+  Note, you must use a `controller-gen` built from the [OpenShift fork](https://github.com/openshift/kubernetes-sigs-controller-tools) of controller-tools.
+- `--required-feature-sets` - optionally generate based on the OpenShift feature sets annotations.
+  This will update only CRDs with a matching value for the `release.openshift.io/feature-set` annotation.
+
+For example, to generate only TechPreviewNoUpgrade versions of CRDs:
+```
+codegen schemapatch --base-dir /go/src/github.com/openshift/api --api-group-versions apps.openshift.io/v1,config.openshift.io/v1,operator.openshift.io/v1 --require-feature-sets TechPreviewNoUpgrade
+```
+
+[controller-tools]: https://github.com/kubernetes-sigs/controller-tools
+[yaml-patch]: https://github.com/vmware-archive/yaml-patch
+
+### Swaggerdocs
+
+To generate SwaggerDoc functions for types within an API, use the `swaggerdocs` subcommand.
+
+This generator inspects the documentation within the API defintions and generates functions
+that return the Go documenation for each struct and field within an API.
+
+The generator can also be used to verify that each API field and struct has appropriate
+documentation, using the `--swagger:enforce-comments` and `--verify` flags in conjunction.
+
+These additional arguments may be provided when using the `swaggerdocs` generator:
+- `--swagger:output-file-name` -  Defines the file name to use for the swagger generated docs for each group version.
+  When omitted, defaults to `zz_generated.swagger_doc_generated.go`.
+- `--swagger:enforce-comments` - Defines whether the generator should enforce that all fields have a comment or not.
+  Only effective when combined with `--verify`. When not specified, a warning will be emitted for each missing comment.

--- a/tools/codegen/README.md
+++ b/tools/codegen/README.md
@@ -137,8 +137,9 @@ documentation, using the `--swagger:enforce-comments` and `--verify` flags in co
 These additional arguments may be provided when using the `swaggerdocs` generator:
 - `--swagger:output-file-name` -  Defines the file name to use for the swagger generated docs for each group version.
   When omitted, defaults to `zz_generated.swagger_doc_generated.go`.
-- `--swagger:enforce-comments` - Defines whether the generator should enforce that all fields have a comment or not.
-  Only effective when combined with `--verify`. When not specified, a warning will be emitted for each missing comment.
+- `--swagger:comment-policy` - Defines the policy to use when a field is missing documentation. Valid values are 'Ignore', 'Warn' and 'Enforce'.
+  The default policy is 'Warn'. Missing comments will be ignored when the policy is set to 'Ignore', a warning will be produced when the policy is set to 'Warn',
+  and the generator will fail when the policy is set to 'Enforce'. Only effective when combined with `--verify`. 
 
 ## Using configuration files
 
@@ -168,6 +169,6 @@ schemapatch:
 # Configuration for the swaggerdocs generator.
 swaggerdocs:
   disabled: false # Defaults to false, set to true to disable.
-  enforceComments: false # Defaults to false, set to true to enforce comments when verifying.
+  commentPolicy: Warn # Valid values are `Ignore`, `Warn` and `Enforce`.
   outputFileName: zz_generated.swagger_doc_generated.go # Change this if you want to rename the output file.
 ```

--- a/tools/codegen/cmd/root.go
+++ b/tools/codegen/cmd/root.go
@@ -73,7 +73,12 @@ func executeGenerators(genCtx generation.Context, generators ...generation.Gener
 		klog.Infof("Running generators for %s", group.Name)
 
 		for _, gen := range generators {
-			if err := gen.GenGroup(group); err != nil {
+			g := gen
+			if group.Config != nil {
+				g = g.ApplyConfig(group.Config)
+			}
+
+			if err := g.GenGroup(group); err != nil {
 				errs = append(errs, fmt.Errorf("error running generator %s on group %s: %w", gen.Name(), group.Name, err))
 
 				// Don't run any later generators for this group.

--- a/tools/codegen/cmd/schemapatch.go
+++ b/tools/codegen/cmd/schemapatch.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/api/tools/codegen/pkg/generation"
 	"github.com/openshift/api/tools/codegen/pkg/schemapatch"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 var (
@@ -48,8 +49,13 @@ func init() {
 
 // newSchemaPatchGenerator builds a new schemapatch generator.
 func newSchemaPatchGenerator() generation.Generator {
+	requiredFeatureSetsList := []sets.String{}
+	if len(requiredFeatureSets) > 0 {
+		requiredFeatureSetsList = append(requiredFeatureSetsList, sets.NewString(requiredFeatureSets...))
+	}
+
 	return schemapatch.NewGenerator(schemapatch.Options{
 		ControllerGen:       controllerGen,
-		RequiredFeatureSets: requiredFeatureSets,
+		RequiredFeatureSets: requiredFeatureSetsList,
 	})
 }

--- a/tools/codegen/cmd/swaggerdocs.go
+++ b/tools/codegen/cmd/swaggerdocs.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	swaggerOutputFileName  string
-	swaggerEnforceComments bool
+	swaggerOutputFileName string
+
+	swaggerCommentPolicy = swaggerdocs.CommentPolicyWarn
 )
 
 // swaggerDocsCmd represents the swaggerdocs command
@@ -43,14 +44,14 @@ func init() {
 	rootCmd.AddCommand(swaggerDocsCmd)
 
 	rootCmd.PersistentFlags().StringVar(&swaggerOutputFileName, "swagger:output-file-name", swaggerdocs.DefaultOutputFileName, "Defines the file name to use for the swagger generated docs for each group version.")
-	rootCmd.PersistentFlags().BoolVar(&swaggerEnforceComments, "swagger:enforce-comments", false, "Defines whether the generator should enforce that all fields have a comment or not. Only effective when combined with --verify.")
+	rootCmd.PersistentFlags().Var(newEnum(&swaggerCommentPolicy, swaggerdocs.CommentPolicyIgnore, swaggerdocs.CommentPolicyWarn, swaggerdocs.CommentPolicyEnforce), "swagger:comment-policy", "Defines the policy to use when a field is missing documentation. Valid values are 'Ignore', 'Warn' and 'Enforce'. The default policy is 'Warn'. Missing comments will be ignored when the policy is set to 'Ignore', a warning will be produced when the policy is set to 'Warn', the generator will fail when the policy is set to 'Enforce'.")
 }
 
 // newSwaggerDocsGenerator builds a new swaggerdocs generator.
 func newSwaggerDocsGenerator() generation.Generator {
 	return swaggerdocs.NewGenerator(swaggerdocs.Options{
-		EnforceComments: swaggerEnforceComments,
-		OutputFileName:  swaggerOutputFileName,
-		Verify:          verify,
+		CommentPolicy:  swaggerCommentPolicy,
+		OutputFileName: swaggerOutputFileName,
+		Verify:         verify,
 	})
 }

--- a/tools/codegen/cmd/swaggerdocs.go
+++ b/tools/codegen/cmd/swaggerdocs.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	swaggerOutputFileName string
+	swaggerOutputFileName  string
+	swaggerEnforceComments bool
 )
 
 // swaggerDocsCmd represents the swaggerdocs command
@@ -42,12 +43,14 @@ func init() {
 	rootCmd.AddCommand(swaggerDocsCmd)
 
 	rootCmd.PersistentFlags().StringVar(&swaggerOutputFileName, "swagger:output-file-name", swaggerdocs.DefaultOutputFileName, "Defines the file name to use for the swagger generated docs for each group version.")
+	rootCmd.PersistentFlags().BoolVar(&swaggerEnforceComments, "swagger:enforce-comments", false, "Defines whether the generator should enforce that all fields have a comment or not. Only effective when combined with --verify.")
 }
 
 // newSwaggerDocsGenerator builds a new swaggerdocs generator.
 func newSwaggerDocsGenerator() generation.Generator {
 	return swaggerdocs.NewGenerator(swaggerdocs.Options{
-		OutputFileName: swaggerOutputFileName,
-		Verify:         verify,
+		EnforceComments: swaggerEnforceComments,
+		OutputFileName:  swaggerOutputFileName,
+		Verify:          verify,
 	})
 }

--- a/tools/codegen/cmd/util.go
+++ b/tools/codegen/cmd/util.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var _ pflag.Value = &enum{}
+
+// newEnum create a new enum flag value.
+func newEnum(value *string, allowedValues ...string) *enum {
+	return &enum{
+		value:         value,
+		allowedValues: sets.NewString(allowedValues...),
+	}
+}
+
+// enum implements the pflag.Value interface.
+
+type enum struct {
+	value         *string
+	allowedValues sets.String
+}
+
+// String returns the string representation of the enum value.
+func (e *enum) String() string {
+	if e.value == nil {
+		return ""
+	}
+	return *e.value
+}
+
+// Type returns the type of the enum value.
+func (e *enum) Type() string {
+	return "enum"
+}
+
+// Set sets the enum value.
+// It returns an error if the value is not allowed.
+func (e *enum) Set(value string) error {
+	if !e.allowedValues.Has(value) {
+		return fmt.Errorf("invalid value %q, allowed values are %v", value, e.allowedValues.List())
+	}
+
+	*e.value = value
+	return nil
+}

--- a/tools/codegen/pkg/generation/config.go
+++ b/tools/codegen/pkg/generation/config.go
@@ -1,0 +1,89 @@
+package generation
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+)
+
+// getAPIGroupConfigs populates the API group context with the
+// configuration for the API group if it exists.
+func getAPIGroupConfigs(apiGroups []APIGroupContext) error {
+	for i := range apiGroups {
+		if err := getAPIGroupConfig(&apiGroups[i]); err != nil {
+			return fmt.Errorf("could not get API group config for %s: %w", apiGroups[i].Name, err)
+		}
+	}
+
+	return nil
+}
+
+// getAPIGroupConfig populates the API group context with the
+// configuration for the API group if it exists.
+func getAPIGroupConfig(apiGroup *APIGroupContext) error {
+	configPath, err := getConfigFilePath(apiGroup.Versions)
+	if err != nil {
+		return fmt.Errorf("could not get config file path: %w", err)
+	}
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	config, err := readAPIGroupConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("could not read API group config: %w", err)
+	}
+
+	apiGroup.Config = config
+	return nil
+}
+
+// getConfigFilePath returns the expected path to the API group config file.
+// All versions of the API group must be contained with the same group directory.
+// The config file is expected to be in the group directory.
+func getConfigFilePath(versions []APIVersionContext) (string, error) {
+	if len(versions) == 0 {
+		return "", fmt.Errorf("no versions found")
+	}
+
+	groupDir := ""
+	for _, version := range versions {
+		baseDir := filepath.Dir(version.Path)
+		if groupDir == "" {
+			groupDir = baseDir
+		}
+
+		if baseDir != groupDir {
+			return "", fmt.Errorf("versions found in different directories")
+		}
+	}
+
+	return filepath.Join(groupDir, ".codegen.yaml"), nil
+}
+
+// readAPIGroupConfig reads the API group config file into a Config struct.
+func readAPIGroupConfig(path string) (*Config, error) {
+	config := &Config{}
+	if err := readYAML(path, config); err != nil {
+		return nil, fmt.Errorf("could not read API group config: %w", err)
+	}
+
+	return config, nil
+}
+
+// readYAML reads a YAML file from a path into a struct.
+func readYAML(path string, out interface{}) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("could not read file: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("could not unmarshal YAML: %w", err)
+	}
+
+	return nil
+}

--- a/tools/codegen/pkg/generation/context.go
+++ b/tools/codegen/pkg/generation/context.go
@@ -40,6 +40,10 @@ type APIGroupContext struct {
 
 	// Versions is a list of API versions found within the group.
 	Versions []APIVersionContext
+
+	// Config is the group's generation configuration.
+	// This is populated from the `.codegen.yaml` configuration for the API group.
+	Config *Config
 }
 
 // APIVersionContext is the context gathered for a particular API version.
@@ -74,6 +78,10 @@ func NewContext(opts Options) (Context, error) {
 	apiGroups, err := newAPIGroupsContext(baseDir, opts.APIGroupVersions)
 	if err != nil {
 		return Context{}, fmt.Errorf("could not build API Groups context: %w", err)
+	}
+
+	if err := getAPIGroupConfigs(apiGroups); err != nil {
+		return Context{}, fmt.Errorf("could not get API Group configs: %w", err)
 	}
 
 	return Context{

--- a/tools/codegen/pkg/generation/generator.go
+++ b/tools/codegen/pkg/generation/generator.go
@@ -7,4 +7,7 @@ type Generator interface {
 
 	// GenGroup runs the generator against the given APIGroupContext.
 	GenGroup(APIGroupContext) error
+
+	// ApplyConfig creates a new generator instance with the given configuration.
+	ApplyConfig(*Config) Generator
 }

--- a/tools/codegen/pkg/generation/types.go
+++ b/tools/codegen/pkg/generation/types.go
@@ -3,10 +3,21 @@ package generation
 // Config represents the configuration of a API group version
 // and the configuration for each generator within it.
 type Config struct {
+	// Compatibility represents the configuration of the compatiblity generator.
+	// When omitted, the default configuration will be used.
+	Compatibility *CompatibilityConfig `json:"compatibility,omitempty"`
+
 	// SchemaPatch represents the configuration for the schemapatch generator.
 	// When omitted, the default configuration will be used.
 	// When provided, any equivalent flag provided values are ignored.
 	SchemaPatch *SchemaPatchConfig `json:"schemapatch,omitempty"`
+}
+
+// CompatibilityConfig is the configuration for the compatibility generator.
+type CompatibilityConfig struct {
+	// Disabled determines whether the compatibility generator should be run or not.
+	// This generator is enabled by default so this field defaults to false.
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // SchemaPatchConfig is the configuration for the schemapatch generator.

--- a/tools/codegen/pkg/generation/types.go
+++ b/tools/codegen/pkg/generation/types.go
@@ -47,14 +47,17 @@ type SwaggerDocsConfig struct {
 	// This generator is enabled by default so this field defaults to false.
 	Disabled bool `json:"disabled,omitempty"`
 
+	// CommentPolicy determines how, when verifying swaggerdocs, the generator
+	// should handle missing comments.
+	// Valid values are `Ignore`, `Warn` and `Enforce`.
+	// This defaults to `Warn`.
+	// When set to `Ignore`, the generator will ignore any missing comments.
+	// When set to `Warn`, the generator will emit a warning for any missing comments.
+	// When set to `Enforce`, the generator will return an error for any missing comments.
+	CommentPolicy string `json:"commentPolicy,omitempty"`
+
 	// OutputFileName is the file name to use for writing the generated swagger
 	// docs to. This file will be created for each group version.
 	// Whem omitted, this will default to `zz_generated.swagger_doc_generated.go`.
 	OutputFileName string `json:"outputFileName,omitempty"`
-
-	// EnforceComments determines whether the generator should enforce that all
-	// fields have a comment or not.
-	// When set to true, verification will fail if any field in the API group is
-	// missing a comment.
-	EnforceComments bool `json:"enforceComments,omitempty"`
 }

--- a/tools/codegen/pkg/generation/types.go
+++ b/tools/codegen/pkg/generation/types.go
@@ -11,6 +11,11 @@ type Config struct {
 	// When omitted, the default configuration will be used.
 	// When provided, any equivalent flag provided values are ignored.
 	SchemaPatch *SchemaPatchConfig `json:"schemapatch,omitempty"`
+
+	// SwaggerDocs represents the configuration for the swaggerdocs generator.
+	// When omitted, the default configuration will be used.
+	// When provided, any equivalent flag provided values are ignored.
+	SwaggerDocs *SwaggerDocsConfig `json:"swaggerdocs,omitempty"`
 }
 
 // CompatibilityConfig is the configuration for the compatibility generator.
@@ -34,4 +39,22 @@ type SchemaPatchConfig struct {
 	// When omitted, any manifest with a feature set annotation will be ignored.
 	// Example entries are `""` (empty string), `"TechPreviewNoUpgrade"` or `"TechPreviewNoUpgrade,CustomNoUpgrade"`.
 	RequiredFeatureSets []string `json:"requiredFeatureSets,omitempty"`
+}
+
+// SwaggerDocsConfig is the configuration for the swaggerdocs generator.
+type SwaggerDocsConfig struct {
+	// Disabled determines whether the swaggerdocs generator should be run or not.
+	// This generator is enabled by default so this field defaults to false.
+	Disabled bool `json:"disabled,omitempty"`
+
+	// OutputFileName is the file name to use for writing the generated swagger
+	// docs to. This file will be created for each group version.
+	// Whem omitted, this will default to `zz_generated.swagger_doc_generated.go`.
+	OutputFileName string `json:"outputFileName,omitempty"`
+
+	// EnforceComments determines whether the generator should enforce that all
+	// fields have a comment or not.
+	// When set to true, verification will fail if any field in the API group is
+	// missing a comment.
+	EnforceComments bool `json:"enforceComments,omitempty"`
 }

--- a/tools/codegen/pkg/generation/types.go
+++ b/tools/codegen/pkg/generation/types.go
@@ -1,0 +1,6 @@
+package generation
+
+// Config represents the configuration of a API group version
+// and the configuration for each generator within it.
+type Config struct {
+}

--- a/tools/codegen/pkg/generation/types.go
+++ b/tools/codegen/pkg/generation/types.go
@@ -3,4 +3,24 @@ package generation
 // Config represents the configuration of a API group version
 // and the configuration for each generator within it.
 type Config struct {
+	// SchemaPatch represents the configuration for the schemapatch generator.
+	// When omitted, the default configuration will be used.
+	// When provided, any equivalent flag provided values are ignored.
+	SchemaPatch *SchemaPatchConfig `json:"schemapatch,omitempty"`
+}
+
+// SchemaPatchConfig is the configuration for the schemapatch generator.
+type SchemaPatchConfig struct {
+	// Disabled determines whether the schemapatch generator should be run or not.
+	// This generator is enabled by default so this field defaults to false.
+	Disabled bool `json:"disabled,omitempty"`
+
+	// RequiredFeatureSets is a list of feature sets combinations that should be
+	// generated for this API group.
+	// Each entry in this list is a comma separated list of feature set names
+	// which will be matched with the `release.openshift.io/feature-set` annotation
+	// on the CRD definition.
+	// When omitted, any manifest with a feature set annotation will be ignored.
+	// Example entries are `""` (empty string), `"TechPreviewNoUpgrade"` or `"TechPreviewNoUpgrade,CustomNoUpgrade"`.
+	RequiredFeatureSets []string `json:"requiredFeatureSets,omitempty"`
 }

--- a/tools/codegen/pkg/schemapatch/schemapatch.go
+++ b/tools/codegen/pkg/schemapatch/schemapatch.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift/api/tools/codegen/pkg/generation"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-tools/pkg/crd/markers"
 	"sigs.k8s.io/controller-tools/pkg/genall"
 	"sigs.k8s.io/controller-tools/pkg/schemapatcher"
@@ -36,7 +35,6 @@ func executeSchemaPatchForGroupVersionWithBinary(controllerGen string, group str
 	args = append(args, pathsArgs(versionPaths)...)
 	args = append(args, outputArg(version.Path))
 
-	klog.V(2).Infof("Generating API schema for %s/%s", group, version.Name)
 	cmd := exec.Command(controllerGen, args...)
 
 	// Ensure we get the output from the command.
@@ -94,7 +92,6 @@ func executeSchemaPatchForGroupVersion(group string, version generation.APIVersi
 		return fmt.Errorf("could not register markers: %w", err)
 	}
 
-	klog.V(2).Infof("Generating API schema for %s/%s", group, version.Name)
 	if err := gen.Generate(&ctx); err != nil {
 		return fmt.Errorf("could not run schemapatch generator: %w", err)
 	}

--- a/tools/codegen/pkg/schemapatch/yamlpatch.go
+++ b/tools/codegen/pkg/schemapatch/yamlpatch.go
@@ -15,7 +15,7 @@ import (
 )
 
 // executeYAMLPatchForGroupVersion runs the yaml patch against a particular version.
-func executeYAMLPatchForGroupVersion(version generation.APIVersionContext, requiredFeatureSets sets.String) error {
+func executeYAMLPatchForGroupVersion(version generation.APIVersionContext, requiredFeatureSets []sets.String) error {
 	patchPairs, err := loadPatchFilesForGroupVersion(version.Path)
 	if err != nil {
 		return fmt.Errorf("could not load patch files: %v", err)
@@ -78,7 +78,7 @@ func findFile(dirEntries []fs.FileInfo, name string) (fs.FileInfo, error) {
 }
 
 // patchFile applies a patch file to a CRD file.
-func patchFile(groupVersionDir string, baseInfo, patchInfo fs.FileInfo, requiredFeatureSets sets.String) error {
+func patchFile(groupVersionDir string, baseInfo, patchInfo fs.FileInfo, requiredFeatureSets []sets.String) error {
 	klog.V(2).Infof("Patching CRD %s with patch file %s", baseInfo.Name(), patchInfo.Name())
 
 	placeholderWrapper := yamlpatch.NewPlaceholderWrapper("{{", "}}")

--- a/tools/codegen/pkg/swaggerdocs/generator.go
+++ b/tools/codegen/pkg/swaggerdocs/generator.go
@@ -12,6 +12,16 @@ import (
 
 // Options contains the configuration required for the swaggerdocs generator.
 type Options struct {
+	// Disabled indicates whether the swaggerdocs generator is enabled or not.
+	// This default to false as the swaggerdocs generator is enabled by default.
+	Disabled bool
+
+	// enforceComments determines whether the generator should enforce that all
+	// fields have a comment or not.
+	// When set to true, verification will fail if any field in the API group is
+	// missing a comment.
+	EnforceComments bool `json:"enforceComments,omitempty"`
+
 	// OutputFileName is the file name to use for writing the generated swagger
 	// docs to. This file will be created for each group version.
 	OutputFileName string
@@ -24,16 +34,40 @@ type Options struct {
 // generator implements the generation.Generator interface.
 // It is designed to generate swaggerdocs documentation for a particular API group.
 type generator struct {
-	outputFileName string
-	verify         bool
+	disabled        bool
+	enforceComments bool
+	outputFileName  string
+	verify          bool
 }
 
 // NewGenerator builds a new schemapatch generator.
 func NewGenerator(opts Options) generation.Generator {
 	return &generator{
-		outputFileName: opts.OutputFileName,
-		verify:         opts.Verify,
+		disabled:        opts.Disabled,
+		enforceComments: opts.EnforceComments,
+		outputFileName:  opts.OutputFileName,
+		verify:          opts.Verify,
 	}
+}
+
+// ApplyConfig creates returns a new generator based on the configuration passed.
+// If the schemapatch configuration is empty, the existing generation is returned.
+func (g *generator) ApplyConfig(config *generation.Config) generation.Generator {
+	if config == nil || config.SwaggerDocs == nil {
+		return g
+	}
+
+	outputFileName := DefaultOutputFileName
+	if config.SwaggerDocs.OutputFileName != "" {
+		outputFileName = config.SwaggerDocs.OutputFileName
+	}
+
+	return NewGenerator(Options{
+		Disabled:        config.SwaggerDocs.Disabled,
+		EnforceComments: config.SwaggerDocs.EnforceComments,
+		OutputFileName:  outputFileName,
+		Verify:          g.verify,
+	})
 }
 
 // Name returns the name of the generator.
@@ -43,6 +77,11 @@ func (g *generator) Name() string {
 
 // GenGroup runs the schemapatch generator against the given group context.
 func (g *generator) GenGroup(groupCtx generation.APIGroupContext) error {
+	if g.disabled {
+		klog.V(3).Infof("Skipping swaggerdocs generation for %s", groupCtx.Name)
+		return nil
+	}
+
 	for _, version := range groupCtx.Versions {
 		if err := g.generateGroupVersion(groupCtx.Name, version); err != nil {
 			return fmt.Errorf("error generating swagger docs for %s/%s: %w", groupCtx.Name, version.Name, err)
@@ -74,7 +113,7 @@ func (g *generator) generateGroupVersion(groupName string, version generation.AP
 	if g.verify {
 		klog.V(2).Infof("Verifiying swagger docs for %s/%s", groupName, version.Name)
 
-		return verifySwaggerDocs(version.PackageName, outFilePath, docsForTypes)
+		return verifySwaggerDocs(version.PackageName, outFilePath, docsForTypes, g.enforceComments)
 	}
 
 	klog.V(2).Infof("Generating swagger docs for %s/%s", groupName, version.Name)

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/dave/dst v0.27.1
+	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/google/go-cmp v0.5.8
 	github.com/mikefarah/yq/v4 v4.27.5

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -31,6 +31,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/tools/vendor/github.com/ghodss/yaml/.gitignore
+++ b/tools/vendor/github.com/ghodss/yaml/.gitignore
@@ -1,0 +1,20 @@
+# OSX leaves these everywhere on SMB shares
+._*
+
+# Eclipse files
+.classpath
+.project
+.settings/**
+
+# Emacs save files
+*~
+
+# Vim-related files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+
+# Go test binaries
+*.test

--- a/tools/vendor/github.com/ghodss/yaml/.travis.yml
+++ b/tools/vendor/github.com/ghodss/yaml/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+go:
+  - 1.3
+  - 1.4
+script:
+  - go test
+  - go build

--- a/tools/vendor/github.com/ghodss/yaml/LICENSE
+++ b/tools/vendor/github.com/ghodss/yaml/LICENSE
@@ -1,0 +1,50 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Sam Ghods
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tools/vendor/github.com/ghodss/yaml/README.md
+++ b/tools/vendor/github.com/ghodss/yaml/README.md
@@ -1,0 +1,121 @@
+# YAML marshaling and unmarshaling support for Go
+
+[![Build Status](https://travis-ci.org/ghodss/yaml.svg)](https://travis-ci.org/ghodss/yaml)
+
+## Introduction
+
+A wrapper around [go-yaml](https://github.com/go-yaml/yaml) designed to enable a better way of handling YAML when marshaling to and from structs.
+
+In short, this library first converts YAML to JSON using go-yaml and then uses `json.Marshal` and `json.Unmarshal` to convert to or from the struct. This means that it effectively reuses the JSON struct tags as well as the custom JSON methods `MarshalJSON` and `UnmarshalJSON` unlike go-yaml. For a detailed overview of the rationale behind this method, [see this blog post](http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/).
+
+## Compatibility
+
+This package uses [go-yaml](https://github.com/go-yaml/yaml) and therefore supports [everything go-yaml supports](https://github.com/go-yaml/yaml#compatibility).
+
+## Caveats
+
+**Caveat #1:** When using `yaml.Marshal` and `yaml.Unmarshal`, binary data should NOT be preceded with the `!!binary` YAML tag. If you do, go-yaml will convert the binary data from base64 to native binary data, which is not compatible with JSON. You can still use binary in your YAML files though - just store them without the `!!binary` tag and decode the base64 in your code (e.g. in the custom JSON methods `MarshalJSON` and `UnmarshalJSON`). This also has the benefit that your YAML and your JSON binary data will be decoded exactly the same way. As an example:
+
+```
+BAD:
+	exampleKey: !!binary gIGC
+
+GOOD:
+	exampleKey: gIGC
+... and decode the base64 data in your code.
+```
+
+**Caveat #2:** When using `YAMLToJSON` directly, maps with keys that are maps will result in an error since this is not supported by JSON. This error will occur in `Unmarshal` as well since you can't unmarshal map keys anyways since struct fields can't be keys.
+
+## Installation and usage
+
+To install, run:
+
+```
+$ go get github.com/ghodss/yaml
+```
+
+And import using:
+
+```
+import "github.com/ghodss/yaml"
+```
+
+Usage is very similar to the JSON library:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+)
+
+type Person struct {
+	Name string `json:"name"` // Affects YAML field names too.
+	Age  int    `json:"age"`
+}
+
+func main() {
+	// Marshal a Person struct to YAML.
+	p := Person{"John", 30}
+	y, err := yaml.Marshal(p)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return
+	}
+	fmt.Println(string(y))
+	/* Output:
+	age: 30
+	name: John
+	*/
+
+	// Unmarshal the YAML back into a Person struct.
+	var p2 Person
+	err = yaml.Unmarshal(y, &p2)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return
+	}
+	fmt.Println(p2)
+	/* Output:
+	{John 30}
+	*/
+}
+```
+
+`yaml.YAMLToJSON` and `yaml.JSONToYAML` methods are also available:
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+)
+
+func main() {
+	j := []byte(`{"name": "John", "age": 30}`)
+	y, err := yaml.JSONToYAML(j)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return
+	}
+	fmt.Println(string(y))
+	/* Output:
+	name: John
+	age: 30
+	*/
+	j2, err := yaml.YAMLToJSON(y)
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return
+	}
+	fmt.Println(string(j2))
+	/* Output:
+	{"age":30,"name":"John"}
+	*/
+}
+```

--- a/tools/vendor/github.com/ghodss/yaml/fields.go
+++ b/tools/vendor/github.com/ghodss/yaml/fields.go
@@ -1,0 +1,501 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package yaml
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
+)
+
+// indirect walks down v allocating pointers as needed,
+// until it gets to a non-pointer.
+// if it encounters an Unmarshaler, indirect stops and returns that.
+// if decodingNull is true, indirect stops at the last pointer so it can be set to nil.
+func indirect(v reflect.Value, decodingNull bool) (json.Unmarshaler, encoding.TextUnmarshaler, reflect.Value) {
+	// If v is a named type and is addressable,
+	// start with its address, so that if the type has pointer methods,
+	// we find them.
+	if v.Kind() != reflect.Ptr && v.Type().Name() != "" && v.CanAddr() {
+		v = v.Addr()
+	}
+	for {
+		// Load value from interface, but only if the result will be
+		// usefully addressable.
+		if v.Kind() == reflect.Interface && !v.IsNil() {
+			e := v.Elem()
+			if e.Kind() == reflect.Ptr && !e.IsNil() && (!decodingNull || e.Elem().Kind() == reflect.Ptr) {
+				v = e
+				continue
+			}
+		}
+
+		if v.Kind() != reflect.Ptr {
+			break
+		}
+
+		if v.Elem().Kind() != reflect.Ptr && decodingNull && v.CanSet() {
+			break
+		}
+		if v.IsNil() {
+			if v.CanSet() {
+				v.Set(reflect.New(v.Type().Elem()))
+			} else {
+				v = reflect.New(v.Type().Elem())
+			}
+		}
+		if v.Type().NumMethod() > 0 {
+			if u, ok := v.Interface().(json.Unmarshaler); ok {
+				return u, nil, reflect.Value{}
+			}
+			if u, ok := v.Interface().(encoding.TextUnmarshaler); ok {
+				return nil, u, reflect.Value{}
+			}
+		}
+		v = v.Elem()
+	}
+	return nil, nil, v
+}
+
+// A field represents a single field found in a struct.
+type field struct {
+	name      string
+	nameBytes []byte                 // []byte(name)
+	equalFold func(s, t []byte) bool // bytes.EqualFold or equivalent
+
+	tag       bool
+	index     []int
+	typ       reflect.Type
+	omitEmpty bool
+	quoted    bool
+}
+
+func fillField(f field) field {
+	f.nameBytes = []byte(f.name)
+	f.equalFold = foldFunc(f.nameBytes)
+	return f
+}
+
+// byName sorts field by name, breaking ties with depth,
+// then breaking ties with "name came from json tag", then
+// breaking ties with index sequence.
+type byName []field
+
+func (x byName) Len() int { return len(x) }
+
+func (x byName) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byName) Less(i, j int) bool {
+	if x[i].name != x[j].name {
+		return x[i].name < x[j].name
+	}
+	if len(x[i].index) != len(x[j].index) {
+		return len(x[i].index) < len(x[j].index)
+	}
+	if x[i].tag != x[j].tag {
+		return x[i].tag
+	}
+	return byIndex(x).Less(i, j)
+}
+
+// byIndex sorts field by index sequence.
+type byIndex []field
+
+func (x byIndex) Len() int { return len(x) }
+
+func (x byIndex) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
+
+func (x byIndex) Less(i, j int) bool {
+	for k, xik := range x[i].index {
+		if k >= len(x[j].index) {
+			return false
+		}
+		if xik != x[j].index[k] {
+			return xik < x[j].index[k]
+		}
+	}
+	return len(x[i].index) < len(x[j].index)
+}
+
+// typeFields returns a list of fields that JSON should recognize for the given type.
+// The algorithm is breadth-first search over the set of structs to include - the top struct
+// and then any reachable anonymous structs.
+func typeFields(t reflect.Type) []field {
+	// Anonymous fields to explore at the current level and the next.
+	current := []field{}
+	next := []field{{typ: t}}
+
+	// Count of queued names for current level and the next.
+	count := map[reflect.Type]int{}
+	nextCount := map[reflect.Type]int{}
+
+	// Types already visited at an earlier level.
+	visited := map[reflect.Type]bool{}
+
+	// Fields found.
+	var fields []field
+
+	for len(next) > 0 {
+		current, next = next, current[:0]
+		count, nextCount = nextCount, map[reflect.Type]int{}
+
+		for _, f := range current {
+			if visited[f.typ] {
+				continue
+			}
+			visited[f.typ] = true
+
+			// Scan f.typ for fields to include.
+			for i := 0; i < f.typ.NumField(); i++ {
+				sf := f.typ.Field(i)
+				if sf.PkgPath != "" { // unexported
+					continue
+				}
+				tag := sf.Tag.Get("json")
+				if tag == "-" {
+					continue
+				}
+				name, opts := parseTag(tag)
+				if !isValidTag(name) {
+					name = ""
+				}
+				index := make([]int, len(f.index)+1)
+				copy(index, f.index)
+				index[len(f.index)] = i
+
+				ft := sf.Type
+				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
+					// Follow pointer.
+					ft = ft.Elem()
+				}
+
+				// Record found field and index sequence.
+				if name != "" || !sf.Anonymous || ft.Kind() != reflect.Struct {
+					tagged := name != ""
+					if name == "" {
+						name = sf.Name
+					}
+					fields = append(fields, fillField(field{
+						name:      name,
+						tag:       tagged,
+						index:     index,
+						typ:       ft,
+						omitEmpty: opts.Contains("omitempty"),
+						quoted:    opts.Contains("string"),
+					}))
+					if count[f.typ] > 1 {
+						// If there were multiple instances, add a second,
+						// so that the annihilation code will see a duplicate.
+						// It only cares about the distinction between 1 or 2,
+						// so don't bother generating any more copies.
+						fields = append(fields, fields[len(fields)-1])
+					}
+					continue
+				}
+
+				// Record new anonymous struct to explore in next round.
+				nextCount[ft]++
+				if nextCount[ft] == 1 {
+					next = append(next, fillField(field{name: ft.Name(), index: index, typ: ft}))
+				}
+			}
+		}
+	}
+
+	sort.Sort(byName(fields))
+
+	// Delete all fields that are hidden by the Go rules for embedded fields,
+	// except that fields with JSON tags are promoted.
+
+	// The fields are sorted in primary order of name, secondary order
+	// of field index length. Loop over names; for each name, delete
+	// hidden fields by choosing the one dominant field that survives.
+	out := fields[:0]
+	for advance, i := 0, 0; i < len(fields); i += advance {
+		// One iteration per name.
+		// Find the sequence of fields with the name of this first field.
+		fi := fields[i]
+		name := fi.name
+		for advance = 1; i+advance < len(fields); advance++ {
+			fj := fields[i+advance]
+			if fj.name != name {
+				break
+			}
+		}
+		if advance == 1 { // Only one field with this name
+			out = append(out, fi)
+			continue
+		}
+		dominant, ok := dominantField(fields[i : i+advance])
+		if ok {
+			out = append(out, dominant)
+		}
+	}
+
+	fields = out
+	sort.Sort(byIndex(fields))
+
+	return fields
+}
+
+// dominantField looks through the fields, all of which are known to
+// have the same name, to find the single field that dominates the
+// others using Go's embedding rules, modified by the presence of
+// JSON tags. If there are multiple top-level fields, the boolean
+// will be false: This condition is an error in Go and we skip all
+// the fields.
+func dominantField(fields []field) (field, bool) {
+	// The fields are sorted in increasing index-length order. The winner
+	// must therefore be one with the shortest index length. Drop all
+	// longer entries, which is easy: just truncate the slice.
+	length := len(fields[0].index)
+	tagged := -1 // Index of first tagged field.
+	for i, f := range fields {
+		if len(f.index) > length {
+			fields = fields[:i]
+			break
+		}
+		if f.tag {
+			if tagged >= 0 {
+				// Multiple tagged fields at the same level: conflict.
+				// Return no field.
+				return field{}, false
+			}
+			tagged = i
+		}
+	}
+	if tagged >= 0 {
+		return fields[tagged], true
+	}
+	// All remaining fields have the same length. If there's more than one,
+	// we have a conflict (two fields named "X" at the same level) and we
+	// return no field.
+	if len(fields) > 1 {
+		return field{}, false
+	}
+	return fields[0], true
+}
+
+var fieldCache struct {
+	sync.RWMutex
+	m map[reflect.Type][]field
+}
+
+// cachedTypeFields is like typeFields but uses a cache to avoid repeated work.
+func cachedTypeFields(t reflect.Type) []field {
+	fieldCache.RLock()
+	f := fieldCache.m[t]
+	fieldCache.RUnlock()
+	if f != nil {
+		return f
+	}
+
+	// Compute fields without lock.
+	// Might duplicate effort but won't hold other computations back.
+	f = typeFields(t)
+	if f == nil {
+		f = []field{}
+	}
+
+	fieldCache.Lock()
+	if fieldCache.m == nil {
+		fieldCache.m = map[reflect.Type][]field{}
+	}
+	fieldCache.m[t] = f
+	fieldCache.Unlock()
+	return f
+}
+
+func isValidTag(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case strings.ContainsRune("!#$%&()*+-./:<=>?@[]^_{|}~ ", c):
+			// Backslash and quote chars are reserved, but
+			// otherwise any punctuation chars are allowed
+			// in a tag name.
+		default:
+			if !unicode.IsLetter(c) && !unicode.IsDigit(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+const (
+	caseMask     = ^byte(0x20) // Mask to ignore case in ASCII.
+	kelvin       = '\u212a'
+	smallLongEss = '\u017f'
+)
+
+// foldFunc returns one of four different case folding equivalence
+// functions, from most general (and slow) to fastest:
+//
+// 1) bytes.EqualFold, if the key s contains any non-ASCII UTF-8
+// 2) equalFoldRight, if s contains special folding ASCII ('k', 'K', 's', 'S')
+// 3) asciiEqualFold, no special, but includes non-letters (including _)
+// 4) simpleLetterEqualFold, no specials, no non-letters.
+//
+// The letters S and K are special because they map to 3 runes, not just 2:
+//  * S maps to s and to U+017F 'ſ' Latin small letter long s
+//  * k maps to K and to U+212A 'K' Kelvin sign
+// See http://play.golang.org/p/tTxjOc0OGo
+//
+// The returned function is specialized for matching against s and
+// should only be given s. It's not curried for performance reasons.
+func foldFunc(s []byte) func(s, t []byte) bool {
+	nonLetter := false
+	special := false // special letter
+	for _, b := range s {
+		if b >= utf8.RuneSelf {
+			return bytes.EqualFold
+		}
+		upper := b & caseMask
+		if upper < 'A' || upper > 'Z' {
+			nonLetter = true
+		} else if upper == 'K' || upper == 'S' {
+			// See above for why these letters are special.
+			special = true
+		}
+	}
+	if special {
+		return equalFoldRight
+	}
+	if nonLetter {
+		return asciiEqualFold
+	}
+	return simpleLetterEqualFold
+}
+
+// equalFoldRight is a specialization of bytes.EqualFold when s is
+// known to be all ASCII (including punctuation), but contains an 's',
+// 'S', 'k', or 'K', requiring a Unicode fold on the bytes in t.
+// See comments on foldFunc.
+func equalFoldRight(s, t []byte) bool {
+	for _, sb := range s {
+		if len(t) == 0 {
+			return false
+		}
+		tb := t[0]
+		if tb < utf8.RuneSelf {
+			if sb != tb {
+				sbUpper := sb & caseMask
+				if 'A' <= sbUpper && sbUpper <= 'Z' {
+					if sbUpper != tb&caseMask {
+						return false
+					}
+				} else {
+					return false
+				}
+			}
+			t = t[1:]
+			continue
+		}
+		// sb is ASCII and t is not. t must be either kelvin
+		// sign or long s; sb must be s, S, k, or K.
+		tr, size := utf8.DecodeRune(t)
+		switch sb {
+		case 's', 'S':
+			if tr != smallLongEss {
+				return false
+			}
+		case 'k', 'K':
+			if tr != kelvin {
+				return false
+			}
+		default:
+			return false
+		}
+		t = t[size:]
+
+	}
+	if len(t) > 0 {
+		return false
+	}
+	return true
+}
+
+// asciiEqualFold is a specialization of bytes.EqualFold for use when
+// s is all ASCII (but may contain non-letters) and contains no
+// special-folding letters.
+// See comments on foldFunc.
+func asciiEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, sb := range s {
+		tb := t[i]
+		if sb == tb {
+			continue
+		}
+		if ('a' <= sb && sb <= 'z') || ('A' <= sb && sb <= 'Z') {
+			if sb&caseMask != tb&caseMask {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+// simpleLetterEqualFold is a specialization of bytes.EqualFold for
+// use when s is all ASCII letters (no underscores, etc) and also
+// doesn't contain 'k', 'K', 's', or 'S'.
+// See comments on foldFunc.
+func simpleLetterEqualFold(s, t []byte) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i, b := range s {
+		if b&caseMask != t[i]&caseMask {
+			return false
+		}
+	}
+	return true
+}
+
+// tagOptions is the string following a comma in a struct field's "json"
+// tag, or the empty string. It does not include the leading comma.
+type tagOptions string
+
+// parseTag splits a struct field's json tag into its name and
+// comma-separated options.
+func parseTag(tag string) (string, tagOptions) {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tagOptions(tag[idx+1:])
+	}
+	return tag, tagOptions("")
+}
+
+// Contains reports whether a comma-separated list of options
+// contains a particular substr flag. substr must be surrounded by a
+// string boundary or commas.
+func (o tagOptions) Contains(optionName string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var next string
+		i := strings.Index(s, ",")
+		if i >= 0 {
+			s, next = s[:i], s[i+1:]
+		}
+		if s == optionName {
+			return true
+		}
+		s = next
+	}
+	return false
+}

--- a/tools/vendor/github.com/ghodss/yaml/yaml.go
+++ b/tools/vendor/github.com/ghodss/yaml/yaml.go
@@ -1,0 +1,277 @@
+package yaml
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Marshals the object into JSON then converts JSON to YAML and returns the
+// YAML.
+func Marshal(o interface{}) ([]byte, error) {
+	j, err := json.Marshal(o)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling into JSON: %v", err)
+	}
+
+	y, err := JSONToYAML(j)
+	if err != nil {
+		return nil, fmt.Errorf("error converting JSON to YAML: %v", err)
+	}
+
+	return y, nil
+}
+
+// Converts YAML to JSON then uses JSON to unmarshal into an object.
+func Unmarshal(y []byte, o interface{}) error {
+	vo := reflect.ValueOf(o)
+	j, err := yamlToJSON(y, &vo)
+	if err != nil {
+		return fmt.Errorf("error converting YAML to JSON: %v", err)
+	}
+
+	err = json.Unmarshal(j, o)
+	if err != nil {
+		return fmt.Errorf("error unmarshaling JSON: %v", err)
+	}
+
+	return nil
+}
+
+// Convert JSON to YAML.
+func JSONToYAML(j []byte) ([]byte, error) {
+	// Convert the JSON to an object.
+	var jsonObj interface{}
+	// We are using yaml.Unmarshal here (instead of json.Unmarshal) because the
+	// Go JSON library doesn't try to pick the right number type (int, float,
+	// etc.) when unmarshalling to interface{}, it just picks float64
+	// universally. go-yaml does go through the effort of picking the right
+	// number type, so we can preserve number type throughout this process.
+	err := yaml.Unmarshal(j, &jsonObj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Marshal this object into YAML.
+	return yaml.Marshal(jsonObj)
+}
+
+// Convert YAML to JSON. Since JSON is a subset of YAML, passing JSON through
+// this method should be a no-op.
+//
+// Things YAML can do that are not supported by JSON:
+// * In YAML you can have binary and null keys in your maps. These are invalid
+//   in JSON. (int and float keys are converted to strings.)
+// * Binary data in YAML with the !!binary tag is not supported. If you want to
+//   use binary data with this library, encode the data as base64 as usual but do
+//   not use the !!binary tag in your YAML. This will ensure the original base64
+//   encoded data makes it all the way through to the JSON.
+func YAMLToJSON(y []byte) ([]byte, error) {
+	return yamlToJSON(y, nil)
+}
+
+func yamlToJSON(y []byte, jsonTarget *reflect.Value) ([]byte, error) {
+	// Convert the YAML to an object.
+	var yamlObj interface{}
+	err := yaml.Unmarshal(y, &yamlObj)
+	if err != nil {
+		return nil, err
+	}
+
+	// YAML objects are not completely compatible with JSON objects (e.g. you
+	// can have non-string keys in YAML). So, convert the YAML-compatible object
+	// to a JSON-compatible object, failing with an error if irrecoverable
+	// incompatibilties happen along the way.
+	jsonObj, err := convertToJSONableObject(yamlObj, jsonTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert this object to JSON and return the data.
+	return json.Marshal(jsonObj)
+}
+
+func convertToJSONableObject(yamlObj interface{}, jsonTarget *reflect.Value) (interface{}, error) {
+	var err error
+
+	// Resolve jsonTarget to a concrete value (i.e. not a pointer or an
+	// interface). We pass decodingNull as false because we're not actually
+	// decoding into the value, we're just checking if the ultimate target is a
+	// string.
+	if jsonTarget != nil {
+		ju, tu, pv := indirect(*jsonTarget, false)
+		// We have a JSON or Text Umarshaler at this level, so we can't be trying
+		// to decode into a string.
+		if ju != nil || tu != nil {
+			jsonTarget = nil
+		} else {
+			jsonTarget = &pv
+		}
+	}
+
+	// If yamlObj is a number or a boolean, check if jsonTarget is a string -
+	// if so, coerce.  Else return normal.
+	// If yamlObj is a map or array, find the field that each key is
+	// unmarshaling to, and when you recurse pass the reflect.Value for that
+	// field back into this function.
+	switch typedYAMLObj := yamlObj.(type) {
+	case map[interface{}]interface{}:
+		// JSON does not support arbitrary keys in a map, so we must convert
+		// these keys to strings.
+		//
+		// From my reading of go-yaml v2 (specifically the resolve function),
+		// keys can only have the types string, int, int64, float64, binary
+		// (unsupported), or null (unsupported).
+		strMap := make(map[string]interface{})
+		for k, v := range typedYAMLObj {
+			// Resolve the key to a string first.
+			var keyString string
+			switch typedKey := k.(type) {
+			case string:
+				keyString = typedKey
+			case int:
+				keyString = strconv.Itoa(typedKey)
+			case int64:
+				// go-yaml will only return an int64 as a key if the system
+				// architecture is 32-bit and the key's value is between 32-bit
+				// and 64-bit. Otherwise the key type will simply be int.
+				keyString = strconv.FormatInt(typedKey, 10)
+			case float64:
+				// Stolen from go-yaml to use the same conversion to string as
+				// the go-yaml library uses to convert float to string when
+				// Marshaling.
+				s := strconv.FormatFloat(typedKey, 'g', -1, 32)
+				switch s {
+				case "+Inf":
+					s = ".inf"
+				case "-Inf":
+					s = "-.inf"
+				case "NaN":
+					s = ".nan"
+				}
+				keyString = s
+			case bool:
+				if typedKey {
+					keyString = "true"
+				} else {
+					keyString = "false"
+				}
+			default:
+				return nil, fmt.Errorf("Unsupported map key of type: %s, key: %+#v, value: %+#v",
+					reflect.TypeOf(k), k, v)
+			}
+
+			// jsonTarget should be a struct or a map. If it's a struct, find
+			// the field it's going to map to and pass its reflect.Value. If
+			// it's a map, find the element type of the map and pass the
+			// reflect.Value created from that type. If it's neither, just pass
+			// nil - JSON conversion will error for us if it's a real issue.
+			if jsonTarget != nil {
+				t := *jsonTarget
+				if t.Kind() == reflect.Struct {
+					keyBytes := []byte(keyString)
+					// Find the field that the JSON library would use.
+					var f *field
+					fields := cachedTypeFields(t.Type())
+					for i := range fields {
+						ff := &fields[i]
+						if bytes.Equal(ff.nameBytes, keyBytes) {
+							f = ff
+							break
+						}
+						// Do case-insensitive comparison.
+						if f == nil && ff.equalFold(ff.nameBytes, keyBytes) {
+							f = ff
+						}
+					}
+					if f != nil {
+						// Find the reflect.Value of the most preferential
+						// struct field.
+						jtf := t.Field(f.index[0])
+						strMap[keyString], err = convertToJSONableObject(v, &jtf)
+						if err != nil {
+							return nil, err
+						}
+						continue
+					}
+				} else if t.Kind() == reflect.Map {
+					// Create a zero value of the map's element type to use as
+					// the JSON target.
+					jtv := reflect.Zero(t.Type().Elem())
+					strMap[keyString], err = convertToJSONableObject(v, &jtv)
+					if err != nil {
+						return nil, err
+					}
+					continue
+				}
+			}
+			strMap[keyString], err = convertToJSONableObject(v, nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return strMap, nil
+	case []interface{}:
+		// We need to recurse into arrays in case there are any
+		// map[interface{}]interface{}'s inside and to convert any
+		// numbers to strings.
+
+		// If jsonTarget is a slice (which it really should be), find the
+		// thing it's going to map to. If it's not a slice, just pass nil
+		// - JSON conversion will error for us if it's a real issue.
+		var jsonSliceElemValue *reflect.Value
+		if jsonTarget != nil {
+			t := *jsonTarget
+			if t.Kind() == reflect.Slice {
+				// By default slices point to nil, but we need a reflect.Value
+				// pointing to a value of the slice type, so we create one here.
+				ev := reflect.Indirect(reflect.New(t.Type().Elem()))
+				jsonSliceElemValue = &ev
+			}
+		}
+
+		// Make and use a new array.
+		arr := make([]interface{}, len(typedYAMLObj))
+		for i, v := range typedYAMLObj {
+			arr[i], err = convertToJSONableObject(v, jsonSliceElemValue)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return arr, nil
+	default:
+		// If the target type is a string and the YAML type is a number,
+		// convert the YAML type to a string.
+		if jsonTarget != nil && (*jsonTarget).Kind() == reflect.String {
+			// Based on my reading of go-yaml, it may return int, int64,
+			// float64, or uint64.
+			var s string
+			switch typedVal := typedYAMLObj.(type) {
+			case int:
+				s = strconv.FormatInt(int64(typedVal), 10)
+			case int64:
+				s = strconv.FormatInt(typedVal, 10)
+			case float64:
+				s = strconv.FormatFloat(typedVal, 'g', -1, 32)
+			case uint64:
+				s = strconv.FormatUint(typedVal, 10)
+			case bool:
+				if typedVal {
+					s = "true"
+				} else {
+					s = "false"
+				}
+			}
+			if len(s) > 0 {
+				yamlObj = interface{}(s)
+			}
+		}
+		return yamlObj, nil
+	}
+
+	return nil, nil
+}

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -28,6 +28,9 @@ github.com/emicklei/go-restful/v3/log
 # github.com/fatih/color v1.13.0
 ## explicit; go 1.13
 github.com/fatih/color
+# github.com/ghodss/yaml v1.0.0
+## explicit
+github.com/ghodss/yaml
 # github.com/go-logr/logr v1.2.3
 ## explicit; go 1.16
 github.com/go-logr/logr


### PR DESCRIPTION
This PR adds a new configuration file in the form of a per-group `.codegen.yaml` file.

The syntax is exemplified in the example API group, but I'll copy here for discussion:
```
schemapatch:
  enabled: true
  requiredFeatureSets:
  - ""
  - "Default"
  - "TechPreviewNoUpgrade"
swaggerdocs:
  enabled: true
  enforceComments: false
  outputFileName: zz_generated.swagger_doc_generated.go
compatibility:
  enabled: true
```

Changes of note:
* The schemapatch generator can now handle multiple feature set generations in a single run (via config file only)
* The swaggerdocs has a new `enforce-comments` option for use with `verify`, which is now configurable per group
* I've set up config files for all of the groups that use feature sets so far
* The config file, if found, will take precedence for configuration over the flags

ToDo:
* Get feedback on config design
* Make sure config overrides flags is what we want to do