### PR TITLE
OCPBUGS-11729: VSphereStorageDriver does not document the platform default

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -46774,7 +46774,7 @@ func schema_openshift_api_operator_v1_StorageSpec(ref common.ReferenceCallback) 
 					},
 					"vsphereStorageDriver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
+							Description: "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. The current default is CSIWithMigrationDriver and may not be changed. DEPRECATED: This field will be removed in a future release.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -27487,7 +27487,7 @@
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
         },
         "vsphereStorageDriver": {
-          "description": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
+          "description": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. The current default is CSIWithMigrationDriver and may not be changed. DEPRECATED: This field will be removed in a future release.",
           "type": "string",
           "default": ""
         }

--- a/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
+++ b/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
@@ -70,7 +70,7 @@ spec:
                   nullable: true
                   x-kubernetes-preserve-unknown-fields: true
                 vsphereStorageDriver:
-                  description: 'VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.'
+                  description: 'VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. The current default is CSIWithMigrationDriver and may not be changed. DEPRECATED: This field will be removed in a future release.'
                   type: string
                   enum:
                     - ""
@@ -79,6 +79,8 @@ spec:
                   x-kubernetes-validations:
                     - rule: oldSelf != "CSIWithMigrationDriver" || self == "CSIWithMigrationDriver"
                       message: VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver
+                    - rule: self != "LegacyDeprecatedInTreeDriver"
+                      message: VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver
               x-kubernetes-validations:
                 - rule: '!has(oldSelf.vsphereStorageDriver) || has(self.vsphereStorageDriver)'
                   message: VSphereStorageDriver is required once set

--- a/operator/v1/stable.storage.testsuite.yaml
+++ b/operator/v1/stable.storage.testsuite.yaml
@@ -14,6 +14,28 @@ tests:
       spec:
         logLevel: Normal
         operatorLogLevel: Normal
+  onCreate:
+  - name: Should allow creating Storage with vsphere migration enabled
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: CSIWithMigrationDriver
+        logLevel: Normal
+        operatorLogLevel: Normal
+  onCreate:
+  - name: Should not allow creating Storage with vsphere migration disabled
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
+    expectedError: "VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver"
   onUpdate:
   - name: Should allow enabling CSI migration for vSphere
     initial: |
@@ -32,7 +54,7 @@ tests:
         vsphereStorageDriver: CSIWithMigrationDriver
         logLevel: Normal
         operatorLogLevel: Normal
-  - name: Should allow disabling CSI migration for vSphere
+  - name: Should not allow disabling CSI migration for vSphere
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Storage
@@ -42,31 +64,7 @@ tests:
       kind: Storage
       spec:
         vsphereStorageDriver: LegacyDeprecatedInTreeDriver
-    expected: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
-        logLevel: Normal
-        operatorLogLevel: Normal
-  - name: Should allow changing LegacyDeprecatedInTreeDriver to CSIWithMigrationDriver
-    initial: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
-    updated: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: CSIWithMigrationDriver
-    expected: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: CSIWithMigrationDriver
-        logLevel: Normal
-        operatorLogLevel: Normal
+    expectedError: "VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver"
   - name: Should not allow changing CSIWithMigrationDriver to LegacyDeprecatedInTreeDriver
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -102,21 +100,3 @@ tests:
       kind: Storage
       spec: {}
     expectedError: "VSphereStorageDriver is required once set"
-  - name: Should allow changing LegacyDeprecatedInTreeDriver to empty string
-    initial: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: LegacyDeprecatedInTreeDriver
-    updated: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: ""
-    expected: |
-      apiVersion: operator.openshift.io/v1
-      kind: Storage
-      spec:
-        vsphereStorageDriver: ""
-        logLevel: Normal
-        operatorLogLevel: Normal

--- a/operator/v1/types_storage.go
+++ b/operator/v1/types_storage.go
@@ -47,8 +47,10 @@ type StorageSpec struct {
 	// Once this field is set to CSIWithMigrationDriver, it can not be changed.
 	// If this is empty, the platform will choose a good default,
 	// which may change over time without notice.
+	// The current default is CSIWithMigrationDriver and may not be changed.
 	// DEPRECATED: This field will be removed in a future release.
 	// +kubebuilder:validation:XValidation:rule="oldSelf != \"CSIWithMigrationDriver\" || self == \"CSIWithMigrationDriver\"",message="VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
+	// +kubebuilder:validation:XValidation:rule="self != \"LegacyDeprecatedInTreeDriver\"",message="VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver"
 	// +optional
 	VSphereStorageDriver StorageDriverType `json:"vsphereStorageDriver"`
 }

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1654,7 +1654,7 @@ func (StorageList) SwaggerDoc() map[string]string {
 
 var map_StorageSpec = map[string]string{
 	"":                     "StorageSpec is the specification of the desired behavior of the cluster storage operator.",
-	"vsphereStorageDriver": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. DEPRECATED: This field will be removed in a future release.",
+	"vsphereStorageDriver": "VSphereStorageDriver indicates the storage driver to use on VSphere clusters. Once this field is set to CSIWithMigrationDriver, it can not be changed. If this is empty, the platform will choose a good default, which may change over time without notice. The current default is CSIWithMigrationDriver and may not be changed. DEPRECATED: This field will be removed in a future release.",
 }
 
 func (StorageSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-11729
This also disables setting LegacyDeprecatedInTreeDriver in 4.14. That setting is only valid in 4.13. Integration tests are updated accordingly, since this caused any test case using that setting to fail.
/cc @JoelSpeed
