### PR TITLE
Ensure baremetal cap is not enabled without MachineAPI cap

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -436,6 +436,9 @@ spec:
                 versionHash:
                   description: versionHash is a fingerprint of the content that the cluster will be updated with. It is used by the operator to avoid unnecessary work and is for internal use only.
                   type: string
+          x-kubernetes-validations:
+            - rule: 'has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == ''None'' && ''baremetal'' in self.spec.capabilities.additionalEnabledCapabilities ? ''MachineAPI'' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && ''MachineAPI'' in self.status.capabilities.enabledCapabilities) : true'
+              message: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
       served: true
       storage: true
       subresources:

--- a/config/v1/stable.clusterversion.testsuite.yaml
+++ b/config/v1/stable.clusterversion.testsuite.yaml
@@ -98,6 +98,38 @@ tests:
           version: 4.11.1
           image: bar
     expectedError: "cannot set both Architecture and Image"
+  - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities baremetal and MachineAPI
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+          - MachineAPI
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+          - MachineAPI
+  - name: Should not be able to create a ClusterVersion with base capability None, and additional capabilities baremetal without MachineAPI
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+    expectedError: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
   onUpdate:
   - name: Should not allow image to be set if architecture set
     initial: |
@@ -136,3 +168,111 @@ tests:
           version: 4.11.1
           image: bar
     expectedError: "cannot set both Architecture and Image"
+  - name: Should be able to add the baremetal capability with a ClusterVersion with base capability None, and implicitly enabled MachineAPI
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - MachineAPI
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - MachineAPI
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - MachineAPI
+  - name: Should be able to add the baremetal capability with a ClusterVersion with base capability None, with the Machine API capability
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+          - MachineAPI
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+          - MachineAPI
+  - name: Should not be able to add the baremetal capability with a ClusterVersion with base capability None, and without MachineAPI
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - baremetal
+    expectedError: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -13,6 +13,7 @@ import (
 //
 // Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 // +openshift:compatibility-gen:level=1
+// +kubebuilder:validation:XValidation:rule="has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == 'None' && 'baremetal' in self.spec.capabilities.additionalEnabledCapabilities ? 'MachineAPI' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && 'MachineAPI' in self.status.capabilities.enabledCapabilities) : true",message="the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability"
 type ClusterVersion struct {
 	metav1.TypeMeta `json:",inline"`
 


### PR DESCRIPTION
Opening for discussion as to whether this is the right thing to do

We understand that the `baremetal` capability relies on the `MachineAPI` capability.

The API for capabilities means that, for any cluster that has defined `None` as the baseline capability set, on upgrade, any capability that is new to the cluster version (eg `MachineAPI` added in 4,14), it will be added to the status `enabledCapabilities` on upgrade.

So, if we add this validation, on upgrade, all existing clusters should pass the validation if they either have the `baseline` capability already added, or, want to add it at a later date.

For new clusters in 4.14, if the user wants the baseline set `None`, they are required to enable `MachineAPI` at cluster creation, so the validation should also pass for the create test cases.

One hitch that could come up, is the fact that, while CVO is doing the upgrade, is it possible that the CVO would update the ClusterVersion CRD, before it updates the list of `enabledCapabilities`? If it does, there's a period where the validation could fail for updates, until the CVO updates the status to include the new capabilities. I think we should E2E test this case.