### PR TITLE
Add 'kubebuilder' validations for maxLogFiles

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -46407,7 +46407,7 @@ func schema_openshift_api_operator_v1_PolicyAuditConfig(ref common.ReferenceCall
 					},
 					"maxLogFiles": {
 						SchemaProps: spec.SchemaProps{
-							Description: "maxLogFiles specifies the maximum number of ACL_audit log files that can be present. Default: 5",
+							Description: "maxLogFiles specifies the maximum number of ACL_audit log files that can be present.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -27234,7 +27234,7 @@
           "format": "int64"
         },
         "maxLogFiles": {
-          "description": "maxLogFiles specifies the maximum number of ACL_audit log files that can be present. Default: 5",
+          "description": "maxLogFiles specifies the maximum number of ACL_audit log files that can be present.",
           "type": "integer",
           "format": "int32"
         },

--- a/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
@@ -272,9 +272,11 @@ spec:
                               default: 50
                               minimum: 1
                             maxLogFiles:
-                              description: 'maxLogFiles specifies the maximum number of ACL_audit log files that can be present. Default: 5'
+                              description: maxLogFiles specifies the maximum number of ACL_audit log files that can be present.
                               type: integer
                               format: int32
+                              default: 5
+                              minimum: 1
                             rateLimit:
                               description: rateLimit is the approximate maximum number of messages to generate per-second per-node. If unset the default of 20 msg/sec is used.
                               type: integer

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -562,7 +562,8 @@ type PolicyAuditConfig struct {
 	MaxFileSize *uint32 `json:"maxFileSize,omitempty"`
 
 	// maxLogFiles specifies the maximum number of ACL_audit log files that can be present.
-	// Default: 5
+	// +kubebuilder:default=5
+	// +kubebuilder:validation:Minimum=1
 	// +optional
 	MaxLogFiles *int32 `json:"maxLogFiles,omitempty"`
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1427,7 +1427,7 @@ func (OpenShiftSDNConfig) SwaggerDoc() map[string]string {
 var map_PolicyAuditConfig = map[string]string{
 	"rateLimit":      "rateLimit is the approximate maximum number of messages to generate per-second per-node. If unset the default of 20 msg/sec is used.",
 	"maxFileSize":    "maxFilesSize is the max size an ACL_audit log file is allowed to reach before rotation occurs Units are in MB and the Default is 50MB",
-	"maxLogFiles":    "maxLogFiles specifies the maximum number of ACL_audit log files that can be present. Default: 5",
+	"maxLogFiles":    "maxLogFiles specifies the maximum number of ACL_audit log files that can be present.",
 	"destination":    "destination is the location for policy log messages. Regardless of this config, persistent logs will always be dumped to the host at /var/log/ovn/ however Additionally syslog output may be configured as follows. Valid values are: - \"libc\" -> to use the libc syslog() function of the host node's journdald process - \"udp:host:port\" -> for sending syslog over UDP - \"unix:file\" -> for using the UNIX domain socket directly - \"null\" -> to discard all messages logged to syslog The default is \"null\"",
 	"syslogFacility": "syslogFacility the RFC5424 facility for generated messages, e.g. \"kern\". Default is \"local0\"",
 }


### PR DESCRIPTION
These were missed in the original commit [0] to add maxLogFiles to defaultNetwork:ovnKubernetesConfig:properties:policyAuditConfig

[0] https://github.com/openshift/api/commit/fca46d2460bf38a6e22d987b6e682717365467fc