### PR TITLE
[OCPCLOUD-2034] Add Azure/GCP specific external cloud provider feature gates

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -160,6 +160,8 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
 		with("ExternalCloudProvider").             // sig-cloud-provider, jspeed, OCP specific
+		with("ExternalCloudProviderAzure").        // sig-cloud-provider, jspeed, OCP specific
+		with("ExternalCloudProviderGCP").          // sig-cloud-provider, jspeed, OCP specific
 		with("CSIDriverSharedResource").           // sig-build, adkaplan, OCP specific
 		with("BuildCSIVolumes").                   // sig-build, adkaplan, OCP specific
 		with("NodeSwap").                          // sig-node, ehashman, Kubernetes feature gate


### PR DESCRIPTION
We need to have the ability to promote these two providers individually. I will teach the library-go code to observer both feature gates for these platforms and then, once we have the new feature gate, status based decisions in place, will be able to promote each of these individually in a single PR.

CC @deads2k have I missed anything for adding a new feature gate? 