### PR TITLE
openstack: Test no failure domains

### DIFF
--- a/machine/v1/stable.controlplanemachineset.openstack.testsuite.yaml
+++ b/machine/v1/stable.controlplanemachineset.openstack.testsuite.yaml
@@ -71,6 +71,51 @@ tests:
               platform: OpenStack
               openstack: {}
     expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.openstack in body must be of type array: \"object\""
+  - name: Should accept no failureDomains
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: ""
+    expected: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        replicas: 3
+        state: Inactive
+        strategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: ""
   - name: Should reject an OpenStack configured failure domain with the wrong platform type
     initial: |
       apiVersion: machine.openshift.io/v1


### PR DESCRIPTION
This patch adds an integration test validating the spec for a default cluster that does not use explicit availability zones.