### PR TITLE
OSASINFRA-3152: move `loadBalancer` API to GA for OpenStack

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
@@ -682,6 +682,22 @@ spec:
                             type: string
                           maxItems: 2
                           type: array
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on OpenStack platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
                         nodeDNSIP:
                           description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for OpenStack deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
                           type: string

--- a/config/v1/stable.infrastructure.testsuite.yaml
+++ b/config/v1/stable.infrastructure.testsuite.yaml
@@ -311,3 +311,166 @@ tests:
             powervs:
               region: some-region
       expectedStatusError: "status.platformStatus.powervs: Invalid value: \"object\": cannot unset resourceGroup once set"
+    - name: Should set load balancer type to OpenShiftManagedDefault if not specified
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+        status:
+          platform: OpenStack
+          platformStatus:
+            openstack: {}
+            type: OpenStack
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: OpenStack
+          platformStatus:
+            openstack:
+              loadBalancer:
+                type: OpenShiftManagedDefault
+            type: OpenStack
+    - name: Should be able to override the default load balancer with a valid value
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+        status:
+          platform: OpenStack
+          platformStatus:
+            openstack:
+              loadBalancer:
+                type: UserManaged
+            type: OpenStack
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: OpenStack
+          platformStatus:
+            openstack:
+              loadBalancer:
+                type: UserManaged
+            type: OpenStack
+    - name: Should not allow changing the immutable load balancer type field
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: OpenStack
+          platformStatus:
+            openstack:
+              loadBalancer:
+                type: OpenShiftManagedDefault
+            type: OpenStack
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: OpenStack
+            openstack: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: OpenStack
+          platformStatus:
+            openstack:
+              loadBalancer:
+                type: UserManaged
+            type: OpenStack
+      expectedStatusError: "status.platformStatus.openstack.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
+    - name: Should not allow removing the immutable load balancer type field that was initially set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: OpenStack
+          platformStatus:
+            openstack:
+              loadBalancer:
+                type: UserManaged
+            type: OpenStack
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: OpenStack
+            openstack: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: OpenStack
+          platformStatus:
+            openstack: {}
+            type: OpenStack
+      expectedStatusError: "status.platformStatus.openstack.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
+    - name: Should not allow setting the load balancer type to a wrong value
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            openstack: {}
+            type: OpenStack
+        status:
+          platform: OpenStack
+          platformStatus:
+            openstack:
+              loadBalancer:
+                type: FooBar
+            type: OpenStack
+      expectedStatusError: "status.platformStatus.openstack.loadBalancer.type: Unsupported value: \"FooBar\": supported values: \"OpenShiftManagedDefault\", \"UserManaged\""

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -701,7 +701,6 @@ type OpenStackPlatformStatus struct {
 	// loadBalancer defines how the load balancer used by the cluster is configured.
 	// +default={"type": "OpenShiftManagedDefault"}
 	// +kubebuilder:default={"type": "OpenShiftManagedDefault"}
-	// +openshift:enable:FeatureSets=TechPreviewNoUpgrade
 	// +optional
 	LoadBalancer *OpenStackPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 }


### PR DESCRIPTION
This API has not moved and there is no plan to make any change that
would be backward incompatible in the future.

The feature was well tested (and automated) by our QE on this platform,
as well documented on OCP 4.13.

We think this API is ready to be GA'ed.
