### PR TITLE
OCPCLOUD-1783: Make machine phases public consts

### DIFF
--- a/machine/v1beta1/types_machine.go
+++ b/machine/v1beta1/types_machine.go
@@ -135,6 +135,34 @@ const (
 	RollingUpdateMachineDeploymentStrategyType MachineDeploymentStrategyType = "RollingUpdate"
 )
 
+const (
+	// PhaseFailed indicates a state that will need to be fixed before progress can be made.
+	// Failed machines have encountered a terminal error and must be deleted.
+	// https://github.com/openshift/enhancements/blob/master/enhancements/machine-instance-lifecycle.md
+	// e.g. Instance does NOT exist but Machine has providerID/addresses.
+	// e.g. Cloud service returns a 4xx response.
+	PhaseFailed string = "Failed"
+
+	// PhaseProvisioning indicates the instance does NOT exist.
+	// The machine has NOT been given a providerID or addresses.
+	// Provisioning implies that the Machine API is in the process of creating the instance.
+	PhaseProvisioning string = "Provisioning"
+
+	// PhaseProvisioned indicates the instance exists.
+	// The machine has been given a providerID and addresses.
+	// The machine API successfully provisioned an instance which has not yet joined the cluster,
+	// as such, the machine has NOT yet been given a nodeRef.
+	PhaseProvisioned string = "Provisioned"
+
+	// PhaseRunning indicates the instance exists and the node has joined the cluster.
+	// The machine has been given a providerID, addresses, and a nodeRef.
+	PhaseRunning string = "Running"
+
+	// PhaseDeleting indicates the machine has a deletion timestamp and that the
+	// Machine API is now in the process of removing the machine from the cluster.
+	PhaseDeleting string = "Deleting"
+)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 


### PR DESCRIPTION
Rather than forcing machine providers to replicate machine phases, if needed, the phases should be made public consts instead.

Related: https://issues.redhat.com/browse/OCPCLOUD-1783