### PR TITLE
[CNF-5643] add machine-api capability

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -71,6 +71,7 @@ spec:
                           - Storage
                           - CSISnapshot
                           - NodeTuning
+                          - MachineAPI
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -80,6 +81,7 @@ spec:
                         - v4.11
                         - v4.12
                         - v4.13
+                        - v4.14
                         - vCurrent
                 channel:
                   description: channel is an identifier for explicitly requesting that a non-default set of updates be applied to this cluster. The default channel will be contain stable updates that are appropriate for production clusters.
@@ -192,6 +194,7 @@ spec:
                           - Storage
                           - CSISnapshot
                           - NodeTuning
+                          - MachineAPI
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -208,6 +211,7 @@ spec:
                           - Storage
                           - CSISnapshot
                           - NodeTuning
+                          - MachineAPI
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -247,7 +247,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI
 type ClusterVersionCapability string
 
 const (
@@ -296,6 +296,23 @@ const (
 	// objects and manages the containerized TuneD daemon which controls
 	// system level tuning of Nodes
 	ClusterVersionCapabilityNodeTuning ClusterVersionCapability = "NodeTuning"
+
+	// ClusterVersionCapabilityMachineAPI manages
+	// machine-api-operator
+	// cluster-autoscaler-operator
+	// cluster-control-plane-machine-set-operator
+	// which is responsible for machines configuration and heavily
+	// targeted for SNO clusters.
+	//
+	// The following CRDs are disabled as well
+	// machines
+	// machineset
+	// controlplanemachineset
+	//
+	// WARNING: Do not disable that capability without reading
+	// documentation. This is important part of openshift system
+	// and may cause cluster damage
+	ClusterVersionCapabilityMachineAPI ClusterVersionCapability = "MachineAPI"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -308,10 +325,11 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityOpenShiftSamples,
 	ClusterVersionCapabilityCSISnapshot,
 	ClusterVersionCapabilityNodeTuning,
+	ClusterVersionCapabilityMachineAPI,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
-// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;vCurrent
+// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;v4.14;vCurrent
 type ClusterVersionCapabilitySet string
 
 const (
@@ -336,6 +354,12 @@ const (
 	// OpenShift.  This list will remain the same no matter which
 	// version of OpenShift is installed.
 	ClusterVersionCapabilitySet4_13 ClusterVersionCapabilitySet = "v4.13"
+
+	// ClusterVersionCapabilitySet4_14 is the recommended set of
+	// optional capabilities to enable for the 4.14 version of
+	// OpenShift.  This list will remain the same no matter which
+	// version of OpenShift is installed.
+	ClusterVersionCapabilitySet4_14 ClusterVersionCapabilitySet = "v4.14"
 
 	// ClusterVersionCapabilitySetCurrent is the recommended set
 	// of optional capabilities to enable for the cluster's
@@ -370,6 +394,17 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityCSISnapshot,
 		ClusterVersionCapabilityNodeTuning,
 	},
+	ClusterVersionCapabilitySet4_14: {
+		ClusterVersionCapabilityBaremetal,
+		ClusterVersionCapabilityConsole,
+		ClusterVersionCapabilityInsights,
+		ClusterVersionCapabilityMarketplace,
+		ClusterVersionCapabilityStorage,
+		ClusterVersionCapabilityOpenShiftSamples,
+		ClusterVersionCapabilityCSISnapshot,
+		ClusterVersionCapabilityNodeTuning,
+		ClusterVersionCapabilityMachineAPI,
+	},
 	ClusterVersionCapabilitySetCurrent: {
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityConsole,
@@ -379,6 +414,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityOpenShiftSamples,
 		ClusterVersionCapabilityCSISnapshot,
 		ClusterVersionCapabilityNodeTuning,
+		ClusterVersionCapabilityMachineAPI,
 	},
 }
 


### PR DESCRIPTION
This PR add machine-api capability which
disables the following operators
- machine-api-operator
- cluster-autoscaler-operator
- cluster-control-plane-machine-set-operator
This capability is responsible for machines configuration
and heavily targeted for SNO clusters.