### PR TITLE
disable new beta feature in Default, enable new beta features in TechPreview

### DIFF
--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -6,6 +6,12 @@ import (
 )
 
 func TestFeatureBuilder(t *testing.T) {
+
+	var testStart = &FeatureGateEnabledDisabled{
+		Enabled:  []string{"alpha", "bravo"},
+		Disabled: []string{"charlie", "delta"},
+	}
+
 	tests := []struct {
 		name     string
 		actual   *FeatureGateEnabledDisabled
@@ -13,68 +19,60 @@ func TestFeatureBuilder(t *testing.T) {
 	}{
 		{
 			name:     "nothing",
-			actual:   newDefaultFeatures().toFeatures(),
+			actual:   newDefaultFeatures(defaultFeatures).toFeatures(),
 			expected: defaultFeatures,
 		},
 		{
 			name:   "disable-existing",
-			actual: newDefaultFeatures().without("APIPriorityAndFairness").toFeatures(),
+			actual: newDefaultFeatures(testStart).without("alpha").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
-				Enabled: []string{
-					"RotateKubeletServerCertificate",
-					"DownwardAPIHugePages",
-				},
+				Enabled: []string{"bravo"},
 				Disabled: []string{
-					"CSIMigrationAzureFile",
-					"CSIMigrationvSphere",
-					"APIPriorityAndFairness",
+					"charlie",
+					"delta",
+					"alpha",
 				},
 			},
 		},
 		{
 			name:   "enable-existing",
-			actual: newDefaultFeatures().with("CSIMigrationAzureFile").toFeatures(),
+			actual: newDefaultFeatures(testStart).with("charlie").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
-					"APIPriorityAndFairness",
-					"RotateKubeletServerCertificate",
-					"DownwardAPIHugePages",
-					"CSIMigrationAzureFile",
+					"alpha",
+					"bravo",
+					"charlie",
 				},
 				Disabled: []string{
-					"CSIMigrationvSphere",
+					"delta",
 				},
 			},
 		},
 		{
 			name:   "disable-more",
-			actual: newDefaultFeatures().without("APIPriorityAndFairness", "other").toFeatures(),
+			actual: newDefaultFeatures(testStart).without("alpha", "other").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
-				Enabled: []string{
-					"RotateKubeletServerCertificate",
-					"DownwardAPIHugePages",
-				},
+				Enabled: []string{"bravo"},
 				Disabled: []string{
-					"CSIMigrationAzureFile",
-					"CSIMigrationvSphere",
-					"APIPriorityAndFairness",
+					"charlie",
+					"delta",
+					"alpha",
 					"other",
 				},
 			},
 		},
 		{
 			name:   "enable-more",
-			actual: newDefaultFeatures().with("CSIMigrationAzureFile", "other").toFeatures(),
+			actual: newDefaultFeatures(testStart).with("charlie", "other").toFeatures(),
 			expected: &FeatureGateEnabledDisabled{
 				Enabled: []string{
-					"APIPriorityAndFairness",
-					"RotateKubeletServerCertificate",
-					"DownwardAPIHugePages",
-					"CSIMigrationAzureFile",
+					"alpha",
+					"bravo",
+					"charlie",
 					"other",
 				},
 				Disabled: []string{
-					"CSIMigrationvSphere",
+					"delta",
 				},
 			},
 		},


### PR DESCRIPTION
The existing on/off status of existing beta features matches the kube 1.25 --feature-gate list.

All new kube beta features will be disabled in a standard deployment by default. A team may explicitly opt-in to enable a particular beta feature by adding it to the list, signing the team up for support and signing up to keep the feature backwards compatible and upgradeable even though kubernetes does not guarantee this.

All new kube beta features will be enabled in TechPreview. A team may only disable beta features if there is a severe, intractable bug or if the kubernetes project plans to keep a feature disableable forever.  Keep in mind that kube has a stated goal for all featuregates to become force-enabled with no residual code to allow long term disablement.

/hold for discussion
