### PR TITLE
OCPCLOUD-1989: Promote GCP CCM from TPNU to default

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -164,8 +164,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
 		without(validatingAdmissionPolicy).
-		with(externalCloudProvider).
-		with(externalCloudProviderGCP).
 		with(csiDriverSharedResource).
 		with(nodeSwap).
 		with(machineAPIProviderOpenStack).
@@ -194,7 +192,9 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		alibabaPlatform, // This is a bug, it should be TechPreviewNoUpgrade. This must be downgraded before 4.14 is shipped.
 		azureWorkloadIdentity,
 		cloudDualStackNodeIPs,
+		externalCloudProvider,
 		externalCloudProviderAzure,
+		externalCloudProviderGCP,
 		externalCloudProviderExternal,
 		privateHostedZoneAWS,
 		buildCSIVolumes,


### PR DESCRIPTION
We would like to promote the GCP CCM to on-by-default, to do this, we need to switch the feature gate to on-by-default.

Opening this early to test run to find obvious issues that need to be fixed before we can promote this. 