### PR TITLE
WRKLDS-746: TechPreviewNoUpgrade: enable MaxUnavailableStatefulSet

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -182,4 +182,14 @@ var (
 		ResponsiblePerson:   "abutcher",
 		OwningProduct:       ocpSpecific,
 	}
+
+	FeatureGateMaxUnavailableStatefulSet = FeatureGateName("MaxUnavailableStatefulSet")
+	maxUnavailableStatefulSet            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateMaxUnavailableStatefulSet,
+		},
+		OwningJiraComponent: "apps",
+		ResponsiblePerson:   "atiratree",
+		OwningProduct:       kubernetes,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -178,6 +178,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(admissionWebhookMatchConditions).
 		with(azureWorkloadIdentity).
 		with(gateGatewayAPI).
+		with(maxUnavailableStatefulSet).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),


### PR DESCRIPTION
To enable https://kubernetes.io/blog/2022/05/27/maxunavailable-for-statefulset/ for TP testing.