### PR TITLE
Update storage vSphere driver validation

### DIFF
--- a/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
+++ b/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
@@ -77,7 +77,7 @@ spec:
                     - LegacyDeprecatedInTreeDriver
                     - CSIWithMigrationDriver
                   x-kubernetes-validations:
-                    - rule: self == oldSelf || oldSelf == "" || self == "CSIWithMigrationDriver"
+                    - rule: oldSelf != "CSIWithMigrationDriver" || self == "CSIWithMigrationDriver"
                       message: VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver
               x-kubernetes-validations:
                 - rule: '!has(oldSelf.vsphereStorageDriver) || has(self.vsphereStorageDriver)'

--- a/operator/v1/stable.storage.testsuite.yaml
+++ b/operator/v1/stable.storage.testsuite.yaml
@@ -102,3 +102,21 @@ tests:
       kind: Storage
       spec: {}
     expectedError: "VSphereStorageDriver is required once set"
+  - name: Should allow changing LegacyDeprecatedInTreeDriver to empty string
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: ""
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: ""
+        logLevel: Normal
+        operatorLogLevel: Normal

--- a/operator/v1/types_storage.go
+++ b/operator/v1/types_storage.go
@@ -48,7 +48,7 @@ type StorageSpec struct {
 	// If this is empty, the platform will choose a good default,
 	// which may change over time without notice.
 	// DEPRECATED: This field will be removed in a future release.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf || oldSelf == \"\" || self == \"CSIWithMigrationDriver\"",message="VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
+	// +kubebuilder:validation:XValidation:rule="oldSelf != \"CSIWithMigrationDriver\" || self == \"CSIWithMigrationDriver\"",message="VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
 	// +optional
 	VSphereStorageDriver StorageDriverType `json:"vsphereStorageDriver"`
 }


### PR DESCRIPTION
We need to be able to switch between `LegacyDeprecatedInTreeDriver` and `""` so this updates the validation to relax it so that we can do so.
I've simplified based on what I believe the intention is, allowing changing to CSIWithMigraitonDriver, but not allowing changing away from it, so once oldSelf is CSIMigration driver, self must be too