### PR TITLE
[CNF-5643] add capability name to machine crd

### DIFF
--- a/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    capability.openshift.io/name: MachineAPI
     api-approved.openshift.io: https://github.com/openshift/api/pull/1112
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/machine/v1beta1/0000_10_machine.crd.yaml
+++ b/machine/v1beta1/0000_10_machine.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    capability.openshift.io/name: MachineAPI
     api-approved.openshift.io: https://github.com/openshift/api/pull/948
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/machine/v1beta1/0000_10_machinehealthcheck.yaml
+++ b/machine/v1beta1/0000_10_machinehealthcheck.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    capability.openshift.io/name: MachineAPI
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/machine/v1beta1/0000_10_machineset.crd.yaml
+++ b/machine/v1beta1/0000_10_machineset.crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    capability.openshift.io/name: MachineAPI
     api-approved.openshift.io: https://github.com/openshift/api/pull/1032
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/tests/hack/test.sh
+++ b/tests/hack/test.sh
@@ -8,7 +8,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 ARTIFACT_DIR=${ARTIFACT_DIR:-""}
 GINKGO=${GINKGO:-"go run ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
-GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --randomize-all --randomize-suites --keep-going --timeout=10m"}
+GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --randomize-all --randomize-suites --keep-going --timeout=15m"}
 GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}
 
 # Ensure that some home var is set and that it's not the root.


### PR DESCRIPTION
In order to merge https://github.com/openshift/machine-api-operator/pull/1119 I need to add capability annotations to api files because they are directly copied at machine-api-operator