### PR TITLE
Minor codegen fixes

### DIFF
--- a/tools/codegen/pkg/generation/context.go
+++ b/tools/codegen/pkg/generation/context.go
@@ -194,7 +194,7 @@ func findAPIGroups(goPackages map[string]*packages.Package, desiredGroupVersions
 
 			// If a group was found and either the desired list is empty or contains this group version,
 			// add it to the output.
-			if gvv.groupVersion.Group != "" && (desired.Len() == 0 || desired.Has(gvv.groupVersion.String())) {
+			if gvv.groupVersion.String() != "" && (desired.Len() == 0 || desired.Has(gvv.groupVersion.String())) {
 				klog.V(3).Infof("Found GroupVersion in path %s: %+v", pkgPath, gvv.groupVersion)
 				group := gvv.groupVersion.Group
 				version := gvv.groupVersion.Version

--- a/tools/codegen/pkg/generation/types.go
+++ b/tools/codegen/pkg/generation/types.go
@@ -33,7 +33,7 @@ type CompatibilityConfig struct {
 type DeepcopyConfig struct {
 	// Disabled determines whether the deepcopy generator should be run or not.
 	// This generator is enabled by default so this field defaults to false.
-	Disabled bool `json:"enabled,omitempty"`
+	Disabled bool `json:"disabled,omitempty"`
 
 	// HeaderFilePath is the path to the file containing the boilerplate header text.
 	// When omitted, no header is added to the generated files.


### PR DESCRIPTION
I noticed a couple of things while working on other features:
- The legacyconfig group has no group name which means the generator was ignoring it, switch the check to check for a non-empty groupversion string which should cover the same check as the original intention
- The deepcopy serialisation for disabled wasn't correct