### PR TITLE
OCPBUGS-11146: Add CSI migration option to Storage operator spec

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -46067,6 +46067,14 @@ func schema_openshift_api_operator_v1_StorageSpec(ref common.ReferenceCallback) 
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
+					"vsphereStorageDriver": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"managementState"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -26993,6 +26993,11 @@
           "description": "unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides",
           "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
+        },
+        "vsphereStorageDriver": {
+          "description": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
+          "type": "string",
+          "default": ""
         }
       }
     },

--- a/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
+++ b/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
@@ -69,6 +69,19 @@ spec:
                   type: object
                   nullable: true
                   x-kubernetes-preserve-unknown-fields: true
+                vsphereStorageDriver:
+                  description: 'VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.'
+                  type: string
+                  enum:
+                    - ""
+                    - LegacyDeprecatedInTreeDriver
+                    - CSIWithMigrationDriver
+                  x-kubernetes-validations:
+                    - rule: self == oldSelf || oldSelf == "" || self == "CSIWithMigrationDriver"
+                      message: VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver
+              x-kubernetes-validations:
+                - rule: '!has(oldSelf.vsphereStorageDriver) || has(self.vsphereStorageDriver)'
+                  message: VSphereStorageDriver is required once set
             status:
               description: status holds observed values from the cluster. They may not be overridden.
               type: object

--- a/operator/v1/stable.storage.testsuite.yaml
+++ b/operator/v1/stable.storage.testsuite.yaml
@@ -14,3 +14,91 @@ tests:
       spec:
         logLevel: Normal
         operatorLogLevel: Normal
+  onUpdate:
+  - name: Should allow enabling CSI migration for vSphere
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec: {} # No spec is required
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+        logLevel: Normal
+        operatorLogLevel: Normal
+  - name: Should allow disabling CSI migration for vSphere
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec: {} # No spec is required
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+        logLevel: Normal
+        operatorLogLevel: Normal
+  - name: Should allow changing LegacyDeprecatedInTreeDriver to CSIWithMigrationDriver
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+        logLevel: Normal
+        operatorLogLevel: Normal
+  - name: Should not allow changing CSIWithMigrationDriver to LegacyDeprecatedInTreeDriver
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+    expectedError: "VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
+  - name: Should not allow changing CSIWithMigrationDriver to empty string
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: ""
+    expectedError: "VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
+  - name: Should not allow unsetting VSphereStorageDriver once it is set
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec: {}
+    expectedError: "VSphereStorageDriver is required once set"

--- a/operator/v1/types_storage.go
+++ b/operator/v1/types_storage.go
@@ -26,9 +26,28 @@ type Storage struct {
 	Status StorageStatus `json:"status"`
 }
 
+// StorageDriverType indicates whether CSI migration should be enabled for drivers where it is optional.
+// +kubebuilder:validation:Enum="";LegacyDeprecatedInTreeDriver;CSIWithMigrationDriver
+type StorageDriverType string
+
+const (
+	LegacyDeprecatedInTreeDriver StorageDriverType = "LegacyDeprecatedInTreeDriver"
+	CSIWithMigrationDriver       StorageDriverType = "CSIWithMigrationDriver"
+)
+
 // StorageSpec is the specification of the desired behavior of the cluster storage operator.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.vsphereStorageDriver) || has(self.vsphereStorageDriver)", message="VSphereStorageDriver is required once set"
 type StorageSpec struct {
 	OperatorSpec `json:",inline"`
+
+	// VSphereStorageDriver indicates the storage driver to use on VSphere clusters.
+	// Once this field is set to CSIWithMigrationDriver, it can not be changed.
+	// If this is empty, the platform will choose a good default,
+	// which may change over time without notice.
+	// DEPRECATED: This field will be removed in a future release.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || oldSelf == \"\" || self == \"CSIWithMigrationDriver\"",message="VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
+	// +optional
+	VSphereStorageDriver StorageDriverType `json:"vsphereStorageDriver"`
 }
 
 // StorageStatus defines the observed status of the cluster storage operator.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1610,7 +1610,8 @@ func (StorageList) SwaggerDoc() map[string]string {
 }
 
 var map_StorageSpec = map[string]string{
-	"": "StorageSpec is the specification of the desired behavior of the cluster storage operator.",
+	"":                     "StorageSpec is the specification of the desired behavior of the cluster storage operator.",
+	"vsphereStorageDriver": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
 }
 
 func (StorageSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-1266
/cc @openshift/storage @JoelSpeed @deads2k @jsafrane

This is a simple backport of https://github.com/openshift/api/pull/1423
`git cherry-pick 426d59473937ba3aaec1e6ef768051090d1c78ac`
