### PR TITLE
OCPBUGS-11393: Fix incorrect API usage documentation for insecureEdgeTerminationPolicy

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -50772,7 +50772,7 @@ func schema_openshift_api_route_v1_TLSConfig(ref common.ReferenceCallback) commo
 					},
 					"insecureEdgeTerminationPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80.\n\n* Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
+							Description: "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80.\n\n* Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default). * None - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -29874,7 +29874,7 @@
           "type": "string"
         },
         "insecureEdgeTerminationPolicy": {
-          "description": "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80.\n\n* Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
+          "description": "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80.\n\n* Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default). * None - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
           "type": "string"
         },
         "key": {

--- a/route/v1/generated.proto
+++ b/route/v1/generated.proto
@@ -238,6 +238,8 @@ message RouterShard {
 }
 
 // TLSConfig defines config used to secure a route and provide termination
+//
+// +kubebuilder:validation:XValidation:rule="has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination=='passthrough') && (self.insecureEdgeTerminationPolicy=='Allow')) : true", message="cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow"
 message TLSConfig {
   // termination indicates termination type.
   //
@@ -271,6 +273,8 @@ message TLSConfig {
   // * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default).
   // * None - no traffic is allowed on the insecure port.
   // * Redirect - clients are redirected to the secure port.
+  //
+  // +kubebuilder:validation:Enum=Allow;None;Redirect;""
   optional string insecureEdgeTerminationPolicy = 6;
 }
 

--- a/route/v1/generated.proto
+++ b/route/v1/generated.proto
@@ -268,8 +268,8 @@ message TLSConfig {
   // insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While
   // each router may make its own decisions on which ports to expose, this is normally port 80.
   //
-  // * Allow - traffic is sent to the server on the insecure port (default)
-  // * Disable - no traffic is allowed on the insecure port.
+  // * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default).
+  // * None - no traffic is allowed on the insecure port.
   // * Redirect - clients are redirected to the secure port.
   optional string insecureEdgeTerminationPolicy = 6;
 }

--- a/route/v1/route.crd.yaml
+++ b/route/v1/route.crd.yaml
@@ -151,32 +151,6 @@ spec:
                               termination:
                                 enum:
                                   - edge
-                    - anyOf:
-                        - properties:
-                            insecureEdgeTerminationPolicy:
-                              enum:
-                                - ""
-                                - None
-                                - Allow
-                                - Redirect
-                        - not:
-                            properties:
-                              termination:
-                                enum:
-                                  - edge
-                                  - reencrypt
-                    - anyOf:
-                        - properties:
-                            insecureEdgeTerminationPolicy:
-                              enum:
-                                - ""
-                                - None
-                                - Redirect
-                        - not:
-                            properties:
-                              termination:
-                                enum:
-                                  - passthrough
                   description: The tls field provides the ability to configure certificates and termination for the route.
                   properties:
                     caCertificate:
@@ -190,6 +164,11 @@ spec:
                       type: string
                     insecureEdgeTerminationPolicy:
                       description: "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. \n * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default). * None - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port."
+                      enum:
+                        - Allow
+                        - None
+                        - Redirect
+                        - ""
                       type: string
                     key:
                       description: key provides key file contents
@@ -204,6 +183,9 @@ spec:
                   required:
                     - termination
                   type: object
+                  x-kubernetes-validations:
+                    - message: 'cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow'
+                      rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow'')) : true'
                 to:
                   description: to is an object the route should use as the primary backend. Only the Service kind is allowed, and it will be defaulted to Service. If the weight field (0-256 default 100) is set to zero, no traffic will be sent to this backend.
                   properties:

--- a/route/v1/route.crd.yaml
+++ b/route/v1/route.crd.yaml
@@ -189,7 +189,7 @@ spec:
                       description: destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.
                       type: string
                     insecureEdgeTerminationPolicy:
-                      description: "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. \n * Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port."
+                      description: "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. \n * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default). * None - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port."
                       type: string
                     key:
                       description: key provides key file contents

--- a/route/v1/route.crd.yaml-patch
+++ b/route/v1/route.crd.yaml-patch
@@ -65,22 +65,3 @@
         properties:
           termination:
             enum: ["edge"]
-  # Any insecure edge-termination policy may be used if we terminate TLS.
-  - anyOf:
-    - properties:
-        insecureEdgeTerminationPolicy:
-          enum: ["", "None", "Allow", "Redirect"]
-    - not:
-        properties:
-          termination:
-            enum: ["edge","reencrypt"]
-  # Any insecure edge-termination policy *except* for "Allow" maybe used when
-  # using passthrough TLS.
-  - anyOf:
-    - properties:
-        insecureEdgeTerminationPolicy:
-          enum: ["", "None", "Redirect"]
-    - not:
-        properties:
-          termination:
-            enum: ["passthrough"]

--- a/route/v1/stable.route.testsuite.yaml
+++ b/route/v1/stable.route.testsuite.yaml
@@ -20,3 +20,65 @@ tests:
           name: foo
           weight: 100
         wildcardPolicy: None
+  - name: "cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow"
+    initial: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        to:
+          kind: Service
+          name: foo
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: Allow
+    expectedError: "cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow"
+  - name: "spec.tls.termination: passthrough is compatible with spec.tls.insecureEdgeTerminationPolicy: Redirect"
+    initial: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        host: test.foo
+        to:
+          kind: Service
+          name: foo
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: Redirect
+    expected: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        host: test.foo
+        to:
+          kind: Service
+          name: foo
+          weight: 100
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: Redirect
+        wildcardPolicy: None
+  - name: "spec.tls.termination: passthrough is compatible with spec.tls.insecureEdgeTerminationPolicy: None"
+    initial: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        host: test.foo
+        to:
+          kind: Service
+          name: foo
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: None
+    expected: |
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      spec:
+        host: test.foo
+        to:
+          kind: Service
+          name: foo
+          weight: 100
+        tls:
+          termination: passthrough
+          insecureEdgeTerminationPolicy: None
+        wildcardPolicy: None

--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -270,8 +270,8 @@ type TLSConfig struct {
 	// insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While
 	// each router may make its own decisions on which ports to expose, this is normally port 80.
 	//
-	// * Allow - traffic is sent to the server on the insecure port (default)
-	// * Disable - no traffic is allowed on the insecure port.
+	// * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default).
+	// * None - no traffic is allowed on the insecure port.
 	// * Redirect - clients are redirected to the secure port.
 	InsecureEdgeTerminationPolicy InsecureEdgeTerminationPolicyType `json:"insecureEdgeTerminationPolicy,omitempty" protobuf:"bytes,6,opt,name=insecureEdgeTerminationPolicy,casttype=InsecureEdgeTerminationPolicyType"`
 }

--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -240,6 +240,8 @@ type RouterShard struct {
 }
 
 // TLSConfig defines config used to secure a route and provide termination
+//
+// +kubebuilder:validation:XValidation:rule="has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination=='passthrough') && (self.insecureEdgeTerminationPolicy=='Allow')) : true", message="cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow"
 type TLSConfig struct {
 	// termination indicates termination type.
 	//
@@ -273,6 +275,8 @@ type TLSConfig struct {
 	// * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default).
 	// * None - no traffic is allowed on the insecure port.
 	// * Redirect - clients are redirected to the secure port.
+	//
+	// +kubebuilder:validation:Enum=Allow;None;Redirect;""
 	InsecureEdgeTerminationPolicy InsecureEdgeTerminationPolicyType `json:"insecureEdgeTerminationPolicy,omitempty" protobuf:"bytes,6,opt,name=insecureEdgeTerminationPolicy,casttype=InsecureEdgeTerminationPolicyType"`
 }
 

--- a/route/v1/zz_generated.swagger_doc_generated.go
+++ b/route/v1/zz_generated.swagger_doc_generated.go
@@ -118,7 +118,7 @@ var map_TLSConfig = map[string]string{
 	"key":                           "key provides key file contents",
 	"caCertificate":                 "caCertificate provides the cert authority certificate contents",
 	"destinationCACertificate":      "destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.",
-	"insecureEdgeTerminationPolicy": "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80.\n\n* Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
+	"insecureEdgeTerminationPolicy": "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80.\n\n* Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only) (default). * None - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
 }
 
 func (TLSConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
For insecureEdgeTerminationPolicy, "Disable" is not a valid option and "Allow" is only valid for edge/reencrypt termination types.

- `route/v1/types.go`: Update doc for `InsecureEdgeTerminationPolicy`
- `openapi/generated_openapi/zz_generated.openapi.go`:
- `openapi/openapi.json`:
- `route/v1/route.crd.yaml`:
- `route/v1/generated.proto`:
- `route/v1/zz_generated.swagger_doc_generated.go`:  Generated Updates