### PR TITLE
CPMS/openstack: add root volume AZ validation

### DIFF
--- a/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -274,6 +274,9 @@ spec:
                                         type: string
                                         maxLength: 255
                                         minLength: 1
+                                x-kubernetes-validations:
+                                  - rule: '!has(self.availabilityZone) || !has(self.rootVolume) || has(self.rootVolume.availabilityZone)'
+                                    message: rootVolume.availabilityZone is required when availabilityZone is set
                             platform:
                               description: Platform identifies the platform for which the FailureDomain represents. Currently supported values are AWS, Azure, and GCP.
                               type: string

--- a/machine/v1/stable.controlplanemachineset.openstack.testsuite.yaml
+++ b/machine/v1/stable.controlplanemachineset.openstack.testsuite.yaml
@@ -368,6 +368,7 @@ tests:
               openstack:
               - availabilityZone: foo
                 rootVolume:
+                  availabilityZone: foo
                   volumeType: bar
     expected: |
       apiVersion: machine.openshift.io/v1
@@ -396,6 +397,7 @@ tests:
               openstack:
               - availabilityZone: foo
                 rootVolume:
+                  availabilityZone: foo
                   volumeType: bar
   - name: Should reject an OpenStack failure domain with too long a rootVolume volumeType name
     initial: |
@@ -448,6 +450,32 @@ tests:
               - availabilityZone: foo
                 rootVolume: {}
     expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.openstack[0].rootVolume in body should have at least 1 properties"
+  - name: Should reject an OpenStack failure domain with both availabilityZone and root volume provided but with missing root volume availabilityZone
+    initial: |
+      apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      spec:
+        selector:
+          matchLabels:
+            machine.openshift.io/cluster-api-machine-role: master
+            machine.openshift.io/cluster-api-machine-type: master
+        template:
+          machineType: machines_v1beta1_machine_openshift_io
+          machines_v1beta1_machine_openshift_io:
+            metadata:
+              labels:
+                machine.openshift.io/cluster-api-machine-role: master
+                machine.openshift.io/cluster-api-machine-type: master
+                machine.openshift.io/cluster-api-cluster: cluster
+            spec:
+              providerSpec: {}
+            failureDomains:
+              platform: OpenStack
+              openstack:
+              - availabilityZone: foo
+                rootVolume:
+                  volumeType: bar
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.openstack[0]: Invalid value: \"object\": rootVolume.availabilityZone is required when availabilityZone is set"
   - name: Should reject an empty OpenStack failure domain
     initial: |
       apiVersion: machine.openshift.io/v1

--- a/machine/v1/types_controlplanemachineset.go
+++ b/machine/v1/types_controlplanemachineset.go
@@ -298,6 +298,7 @@ type GCPFailureDomain struct {
 
 // OpenStackFailureDomain configures failure domain information for the OpenStack platform.
 // +kubebuilder:validation:MinProperties:=1
+// +kubebuilder:validation:XValidation:rule="!has(self.availabilityZone) || !has(self.rootVolume) || has(self.rootVolume.availabilityZone)",message="rootVolume.availabilityZone is required when availabilityZone is set"
 type OpenStackFailureDomain struct {
 	// availabilityZone is the nova availability zone in which the OpenStack machine provider will create the VM.
 	// If not specified, the VM will be created in the default availability zone specified in the nova configuration.


### PR DESCRIPTION
## Problem

When a machine is created with a compute availability zone (defined in a failure domain as `availabilityZone`) and a storage root volume (defined as `rootVolume`) and that `rootVolume` has no specified `rootVolume.availabilityZone`, CAPO will use the compute AZ for the volume AZ.
This can be problematic if the AZ doesn't exist in Cinder.

Source:
https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/9d183bd479fe9aed4f6e7ac3d5eee46681c518e7/pkg/cloud/services/compute/instance.go#L439-L442

```golang
func (s *Service) getOrCreateRootVolume(eventObject runtime.Object, instanceSpec *InstanceSpec, imageID string) (*volumes.Volume, error) {

(...)

        availabilityZone := instanceSpec.FailureDomain
        if rootVolume.AvailabilityZone != "" {
                availabilityZone = rootVolume.AvailabilityZone
        }

(...)
```

## Proposed solution

If a compute AZ is provided alongside with a root volume, we now require the root volume to have an AZ, so we force the user to make a choice on which AZ the root volume is deployed on in the Failure Domain.
This CEL validation will also come with some validations in the [installer](https://github.com/openshift/installer/pull/7309) to make sure the validation happens on day 1 before the cluster is even deployed.

## Alternatives

* Do nothing - at the risk of hitting this situation: a failure domain with a Compute AZ and a root volume with no AZ, CAPO using the compute AZ to create the volume but that AZ doesn't exist in Cinder, leading into Machine creation errors.
* Only do a validation in the installer - can be problematic on day 2 if a user manually creates a failure domain with a compute AZ but without a root volume AZ, which would lead to Machine creation errors.
* Change logic in CAPO wrt how root volume AZ is picked - unlikely to happen