### PR TITLE
(PSAP-741) config/v1/types_cluster_version: add node-tuning capability

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -70,6 +70,7 @@ spec:
                           - Insights
                           - Storage
                           - CSISnapshot
+                          - NodeTuning
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -190,6 +191,7 @@ spec:
                           - Insights
                           - Storage
                           - CSISnapshot
+                          - NodeTuning
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -205,6 +207,7 @@ spec:
                           - Insights
                           - Storage
                           - CSISnapshot
+                          - NodeTuning
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.

--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -78,6 +78,7 @@ spec:
                         - None
                         - v4.11
                         - v4.12
+                        - v4.13
                         - vCurrent
                 channel:
                   description: channel is an identifier for explicitly requesting that a non-default set of updates be applied to this cluster. The default channel will be contain stable updates that are appropriate for production clusters.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -244,7 +244,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning
 type ClusterVersionCapability string
 
 const (
@@ -287,6 +287,12 @@ const (
 	// VolumeSnapshot CRD objects and manages the creation and deletion
 	// lifecycle of volume snapshots
 	ClusterVersionCapabilityCSISnapshot ClusterVersionCapability = "CSISnapshot"
+
+	// ClusterVersionCapabilityNodeTuning manages the Node Tuning Operator
+	// which is responsible for watching the Tuned and Profile CRD
+	// objects and manages the containerized TuneD daemon which controls
+	// system level tuning of Nodes
+	ClusterVersionCapabilityNodeTuning ClusterVersionCapability = "NodeTuning"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -298,6 +304,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityStorage,
 	ClusterVersionCapabilityOpenShiftSamples,
 	ClusterVersionCapabilityCSISnapshot,
+	ClusterVersionCapabilityNodeTuning,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
@@ -358,6 +365,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityStorage,
 		ClusterVersionCapabilityOpenShiftSamples,
 		ClusterVersionCapabilityCSISnapshot,
+		ClusterVersionCapabilityNodeTuning,
 	},
 	ClusterVersionCapabilitySetCurrent: {
 		ClusterVersionCapabilityBaremetal,
@@ -367,6 +375,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityStorage,
 		ClusterVersionCapabilityOpenShiftSamples,
 		ClusterVersionCapabilityCSISnapshot,
+		ClusterVersionCapabilityNodeTuning,
 	},
 }
 

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -301,7 +301,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
-// +kubebuilder:validation:Enum=None;v4.11;v4.12;vCurrent
+// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;vCurrent
 type ClusterVersionCapabilitySet string
 
 const (
@@ -321,6 +321,12 @@ const (
 	// version of OpenShift is installed.
 	ClusterVersionCapabilitySet4_12 ClusterVersionCapabilitySet = "v4.12"
 
+	// ClusterVersionCapabilitySet4_13 is the recommended set of
+	// optional capabilities to enable for the 4.13 version of
+	// OpenShift.  This list will remain the same no matter which
+	// version of OpenShift is installed.
+	ClusterVersionCapabilitySet4_13 ClusterVersionCapabilitySet = "v4.13"
+
 	// ClusterVersionCapabilitySetCurrent is the recommended set
 	// of optional capabilities to enable for the cluster's
 	// current version of OpenShift.
@@ -336,6 +342,15 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityOpenShiftSamples,
 	},
 	ClusterVersionCapabilitySet4_12: {
+		ClusterVersionCapabilityBaremetal,
+		ClusterVersionCapabilityConsole,
+		ClusterVersionCapabilityInsights,
+		ClusterVersionCapabilityMarketplace,
+		ClusterVersionCapabilityStorage,
+		ClusterVersionCapabilityOpenShiftSamples,
+		ClusterVersionCapabilityCSISnapshot,
+	},
+	ClusterVersionCapabilitySet4_13: {
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityConsole,
 		ClusterVersionCapabilityInsights,


### PR DESCRIPTION
Along with adding a 4.13 capability set, this PR adds node-tuning to the set of OpenShift capabilities that can be optionally disabled at cluster install starting with OpenShift 4.13. This can be used to disable the Node Tuning Operator (NTO) and the containerized TuneD daemon which it manages. 

The Node Tuning Operator applies TuneD default profiles to the control plane and worker nodes, and enables users to apply custom OS-level tuning. When disabled, the default tuning profiles will not be applied which may impact the performance of certain workloads, and will impact scalability of very large clusters (~900 nodes or ~1000 routes).  

Any tuning that is functionally required will be handled by MCO going forward (see https://github.com/openshift/machine-config-operator/pull/3440)

Related to [PSAP-741](https://issues.redhat.com/browse/PSAP-741). This must be merged before https://github.com/openshift/cluster-node-tuning-operator/pull/524