### PR TITLE
OPNET-263: Enable CloudDualStackNodeIPs feature gate

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -242,4 +242,14 @@ var (
 		ResponsiblePerson:   "jspeed",
 		OwningProduct:       ocpSpecific,
 	}
+
+	FeatureGateCloudDualStackNodeIPs = FeatureGateName("CloudDualStackNodeIPs")
+	cloudDualStackNodeIPs            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateCloudDualStackNodeIPs,
+		},
+		OwningJiraComponent: "machine-config-operator/platform-baremetal",
+		ResponsiblePerson:   "mkowalsk",
+		OwningProduct:       kubernetes,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -192,6 +192,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 	Enabled: []FeatureGateDescription{
 		openShiftPodSecurityAdmission,
 		alibabaPlatform, // This is a bug, it should be TechPreviewNoUpgrade. This must be downgraded before 4.14 is shipped.
+		cloudDualStackNodeIPs,
 	},
 	Disabled: []FeatureGateDescription{
 		retroactiveDefaultStorageClass,


### PR DESCRIPTION
In order to allow passing dual-stack IPs to the `--node-ip` when using cloud provider, we are enabling the CloudDualStackNodeIPs feature gate.

This affects only behaviour of deployments that want to pass 2 IP addresses as `--node-ip` together with `--cloud-provider`. Before K8s 1.27 this was not possible (you can either have dual-stack Node IPs or use a cloud provider, but not both).

Upstream KEP https://github.com/kubernetes/enhancements/issues/3705 adds ability to pass exactly 2 IPs as `--node-ip` also when using cloud provider, but given its alpha stage, feature gate is required here.

Enablement of this feature gate is not affecting in any way single-stack deployments as well as dual-stack deployments with no cloud provider.

Enablement of this feature gate is not affecting in any way single-stack deployments that use cloud provider.

Enablement of this feature gate is not changing the behaviour of any configuration that is working today (i.e. before K8s 1.27).

Relates-to: [OPNET-13](https://issues.redhat.com//browse/OPNET-13)
Relates-to: [OPNET-230](https://issues.redhat.com//browse/OPNET-230)