### PR TITLE
OCPNODE-1515 : Support Evented PLEG feature in Openshift

### DIFF
--- a/config/v1/0000_10_config-operator_01_node-Default.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_node-Default.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
   name: nodes.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/0000_10_config-operator_01_node-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_node-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1107
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: nodes.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Node
+    listKind: NodeList
+    plural: nodes
+    singular: node
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Node holds cluster-wide information about node specific features. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                cgroupMode:
+                  description: CgroupMode determines the cgroups version on the node
+                  type: string
+                  enum:
+                    - v1
+                    - v2
+                    - ""
+                eventedPleg:
+                  description: 'eventedPleg enables the event based PLEG between the kubelet and CRI-O Reference: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3386-kubelet-evented-pleg/README.md Valid values are `Enabled`, `Disabled` and "" By default, the evented pleg feature is not enabled in the cluster'
+                  type: string
+                  enum:
+                    - Enabled
+                    - Disabled
+                    - ""
+                workerLatencyProfile:
+                  description: WorkerLatencyProfile determins the how fast the kubelet is updating the status and corresponding reaction of the cluster
+                  type: string
+                  enum:
+                    - Default
+                    - MediumUpdateAverageReaction
+                    - LowUpdateSlowReaction
+            status:
+              description: status holds observed values.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/v1/techpreview.node.testsuite.yaml
+++ b/config/v1/techpreview.node.testsuite.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
-name: "[Stable] Node"
-crd: 0000_10_config-operator_01_node-Default.crd.yaml
+name: "[TechPreviewNoUpgrade] Node"
+crd: 0000_10_config-operator_01_node-TechPreviewNoUpgrade.crd.yaml
 tests:
   onCreate:
   - name: Should be able to create a minimal Node

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -173,7 +173,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(dynamicResourceAllocation).
 		with(gateGatewayAPI).
 		with(maxUnavailableStatefulSet).
-		without(eventedPleg).
+		with(eventedPleg).
 		with(sigstoreImageVerification).
 		with(gcpLabelsTags).
 		with(gcpClusterHostedDNS).
@@ -215,6 +215,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		privateHostedZoneAWS,
 		buildCSIVolumes,
 		kmsv1,
+		eventedPleg,
 	},
 	Disabled: []FeatureGateDescription{
 		disableKubeletCloudCredentialProviders, // We do not currently ship the correct config to use the external credentials provider.

--- a/config/v1/types_node.go
+++ b/config/v1/types_node.go
@@ -42,6 +42,14 @@ type NodeSpec struct {
 	// the status and corresponding reaction of the cluster
 	// +optional
 	WorkerLatencyProfile WorkerLatencyProfileType `json:"workerLatencyProfile,omitempty"`
+
+	// eventedPleg enables the event based PLEG between the kubelet and CRI-O
+	// Reference: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3386-kubelet-evented-pleg/README.md
+	// Valid values are `Enabled`, `Disabled` and ""
+	// By default, the evented pleg feature is not enabled in the cluster
+	// +openshift:enable:FeatureSets=TechPreviewNoUpgrade
+	// +optional
+	EventedPleg EventedPLEG `json:"eventedPleg"`
 }
 
 type NodeStatus struct{}
@@ -68,6 +76,17 @@ const (
 
 	// Default values of relavent Kubelet, Kube Controller Manager and Kube API Server
 	DefaultUpdateDefaultReaction WorkerLatencyProfileType = "Default"
+)
+
+// +kubebuilder:validation:Enum=Enabled;Disabled;""
+type EventedPLEG string
+
+const (
+	// Enabled enables the event based pleg between the kubelet and the cri-o
+	Enabled EventedPLEG = "Enabled"
+
+	// Disabled disables the event based pleg between the kubelet and the cri-o
+	Disabled EventedPLEG = "Disabled"
 )
 
 const (

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -2056,6 +2056,7 @@ func (NodeList) SwaggerDoc() map[string]string {
 var map_NodeSpec = map[string]string{
 	"cgroupMode":           "CgroupMode determines the cgroups version on the node",
 	"workerLatencyProfile": "WorkerLatencyProfile determins the how fast the kubelet is updating the status and corresponding reaction of the cluster",
+	"eventedPleg":          "eventedPleg enables the event based PLEG between the kubelet and CRI-O Reference: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3386-kubelet-evented-pleg/README.md Valid values are `Enabled`, `Disabled` and \"\" By default, the evented pleg feature is not enabled in the cluster",
 }
 
 func (NodeSpec) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -15304,6 +15304,14 @@ func schema_openshift_api_config_v1_NodeSpec(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"eventedPleg": {
+						SchemaProps: spec.SchemaProps{
+							Description: "eventedPleg enables the event based PLEG between the kubelet and CRI-O Reference: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3386-kubelet-evented-pleg/README.md Valid values are `Enabled`, `Disabled` and \"\" By default, the evented pleg feature is not enabled in the cluster",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8186,6 +8186,11 @@
           "description": "CgroupMode determines the cgroups version on the node",
           "type": "string"
         },
+        "eventedPleg": {
+          "description": "eventedPleg enables the event based PLEG between the kubelet and CRI-O Reference: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3386-kubelet-evented-pleg/README.md Valid values are `Enabled`, `Disabled` and \"\" By default, the evented pleg feature is not enabled in the cluster",
+          "type": "string",
+          "default": ""
+        },
         "workerLatencyProfile": {
           "description": "WorkerLatencyProfile determins the how fast the kubelet is updating the status and corresponding reaction of the cluster",
           "type": "string"

--- a/payload-manifests/crds/0000_10_config-operator_01_node-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_node-Default.crd.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1107
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
+  name: nodes.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Node
+    listKind: NodeList
+    plural: nodes
+    singular: node
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Node holds cluster-wide information about node specific features. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                cgroupMode:
+                  description: CgroupMode determines the cgroups version on the node
+                  type: string
+                  enum:
+                    - v1
+                    - v2
+                    - ""
+                workerLatencyProfile:
+                  description: WorkerLatencyProfile determins the how fast the kubelet is updating the status and corresponding reaction of the cluster
+                  type: string
+                  enum:
+                    - Default
+                    - MediumUpdateAverageReaction
+                    - LowUpdateSlowReaction
+            status:
+              description: status holds observed values.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_node-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_node-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,67 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1107
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: nodes.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Node
+    listKind: NodeList
+    plural: nodes
+    singular: node
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Node holds cluster-wide information about node specific features. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                cgroupMode:
+                  description: CgroupMode determines the cgroups version on the node
+                  type: string
+                  enum:
+                    - v1
+                    - v2
+                    - ""
+                eventedPleg:
+                  description: 'eventedPleg enables the event based PLEG between the kubelet and CRI-O Reference: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3386-kubelet-evented-pleg/README.md Valid values are `Enabled`, `Disabled` and "" By default, the evented pleg feature is not enabled in the cluster'
+                  type: string
+                  enum:
+                    - Enabled
+                    - Disabled
+                    - ""
+                workerLatencyProfile:
+                  description: WorkerLatencyProfile determins the how fast the kubelet is updating the status and corresponding reaction of the cluster
+                  type: string
+                  enum:
+                    - Default
+                    - MediumUpdateAverageReaction
+                    - LowUpdateSlowReaction
+            status:
+              description: status holds observed values.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/featuregates/featureGate-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Default.yaml
@@ -32,9 +32,6 @@
                         "name": "DynamicResourceAllocation"
                     },
                     {
-                        "name": "EventedPLEG"
-                    },
-                    {
                         "name": "GCPClusterHostedDNS"
                     },
                     {
@@ -119,6 +116,9 @@
                     },
                     {
                         "name": "CloudDualStackNodeIPs"
+                    },
+                    {
+                        "name": "EventedPLEG"
                     },
                     {
                         "name": "ExternalCloudProvider"

--- a/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
+++ b/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
@@ -34,9 +34,6 @@
                         "name": "DynamicResourceAllocation"
                     },
                     {
-                        "name": "EventedPLEG"
-                    },
-                    {
                         "name": "GCPClusterHostedDNS"
                     },
                     {
@@ -121,6 +118,9 @@
                     },
                     {
                         "name": "CloudDualStackNodeIPs"
+                    },
+                    {
+                        "name": "EventedPLEG"
                     },
                     {
                         "name": "ExternalCloudProvider"

--- a/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
@@ -19,9 +19,6 @@
                         "name": "DisableKubeletCloudCredentialProviders"
                     },
                     {
-                        "name": "EventedPLEG"
-                    },
-                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     }
                 ],
@@ -52,6 +49,9 @@
                     },
                     {
                         "name": "DynamicResourceAllocation"
+                    },
+                    {
+                        "name": "EventedPLEG"
                     },
                     {
                         "name": "ExternalCloudProvider"


### PR DESCRIPTION
1. CRI-O sends the container events to the Kubelet so that the pod cache can be updated based on the received events.
More about the Evented PLEG is here - [KEP Reference](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3386-kubelet-evented-pleg/README.md)
2. This feature can be enabled in OCP by adding a new field in the node config custom resource
that can be monitored by the MCO and update both the Kubelet and CRI-O configurations
Enhancement PR: https://github.com/openshift/enhancements/pull/1368