### PR TITLE
Create list of FeatureGates for cloud controller

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -272,3 +272,12 @@ var (
 		OwningProduct:       ocpSpecific,
 	}
 )
+
+// CloudPublicFeatureGates consists of cloud-specific feature keys.
+// It is heavily inspired by k8s.io/component-base/featuregate and allows us to have a list of
+// features that can be passed to the Cloud Controller Manager.
+// The motivation behind is that not all the features defined above are valid for the CCM even
+// though they are valid for kubelet.
+var CloudPublicFeatureGates = []FeatureGateName{
+	"CloudDualStackNodeIPs",
+}


### PR DESCRIPTION
This PR creates a publicly available list of FeatureGates that are valid to be used in the context of Cloud Controller. Currently the problem is that lots of features that are valid for kubelet, are invalid for the cloud provider. With this PR we are introducing a very simple way to filter out undesired features.