### PR TITLE
 OCPBUGS-16614: remove TechPreview feature gate for CCO AWS STS feature

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -174,7 +174,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(pdbUnhealthyPodEvictionPolicy).
 		with(dynamicResourceAllocation).
 		with(admissionWebhookMatchConditions).
-		with(awsSecurityTokenService).
 		with(azureWorkloadIdentity).
 		with(gateGatewayAPI).
 		with(maxUnavailableStatefulSet).


### PR DESCRIPTION
Removes the feature gate, TechPreviewNoUpgrade, for AWS STS features added to the Cloud Credential Operator