### PR TITLE
*: Promote TechPreviewNoUpgrade resources into CustomNoUpgrade

### DIFF
--- a/config/v1/types_dns.go
+++ b/config/v1/types_dns.go
@@ -57,7 +57,7 @@ type DNSSpec struct {
 	// infrastructure provider for DNS.
 	// When omitted, this means the user has no opinion and the platform is left
 	// to choose reasonable defaults. These defaults are subject to change over time.
-	// +openshift:enable:FeatureSets=TechPreviewNoUpgrade
+	// +openshift:enable:FeatureSets=CustomNoUpgrade,TechPreviewNoUpgrade
 	// +optional
 	Platform DNSPlatformSpec `json:"platform,omitempty"`
 }

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -114,7 +114,7 @@ type InfrastructureStatus struct {
 	// +kubebuilder:default=None
 	// +default="None"
 	// +kubebuilder:validation:Enum=None;AllNodes
-	// +openshift:enable:FeatureSets=TechPreviewNoUpgrade
+	// +openshift:enable:FeatureSets=CustomNoUpgrade,TechPreviewNoUpgrade
 	// +optional
 	CPUPartitioning CPUPartitioningMode `json:"cpuPartitioning,omitempty"`
 }
@@ -621,7 +621,7 @@ type BareMetalPlatformStatus struct {
 	// loadBalancer defines how the load balancer used by the cluster is configured.
 	// +default={"type": "OpenShiftManagedDefault"}
 	// +kubebuilder:default={"type": "OpenShiftManagedDefault"}
-	// +openshift:enable:FeatureSets=TechPreviewNoUpgrade
+	// +openshift:enable:FeatureSets=CustomNoUpgrade,TechPreviewNoUpgrade
 	// +optional
 	LoadBalancer *BareMetalPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 }
@@ -771,7 +771,7 @@ type OvirtPlatformStatus struct {
 	// loadBalancer defines how the load balancer used by the cluster is configured.
 	// +default={"type": "OpenShiftManagedDefault"}
 	// +kubebuilder:default={"type": "OpenShiftManagedDefault"}
-	// +openshift:enable:FeatureSets=TechPreviewNoUpgrade
+	// +openshift:enable:FeatureSets=CustomNoUpgrade,TechPreviewNoUpgrade
 	// +optional
 	LoadBalancer *OvirtPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 }
@@ -1037,7 +1037,7 @@ type VSpherePlatformStatus struct {
 	// loadBalancer defines how the load balancer used by the cluster is configured.
 	// +default={"type": "OpenShiftManagedDefault"}
 	// +kubebuilder:default={"type": "OpenShiftManagedDefault"}
-	// +openshift:enable:FeatureSets=TechPreviewNoUpgrade
+	// +openshift:enable:FeatureSets=CustomNoUpgrade,TechPreviewNoUpgrade
 	// +optional
 	LoadBalancer *VSpherePlatformLoadBalancer `json:"loadBalancer,omitempty"`
 }
@@ -1320,7 +1320,7 @@ type NutanixPlatformStatus struct {
 	// loadBalancer defines how the load balancer used by the cluster is configured.
 	// +default={"type": "OpenShiftManagedDefault"}
 	// +kubebuilder:default={"type": "OpenShiftManagedDefault"}
-	// +openshift:enable:FeatureSets=TechPreviewNoUpgrade
+	// +openshift:enable:FeatureSets=CustomNoUpgrade,TechPreviewNoUpgrade
 	// +optional
 	LoadBalancer *NutanixPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 }

--- a/example/v1/types_stable.go
+++ b/example/v1/types_stable.go
@@ -33,7 +33,7 @@ type StableConfigTypeSpec struct {
 	// coolNewField is a field that is for tech preview only.  On normal clusters this shouldn't be present
 	//
 	// +kubebuilder:validation:Optional
-	// +openshift:enable:FeatureSets=TechPreviewNoUpgrade
+	// +openshift:enable:FeatureSets=CustomNoUpgrade,TechPreviewNoUpgrade
 	// +optional
 	CoolNewField string `json:"coolNewField"`
 


### PR DESCRIPTION
`CustomNoUpgrade` is [even-more-cutting-edge][1] than `TechPreviewNoUpgrade`.  Before this commit, custom resources with properties with:

    +openshift:enable:FeatureSets=TechPreviewNoUpgrade

were being sharded into `Default` and `TechPreviewNoUpgrade` flavors, which left `CustomNoUpgrade` clusters with neither shard.  With this commit, the `CustomNoUpgrade` cluster will get the same CRD as the `TechPreviewNoUpgrade` cluster.  It's not entirely clear to me how folks would annotate a `CustomNoUpgrade`-only resource, because:

    +openshift:enable:FeatureSets=CustomNoUpgrade

might not generate a:

    release.openshift.io/feature-set: TechPreviewNoUpgrade,Default

manifest for the less-cutting-edge clusters.  But we can work that out in future work, and get this commit in now to get `CustomNoUpgrade` back off the ground.

Generated with:

```console
$ sed -i 's/openshift:enable:FeatureSets=TechPreviewNoUpgrade/openshift:enable:FeatureSets=CustomNoUpgrade,TechPreviewNoUpgrade/' $(git grep -l openshift:enable:FeatureSets=)
```

[1]: https://github.com/openshift/api/pull/370#issuecomment-510632939