### PR TITLE
STOR-1266: Add CSI migration option to Storage operator spec

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -46544,6 +46544,14 @@ func schema_openshift_api_operator_v1_StorageSpec(ref common.ReferenceCallback) 
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
+					"vsphereStorageDriver": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"managementState"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -27274,6 +27274,11 @@
           "description": "unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.",
           "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
+        },
+        "vsphereStorageDriver": {
+          "description": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
+          "type": "string",
+          "default": ""
         }
       }
     },

--- a/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
+++ b/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
@@ -69,6 +69,19 @@ spec:
                   type: object
                   nullable: true
                   x-kubernetes-preserve-unknown-fields: true
+                vsphereStorageDriver:
+                  description: 'VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.'
+                  type: string
+                  enum:
+                    - ""
+                    - LegacyDeprecatedInTreeDriver
+                    - CSIWithMigrationDriver
+                  x-kubernetes-validations:
+                    - rule: self == oldSelf || oldSelf == "" || self == "CSIWithMigrationDriver"
+                      message: VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver
+              x-kubernetes-validations:
+                - rule: '!has(oldSelf.vsphereStorageDriver) || has(self.vsphereStorageDriver)'
+                  message: VSphereStorageDriver is required once set
             status:
               description: status holds observed values from the cluster. They may not be overridden.
               type: object

--- a/operator/v1/stable.storage.testsuite.yaml
+++ b/operator/v1/stable.storage.testsuite.yaml
@@ -14,3 +14,91 @@ tests:
       spec:
         logLevel: Normal
         operatorLogLevel: Normal
+  onUpdate:
+  - name: Should allow enabling CSI migration for vSphere
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec: {} # No spec is required
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+        logLevel: Normal
+        operatorLogLevel: Normal
+  - name: Should allow disabling CSI migration for vSphere
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec: {} # No spec is required
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+        logLevel: Normal
+        operatorLogLevel: Normal
+  - name: Should allow changing LegacyDeprecatedInTreeDriver to CSIWithMigrationDriver
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+        logLevel: Normal
+        operatorLogLevel: Normal
+  - name: Should not allow changing CSIWithMigrationDriver to LegacyDeprecatedInTreeDriver
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+    expectedError: "VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
+  - name: Should not allow changing CSIWithMigrationDriver to empty string
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: ""
+    expectedError: "VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
+  - name: Should not allow unsetting VSphereStorageDriver once it is set
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec: {}
+    expectedError: "VSphereStorageDriver is required once set"

--- a/operator/v1/types_storage.go
+++ b/operator/v1/types_storage.go
@@ -26,9 +26,28 @@ type Storage struct {
 	Status StorageStatus `json:"status"`
 }
 
+// StorageDriverType indicates whether CSI migration should be enabled for drivers where it is optional.
+// +kubebuilder:validation:Enum="";LegacyDeprecatedInTreeDriver;CSIWithMigrationDriver
+type StorageDriverType string
+
+const (
+	LegacyDeprecatedInTreeDriver StorageDriverType = "LegacyDeprecatedInTreeDriver"
+	CSIWithMigrationDriver       StorageDriverType = "CSIWithMigrationDriver"
+)
+
 // StorageSpec is the specification of the desired behavior of the cluster storage operator.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.vsphereStorageDriver) || has(self.vsphereStorageDriver)", message="VSphereStorageDriver is required once set"
 type StorageSpec struct {
 	OperatorSpec `json:",inline"`
+
+	// VSphereStorageDriver indicates the storage driver to use on VSphere clusters.
+	// Once this field is set to CSIWithMigrationDriver, it can not be changed.
+	// If this is empty, the platform will choose a good default,
+	// which may change over time without notice.
+	// DEPRECATED: This field will be removed in a future release.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || oldSelf == \"\" || self == \"CSIWithMigrationDriver\"",message="VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
+	// +optional
+	VSphereStorageDriver StorageDriverType `json:"vsphereStorageDriver"`
 }
 
 // StorageStatus defines the observed status of the cluster storage operator.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1610,7 +1610,8 @@ func (StorageList) SwaggerDoc() map[string]string {
 }
 
 var map_StorageSpec = map[string]string{
-	"": "StorageSpec is the specification of the desired behavior of the cluster storage operator.",
+	"":                     "StorageSpec is the specification of the desired behavior of the cluster storage operator.",
+	"vsphereStorageDriver": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
 }
 
 func (StorageSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-1266
/cc @openshift/storage

Dependent PR's:
- https://github.com/openshift/kubernetes/pull/1514
- https://github.com/openshift/cluster-kube-apiserver-operator/pull/1466
- https://github.com/openshift/cluster-kube-controller-manager-operator/pull/710
- https://github.com/openshift/cluster-kube-scheduler-operator/pull/469
- https://github.com/openshift/machine-config-operator/pull/3614
- https://github.com/openshift/cluster-storage-operator/pull/351
- https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/145