### PR TITLE
OCPBUGS-12205: remove techpreview from cpu partitioning

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
@@ -381,6 +381,13 @@ spec:
                     - SingleReplica
                     - External
                   type: string
+                cpuPartitioning:
+                  default: None
+                  description: cpuPartitioning expresses if CPU partitioning is a currently enabled feature in the cluster. CPU Partitioning means that this cluster can support partitioning workloads to specific CPU Sets. Valid values are "None" and "AllNodes". When omitted, the default value is "None". The default value of "None" indicates that no nodes will be setup with CPU partitioning. The "AllNodes" value indicates that all nodes have been setup with CPU partitioning, and can then be further configured via the PerformanceProfile API.
+                  enum:
+                    - None
+                    - AllNodes
+                  type: string
                 etcdDiscoveryDomain:
                   description: 'etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery deprecated: as of 4.7, this field is no longer set or honored.  It will be removed in a future release.'
                   type: string

--- a/config/v1/stable.infrastructure.testsuite.yaml
+++ b/config/v1/stable.infrastructure.testsuite.yaml
@@ -208,6 +208,7 @@ tests:
         status:
           controlPlaneTopology: "HighlyAvailable"
           infrastructureTopology: "HighlyAvailable"
+          cpuPartitioning: None
           platform: Azure
           platformStatus:
             azure:
@@ -340,6 +341,7 @@ tests:
             type: OpenStack
         status:
           controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
           infrastructureTopology: HighlyAvailable
           platform: OpenStack
           platformStatus:
@@ -378,6 +380,7 @@ tests:
             type: OpenStack
         status:
           controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
           infrastructureTopology: HighlyAvailable
           platform: OpenStack
           platformStatus:
@@ -550,6 +553,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -657,6 +661,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -764,6 +769,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -822,6 +828,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -857,6 +864,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External
@@ -914,6 +922,7 @@ tests:
         status:
           controlPlaneTopology: HighlyAvailable
           infrastructureTopology: HighlyAvailable
+          cpuPartitioning: None
           platform: External
           platformStatus:
             type: External

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -114,7 +114,6 @@ type InfrastructureStatus struct {
 	// +kubebuilder:default=None
 	// +default="None"
 	// +kubebuilder:validation:Enum=None;AllNodes
-	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	// +optional
 	CPUPartitioning CPUPartitioningMode `json:"cpuPartitioning,omitempty"`
 }


### PR DESCRIPTION
Workload Partitioning was in techpreview to run some tests before the 4.13 GA. The created unit tests and runs have indicated no change in operation to the cluster. The errors we ran into during testing was related to components not having the correct annotation or odd behavior in the CI that was not related to this change. Those have been resolved and now the pipelines and tests are succeeding. 

After the annotations errors were resolved, we had a long history of 4.13 runs succeeding, the 4.14 runs were failing but that seems to have been related to errors in stability in 4.14 nightlies and not this change.

Links:
[Enhancement](https://github.com/openshift/enhancements/pull/1213)

[E2E Tests 4.13 - Sippy](https://sippy.dptools.openshift.org/sippy-ng/tests/4.13?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522current_runs%2522%252C%2522operatorValue%2522%253A%2522%253E%253D%2522%252C%2522value%2522%253A%25227%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522never-stable%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522aggregated%2522%257D%252C%257B%2522id%2522%253A99%252C%2522columnField%2522%253A%2522name%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522CPU%2520Partitioning%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sort=asc&sortField=current_working_percentage)
[E2E Tests 4.14 - Sippy](https://sippy.dptools.openshift.org/sippy-ng/tests/4.14?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522current_runs%2522%252C%2522operatorValue%2522%253A%2522%253E%253D%2522%252C%2522value%2522%253A%25227%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522never-stable%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522aggregated%2522%257D%252C%257B%2522id%2522%253A99%252C%2522columnField%2522%253A%2522name%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522CPU%2520Partitioning%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sort=asc&sortField=current_working_percentage)
[4.13 Periodic Runs](https://prow.ci.openshift.org/?job=periodic-ci-openshift-release-master-nightly-4.13-e2e-aws-ovn-cpu-partitioning)
[4.14 Periodic Runs](https://prow.ci.openshift.org/?job=periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-ovn-cpu-partitioning)

/assign @deads2k 
/cc @MarSik 