### PR TITLE
OCPCLOUD-2113: Api changes to support placementGroupName for AWS machines

### DIFF
--- a/machine/v1beta1/types_awsprovider.go
+++ b/machine/v1beta1/types_awsprovider.go
@@ -79,6 +79,11 @@ type AWSMachineProviderConfig struct {
 	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceMetadataOptionsRequest.html
 	// +optional
 	MetadataServiceOptions MetadataServiceOptions `json:"metadataServiceOptions,omitempty"`
+	// PlacementGroupName specifies the name of the placement group in which to launch the instance.
+	// The placement group must already be created and may use any placement strategy.
+	// When omitted, no placement group is used when creating the EC2 instance.
+	// +optional
+	PlacementGroupName string `json:"placementGroupName,omitempty"`
 }
 
 // BlockDeviceMappingSpec describes a block device mapping

--- a/machine/v1beta1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1beta1/zz_generated.swagger_doc_generated.go
@@ -30,6 +30,7 @@ var map_AWSMachineProviderConfig = map[string]string{
 	"blockDevices":           "BlockDevices is the set of block device mapping associated to this instance, block device without a name will be used as a root device and only one device without a name is allowed https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html",
 	"spotMarketOptions":      "SpotMarketOptions allows users to configure instances to be run using AWS Spot instances.",
 	"metadataServiceOptions": "MetadataServiceOptions allows users to configure instance metadata service interaction options. If nothing specified, default AWS IMDS settings will be applied. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceMetadataOptionsRequest.html",
+	"placementGroupName":     "PlacementGroupName specifies the name of the placement group in which to launch the instance. The placement group must already be created and may use any placement strategy. When omitted, no placement group is used when creating the EC2 instance.",
 }
 
 func (AWSMachineProviderConfig) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -31749,6 +31749,13 @@ func schema_openshift_api_machine_v1beta1_AWSMachineProviderConfig(ref common.Re
 							Ref:         ref("github.com/openshift/api/machine/v1beta1.MetadataServiceOptions"),
 						},
 					},
+					"placementGroupName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PlacementGroupName specifies the name of the placement group in which to launch the instance. The placement group must already be created and may use any placement strategy. When omitted, no placement group is used when creating the EC2 instance.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"ami", "instanceType", "deviceIndex", "subnet", "placement"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -18435,6 +18435,10 @@
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.machine.v1beta1.Placement"
         },
+        "placementGroupName": {
+          "description": "PlacementGroupName specifies the name of the placement group in which to launch the instance. The placement group must already be created and may use any placement strategy. When omitted, no placement group is used when creating the EC2 instance.",
+          "type": "string"
+        },
         "publicIp": {
           "description": "PublicIP specifies whether the instance should get a public IP. If not present, it should use the default of its subnet.",
           "type": "boolean"


### PR DESCRIPTION
This PR adds a field named `placementGroupName` to `AWSMachineProviderConfig` so we can start supporting placement groups in machine-api for AWS.
I have updated the swagger documentation and openapi stuff as well using make commands.