### PR TITLE
OCPNODE-1716: Update `CgroupModeDefault` to `CgroupModeV2`

### DIFF
--- a/config/v1/types_node.go
+++ b/config/v1/types_node.go
@@ -53,7 +53,7 @@ const (
 	CgroupModeEmpty   CgroupMode = "" // Empty string indicates to honor user set value on the system that should not be overridden by OpenShift
 	CgroupModeV1      CgroupMode = "v1"
 	CgroupModeV2      CgroupMode = "v2"
-	CgroupModeDefault CgroupMode = CgroupModeV1
+	CgroupModeDefault CgroupMode = CgroupModeV2
 )
 
 // +kubebuilder:validation:Enum=Default;MediumUpdateAverageReaction;LowUpdateSlowReaction


### PR DESCRIPTION
cgroupsv2 is the default `cgroupMode` since OCP-4.14 , hence, the `CgroupModeDefault` needs to be updated to `CgroupModeV2` in the `nodes.config.openshift.io` object.