### PR TITLE
Update controller tools to fix featureset validation ordering

### DIFF
--- a/route/v1/route-CustomNoUpgrade.crd.yaml
+++ b/route/v1/route-CustomNoUpgrade.crd.yaml
@@ -145,10 +145,10 @@ spec:
                         - reencrypt
                         - passthrough
                   x-kubernetes-validations:
-                    - rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow'')) : true'
-                      message: 'cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow'
                     - rule: '!(has(self.certificate) && has(self.externalCertificate))'
                       message: cannot have both spec.tls.certificate and spec.tls.externalCertificate
+                    - rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow'')) : true'
+                      message: 'cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow'
                 to:
                   description: to is an object the route should use as the primary backend. Only the Service kind is allowed, and it will be defaulted to Service. If the weight field (0-256 default 100) is set to zero, no traffic will be sent to this backend.
                   type: object

--- a/route/v1/route-TechPreviewNoUpgrade.crd.yaml
+++ b/route/v1/route-TechPreviewNoUpgrade.crd.yaml
@@ -145,10 +145,10 @@ spec:
                         - reencrypt
                         - passthrough
                   x-kubernetes-validations:
-                    - rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow'')) : true'
-                      message: 'cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow'
                     - rule: '!(has(self.certificate) && has(self.externalCertificate))'
                       message: cannot have both spec.tls.certificate and spec.tls.externalCertificate
+                    - rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow'')) : true'
+                      message: 'cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow'
                 to:
                   description: to is an object the route should use as the primary backend. Only the Service kind is allowed, and it will be defaulted to Service. If the weight field (0-256 default 100) is set to zero, no traffic will be sent to this backend.
                   type: object

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -25,7 +25,7 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-replace sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.9.3-0.20230615121909-8a188837e02f
+replace sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.11.2-0.20230707132950-4180f051f655
 
 require (
 	github.com/a8m/envsubst v1.3.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -146,8 +146,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/gomega v1.24.2 h1:J/tulyYK6JwBldPViHJReihxxZ+22FHs0piGjQAvoUE=
-github.com/openshift/controller-tools v0.9.3-0.20230615121909-8a188837e02f h1:iofM7geqehip3iwqUAB3/F+ospyx8pmXVNm8Kw6PGpM=
-github.com/openshift/controller-tools v0.9.3-0.20230615121909-8a188837e02f/go.mod h1:dm4bN3Yp1ZP+hbbeSLF8zOEHsI1/bf15u3JNcgRv2TM=
+github.com/openshift/controller-tools v0.11.2-0.20230707132950-4180f051f655 h1:5lj8B+ZGLmk/i/P2fDoHmu+UJuiESEV4pYDFw9mxbyM=
+github.com/openshift/controller-tools v0.11.2-0.20230707132950-4180f051f655/go.mod h1:dm4bN3Yp1ZP+hbbeSLF8zOEHsI1/bf15u3JNcgRv2TM=
 github.com/pjbgf/sha1cd v0.2.3/go.mod h1:HOK9QrgzdHpbc2Kzip0Q1yi3M2MFGPADtR6HjG65m5M=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -393,7 +393,7 @@ k8s.io/utils/internal/third_party/forked/golang/net
 k8s.io/utils/net
 k8s.io/utils/pointer
 k8s.io/utils/strings/slices
-# sigs.k8s.io/controller-tools v0.11.1 => github.com/openshift/controller-tools v0.9.3-0.20230615121909-8a188837e02f
+# sigs.k8s.io/controller-tools v0.11.1 => github.com/openshift/controller-tools v0.11.2-0.20230707132950-4180f051f655
 ## explicit; go 1.19
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
@@ -419,4 +419,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.9.3-0.20230615121909-8a188837e02f
+# sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.11.2-0.20230707132950-4180f051f655

--- a/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
+++ b/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
@@ -88,3 +88,10 @@ func (m FeatureSetXValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) err
 
 	return validation.ApplyToSchema(schema)
 }
+
+// ApplyFirst means that this will be applied in the first run of markers.
+// We do this because, when validations are applied, the markers come out of
+// a map which means that the order is not guaranteed. We want to make sure
+// that the FeatureSetXValidation is applied before the XValidation so that
+// the order is stable.
+func (m FeatureSetXValidation) ApplyFirst() {}


### PR DESCRIPTION
This just bumps the controller-tools dep in the tools repo to the latest commit and regenerates the manifests, they should now be stable in ordering