### PR TITLE
OCPBUGS-13914: allow removal of vsphereStorageDriver field in 4.14

### DIFF
--- a/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
+++ b/operator/v1/0000_50_cluster_storage_operator_01_crd.yaml
@@ -77,13 +77,8 @@ spec:
                     - LegacyDeprecatedInTreeDriver
                     - CSIWithMigrationDriver
                   x-kubernetes-validations:
-                    - rule: oldSelf != "CSIWithMigrationDriver" || self == "CSIWithMigrationDriver"
-                      message: VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver
                     - rule: self != "LegacyDeprecatedInTreeDriver"
                       message: VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver
-              x-kubernetes-validations:
-                - rule: '!has(oldSelf.vsphereStorageDriver) || has(self.vsphereStorageDriver)'
-                  message: VSphereStorageDriver is required once set
             status:
               description: status holds observed values from the cluster. They may not be overridden.
               type: object

--- a/operator/v1/stable.storage.testsuite.yaml
+++ b/operator/v1/stable.storage.testsuite.yaml
@@ -76,8 +76,8 @@ tests:
       kind: Storage
       spec:
         vsphereStorageDriver: LegacyDeprecatedInTreeDriver
-    expectedError: "VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
-  - name: Should not allow changing CSIWithMigrationDriver to empty string
+    expectedError: "VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver"
+  - name: Should allow changing CSIWithMigrationDriver to empty string
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Storage
@@ -88,8 +88,14 @@ tests:
       kind: Storage
       spec:
         vsphereStorageDriver: ""
-    expectedError: "VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
-  - name: Should not allow unsetting VSphereStorageDriver once it is set
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        vsphereStorageDriver: ""
+        logLevel: Normal
+        operatorLogLevel: Normal
+  - name: Should allow unsetting VSphereStorageDriver once it is set
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Storage
@@ -99,4 +105,9 @@ tests:
       apiVersion: operator.openshift.io/v1
       kind: Storage
       spec: {}
-    expectedError: "VSphereStorageDriver is required once set"
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Storage
+      spec:
+        logLevel: Normal
+        operatorLogLevel: Normal

--- a/operator/v1/types_storage.go
+++ b/operator/v1/types_storage.go
@@ -39,7 +39,6 @@ const (
 )
 
 // StorageSpec is the specification of the desired behavior of the cluster storage operator.
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.vsphereStorageDriver) || has(self.vsphereStorageDriver)", message="VSphereStorageDriver is required once set"
 type StorageSpec struct {
 	OperatorSpec `json:",inline"`
 
@@ -49,7 +48,6 @@ type StorageSpec struct {
 	// which may change over time without notice.
 	// The current default is CSIWithMigrationDriver and may not be changed.
 	// DEPRECATED: This field will be removed in a future release.
-	// +kubebuilder:validation:XValidation:rule="oldSelf != \"CSIWithMigrationDriver\" || self == \"CSIWithMigrationDriver\"",message="VSphereStorageDriver can not be changed once it is set to CSIWithMigrationDriver"
 	// +kubebuilder:validation:XValidation:rule="self != \"LegacyDeprecatedInTreeDriver\"",message="VSphereStorageDriver can not be set to LegacyDeprecatedInTreeDriver"
 	// +optional
 	VSphereStorageDriver StorageDriverType `json:"vsphereStorageDriver"`


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-13914
/cc @openshift/storage @jsafrane @JoelSpeed
