### PR TITLE
deprecate operator/v1alpha.OperatorSpec|Status and related types

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -48083,7 +48083,7 @@ func schema_openshift_api_operator_v1alpha1_GenerationHistory(ref common.Referen
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "GenerationHistory keeps track of the generation for a given resource so that decisions about forced updated can be made.",
+				Description: "GenerationHistory keeps track of the generation for a given resource so that decisions about forced updated can be made. DEPRECATED: Use fields in v1.GenerationStatus instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"group": {
@@ -48317,7 +48317,7 @@ func schema_openshift_api_operator_v1alpha1_LoggingConfig(ref common.ReferenceCa
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "LoggingConfig holds information about configuring logging",
+				Description: "LoggingConfig holds information about configuring logging DEPRECATED: Use v1.LogLevel instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"level": {
@@ -48347,7 +48347,7 @@ func schema_openshift_api_operator_v1alpha1_NodeStatus(ref common.ReferenceCallb
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "NodeStatus provides information about the current state of a particular node managed by this operator.",
+				Description: "NodeStatus provides information about the current state of a particular node managed by this operator. Deprecated: Use v1.NodeStatus instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"nodeName": {
@@ -48408,7 +48408,7 @@ func schema_openshift_api_operator_v1alpha1_OperatorCondition(ref common.Referen
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "OperatorCondition is just the standard condition fields.",
+				Description: "OperatorCondition is just the standard condition fields. DEPRECATED: Use v1.OperatorCondition instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
@@ -48456,7 +48456,7 @@ func schema_openshift_api_operator_v1alpha1_OperatorSpec(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included inside of the Spec struct for you particular operator.",
+				Description: "OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included inside of the Spec struct for you particular operator. DEPRECATED: Use v1.OperatorSpec instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"managementState": {
@@ -48511,7 +48511,7 @@ func schema_openshift_api_operator_v1alpha1_OperatorStatus(ref common.ReferenceC
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "OperatorStatus contains common fields for an operator to need.  It is intended to be anonymous included inside of the Status struct for you particular operator.",
+				Description: "OperatorStatus contains common fields for an operator to need.  It is intended to be anonymous included inside of the Status struct for you particular operator. DEPRECATED: Use v1.OperatorStatus instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"observedGeneration": {
@@ -48610,7 +48610,7 @@ func schema_openshift_api_operator_v1alpha1_StaticPodOperatorStatus(ref common.R
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual node status must be tracked.",
+				Description: "StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual node status must be tracked. DEPRECATED: Use v1.StaticPodOperatorStatus instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"observedGeneration": {
@@ -48695,7 +48695,7 @@ func schema_openshift_api_operator_v1alpha1_VersionAvailability(ref common.Refer
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "VersionAvailability gives information about the synchronization and operational status of a particular version of the component",
+				Description: "VersionAvailability gives information about the synchronization and operational status of a particular version of the component DEPRECATED: Use fields in v1.OperatorStatus instead",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"version": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -28235,7 +28235,7 @@
       }
     },
     "com.github.openshift.api.operator.v1alpha1.GenerationHistory": {
-      "description": "GenerationHistory keeps track of the generation for a given resource so that decisions about forced updated can be made.",
+      "description": "GenerationHistory keeps track of the generation for a given resource so that decisions about forced updated can be made. DEPRECATED: Use fields in v1.GenerationStatus instead",
       "type": "object",
       "required": [
         "group",
@@ -28379,7 +28379,7 @@
       }
     },
     "com.github.openshift.api.operator.v1alpha1.LoggingConfig": {
-      "description": "LoggingConfig holds information about configuring logging",
+      "description": "LoggingConfig holds information about configuring logging DEPRECATED: Use v1.LogLevel instead",
       "type": "object",
       "required": [
         "level",
@@ -28400,7 +28400,7 @@
       }
     },
     "com.github.openshift.api.operator.v1alpha1.NodeStatus": {
-      "description": "NodeStatus provides information about the current state of a particular node managed by this operator.",
+      "description": "NodeStatus provides information about the current state of a particular node managed by this operator. Deprecated: Use v1.NodeStatus instead",
       "type": "object",
       "required": [
         "nodeName",
@@ -28444,7 +28444,7 @@
       }
     },
     "com.github.openshift.api.operator.v1alpha1.OperatorCondition": {
-      "description": "OperatorCondition is just the standard condition fields.",
+      "description": "OperatorCondition is just the standard condition fields. DEPRECATED: Use v1.OperatorCondition instead",
       "type": "object",
       "required": [
         "type",
@@ -28472,7 +28472,7 @@
       }
     },
     "com.github.openshift.api.operator.v1alpha1.OperatorSpec": {
-      "description": "OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included inside of the Spec struct for you particular operator.",
+      "description": "OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included inside of the Spec struct for you particular operator. DEPRECATED: Use v1.OperatorSpec instead",
       "type": "object",
       "required": [
         "managementState",
@@ -28509,7 +28509,7 @@
       }
     },
     "com.github.openshift.api.operator.v1alpha1.OperatorStatus": {
-      "description": "OperatorStatus contains common fields for an operator to need.  It is intended to be anonymous included inside of the Status struct for you particular operator.",
+      "description": "OperatorStatus contains common fields for an operator to need.  It is intended to be anonymous included inside of the Status struct for you particular operator. DEPRECATED: Use v1.OperatorStatus instead",
       "type": "object",
       "properties": {
         "conditions": {
@@ -28566,7 +28566,7 @@
       }
     },
     "com.github.openshift.api.operator.v1alpha1.StaticPodOperatorStatus": {
-      "description": "StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual node status must be tracked.",
+      "description": "StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual node status must be tracked. DEPRECATED: Use v1.StaticPodOperatorStatus instead",
       "type": "object",
       "required": [
         "latestAvailableDeploymentGeneration",
@@ -28619,7 +28619,7 @@
       }
     },
     "com.github.openshift.api.operator.v1alpha1.VersionAvailability": {
-      "description": "VersionAvailability gives information about the synchronization and operational status of a particular version of the component",
+      "description": "VersionAvailability gives information about the synchronization and operational status of a particular version of the component DEPRECATED: Use fields in v1.OperatorStatus instead",
       "type": "object",
       "required": [
         "version",

--- a/operator/v1alpha1/types.go
+++ b/operator/v1alpha1/types.go
@@ -6,19 +6,24 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+// DEPRECATED: Use v1.ManagementState instead
 type ManagementState string
 
 const (
 	// Managed means that the operator is actively managing its resources and trying to keep the component active
+	// DEPRECATED: Use v1.Managed instead
 	Managed ManagementState = "Managed"
 	// Unmanaged means that the operator is not taking any action related to the component
+	// DEPRECATED: Use v1.Unmanaged instead
 	Unmanaged ManagementState = "Unmanaged"
 	// Removed means that the operator is actively managing its resources and trying to remove all traces of the component
+	// DEPRECATED: Use v1.Removed instead
 	Removed ManagementState = "Removed"
 )
 
 // OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included
 // inside of the Spec struct for you particular operator.
+// DEPRECATED: Use v1.OperatorSpec instead
 type OperatorSpec struct {
 	// managementState indicates whether and how the operator should manage the component
 	ManagementState ManagementState `json:"managementState"`
@@ -38,6 +43,7 @@ type OperatorSpec struct {
 }
 
 // LoggingConfig holds information about configuring logging
+// DEPRECATED: Use v1.LogLevel instead
 type LoggingConfig struct {
 	// level is passed to glog.
 	Level int64 `json:"level"`
@@ -46,24 +52,34 @@ type LoggingConfig struct {
 	Vmodule string `json:"vmodule"`
 }
 
+// DEPRECATED: Use v1.ConditionStatus instead
 type ConditionStatus string
 
 const (
-	ConditionTrue    ConditionStatus = "True"
-	ConditionFalse   ConditionStatus = "False"
+	// DEPRECATED: Use v1.ConditionTrue instead
+	ConditionTrue ConditionStatus = "True"
+	// DEPRECATED: Use v1.ConditionFalse instead
+	ConditionFalse ConditionStatus = "False"
+	// DEPRECATED: Use v1.ConditionUnknown instead
 	ConditionUnknown ConditionStatus = "Unknown"
 
 	// these conditions match the conditions for the ClusterOperator type.
-	OperatorStatusTypeAvailable   = "Available"
+	// DEPRECATED: Use v1.OperatorStatusTypeAvailable instead
+	OperatorStatusTypeAvailable = "Available"
+	// DEPRECATED: Use v1.OperatorStatusTypeProgressing instead
 	OperatorStatusTypeProgressing = "Progressing"
-	OperatorStatusTypeFailing     = "Failing"
+	// DEPRECATED: Use v1.OperatorStatusTypeDegraded instead
+	OperatorStatusTypeFailing = "Failing"
 
+	// DEPRECATED: Use v1.OperatorStatusTypeProgressing instead
 	OperatorStatusTypeMigrating = "Migrating"
 	// TODO this is going to be removed
+	// DEPRECATED: Use v1.OperatorStatusTypeAvailable instead
 	OperatorStatusTypeSyncSuccessful = "SyncSuccessful"
 )
 
 // OperatorCondition is just the standard condition fields.
+// DEPRECATED: Use v1.OperatorCondition instead
 type OperatorCondition struct {
 	Type               string          `json:"type"`
 	Status             ConditionStatus `json:"status"`
@@ -73,6 +89,7 @@ type OperatorCondition struct {
 }
 
 // VersionAvailability gives information about the synchronization and operational status of a particular version of the component
+// DEPRECATED: Use fields in v1.OperatorStatus instead
 type VersionAvailability struct {
 	// version is the level this availability applies to
 	Version string `json:"version"`
@@ -87,6 +104,7 @@ type VersionAvailability struct {
 }
 
 // GenerationHistory keeps track of the generation for a given resource so that decisions about forced updated can be made.
+// DEPRECATED: Use fields in v1.GenerationStatus instead
 type GenerationHistory struct {
 	// group is the group of the thing you're tracking
 	Group string `json:"group"`
@@ -102,6 +120,7 @@ type GenerationHistory struct {
 
 // OperatorStatus contains common fields for an operator to need.  It is intended to be anonymous included
 // inside of the Status struct for you particular operator.
+// DEPRECATED: Use v1.OperatorStatus instead
 type OperatorStatus struct {
 	// observedGeneration is the last generation change you've dealt with
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
@@ -156,6 +175,7 @@ type DelegatedAuthorization struct {
 
 // StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual
 // node status must be tracked.
+// DEPRECATED: Use v1.StaticPodOperatorStatus instead
 type StaticPodOperatorStatus struct {
 	OperatorStatus `json:",inline"`
 
@@ -167,6 +187,7 @@ type StaticPodOperatorStatus struct {
 }
 
 // NodeStatus provides information about the current state of a particular node managed by this operator.
+// Deprecated: Use v1.NodeStatus instead
 type NodeStatus struct {
 	// nodeName is the name of the node
 	NodeName string `json:"nodeName"`

--- a/operator/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -30,7 +30,7 @@ func (DelegatedAuthorization) SwaggerDoc() map[string]string {
 }
 
 var map_GenerationHistory = map[string]string{
-	"":               "GenerationHistory keeps track of the generation for a given resource so that decisions about forced updated can be made.",
+	"":               "GenerationHistory keeps track of the generation for a given resource so that decisions about forced updated can be made. DEPRECATED: Use fields in v1.GenerationStatus instead",
 	"group":          "group is the group of the thing you're tracking",
 	"resource":       "resource is the resource type of the thing you're tracking",
 	"namespace":      "namespace is where the thing you're tracking is",
@@ -55,7 +55,7 @@ func (GenericOperatorConfig) SwaggerDoc() map[string]string {
 }
 
 var map_LoggingConfig = map[string]string{
-	"":        "LoggingConfig holds information about configuring logging",
+	"":        "LoggingConfig holds information about configuring logging DEPRECATED: Use v1.LogLevel instead",
 	"level":   "level is passed to glog.",
 	"vmodule": "vmodule is passed to glog.",
 }
@@ -65,7 +65,7 @@ func (LoggingConfig) SwaggerDoc() map[string]string {
 }
 
 var map_NodeStatus = map[string]string{
-	"":                               "NodeStatus provides information about the current state of a particular node managed by this operator.",
+	"":                               "NodeStatus provides information about the current state of a particular node managed by this operator. Deprecated: Use v1.NodeStatus instead",
 	"nodeName":                       "nodeName is the name of the node",
 	"currentDeploymentGeneration":    "currentDeploymentGeneration is the generation of the most recently successful deployment",
 	"targetDeploymentGeneration":     "targetDeploymentGeneration is the generation of the deployment we're trying to apply",
@@ -78,7 +78,7 @@ func (NodeStatus) SwaggerDoc() map[string]string {
 }
 
 var map_OperatorCondition = map[string]string{
-	"": "OperatorCondition is just the standard condition fields.",
+	"": "OperatorCondition is just the standard condition fields. DEPRECATED: Use v1.OperatorCondition instead",
 }
 
 func (OperatorCondition) SwaggerDoc() map[string]string {
@@ -86,7 +86,7 @@ func (OperatorCondition) SwaggerDoc() map[string]string {
 }
 
 var map_OperatorSpec = map[string]string{
-	"":                "OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included inside of the Spec struct for you particular operator.",
+	"":                "OperatorSpec contains common fields for an operator to need.  It is intended to be anonymous included inside of the Spec struct for you particular operator. DEPRECATED: Use v1.OperatorSpec instead",
 	"managementState": "managementState indicates whether and how the operator should manage the component",
 	"imagePullSpec":   "imagePullSpec is the image to use for the component.",
 	"imagePullPolicy": "imagePullPolicy specifies the image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
@@ -99,7 +99,7 @@ func (OperatorSpec) SwaggerDoc() map[string]string {
 }
 
 var map_OperatorStatus = map[string]string{
-	"":                           "OperatorStatus contains common fields for an operator to need.  It is intended to be anonymous included inside of the Status struct for you particular operator.",
+	"":                           "OperatorStatus contains common fields for an operator to need.  It is intended to be anonymous included inside of the Status struct for you particular operator. DEPRECATED: Use v1.OperatorStatus instead",
 	"observedGeneration":         "observedGeneration is the last generation change you've dealt with",
 	"conditions":                 "conditions is a list of conditions and their status",
 	"state":                      "state indicates what the operator has observed to be its current operational status.",
@@ -113,7 +113,7 @@ func (OperatorStatus) SwaggerDoc() map[string]string {
 }
 
 var map_StaticPodOperatorStatus = map[string]string{
-	"":                                    "StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual node status must be tracked.",
+	"":                                    "StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual node status must be tracked. DEPRECATED: Use v1.StaticPodOperatorStatus instead",
 	"latestAvailableDeploymentGeneration": "latestAvailableDeploymentGeneration is the deploymentID of the most recent deployment",
 	"nodeStatuses":                        "nodeStatuses track the deployment values and errors across individual nodes",
 }
@@ -123,7 +123,7 @@ func (StaticPodOperatorStatus) SwaggerDoc() map[string]string {
 }
 
 var map_VersionAvailability = map[string]string{
-	"":                "VersionAvailability gives information about the synchronization and operational status of a particular version of the component",
+	"":                "VersionAvailability gives information about the synchronization and operational status of a particular version of the component DEPRECATED: Use fields in v1.OperatorStatus instead",
 	"version":         "version is the level this availability applies to",
 	"updatedReplicas": "updatedReplicas indicates how many replicas are at the desired state",
 	"readyReplicas":   "readyReplicas indicates how many replicas are ready and at the desired state",


### PR DESCRIPTION
Following up on a slack coversation with @soltysh. These (or very similar) types are available in operator/v1.

It was confusing to me when adding a new `operator/v1alpha1` root API (in #1504) whether I should use v1alpha1.OperatorSpec|Status of v1.OperatorSpec|Status.

This will help clarify for future contributors that v1.OperatorSpec|Status should be used. This became especially apparent when working with the `StaticResourceController` and `DeploymentController` in library-go, both of which require v1.OperatorSpec|Status.