### PR TITLE
config/v1/types_cluster_version: Optional, omitempty availableUpdates

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -146,7 +146,6 @@ spec:
               description: status contains information about the available updates and any in-progress updates.
               type: object
               required:
-                - availableUpdates
                 - desired
                 - observedGeneration
                 - versionHash
@@ -172,7 +171,6 @@ spec:
                       version:
                         description: version is a semantic version identifying the update version. When this field is part of spec, version is optional if image is specified.
                         type: string
-                  nullable: true
                 capabilities:
                   description: capabilities describes the state of optional, core cluster components.
                   type: object

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -146,10 +146,8 @@ type ClusterVersionStatus struct {
 	// availableUpdates may expose this cluster to known issues. This list
 	// may be empty if no updates are recommended, if the update service
 	// is unavailable, or if an invalid channel has been specified.
-	// +nullable
-	// +kubebuilder:validation:Required
-	// +required
-	AvailableUpdates []Release `json:"availableUpdates"`
+	// +optional
+	AvailableUpdates []Release `json:"availableUpdates,omitempty"`
 
 	// conditionalUpdates contains the list of updates that may be
 	// recommended for this cluster if it meets specific required

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -10073,7 +10073,7 @@ func schema_openshift_api_config_v1_ClusterVersionStatus(ref common.ReferenceCal
 						},
 					},
 				},
-				Required: []string{"desired", "observedGeneration", "versionHash", "capabilities", "availableUpdates"},
+				Required: []string{"desired", "observedGeneration", "versionHash", "capabilities"},
 			},
 		},
 		Dependencies: []string{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -5144,8 +5144,7 @@
         "desired",
         "observedGeneration",
         "versionHash",
-        "capabilities",
-        "availableUpdates"
+        "capabilities"
       ],
       "properties": {
         "availableUpdates": {


### PR DESCRIPTION
Reverting the d01706c262 (#228) change for this property.  The motivation for making it `required` and `nullable` were unclear.  And making it `optional` allows us to include the new property in HyperShift's HostedCluster CustomResourceDefinition without breaking further object updates:

```console
$ oc patch hc 212871941d57bcfe390c-mgmt --type merge -p '{"metadata":{"finalizers": []}}'
The HostedCluster "212871941d57bcfe390c-mgmt" is invalid: status.version.availableUpdates: Required value
```

There's no obvious semantic difference between "`availableUpdates` unset" and "`availableUpdates` explicitly `null`", so consumers should not care about the increased value flexibility.