### PR TITLE
OCPCLOUD-2130: CPMS: Add subnet to azure FailureDomain

### DIFF
--- a/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -229,6 +229,11 @@ spec:
                                 required:
                                   - zone
                                 properties:
+                                  subnet:
+                                    description: subnet is the name of the network subnet in which the VM will be created. When omitted, the subnet value from the machine providerSpec template will be used.
+                                    type: string
+                                    maxLength: 80
+                                    pattern: ^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9_])?$
                                   zone:
                                     description: Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone.
                                     type: string

--- a/machine/v1/types_controlplanemachineset.go
+++ b/machine/v1/types_controlplanemachineset.go
@@ -287,6 +287,13 @@ type AzureFailureDomain struct {
 	// If nil, the virtual machine should be deployed to no zone.
 	// +kubebuilder:validation:Required
 	Zone string `json:"zone"`
+
+	// subnet is the name of the network subnet in which the VM will be created.
+	// When omitted, the subnet value from the machine providerSpec template will be used.
+	// +kubebuilder:validation:MaxLength=80
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9_])?$`
+	// +optional
+	Subnet string `json:"subnet,omitempty"`
 }
 
 // GCPFailureDomain configures failure domain information for the GCP platform

--- a/machine/v1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1/zz_generated.swagger_doc_generated.go
@@ -159,8 +159,9 @@ func (AWSFailureDomainPlacement) SwaggerDoc() map[string]string {
 }
 
 var map_AzureFailureDomain = map[string]string{
-	"":     "AzureFailureDomain configures failure domain information for the Azure platform.",
-	"zone": "Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone.",
+	"":       "AzureFailureDomain configures failure domain information for the Azure platform.",
+	"zone":   "Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone.",
+	"subnet": "subnet is the name of the network subnet in which the VM will be created. When omitted, the subnet value from the machine providerSpec template will be used.",
 }
 
 func (AzureFailureDomain) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -29613,6 +29613,13 @@ func schema_openshift_api_machine_v1_AzureFailureDomain(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"subnet": {
+						SchemaProps: spec.SchemaProps{
+							Description: "subnet is the name of the network subnet in which the VM will be created. When omitted, the subnet value from the machine providerSpec template will be used.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"zone"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -17198,6 +17198,10 @@
         "zone"
       ],
       "properties": {
+        "subnet": {
+          "description": "subnet is the name of the network subnet in which the VM will be created. When omitted, the subnet value from the machine providerSpec template will be used.",
+          "type": "string"
+        },
         "zone": {
           "description": "Availability Zone for the virtual machine. If nil, the virtual machine should be deployed to no zone.",
           "type": "string",


### PR DESCRIPTION
This PR adds a Subnet and InternalLoadBalancer field to the Azure Failure domain.

The subnet is not marked optional in the providerSpec. What's the default? I don't think we can add a required field to the failure domain.
https://github.com/openshift/api/blob/aaae7101a7ad14abba8be0102efc8ab503ccac9d/machine/v1beta1/types_azureprovider.go#L79C2-L79C2

/assign @JoelSpeed