### PR TITLE
Remove crun and cgroup v2 from TechPreviewNoUpgrade

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -114,8 +114,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("BuildCSIVolumes").                   // sig-build, adkaplan, OCP specific
 		with("NodeSwap").                          // sig-node, ehashman, Kubernetes feature gate
 		with("MachineAPIProviderOpenStack").       // openstack, egarcia (#forum-openstack), OCP specific
-		with("CGroupsV2").                         // sig-node, harche, OCP specific
-		with("Crun").                              // sig-node, haircommander, OCP specific
 		with("InsightsConfigAPI").                 // insights, tremes (#ccx), OCP specific
 		with("CSIInlineVolumeAdmission").          // sig-storage, jdobson, OCP specific
 		with("MatchLabelKeysInPodTopologySpread"). // sig-scheduling, ingvagabund (#forum-workloads), Kubernetes feature gate
@@ -134,7 +132,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		"APIPriorityAndFairness",         // sig-apimachinery, deads2k
 		"RotateKubeletServerCertificate", // sig-pod, sjenning
 		"DownwardAPIHugePages",           // sig-node, rphillips
-		"OpenShiftPodSecurityAdmission",     // bz-auth, stlaz, OCP specific
+		"OpenShiftPodSecurityAdmission",  // bz-auth, stlaz, OCP specific
 	},
 	Disabled: []string{
 		"RetroactiveDefaultStorageClass", // sig-storage, RomanBednar, Kubernetes feature gate


### PR DESCRIPTION
Remove `crun` and `cgroup v2` from TechPreviewNoUpgrade as both of those features have been graduated to GA. 

Signed-off-by: Harshal Patil <harpatil@redhat.com>