### PR TITLE
Improve diff output of schemapatch verification within Prow

### DIFF
--- a/tools/codegen/pkg/schemapatch/generator.go
+++ b/tools/codegen/pkg/schemapatch/generator.go
@@ -142,7 +142,7 @@ func (g *generator) genGroupVersion(group string, version generation.APIVersionC
 
 		if g.verify {
 			if !bytes.Equal(manifestData, gc.manifestData) {
-				diff := utils.Diff(manifestData, gc.manifestData, gc.manifestPath)
+				diff := utils.Diff(gc.manifestData, manifestData, gc.manifestPath)
 
 				return fmt.Errorf("API schema for %s is out of date, please regenerate the API schema:\n%s", gc.manifestPath, diff)
 			}

--- a/tools/codegen/pkg/schemapatch/generator.go
+++ b/tools/codegen/pkg/schemapatch/generator.go
@@ -142,7 +142,7 @@ func (g *generator) genGroupVersion(group string, version generation.APIVersionC
 
 		if g.verify {
 			if !bytes.Equal(manifestData, gc.manifestData) {
-				diff := utils.Diff(manifestData, gc.manifestData)
+				diff := utils.Diff(manifestData, gc.manifestData, gc.manifestPath)
 
 				return fmt.Errorf("API schema for %s is out of date, please regenerate the API schema:\n%s", gc.manifestPath, diff)
 			}


### PR DESCRIPTION
There were a couple of errors in my previous PR.

First up, I got the order wrong, I meant to put the existing data as the base of the patch so that you get the diff in the expected direction, red lines are things that are removed, green lines are things that have been added, this is fixed now.

Secondly, prow, annoyingly, doesn't colour blocks of data, but only individual lines. So we have to print the colour code on every coloured line

Currently have a WIP commit for testing the output.