### PR TITLE
WRKLDS-728: Make Build and DeploymentConfig API optional through capabilities

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -72,6 +72,8 @@ spec:
                           - CSISnapshot
                           - NodeTuning
                           - MachineAPI
+                          - Build
+                          - DeploymentConfig
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -195,6 +197,8 @@ spec:
                           - CSISnapshot
                           - NodeTuning
                           - MachineAPI
+                          - Build
+                          - DeploymentConfig
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -212,6 +216,8 @@ spec:
                           - CSISnapshot
                           - NodeTuning
                           - MachineAPI
+                          - Build
+                          - DeploymentConfig
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -247,7 +247,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig
 type ClusterVersionCapability string
 
 const (
@@ -313,6 +313,23 @@ const (
 	// documentation. This is important part of openshift system
 	// and may cause cluster damage
 	ClusterVersionCapabilityMachineAPI ClusterVersionCapability = "MachineAPI"
+
+	// ClusterVersionCapabilityBuild manages the Build API which is responsible
+	// for watching the Build API objects and managing their lifecycle.
+	// The functionality is located under openshift-apiserver and openshift-controller-manager.
+	//
+	// The following resources are taken into account:
+	// - builds
+	// - buildconfigs
+	ClusterVersionCapabilityBuild ClusterVersionCapability = "Build"
+
+	// ClusterVersionCapabilityDeploymentConfig manages the DeploymentConfig API
+	// which is responsible for watching the DeploymentConfig API and managing their lifecycle.
+	// The functionality is located under openshift-apiserver and openshift-controller-manager.
+	//
+	// The following resources are taken into account:
+	// - deploymentconfigs
+	ClusterVersionCapabilityDeploymentConfig ClusterVersionCapability = "DeploymentConfig"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -326,6 +343,8 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityCSISnapshot,
 	ClusterVersionCapabilityNodeTuning,
 	ClusterVersionCapabilityMachineAPI,
+	ClusterVersionCapabilityBuild,
+	ClusterVersionCapabilityDeploymentConfig,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
@@ -404,6 +423,8 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityCSISnapshot,
 		ClusterVersionCapabilityNodeTuning,
 		ClusterVersionCapabilityMachineAPI,
+		ClusterVersionCapabilityBuild,
+		ClusterVersionCapabilityDeploymentConfig,
 	},
 	ClusterVersionCapabilitySetCurrent: {
 		ClusterVersionCapabilityBaremetal,
@@ -415,6 +436,8 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityCSISnapshot,
 		ClusterVersionCapabilityNodeTuning,
 		ClusterVersionCapabilityMachineAPI,
+		ClusterVersionCapabilityBuild,
+		ClusterVersionCapabilityDeploymentConfig,
 	},
 }
 


### PR DESCRIPTION
Both Build and DeploymentConfig APIs have been selected as optional APIs to reduce the resource footprint and bug surface area for clusters that do not need to utilize the deploymentconfig functionality, such as SNO and OKE. OCP 4.14 will be the first release where both APIs are optional, yet still enabled. Corresponding epics:
- Build: https://issues.redhat.com/browse/BUILD-565
- DC: https://issues.redhat.com/browse/WRKLDS-695

This PR is a prerequisite for merging any work over OAM and OCM. E.g.:
- https://github.com/openshift/cluster-openshift-apiserver-operator/pull/532
- https://github.com/openshift/openshift-apiserver/pull/366
- https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/291 