### PR TITLE
Print errors that are not currently surfaced by the schemapatch generator

### DIFF
--- a/tools/codegen/cmd/root.go
+++ b/tools/codegen/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/api/tools/codegen/pkg/generation"
+	"github.com/openshift/api/tools/codegen/pkg/utils"
 	"github.com/spf13/cobra"
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -90,7 +91,7 @@ func executeGenerators(genCtx generation.Context, generators ...generation.Gener
 	}
 
 	if len(errs) > 0 {
-		return kerrors.NewAggregate(errs)
+		return utils.NewAggregatePrinter(kerrors.NewAggregate(errs))
 	}
 
 	return nil

--- a/tools/codegen/pkg/utils/aggregate.go
+++ b/tools/codegen/pkg/utils/aggregate.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// AggregatePrinter is an error wrapper that prints out aggregate and wrapped
+// errors as individual errors in individual lines.
+type AggregatePrinter struct {
+	inner error
+}
+
+// NewAggregatePrinter creates a new Aggregate error.
+func NewAggregatePrinter(err error) AggregatePrinter {
+	return AggregatePrinter{
+		inner: err,
+	}
+}
+
+// Error prints the error out as a string.
+// It unwraps wrapped errors and iterates over aggregate errors
+// to print errors on invidividual lines.
+func (a AggregatePrinter) Error() string {
+	buf := bytes.NewBuffer([]byte("\n"))
+
+	handleError(buf, a.inner, 0)
+
+	return buf.String()
+}
+
+// handleError checks if the error given is an aggregate and iterates
+// over its sub-errors if it is, else it checks if it is a wrapped
+// error, in which case it prints out the context and unwraps the error.
+// At 100 levels of indent the function stops to avoid infinite loops.
+func handleError(buf *bytes.Buffer, err error, indent int) {
+	if agg, ok := err.(kerrors.Aggregate); ok && indent < 100 {
+		for _, aggErr := range agg.Errors() {
+			handleError(buf, aggErr, indent)
+		}
+	} else if u := errors.Unwrap(err); u != nil && indent < 100 {
+		errorContext := strings.Split(err.Error(), u.Error())[0]
+		printError(buf, errors.New(errorContext), indent)
+		handleError(buf, u, indent+1)
+	} else {
+		printError(buf, err, indent)
+	}
+}
+
+// printError prints the error after indenting it by the given amount.
+func printError(buf *bytes.Buffer, err error, indent int) {
+	for i := 0; i < indent; i++ {
+		buf.WriteString("\t")
+	}
+	buf.WriteString(err.Error())
+	buf.WriteString("\n")
+}


### PR DESCRIPTION
In a recent PR, we saw the generators updated a bunch of files and created invalid CRD schemas because of a typo within the configv1 API group. After reviewing the code and stepping through with a debugger, I noticed that errors were being surfaced in the packages themselves which were causing the generation to fail, however, these were never surfaced higher and the generator happily produced an incorrect result.

To make this easier to spot in the future, I've added some code to gather errors observed in the packages we generate and then print these out in a hopefully readable format.

The printing of the errors splits the wrapped errors and prints each error wrap on a new line, with aggregate errors printed on each line separately as well.

Currently there's an extra commit to show what happens when there is an error in the generation