### PR TITLE
OCPBUGS-3176: Add config knob for enabling ip forwarding

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -41739,6 +41739,13 @@ func schema_openshift_api_operator_v1_GatewayConfig(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"enableIPForwarding": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces on the host.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -24420,6 +24420,10 @@
       "description": "GatewayConfig holds node gateway-related parsed config file parameters and command-line overrides",
       "type": "object",
       "properties": {
+        "enableIPForwarding": {
+          "description": "EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces on the host.",
+          "type": "boolean"
+        },
         "routingViaHost": {
           "description": "RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.",
           "type": "boolean"

--- a/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
@@ -216,6 +216,10 @@ spec:
                           description: gatewayConfig holds the configuration for node gateway options.
                           type: object
                           properties:
+                            enableIPForwarding:
+                              description: EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces on the host.
+                              type: boolean
+                              default: false
                             routingViaHost:
                               description: RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.
                               type: boolean

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -489,6 +489,13 @@ type GatewayConfig struct {
 	// +kubebuilder:default:=false
 	// +optional
 	RoutingViaHost bool `json:"routingViaHost,omitempty"`
+	// EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex).
+	// By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting
+	// is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces
+	// on the host.
+	// +kubebuilder:default:=false
+	// +optional
+	EnableIPForwarding bool `json:"enableIPForwarding,omitempty"`
 }
 
 type ExportNetworkFlows struct {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1257,8 +1257,9 @@ func (FeaturesMigration) SwaggerDoc() map[string]string {
 }
 
 var map_GatewayConfig = map[string]string{
-	"":               "GatewayConfig holds node gateway-related parsed config file parameters and command-line overrides",
-	"routingViaHost": "RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.",
+	"":                   "GatewayConfig holds node gateway-related parsed config file parameters and command-line overrides",
+	"routingViaHost":     "RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.",
+	"enableIPForwarding": "EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces on the host.",
 }
 
 func (GatewayConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
With https://github.com/ovn-org/ovn-kubernetes/pull/3374 and https://github.com/openshift/machine-config-operator/pull/3676 we stopped enabling IP forwarding globally in the OCP host. It is now only enabled on interfaces that OVNK manages. Additionally iptables rules are put in place to limit what traffic is forwarded. This was to resolve an issue where our node by default acts as a router: https://issues.redhat.com/browse/OCPBUGS-3176

With these changes, by default in OCP we will no longer forward IP traffic. Most users should welcome this change as it means the OCP node will not be forwarding traffic unintentionally on their network. However, in case there is some corner case where a user expects traffic to be forwarded we will expose this new config knob to allow them to go back to the old behavior.