### PR TITLE
Fix missing group versions for some API groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ verify-scripts:
 	bash -x hack/verify-types.sh
 	bash -x hack/verify-compatibility.sh
 	bash -x hack/verify-integration-tests.sh
+	bash -x hack/verify-group-versions.sh
 
 .PHONY: verify
 verify: verify-scripts verify-codegen-crds verify-codegen-TechPreviewNoUpgrade-crds verify-codegen-Default-crds

--- a/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
+++ b/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
@@ -13,136 +13,92 @@ spec:
     singular: cloudprivateipconfig
   scope: Cluster
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: "CloudPrivateIPConfig performs an assignment of a private IP
-          address to the primary NIC associated with cloud VMs. This is done by specifying
-          the IP and Kubernetes node which the IP should be assigned to. This CRD
-          is intended to be used by the network plugin which manages the cluster network.
-          The spec side represents the desired state requested by the network plugin,
-          and the status side represents the current state that this CRD's controller
-          has executed. No users will have permission to modify it, and if a cluster-admin
-          decides to edit it for some reason, their changes will be overwritten the
-          next time the network plugin reconciles the object. Note: the CR's name
-          must specify the requested private IP address (can be IPv4 or IPv6). \n
-          Compatibility level 1: Stable within a major release for a minimum of 12
-          months or 3 minor releases (whichever is longer)."
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            properties:
-              name:
-                anyOf:
-                - format: ipv4
-                - format: ipv6
-                type: string
-            type: object
-          spec:
-            description: spec is the definition of the desired private IP request.
-            properties:
-              node:
-                description: 'node is the node name, as specified by the Kubernetes
-                  field: node.metadata.name'
-                type: string
-            type: object
-          status:
-            description: status is the observed status of the desired private IP request.
-              Read-only.
-            properties:
-              conditions:
-                description: condition is the assignment condition of the private
-                  IP and its status
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              node:
-                description: 'node is the node name, as specified by the Kubernetes
-                  field: node.metadata.name'
-                type: string
-            required:
-            - conditions
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "CloudPrivateIPConfig performs an assignment of a private IP address to the primary NIC associated with cloud VMs. This is done by specifying the IP and Kubernetes node which the IP should be assigned to. This CRD is intended to be used by the network plugin which manages the cluster network. The spec side represents the desired state requested by the network plugin, and the status side represents the current state that this CRD's controller has executed. No users will have permission to modify it, and if a cluster-admin decides to edit it for some reason, their changes will be overwritten the next time the network plugin reconciles the object. Note: the CR's name must specify the requested private IP address (can be IPv4 or IPv6). \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              properties:
+                name:
+                  anyOf:
+                    - format: ipv4
+                    - format: ipv6
+                  type: string
+              type: object
+            spec:
+              description: spec is the definition of the desired private IP request.
+              properties:
+                node:
+                  description: 'node is the node name, as specified by the Kubernetes field: node.metadata.name'
+                  type: string
+              type: object
+            status:
+              description: status is the observed status of the desired private IP request. Read-only.
+              properties:
+                conditions:
+                  description: condition is the assignment condition of the private IP and its status
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                node:
+                  description: 'node is the node name, as specified by the Kubernetes field: node.metadata.name'
+                  type: string
+              required:
+                - conditions
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/hack/verify-group-versions.sh
+++ b/hack/verify-group-versions.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+set -e
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+error=0
+
+validate_group_versions() {
+  FOLDER=$1
+
+  if [ ! -f ${FOLDER}/register.go ]; then
+      echo "No register.go file found for ${FOLDER}"
+      error=1
+      return
+  fi
+
+  gv=$(cat ${FOLDER}/register.go | grep -E "\sGroupVersion += schema.GroupVersion{Group: .*, Version: .*}") || true
+  if [ -z "${gv}" ]; then
+      echo "No GroupVersion found for ${FOLDER}"
+      error=1
+  fi
+}
+
+for groupVersion in ${API_GROUP_VERSIONS}; do
+  echo "Validating groups version for ${groupVersion}"
+  validate_group_versions ${SCRIPT_ROOT}/${groupVersion}
+done
+
+if [ $error -eq 1 ]; then
+  echo "FAILURE: Validation of group versions failed!"
+  exit 1
+fi

--- a/image/docker10/register.go
+++ b/image/docker10/register.go
@@ -12,14 +12,23 @@ const (
 
 // SchemeGroupVersion is group version used to register these objects
 var (
-	SchemeGroupVersion       = schema.GroupVersion{Group: GroupName, Version: "1.0"}
+	GroupVersion             = schema.GroupVersion{Group: GroupName, Version: "1.0"}
 	LegacySchemeGroupVersion = schema.GroupVersion{Group: LegacyGroupName, Version: "1.0"}
 
 	SchemeBuilder       = runtime.NewSchemeBuilder(addKnownTypes)
 	LegacySchemeBuilder = runtime.NewSchemeBuilder(addLegacyKnownTypes)
 
-	AddToScheme            = SchemeBuilder.AddToScheme
 	AddToSchemeInCoreGroup = LegacySchemeBuilder.AddToScheme
+
+	// Install is a function which adds this version to a scheme
+	Install = SchemeBuilder.AddToScheme
+
+	// SchemeGroupVersion generated code relies on this name
+	// Deprecated
+	SchemeGroupVersion = GroupVersion
+	// AddToScheme exists solely to keep the old generators creating valid code
+	// DEPRECATED
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 // Adds the list of known types to api.Scheme.

--- a/image/dockerpre012/register.go
+++ b/image/dockerpre012/register.go
@@ -11,14 +11,23 @@ const (
 )
 
 var (
-	SchemeGroupVersion       = schema.GroupVersion{Group: GroupName, Version: "pre012"}
+	GroupVersion             = schema.GroupVersion{Group: GroupName, Version: "pre012"}
 	LegacySchemeGroupVersion = schema.GroupVersion{Group: LegacyGroupName, Version: "pre012"}
 
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
 
 	LegacySchemeBuilder    = runtime.NewSchemeBuilder(addLegacyKnownTypes)
 	AddToSchemeInCoreGroup = LegacySchemeBuilder.AddToScheme
+
+	// Install is a function which adds this version to a scheme
+	Install = SchemeBuilder.AddToScheme
+
+	// SchemeGroupVersion generated code relies on this name
+	// Deprecated
+	SchemeGroupVersion = GroupVersion
+	// AddToScheme exists solely to keep the old generators creating valid code
+	// DEPRECATED
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 // Adds the list of known types to api.Scheme.

--- a/legacyconfig/v1/register.go
+++ b/legacyconfig/v1/register.go
@@ -8,7 +8,8 @@ import (
 var (
 	// Legacy is the 'v1' apiVersion of config
 	LegacyGroupName          = ""
-	LegacySchemeGroupVersion = schema.GroupVersion{Group: LegacyGroupName, Version: "v1"}
+	GroupVersion             = schema.GroupVersion{Group: LegacyGroupName, Version: "v1"}
+	LegacySchemeGroupVersion = GroupVersion
 	legacySchemeBuilder      = runtime.NewSchemeBuilder(
 		addKnownTypesToLegacy,
 	)

--- a/samples/v1/0000_10_samplesconfig.crd.yaml
+++ b/samples/v1/0000_10_samplesconfig.crd.yaml
@@ -19,162 +19,109 @@ spec:
   preserveUnknownFields: false
   scope: Cluster
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: "Config contains the configuration and detailed condition status
-          for the Samples Operator. \n Compatibility level 1: Stable within a major
-          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ConfigSpec contains the desired configuration and state for
-              the Samples Operator, controlling various behavior around the imagestreams
-              and templates it creates/updates in the openshift namespace.
-            properties:
-              architectures:
-                description: architectures determine which hardware architecture(s)
-                  to install, where x86_64, ppc64le, and s390x are the only supported
-                  choices currently.
-                items:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Config contains the configuration and detailed condition status for the Samples Operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConfigSpec contains the desired configuration and state for the Samples Operator, controlling various behavior around the imagestreams and templates it creates/updates in the openshift namespace.
+              type: object
+              properties:
+                architectures:
+                  description: architectures determine which hardware architecture(s) to install, where x86_64, ppc64le, and s390x are the only supported choices currently.
+                  type: array
+                  items:
+                    type: string
+                managementState:
+                  description: managementState is top level on/off type of switch for all operators. When "Managed", this operator processes config and manipulates the samples accordingly. When "Unmanaged", this operator ignores any updates to the resources it watches. When "Removed", it reacts that same wasy as it does if the Config object is deleted, meaning any ImageStreams or Templates it manages (i.e. it honors the skipped lists) and the registry secret are deleted, along with the ConfigMap in the operator's namespace that represents the last config used to manipulate the samples,
                   type: string
-                type: array
-              managementState:
-                description: managementState is top level on/off type of switch for
-                  all operators. When "Managed", this operator processes config and
-                  manipulates the samples accordingly. When "Unmanaged", this operator
-                  ignores any updates to the resources it watches. When "Removed",
-                  it reacts that same wasy as it does if the Config object is deleted,
-                  meaning any ImageStreams or Templates it manages (i.e. it honors
-                  the skipped lists) and the registry secret are deleted, along with
-                  the ConfigMap in the operator's namespace that represents the last
-                  config used to manipulate the samples,
-                pattern: ^(Managed|Unmanaged|Force|Removed)$
-                type: string
-              samplesRegistry:
-                description: samplesRegistry allows for the specification of which
-                  registry is accessed by the ImageStreams for their image content.  Defaults
-                  on the content in https://github.com/openshift/library that are
-                  pulled into this github repository, but based on our pulling only
-                  ocp content it typically defaults to registry.redhat.io.
-                type: string
-              skippedImagestreams:
-                description: skippedImagestreams specifies names of image streams
-                  that should NOT be created/updated.  Admins can use this to allow
-                  them to delete content they don’t want.  They will still have to
-                  manually delete the content but the operator will not recreate(or
-                  update) anything listed here.
-                items:
+                  pattern: ^(Managed|Unmanaged|Force|Removed)$
+                samplesRegistry:
+                  description: samplesRegistry allows for the specification of which registry is accessed by the ImageStreams for their image content.  Defaults on the content in https://github.com/openshift/library that are pulled into this github repository, but based on our pulling only ocp content it typically defaults to registry.redhat.io.
                   type: string
-                type: array
-              skippedTemplates:
-                description: skippedTemplates specifies names of templates that should
-                  NOT be created/updated.  Admins can use this to allow them to delete
-                  content they don’t want.  They will still have to manually delete
-                  the content but the operator will not recreate(or update) anything
-                  listed here.
-                items:
+                skippedImagestreams:
+                  description: skippedImagestreams specifies names of image streams that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.
+                  type: array
+                  items:
+                    type: string
+                skippedTemplates:
+                  description: skippedTemplates specifies names of templates that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.
+                  type: array
+                  items:
+                    type: string
+            status:
+              description: ConfigStatus contains the actual configuration in effect, as well as various details that describe the state of the Samples Operator.
+              type: object
+              properties:
+                architectures:
+                  description: architectures determine which hardware architecture(s) to install, where x86_64 and ppc64le are the supported choices.
+                  type: array
+                  items:
+                    type: string
+                conditions:
+                  description: conditions represents the available maintenance status of the sample imagestreams and templates.
+                  type: array
+                  items:
+                    description: ConfigCondition captures various conditions of the Config as entries are processed.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another.
+                        type: string
+                        format: date-time
+                      lastUpdateTime:
+                        description: lastUpdateTime is the last time this condition was updated.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: reason is what caused the condition's last transition.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: type of condition.
+                        type: string
+                managementState:
+                  description: managementState reflects the current operational status of the on/off switch for the operator.  This operator compares the ManagementState as part of determining that we are turning the operator back on (i.e. "Managed") when it was previously "Unmanaged".
                   type: string
-                type: array
-            type: object
-          status:
-            description: ConfigStatus contains the actual configuration in effect,
-              as well as various details that describe the state of the Samples Operator.
-            properties:
-              architectures:
-                description: architectures determine which hardware architecture(s)
-                  to install, where x86_64 and ppc64le are the supported choices.
-                items:
+                  pattern: ^(Managed|Unmanaged|Force|Removed)$
+                samplesRegistry:
+                  description: samplesRegistry allows for the specification of which registry is accessed by the ImageStreams for their image content.  Defaults on the content in https://github.com/openshift/library that are pulled into this github repository, but based on our pulling only ocp content it typically defaults to registry.redhat.io.
                   type: string
-                type: array
-              conditions:
-                description: conditions represents the available maintenance status
-                  of the sample imagestreams and templates.
-                items:
-                  description: ConfigCondition captures various conditions of the
-                    Config as entries are processed.
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another.
-                      format: date-time
-                      type: string
-                    lastUpdateTime:
-                      description: lastUpdateTime is the last time this condition
-                        was updated.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition.
-                      type: string
-                    reason:
-                      description: reason is what caused the condition's last transition.
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      type: string
-                    type:
-                      description: type of condition.
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              managementState:
-                description: managementState reflects the current operational status
-                  of the on/off switch for the operator.  This operator compares the
-                  ManagementState as part of determining that we are turning the operator
-                  back on (i.e. "Managed") when it was previously "Unmanaged".
-                pattern: ^(Managed|Unmanaged|Force|Removed)$
-                type: string
-              samplesRegistry:
-                description: samplesRegistry allows for the specification of which
-                  registry is accessed by the ImageStreams for their image content.  Defaults
-                  on the content in https://github.com/openshift/library that are
-                  pulled into this github repository, but based on our pulling only
-                  ocp content it typically defaults to registry.redhat.io.
-                type: string
-              skippedImagestreams:
-                description: skippedImagestreams specifies names of image streams
-                  that should NOT be created/updated.  Admins can use this to allow
-                  them to delete content they don’t want.  They will still have to
-                  manually delete the content but the operator will not recreate(or
-                  update) anything listed here.
-                items:
+                skippedImagestreams:
+                  description: skippedImagestreams specifies names of image streams that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.
+                  type: array
+                  items:
+                    type: string
+                skippedTemplates:
+                  description: skippedTemplates specifies names of templates that should NOT be created/updated.  Admins can use this to allow them to delete content they don’t want.  They will still have to manually delete the content but the operator will not recreate(or update) anything listed here.
+                  type: array
+                  items:
+                    type: string
+                version:
+                  description: version is the value of the operator's payload based version indicator when it was last successfully processed
                   type: string
-                type: array
-              skippedTemplates:
-                description: skippedTemplates specifies names of templates that should
-                  NOT be created/updated.  Admins can use this to allow them to delete
-                  content they don’t want.  They will still have to manually delete
-                  the content but the operator will not recreate(or update) anything
-                  listed here.
-                items:
-                  type: string
-                type: array
-              version:
-                description: version is the value of the operator's payload based
-                  version indicator when it was last successfully processed
-                type: string
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/samples/v1/register.go
+++ b/samples/v1/register.go
@@ -13,12 +13,17 @@ const (
 
 var (
 	scheme        = runtime.NewScheme()
+	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: Version}
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
-	// SchemeGroupVersion is the group version used to register these objects.
-	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: Version}
 	// Install is a function which adds this version to a scheme
 	Install = SchemeBuilder.AddToScheme
+
+	// SchemeGroupVersion generated code relies on this name
+	// Deprecated
+	SchemeGroupVersion = GroupVersion
+	// AddToScheme exists solely to keep the old generators creating valid code
+	// DEPRECATED
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 func init() {

--- a/sharedresource/v1alpha1/0000_10_sharedconfigmap.crd.yaml
+++ b/sharedresource/v1alpha1/0000_10_sharedconfigmap.crd.yaml
@@ -15,141 +15,91 @@ spec:
     singular: sharedconfigmap
   scope: Cluster
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: "SharedConfigMap allows a ConfigMap to be shared across namespaces.
-          Pods can mount the shared ConfigMap by adding a CSI volume to the pod specification
-          using the \"csi.sharedresource.openshift.io\" CSI driver and a reference
-          to the SharedConfigMap in the volume attributes: \n spec: volumes: - name:
-          shared-configmap csi: driver: csi.sharedresource.openshift.io volumeAttributes:
-          sharedConfigMap: my-share \n For the mount to be successful, the pod's service
-          account must be granted permission to 'use' the named SharedConfigMap object
-          within its namespace with an appropriate Role and RoleBinding. For compactness,
-          here are example `oc` invocations for creating such Role and RoleBinding
-          objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedconfigmaps.sharedresource.openshift.io
-          --resource-name=my-share` `oc create rolebinding shared-resource-my-share
-          --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n
-          Shared resource objects, in this case ConfigMaps, have default permissions
-          of list, get, and watch for system authenticated users. \n Compatibility
-          level 4: No compatibility is provided, the API can change at any point for
-          any reason. These capabilities should not be used by applications needing
-          long term support. These capabilities should not be used by applications
-          needing long term support."
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec is the specification of the desired shared configmap
-            properties:
-              configMapRef:
-                description: configMapRef is a reference to the ConfigMap to share
-                properties:
-                  name:
-                    description: name represents the name of the ConfigMap that is
-                      being referenced.
-                    type: string
-                  namespace:
-                    description: namespace represents the namespace where the referenced
-                      ConfigMap is located.
-                    type: string
-                required:
-                - name
-                - namespace
-                type: object
-              description:
-                description: description is a user readable explanation of what the
-                  backing resource provides.
-                type: string
-            required:
-            - configMapRef
-            type: object
-          status:
-            description: status is the observed status of the shared configmap
-            properties:
-              conditions:
-                description: conditions represents any observations made on this particular
-                  shared resource by the underlying CSI driver or Share controller.
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: "SharedConfigMap allows a ConfigMap to be shared across namespaces. Pods can mount the shared ConfigMap by adding a CSI volume to the pod specification using the \"csi.sharedresource.openshift.io\" CSI driver and a reference to the SharedConfigMap in the volume attributes: \n spec: volumes: - name: shared-configmap csi: driver: csi.sharedresource.openshift.io volumeAttributes: sharedConfigMap: my-share \n For the mount to be successful, the pod's service account must be granted permission to 'use' the named SharedConfigMap object within its namespace with an appropriate Role and RoleBinding. For compactness, here are example `oc` invocations for creating such Role and RoleBinding objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedconfigmaps.sharedresource.openshift.io --resource-name=my-share` `oc create rolebinding shared-resource-my-share --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n Shared resource objects, in this case ConfigMaps, have default permissions of list, get, and watch for system authenticated users. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support. These capabilities should not be used by applications needing long term support."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec is the specification of the desired shared configmap
+              type: object
+              required:
+                - configMapRef
+              properties:
+                configMapRef:
+                  description: configMapRef is a reference to the ConfigMap to share
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  required:
+                    - name
+                    - namespace
+                  properties:
+                    name:
+                      description: name represents the name of the ConfigMap that is being referenced.
+                      type: string
+                    namespace:
+                      description: namespace represents the namespace where the referenced ConfigMap is located.
+                      type: string
+                description:
+                  description: description is a user readable explanation of what the backing resource provides.
+                  type: string
+            status:
+              description: status is the observed status of the shared configmap
+              type: object
+              properties:
+                conditions:
+                  description: conditions represents any observations made on this particular shared resource by the underlying CSI driver or Share controller.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/sharedresource/v1alpha1/0000_10_sharedsecret.crd.yaml
+++ b/sharedresource/v1alpha1/0000_10_sharedsecret.crd.yaml
@@ -15,141 +15,91 @@ spec:
     singular: sharedsecret
   scope: Cluster
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: "SharedSecret allows a Secret to be shared across namespaces.
-          Pods can mount the shared Secret by adding a CSI volume to the pod specification
-          using the \"csi.sharedresource.openshift.io\" CSI driver and a reference
-          to the SharedSecret in the volume attributes: \n spec: volumes: - name:
-          shared-secret csi: driver: csi.sharedresource.openshift.io volumeAttributes:
-          sharedSecret: my-share \n For the mount to be successful, the pod's service
-          account must be granted permission to 'use' the named SharedSecret object
-          within its namespace with an appropriate Role and RoleBinding. For compactness,
-          here are example `oc` invocations for creating such Role and RoleBinding
-          objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedsecrets.sharedresource.openshift.io
-          --resource-name=my-share` `oc create rolebinding shared-resource-my-share
-          --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n
-          Shared resource objects, in this case Secrets, have default permissions
-          of list, get, and watch for system authenticated users. \n Compatibility
-          level 4: No compatibility is provided, the API can change at any point for
-          any reason. These capabilities should not be used by applications needing
-          long term support. These capabilities should not be used by applications
-          needing long term support."
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec is the specification of the desired shared secret
-            properties:
-              description:
-                description: description is a user readable explanation of what the
-                  backing resource provides.
-                type: string
-              secretRef:
-                description: secretRef is a reference to the Secret to share
-                properties:
-                  name:
-                    description: name represents the name of the Secret that is being
-                      referenced.
-                    type: string
-                  namespace:
-                    description: namespace represents the namespace where the referenced
-                      Secret is located.
-                    type: string
-                required:
-                - name
-                - namespace
-                type: object
-            required:
-            - secretRef
-            type: object
-          status:
-            description: status is the observed status of the shared secret
-            properties:
-              conditions:
-                description: conditions represents any observations made on this particular
-                  shared resource by the underlying CSI driver or Share controller.
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: "SharedSecret allows a Secret to be shared across namespaces. Pods can mount the shared Secret by adding a CSI volume to the pod specification using the \"csi.sharedresource.openshift.io\" CSI driver and a reference to the SharedSecret in the volume attributes: \n spec: volumes: - name: shared-secret csi: driver: csi.sharedresource.openshift.io volumeAttributes: sharedSecret: my-share \n For the mount to be successful, the pod's service account must be granted permission to 'use' the named SharedSecret object within its namespace with an appropriate Role and RoleBinding. For compactness, here are example `oc` invocations for creating such Role and RoleBinding objects. \n `oc create role shared-resource-my-share --verb=use --resource=sharedsecrets.sharedresource.openshift.io --resource-name=my-share` `oc create rolebinding shared-resource-my-share --role=shared-resource-my-share --serviceaccount=my-namespace:default` \n Shared resource objects, in this case Secrets, have default permissions of list, get, and watch for system authenticated users. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support. These capabilities should not be used by applications needing long term support."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec is the specification of the desired shared secret
+              type: object
+              required:
+                - secretRef
+              properties:
+                description:
+                  description: description is a user readable explanation of what the backing resource provides.
+                  type: string
+                secretRef:
+                  description: secretRef is a reference to the Secret to share
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  required:
+                    - name
+                    - namespace
+                  properties:
+                    name:
+                      description: name represents the name of the Secret that is being referenced.
+                      type: string
+                    namespace:
+                      description: namespace represents the namespace where the referenced Secret is located.
+                      type: string
+            status:
+              description: status is the observed status of the shared secret
+              type: object
+              properties:
+                conditions:
+                  description: conditions represents any observations made on this particular shared resource by the underlying CSI driver or Share controller.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/sharedresource/v1alpha1/register.go
+++ b/sharedresource/v1alpha1/register.go
@@ -13,12 +13,17 @@ const (
 
 var (
 	scheme        = runtime.NewScheme()
+	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: Version}
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
-	// SchemeGroupVersion is the group version used to register these objects.
-	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: Version}
 	// Install is a function which adds this version to a scheme
 	Install = SchemeBuilder.AddToScheme
+
+	// SchemeGroupVersion generated code relies on this name
+	// Deprecated
+	SchemeGroupVersion = GroupVersion
+	// AddToScheme exists solely to keep the old generators creating valid code
+	// DEPRECATED
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 func init() {

--- a/tools/codegen/pkg/generation/context.go
+++ b/tools/codegen/pkg/generation/context.go
@@ -49,6 +49,9 @@ type APIVersionContext struct {
 
 	// Path is the path to the folder containing the API version.
 	Path string
+
+	// PackageName is the golang packagh name for the API version.
+	PackageName string
 }
 
 // Options represents the base configuration used to generate a context.
@@ -185,8 +188,9 @@ func findAPIGroups(goPackages []string, desiredGroupVersions []string) (map[stri
 				version := gvv.groupVersion.Version
 
 				apiGroups[group] = append(apiGroups[group], APIVersionContext{
-					Name: version,
-					Path: pkgPath,
+					Name:        version,
+					Path:        pkgPath,
+					PackageName: p.Name,
 				})
 			} else {
 				klog.V(3).Infof("No GroupVersion found in path %s", pkgPath)

--- a/tools/codegen/pkg/generation/context.go
+++ b/tools/codegen/pkg/generation/context.go
@@ -188,6 +188,8 @@ func findAPIGroups(goPackages []string, desiredGroupVersions []string) (map[stri
 					Name: version,
 					Path: pkgPath,
 				})
+			} else {
+				klog.V(3).Infof("No GroupVersion found in path %s", pkgPath)
 			}
 		}
 	}

--- a/tools/codegen/pkg/swaggerdocs/generator.go
+++ b/tools/codegen/pkg/swaggerdocs/generator.go
@@ -74,12 +74,12 @@ func (g *generator) generateGroupVersion(groupName string, version generation.AP
 	if g.verify {
 		klog.V(2).Infof("Verifiying swagger docs for %s/%s", groupName, version.Name)
 
-		return verifySwaggerDocs(version.Name, outFilePath, docsForTypes)
+		return verifySwaggerDocs(version.PackageName, outFilePath, docsForTypes)
 	}
 
 	klog.V(2).Infof("Generating swagger docs for %s/%s", groupName, version.Name)
 
-	generatedDocs, err := generateSwaggerDocs(version.Name, docsForTypes)
+	generatedDocs, err := generateSwaggerDocs(version.PackageName, docsForTypes)
 	if err != nil {
 		return fmt.Errorf("error generating swagger docs: %w", err)
 	}

--- a/unidling/v1alpha1/register.go
+++ b/unidling/v1alpha1/register.go
@@ -1,4 +1,4 @@
-package v1
+package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -7,31 +7,29 @@ import (
 )
 
 var (
-	GroupName     = "cloud.network.openshift.io"
-	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: "v1"}
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	GroupName     = "unidling.openshift.io"
+	GroupVersion  = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	// Install is a function which adds this version to a scheme
-	Install = SchemeBuilder.AddToScheme
+	Install = schemeBuilder.AddToScheme
 
 	// SchemeGroupVersion generated code relies on this name
 	// Deprecated
 	SchemeGroupVersion = GroupVersion
 	// AddToScheme exists solely to keep the old generators creating valid code
 	// DEPRECATED
-	AddToScheme = SchemeBuilder.AddToScheme
+	AddToScheme = schemeBuilder.AddToScheme
 )
 
-// Resource takes an unqualified resource and returns a Group qualified GroupResource
+// Resource generated code relies on this being here, but it logically belongs to the group
+// DEPRECATED
 func Resource(resource string) schema.GroupResource {
-	return SchemeGroupVersion.WithResource(resource).GroupResource()
+	return schema.GroupResource{Group: GroupName, Resource: resource}
 }
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
-		&CloudPrivateIPConfig{},
-		&CloudPrivateIPConfigList{},
-	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	scheme.AddKnownTypes(GroupVersion)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
 	return nil
 }


### PR DESCRIPTION
The new codegen tool relies on having a public `GroupVersion` `schema.GroupVersion` in each API group, this is how it discovers the API group/version. Some of our APIs didn't have this so weren't being picked up by the generator.

I've added a log line so we can catch which folders are being ignored in the future, and I've set up a script which should catch this as well. Based on our existing API search (which uses some regexes to look for folders that look like API versions), it checks for a register.go file and the `GroupVersion` within that. This worked well for most of our API groups but a few hadn't been updated and where still using the legacy `SchemeGroupVersion` name.

There are a few formatting changes in the CRDs which are due to the differences in how we were formatting manifests pre-codegen, we used to use YQ, this now uses the same library as other K8s tooling. Purely whitespace and ordering changes.