### PR TITLE
Remove ValidatingAdmissionPolicy from tech preview.

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -169,7 +169,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with("RetroactiveDefaultStorageClass").    // sig-storage, RomanBednar, Kubernetes feature gate
 		with("PDBUnhealthyPodEvictionPolicy").     // sig-apps, atiratree (#forum-workloads), Kubernetes feature gate
 		with("DynamicResourceAllocation").         // sig-scheduling, jchaloup (#forum-workloads), Kubernetes feature gate
-		with("ValidatingAdmissionPolicy").         // sig-api-machinery, benluddy
 		with("AdmissionWebhookMatchConditions").   // sig-api-machinery, benluddy
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().


### PR DESCRIPTION
This requires additional work in cluster-kube-apiserver-operator to recognize the gate and enable related APIs accordingly.