### PR TITLE
config/v1: Add AzureWorkloadIdentity to TechPreviewNoUpgrade

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -127,6 +127,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("DynamicResourceAllocation").         // sig-scheduling, jchaloup (#forum-workloads), Kubernetes feature gate
 		with("ValidatingAdmissionPolicy").         // sig-api-machinery, benluddy
 		with("AdmissionWebhookMatchConditions").   // sig-api-machinery, benluddy
+		with("AzureWorkloadIdentity").             // cco, abutcher (#forum-cloud-credential-operator), OCP specific
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		with(


### PR DESCRIPTION
This PR adds an `"AzureWorkloadIdentity"` feature to `TechPreviewNoUpgrade`.
Enhancement proposal: https://github.com/openshift/enhancements/pull/1301

[CCO-187](https://issues.redhat.com//browse/CCO-187)
