### PR TITLE
OCPBUGS-13547: Promote Azure CCM from TPNU to default

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -164,7 +164,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
 		with(externalCloudProvider).
-		with(externalCloudProviderAzure).
 		with(externalCloudProviderGCP).
 		with(externalCloudProviderExternal).
 		with(csiDriverSharedResource).
@@ -197,6 +196,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		openShiftPodSecurityAdmission,
 		alibabaPlatform, // This is a bug, it should be TechPreviewNoUpgrade. This must be downgraded before 4.14 is shipped.
 		cloudDualStackNodeIPs,
+		externalCloudProviderAzure,
 	},
 	Disabled: []FeatureGateDescription{
 		retroactiveDefaultStorageClass,


### PR DESCRIPTION
This PR promotes the Azure CCM feature gate from TechPreviewNoUpgrade to default.

Will need to be proven with payload tests against config-operator before we merge