### PR TITLE
SDN-4024: Add TechPreview feature gate for OVNK-ANP

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -282,6 +282,16 @@ var (
 		OwningProduct:       ocpSpecific,
 	}
 
+	FeatureGateAdminNetworkPolicy = FeatureGateName("AdminNetworkPolicy")
+	adminNetworkPolicy            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateAdminNetworkPolicy,
+		},
+		OwningJiraComponent: "Networking/ovn-kubernetes",
+		ResponsiblePerson:   "tssurya",
+		OwningProduct:       ocpSpecific,
+	}
+
 	FeatureGateAutomatedEtcdBackup = FeatureGateName("AutomatedEtcdBackup")
 	automatedEtcdBackup            = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -186,6 +186,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(routeExternalCertificate).
 		with(automatedEtcdBackup).
 		without(machineAPIOperatorDisableMachineHealthCheckController).
+		with(adminNetworkPolicy).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),


### PR DESCRIPTION
Related enhancement for the feature: https://github.com/openshift/enhancements/pull/1414
This feature is TechPreview in OCP 4.14 but we want some users to be able to switch this on if they want to, hence adding a feature gate where the feature is to be enabled only on TechPreview Clusters and not in standard cluster.

PS: I hope I am supposed to use `with` and not `without` right? (Goal is to disable the feature by default in 4.14 but enable it only in TechPreviewNoUpgrade clusters)

Once this PR merges, this will be revendered into CNO and used there.