### PR TITLE
OCPBUGS-3635: Set default for spec.to.weight in Route CRD.

### DIFF
--- a/route/v1/generated.proto
+++ b/route/v1/generated.proto
@@ -219,6 +219,7 @@ message RouteTargetReference {
   // +optional
   // +kubebuilder:validation:Minimum=0
   // +kubebuilder:validation:Maximum=256
+  // +kubebuilder:default=100
   optional int32 weight = 3;
 }
 

--- a/route/v1/route.crd.yaml
+++ b/route/v1/route.crd.yaml
@@ -84,6 +84,7 @@ spec:
                         minLength: 1
                         type: string
                       weight:
+                        default: 100
                         description: weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.
                         format: int32
                         maximum: 256
@@ -218,6 +219,7 @@ spec:
                       minLength: 1
                       type: string
                     weight:
+                      default: 100
                       description: weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.
                       format: int32
                       maximum: 256

--- a/route/v1/stable.route.testsuite.yaml
+++ b/route/v1/stable.route.testsuite.yaml
@@ -18,4 +18,5 @@ tests:
         to:
           kind: Service
           name: foo
+          weight: 100
         wildcardPolicy: None

--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -161,6 +161,7 @@ type RouteTargetReference struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=256
+	// +kubebuilder:default=100
 	Weight *int32 `json:"weight" protobuf:"varint,3,opt,name=weight"`
 }
 


### PR DESCRIPTION
Setting the default value for spec.to.weight is typically performed by openshift-apiserver, but it's missing when Route is CRD-backed.