### PR TITLE
Add ResourceGroup field to PowerVSPlatformStatus

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
@@ -736,6 +736,14 @@ spec:
                         region:
                           description: region holds the default Power VS region for new Power VS resources created by the cluster.
                           type: string
+                        resourceGroup:
+                          description: 'resourceGroup is the resource group name for new IBMCloud resources created for a cluster. The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry. More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs. When omitted, the image registry operator won''t be able to configure storage, which results in the image registry cluster operator not being in an available state.'
+                          maxLength: 40
+                          pattern: ^[a-zA-Z0-9-_ ]+$
+                          type: string
+                          x-kubernetes-validations:
+                            - message: resourceGroup is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
                         serviceEndpoints:
                           description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
                           items:
@@ -759,6 +767,9 @@ spec:
                           description: 'zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported'
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                        - message: cannot unset resourceGroup once set
+                          rule: '!has(oldSelf.resourceGroup) || has(self.resourceGroup)'
                     type:
                       description: "type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform. \n This value will be synced with to the `status.platform` and `status.platformStatus.type`. Currently this value cannot be changed once set."
                       enum:

--- a/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
@@ -736,6 +736,14 @@ spec:
                         region:
                           description: region holds the default Power VS region for new Power VS resources created by the cluster.
                           type: string
+                        resourceGroup:
+                          description: 'resourceGroup is the resource group name for new IBMCloud resources created for a cluster. The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry. More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs. When omitted, the image registry operator won''t be able to configure storage, which results in the image registry cluster operator not being in an available state.'
+                          maxLength: 40
+                          pattern: ^[a-zA-Z0-9-_ ]+$
+                          type: string
+                          x-kubernetes-validations:
+                            - message: resourceGroup is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
                         serviceEndpoints:
                           description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
                           items:
@@ -759,6 +767,9 @@ spec:
                           description: 'zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported'
                           type: string
                       type: object
+                      x-kubernetes-validations:
+                        - message: cannot unset resourceGroup once set
+                          rule: '!has(oldSelf.resourceGroup) || has(self.resourceGroup)'
                     type:
                       description: "type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform. \n This value will be synced with to the `status.platform` and `status.platformStatus.type`. Currently this value cannot be changed once set."
                       enum:

--- a/config/v1/stable.infrastructure.testsuite.yaml
+++ b/config/v1/stable.infrastructure.testsuite.yaml
@@ -214,3 +214,100 @@ tests:
               resourceGroupName: bar
               resourceTags:
                 - {key: "key", value: "value"}
+    - name: PowerVS platform status's resourceGroup length should not exceed the max length set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+        status:
+          platform: PowerVS
+          platformStatus:
+            powervs:
+              resourceGroup: resource-group
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+        status:
+          platform: PowerVS
+          platformStatus:
+            powervs:
+              resourceGroup: resource-group-should-not-accept-the-string-that-exceeds-max-length-set
+      expectedStatusError: "status.platformStatus.powervs.resourceGroup: Too long: may not be longer than 40"
+    - name: PowerVS platform status's resourceGroup should match the regex configured
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+        status:
+          platform: PowerVS
+          platformStatus:
+            powervs:
+              resourceGroup: resource-group
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+        status:
+          platform: PowerVS
+          platformStatus:
+            powervs:
+              resourceGroup: re$ource-group
+      expectedStatusError: "status.platformStatus.powervs.resourceGroup in body should match '^[a-zA-Z0-9-_ ]+$'"
+    - name: Should not be able to change PowerVS platform status's resourceGroup once it was set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+        status:
+          platform: PowerVS
+          platformStatus:
+            powervs:
+              resourceGroup: resource-group
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+        status:
+          platform: PowerVS
+          platformStatus:
+            powervs:
+              resourceGroup: other-resource-group-name
+      expectedStatusError: "status.platformStatus.powervs.resourceGroup: Invalid value: \"string\": resourceGroup is immutable once set"
+    - name: Should not be able to unset PowerVS platform status's resourceGroup once it was set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+        status:
+          platform: PowerVS
+          platformStatus:
+            powervs:
+              region: some-region
+              resourceGroup: resource-group
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+        status:
+          platform: PowerVS
+          platformStatus:
+            powervs:
+              region: some-region
+      expectedStatusError: "status.platformStatus.powervs: Invalid value: \"object\": cannot unset resourceGroup once set"

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -1020,6 +1020,7 @@ type PowerVSPlatformSpec struct {
 }
 
 // PowerVSPlatformStatus holds the current status of the IBM Power Systems Virtual Servers infrastrucutre provider.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.resourceGroup) || has(self.resourceGroup)",message="cannot unset resourceGroup once set"
 type PowerVSPlatformStatus struct {
 	// region holds the default Power VS region for new Power VS resources created by the cluster.
 	Region string `json:"region"`
@@ -1027,6 +1028,18 @@ type PowerVSPlatformStatus struct {
 	// zone holds the default zone for the new Power VS resources created by the cluster.
 	// Note: Currently only single-zone OCP clusters are supported
 	Zone string `json:"zone"`
+
+	// resourceGroup is the resource group name for new IBMCloud resources created for a cluster.
+	// The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry.
+	// More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs.
+	// When omitted, the image registry operator won't be able to configure storage,
+	// which results in the image registry cluster operator not being in an available state.
+	//
+	// +kubebuilder:validation:Pattern=^[a-zA-Z0-9-_ ]+$
+	// +kubebuilder:validation:MaxLength=40
+	// +kubebuilder:validation:XValidation:rule="oldSelf == '' || self == oldSelf",message="resourceGroup is immutable once set"
+	// +optional
+	ResourceGroup string `json:"resourceGroup"`
 
 	// serviceEndpoints is a list of custom endpoints which will override the default
 	// service endpoints of a Power VS service.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1392,6 +1392,7 @@ var map_PowerVSPlatformStatus = map[string]string{
 	"":                 "PowerVSPlatformStatus holds the current status of the IBM Power Systems Virtual Servers infrastrucutre provider.",
 	"region":           "region holds the default Power VS region for new Power VS resources created by the cluster.",
 	"zone":             "zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported",
+	"resourceGroup":    "resourceGroup is the resource group name for new IBMCloud resources created for a cluster. The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry. More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs. When omitted, the image registry operator won't be able to configure storage, which results in the image registry cluster operator not being in an available state.",
 	"serviceEndpoints": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.",
 	"cisInstanceCRN":   "CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain",
 	"dnsInstanceCRN":   "DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain",

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -15562,6 +15562,14 @@ func schema_openshift_api_config_v1_PowerVSPlatformStatus(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"resourceGroup": {
+						SchemaProps: spec.SchemaProps{
+							Description: "resourceGroup is the resource group name for new IBMCloud resources created for a cluster. The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry. More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs. When omitted, the image registry operator won't be able to configure storage, which results in the image registry cluster operator not being in an available state.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"serviceEndpoints": {
 						SchemaProps: spec.SchemaProps{
 							Description: "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8441,6 +8441,11 @@
           "type": "string",
           "default": ""
         },
+        "resourceGroup": {
+          "description": "resourceGroup is the resource group name for new IBMCloud resources created for a cluster. The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry. More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs. When omitted, the image registry operator won't be able to configure storage, which results in the image registry cluster operator not being in an available state.",
+          "type": "string",
+          "default": ""
+        },
         "serviceEndpoints": {
           "description": "serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.",
           "type": "array",


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MULTIARCH-3212

These two fields are required to add the storage support for PowerVS cloud platform in https://github.com/openshift/cluster-image-registry-operator. 

With the recent [commit](https://github.com/openshift/cluster-image-registry-operator/pull/820/commits/eac9584446660721c5a31f54fd342f01415a8e92) in cluster-image-registry-operator, powervs platform blocked from using emptyDir as storage.
Trying to use IBMCOS as storage since its already supported as one of the storage option.
It reads location and resource group information from Infrastructure Status object.
So adding these two fields in PowerVSPlatformStatus.