### PR TITLE
Warn of no gopath for protobuf generator

### DIFF
--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -4,6 +4,12 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 [[ -n "${PROTO_OPTIONAL:-}" ]] && exit 0
 
+if [ -z "${GOPATH:-}" ]; then
+  echo "Generating protobuf requires GOPATH to be set. Please set GOPATH.
+To skip protobuf generation, set \$PROTO_OPTIONAL."
+  exit 1
+fi
+
 if [[ "$(protoc --version)" != "libprotoc 3."* ]]; then
   echo "Generating protobuf requires protoc 3.0.x. Please download and
 install the platform appropriate Protobuf package for your OS:


### PR DESCRIPTION
The protobuf generator currently requires that the GOPATH is set to run, this will be fixed in a future version (https://github.com/kubernetes/kubernetes/pull/112061) but for now we must warn that the generator cannot be used without a GOPATH