### PR TITLE
introduce vSphere static IP feature gate

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -272,4 +272,13 @@ var (
 		ResponsiblePerson:   "mkowalsk",
 		OwningProduct:       kubernetes,
 	}
+	FeatureGateVSphereStaticIPs = FeatureGateName("VSphereStaticIPs")
+	vSphereStaticIPs            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateVSphereStaticIPs,
+		},
+		OwningJiraComponent: "splat",
+		ResponsiblePerson:   "rvanderp3",
+		OwningProduct:       kubernetes,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -185,6 +185,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(privateHostedZoneAWS).
 		with(sigstoreImageVerification).
 		with(gcpLabelsTags).
+		with(vSphereStaticIPs).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),


### PR DESCRIPTION
Introduces a new feature gate included with the TechPreviewNoUpgrade featureset which gates the enablement of static IP support for vSphere IPI.