### PR TITLE
make the default DNS only install for default to avoid conflicts

### DIFF
--- a/config/v1/0000_10_config-operator_01_dns.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_dns.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
   name: dnses.config.openshift.io
 spec:
   group: config.openshift.io


### PR DESCRIPTION
found in https://github.com/openshift/cluster-config-operator/pull/314