### PR TITLE
Fix verifying multiple manifests in schemapatch

### DIFF
--- a/tools/codegen/pkg/schemapatch/generator.go
+++ b/tools/codegen/pkg/schemapatch/generator.go
@@ -153,7 +153,7 @@ func (g *generator) genGroupVersion(group string, version generation.APIVersionC
 				return fmt.Errorf("API schema for %s is out of date, please regenerate the API schema:\n%s", gc.manifestPath, diff)
 			}
 
-			return nil
+			continue
 		}
 
 		if err := os.WriteFile(gc.manifestPath, manifestData, gc.manifestFileMode); err != nil {


### PR DESCRIPTION
In #1359 which I merged last week, there was a small bug in the verification stage of the schemapatch. Rather than continuing the loop to the next object when there was an issue, it instead returned from the function.

This meant the verification would only verify the first object in each API group 🤦 