### PR TITLE
OCPBUGS-8356: config/v1/types_cluster_version: Make update architecture omitempty

### DIFF
--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -466,7 +466,7 @@ type Update struct {
 	// Valid values are 'Multi' and empty.
 	//
 	// +optional
-	Architecture ClusterVersionArchitecture `json:"architecture"`
+	Architecture ClusterVersionArchitecture `json:"architecture,omitempty"`
 
 	// version is a semantic version identifying the update version.
 	// version is ignored if image is specified and required if

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -17342,7 +17342,6 @@ func schema_openshift_api_config_v1_Update(ref common.ReferenceCallback) common.
 					"architecture": {
 						SchemaProps: spec.SchemaProps{
 							Description: "architecture is an optional field that indicates the desired value of the cluster architecture. In this context cluster architecture means either a single architecture or a multi architecture. architecture can only be set to Multi thereby only allowing updates from single to multi architecture. If architecture is set, image cannot be set and version must be set. Valid values are 'Multi' and empty.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -9507,8 +9507,7 @@
       "properties": {
         "architecture": {
           "description": "architecture is an optional field that indicates the desired value of the cluster architecture. In this context cluster architecture means either a single architecture or a multi architecture. architecture can only be set to Multi thereby only allowing updates from single to multi architecture. If architecture is set, image cannot be set and version must be set. Valid values are 'Multi' and empty.",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "force": {
           "description": "force allows an administrator to update to an image that has failed verification or upgradeable checks. This option should only be used when the authenticity of the provided image has been verified out of band because the provided image will run with full administrative access to the cluster. Do not use this flag with images that comes from unknown or potentially malicious sources.",


### PR DESCRIPTION
Avoid a cosmetic:

    Warning: unknown field "spec.desiredUpdate.architecture"

when a 4.13 or later `oc adm upgrade --to ...` or similar talks to a 4.12 or earlier ClusterVersion.  Before this commit, `oc` would format a patch body that included an explicit `"architecture": ""`, which the 4.12 ClusterVersion didn't understand.  With this change, `oc` will leave the `architecture` field unset unless it actually has architecture opinions.