### PR TITLE
STOR-1133: set RetroactiveDefaultStorageClass feature as TechPreview

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -119,6 +119,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("InsightsConfigAPI").                 // insights, tremes (#ccx), OCP specific
 		with("CSIInlineVolumeAdmission").          // sig-storage, jdobson, OCP specific
 		with("MatchLabelKeysInPodTopologySpread"). // sig-scheduling, ingvagabund (#forum-workloads), Kubernetes feature gate
+		with("RetroactiveDefaultStorageClass").    // sig-storage, RomanBednar, Kubernetes feature gate
 		toFeatures(),
 	LatencySensitive: newDefaultFeatures().
 		with(
@@ -134,7 +135,9 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		"DownwardAPIHugePages",           // sig-node, rphillips
 		"OpenShiftPodSecurityAdmission",     // bz-auth, stlaz, OCP specific
 	},
-	Disabled: []string{},
+	Disabled: []string{
+		"RetroactiveDefaultStorageClass", // sig-storage, RomanBednar, Kubernetes feature gate
+	},
 }
 
 type featureSetBuilder struct {

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -79,7 +79,7 @@ func TestFeatureBuilder(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if !reflect.DeepEqual(tc.expected, tc.actual) {
-				t.Error(tc.actual)
+				t.Errorf("\nExpected feature gates: \n Enabled: %s \n Disabled: %s \nBut got:\n Enabled: %v \n Disabled: %s\n", tc.expected.Enabled, tc.expected.Disabled, tc.actual.Enabled, tc.actual.Disabled)
 			}
 		})
 	}

--- a/config/v1/types_features_test.go
+++ b/config/v1/types_features_test.go
@@ -26,6 +26,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"OpenShiftPodSecurityAdmission",
 				},
 				Disabled: []string{
+					"RetroactiveDefaultStorageClass",
 					"APIPriorityAndFairness",
 				},
 			},
@@ -41,7 +42,9 @@ func TestFeatureBuilder(t *testing.T) {
 					"OpenShiftPodSecurityAdmission",
 					"CSIMigrationAzureFile",
 				},
-				Disabled: []string{},
+				Disabled: []string{
+					"RetroactiveDefaultStorageClass",
+				},
 			},
 		},
 		{
@@ -54,6 +57,7 @@ func TestFeatureBuilder(t *testing.T) {
 					"OpenShiftPodSecurityAdmission",
 				},
 				Disabled: []string{
+					"RetroactiveDefaultStorageClass",
 					"APIPriorityAndFairness",
 					"other",
 				},
@@ -71,7 +75,9 @@ func TestFeatureBuilder(t *testing.T) {
 					"CSIMigrationAzureFile",
 					"other",
 				},
-				Disabled: []string{},
+				Disabled: []string{
+					"RetroactiveDefaultStorageClass",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
We want to release RetroactiveDefaultStorageClass as TechPreview in 4.13: https://issues.redhat.com/browse/STOR-1133

KEP: https://github.com/kubernetes/enhancements/issues/3333

cc @openshift/storage