### PR TITLE
OCPBUGS-3176: Rework IP Forwarding config

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -41739,10 +41739,10 @@ func schema_openshift_api_operator_v1_GatewayConfig(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
-					"enableIPForwarding": {
+					"ipForwarding": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces on the host.",
-							Type:        []string{"boolean"},
+							Description: "IPForwarding controls IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is set to Restricted, and Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by the OCP node. If there is a desire to allow the host to forward traffic across OVN-Kubernetes managed interfaces, then set this field to \"Global\". The supported values are \"Restricted\" and \"Global\".",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -24420,9 +24420,9 @@
       "description": "GatewayConfig holds node gateway-related parsed config file parameters and command-line overrides",
       "type": "object",
       "properties": {
-        "enableIPForwarding": {
-          "description": "EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces on the host.",
-          "type": "boolean"
+        "ipForwarding": {
+          "description": "IPForwarding controls IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is set to Restricted, and Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by the OCP node. If there is a desire to allow the host to forward traffic across OVN-Kubernetes managed interfaces, then set this field to \"Global\". The supported values are \"Restricted\" and \"Global\".",
+          "type": "string"
         },
         "routingViaHost": {
           "description": "RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.",

--- a/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
@@ -216,10 +216,9 @@ spec:
                           description: gatewayConfig holds the configuration for node gateway options.
                           type: object
                           properties:
-                            enableIPForwarding:
-                              description: EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces on the host.
-                              type: boolean
-                              default: false
+                            ipForwarding:
+                              description: IPForwarding controls IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is set to Restricted, and Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by the OCP node. If there is a desire to allow the host to forward traffic across OVN-Kubernetes managed interfaces, then set this field to "Global". The supported values are "Restricted" and "Global".
+                              type: string
                             routingViaHost:
                               description: RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.
                               type: boolean

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -480,6 +480,17 @@ type HybridOverlayConfig struct {
 type IPsecConfig struct {
 }
 
+type IPForwardingMode string
+
+const (
+	// IPForwardingRestricted limits the IP forwarding on OVN-Kube managed interfaces (br-ex, br-ex1) to only required
+	// service and other k8s related traffic
+	IPForwardingRestricted IPForwardingMode = "Restricted"
+
+	// IPForwardingGlobal allows all IP traffic to be forwarded across OVN-Kube managed interfaces
+	IPForwardingGlobal IPForwardingMode = "Global"
+)
+
 // GatewayConfig holds node gateway-related parsed config file parameters and command-line overrides
 type GatewayConfig struct {
 	// RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port
@@ -489,13 +500,13 @@ type GatewayConfig struct {
 	// +kubebuilder:default:=false
 	// +optional
 	RoutingViaHost bool `json:"routingViaHost,omitempty"`
-	// EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex).
-	// By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting
-	// is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces
-	// on the host.
-	// +kubebuilder:default:=false
+	// IPForwarding controls IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex).
+	// By default this is set to Restricted, and Kubernetes related traffic is still forwarded appropriately, but other
+	// IP traffic will not be routed by the OCP node. If there is a desire to allow the host to forward traffic across
+	// OVN-Kubernetes managed interfaces, then set this field to "Global".
+	// The supported values are "Restricted" and "Global".
 	// +optional
-	EnableIPForwarding bool `json:"enableIPForwarding,omitempty"`
+	IPForwarding IPForwardingMode `json:"ipForwarding,omitempty"`
 }
 
 type ExportNetworkFlows struct {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1257,9 +1257,9 @@ func (FeaturesMigration) SwaggerDoc() map[string]string {
 }
 
 var map_GatewayConfig = map[string]string{
-	"":                   "GatewayConfig holds node gateway-related parsed config file parameters and command-line overrides",
-	"routingViaHost":     "RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.",
-	"enableIPForwarding": "EnableIPForwarding enables IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is disabled, and Kubernetes related traffic is still forwarded appropriately. This setting is only useful if there is a desire to for the node to act as a router and forward traffic between interfaces on the host.",
+	"":               "GatewayConfig holds node gateway-related parsed config file parameters and command-line overrides",
+	"routingViaHost": "RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.",
+	"ipForwarding":   "IPForwarding controls IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is set to Restricted, and Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by the OCP node. If there is a desire to allow the host to forward traffic across OVN-Kubernetes managed interfaces, then set this field to \"Global\". The supported values are \"Restricted\" and \"Global\".",
 }
 
 func (GatewayConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
We are not supposed to use booleans anymore for API, so modifying the config to use a new type.

https://github.com/openshift/crd-schema-checker/blob/master/pkg/manifestcomparators/comp_no_bools.go#L20