### PR TITLE
Runtime should not be shared between generator runs

### DIFF
--- a/example/v1alpha1/0000_50_notstabletype-techpreview.crd.yaml
+++ b/example/v1alpha1/0000_50_notstabletype-techpreview.crd.yaml
@@ -64,19 +64,30 @@ spec:
                       message:
                         description: message is a human readable message indicating details about the transition. This may be an empty string.
                         type: string
+                        maxLength: 32768
                       observedGeneration:
                         description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
                         type: integer
                         format: int64
+                        minimum: 0
                       reason:
                         description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
                         type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       status:
                         description: status of the condition, one of True, False, Unknown.
                         type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
                       type:
                         description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                         type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                   x-kubernetes-list-map-keys:
                     - type
                   x-kubernetes-list-type: map

--- a/machine/v1beta1/0000_10_machine.crd.yaml
+++ b/machine/v1beta1/0000_10_machine.crd.yaml
@@ -175,6 +175,7 @@ spec:
                           uid:
                             description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
                             type: string
+                        x-kubernetes-map-type: atomic
                 providerID:
                   description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
                   type: string

--- a/machine/v1beta1/0000_10_machinehealthcheck.yaml
+++ b/machine/v1beta1/0000_10_machinehealthcheck.yaml
@@ -120,6 +120,7 @@ spec:
                       type: object
                       additionalProperties:
                         type: string
+                  x-kubernetes-map-type: atomic
                 unhealthyConditions:
                   description: UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
                   type: array

--- a/machine/v1beta1/0000_10_machineset.crd.yaml
+++ b/machine/v1beta1/0000_10_machineset.crd.yaml
@@ -102,6 +102,7 @@ spec:
                       type: object
                       additionalProperties:
                         type: string
+                  x-kubernetes-map-type: atomic
                 template:
                   description: Template is the object that describes the machine that will be created if insufficient replicas are detected.
                   type: object
@@ -159,6 +160,7 @@ spec:
                               uid:
                                 description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
                                 type: string
+                            x-kubernetes-map-type: atomic
                     spec:
                       description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                       type: object
@@ -268,6 +270,7 @@ spec:
                                   uid:
                                     description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
                                     type: string
+                                x-kubernetes-map-type: atomic
                         providerID:
                           description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
                           type: string

--- a/tools/codegen/pkg/schemapatch/schemapatch.go
+++ b/tools/codegen/pkg/schemapatch/schemapatch.go
@@ -72,7 +72,12 @@ func outputArg(versionPath string) string {
 }
 
 // executeSchemaPatchForGroupVersion runs the schemapatch code directly for the given group and version.
-func executeSchemaPatchForGroupVersion(rt *genall.Runtime, group string, version generation.APIVersionContext, requiredFeatureSets sets.String) error {
+func executeSchemaPatchForGroupVersion(group string, version generation.APIVersionContext, requiredFeatureSets sets.String, versionPaths []string) error {
+	rt, err := loadGroupRuntime(versionPaths)
+	if err != nil {
+		return fmt.Errorf("error loading group runtime: %w", err)
+	}
+
 	markers.RequiredFeatureSets.Insert(requiredFeatureSets.List()...)
 	defer func() {
 		markers.RequiredFeatureSets = sets.NewString()
@@ -95,4 +100,11 @@ func executeSchemaPatchForGroupVersion(rt *genall.Runtime, group string, version
 	}
 
 	return nil
+}
+
+// loadGroupRuntime builds a genall.Runtime based on the package paths for all version that are passed.
+// This allows the runtime to be shared between each version when it's generated.
+func loadGroupRuntime(paths []string) (*genall.Runtime, error) {
+	generators := &genall.Generators{}
+	return generators.ForRoots(paths...)
 }


### PR DESCRIPTION
The runtime, I thought took ages to load and therefore tried to optimise so that we could share it between generation runs. It turns out, some state within this is being mutated and causes issues when generating multiple groupversions from the same runtime.

This PR removes the shared state and fixes the example and machine APIs which accidentally had some validations removed due to this bug.

This was found because I changed a list to a map within another branch I'm working on, which meant orderings were no longer preserved, I could then see it making weird swaps in a non-deterministic way. This has gone away with this change.