### PR TITLE
Adding etcd tuning profiles api

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -42752,6 +42752,14 @@ func schema_openshift_api_operator_v1_EtcdSpec(ref common.ReferenceCallback) com
 							Format:      "int32",
 						},
 					},
+					"controlPlaneHardwareSpeed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "HardwareSpeed allows user to change the etcd tuning profile which configures the latency parameters for heartbeat interval and leader election timeouts allowing the cluster to tolerate longer round-trip-times between etcd members. Valid values are \"\", \"Standard\" and \"Slower\".\n\t\"\" means no opinion and the platform is left to choose a reasonable default\n\twhich is subject to change without notice.\n\nPossible enum values:\n - `\"Slower\"` provides more tolerance for slower hardware and/or higher latency networks. Sets (values subject to change): ETCD_HEARTBEAT_INTERVAL: 5x Standard ETCD_LEADER_ELECTION_TIMEOUT: 2.5x Standard\n - `\"Standard\"` provides the normal tolerances for hardware speed and latency. Currently sets (values subject to change at any time): ETCD_HEARTBEAT_INTERVAL: 100ms ETCD_LEADER_ELECTION_TIMEOUT: 1000ms",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+							Enum:        []interface{}{"Slower", "Standard"}},
+					},
 				},
 				Required: []string{"managementState", "forceRedeploymentReason"},
 			},
@@ -42847,8 +42855,16 @@ func schema_openshift_api_operator_v1_EtcdStatus(ref common.ReferenceCallback) c
 							},
 						},
 					},
+					"controlPlaneHardwareSpeed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Possible enum values:\n - `\"Slower\"` provides more tolerance for slower hardware and/or higher latency networks. Sets (values subject to change): ETCD_HEARTBEAT_INTERVAL: 5x Standard ETCD_LEADER_ELECTION_TIMEOUT: 2.5x Standard\n - `\"Standard\"` provides the normal tolerances for hardware speed and latency. Currently sets (values subject to change at any time): ETCD_HEARTBEAT_INTERVAL: 100ms ETCD_LEADER_ELECTION_TIMEOUT: 1000ms",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+							Enum:        []interface{}{"Slower", "Standard"}},
+					},
 				},
-				Required: []string{"readyReplicas"},
+				Required: []string{"readyReplicas", "controlPlaneHardwareSpeed"},
 			},
 		},
 		Dependencies: []string{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -24966,6 +24966,15 @@
         "forceRedeploymentReason"
       ],
       "properties": {
+        "controlPlaneHardwareSpeed": {
+          "description": "HardwareSpeed allows user to change the etcd tuning profile which configures the latency parameters for heartbeat interval and leader election timeouts allowing the cluster to tolerate longer round-trip-times between etcd members. Valid values are \"\", \"Standard\" and \"Slower\".\n\t\"\" means no opinion and the platform is left to choose a reasonable default\n\twhich is subject to change without notice.\n\nPossible enum values:\n - `\"Slower\"` provides more tolerance for slower hardware and/or higher latency networks. Sets (values subject to change): ETCD_HEARTBEAT_INTERVAL: 5x Standard ETCD_LEADER_ELECTION_TIMEOUT: 2.5x Standard\n - `\"Standard\"` provides the normal tolerances for hardware speed and latency. Currently sets (values subject to change at any time): ETCD_HEARTBEAT_INTERVAL: 100ms ETCD_LEADER_ELECTION_TIMEOUT: 1000ms",
+          "type": "string",
+          "default": "",
+          "enum": [
+            "Slower",
+            "Standard"
+          ]
+        },
         "failedRevisionLimit": {
           "description": "failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)",
           "type": "integer",
@@ -25009,7 +25018,8 @@
     "com.github.openshift.api.operator.v1.EtcdStatus": {
       "type": "object",
       "required": [
-        "readyReplicas"
+        "readyReplicas",
+        "controlPlaneHardwareSpeed"
       ],
       "properties": {
         "conditions": {
@@ -25019,6 +25029,15 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.OperatorCondition"
           }
+        },
+        "controlPlaneHardwareSpeed": {
+          "description": "Possible enum values:\n - `\"Slower\"` provides more tolerance for slower hardware and/or higher latency networks. Sets (values subject to change): ETCD_HEARTBEAT_INTERVAL: 5x Standard ETCD_LEADER_ELECTION_TIMEOUT: 2.5x Standard\n - `\"Standard\"` provides the normal tolerances for hardware speed and latency. Currently sets (values subject to change at any time): ETCD_HEARTBEAT_INTERVAL: 100ms ETCD_LEADER_ELECTION_TIMEOUT: 1000ms",
+          "type": "string",
+          "default": "",
+          "enum": [
+            "Slower",
+            "Standard"
+          ]
         },
         "generations": {
           "description": "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",

--- a/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
+++ b/operator/v1/0000_12_etcd-operator_01_config.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: etcds.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -36,6 +37,13 @@ spec:
             spec:
               type: object
               properties:
+                controlPlaneHardwareSpeed:
+                  description: HardwareSpeed allows user to change the etcd tuning profile which configures the latency parameters for heartbeat interval and leader election timeouts allowing the cluster to tolerate longer round-trip-times between etcd members. Valid values are "", "Standard" and "Slower". "" means no opinion and the platform is left to choose a reasonable default which is subject to change without notice.
+                  type: string
+                  enum:
+                    - ""
+                    - Standard
+                    - Slower
                 failedRevisionLimit:
                   description: failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)
                   type: integer
@@ -102,6 +110,13 @@ spec:
                         type: string
                       type:
                         type: string
+                controlPlaneHardwareSpeed:
+                  description: ControlPlaneHardwareSpeed declares valid hardware speed tolerance levels
+                  type: string
+                  enum:
+                    - ""
+                    - Standard
+                    - Slower
                 generations:
                   description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
                   type: array

--- a/operator/v1/techpreview.etcd.testsuite.yaml
+++ b/operator/v1/techpreview.etcd.testsuite.yaml
@@ -1,0 +1,62 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[TechPreview] Etcd"
+crd: 0000_12_etcd-operator_01_config.crd.yaml
+tests:
+  onCreate:
+  - name: Should be able to create with Standard hardware speed
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Standard
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        logLevel: Normal
+        operatorLogLevel: Normal
+        controlPlaneHardwareSpeed: Standard
+  - name: Should be able to create with Slower hardware speed
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Slower
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        logLevel: Normal
+        operatorLogLevel: Normal
+        controlPlaneHardwareSpeed: Slower
+  onUpdate:
+  - name: Should be able to create with Standard, then set to Slower
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Standard
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Slower
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        logLevel: Normal
+        operatorLogLevel: Normal
+        controlPlaneHardwareSpeed: Slower
+  - name: Should not be allowed to try to set invalid hardware speed
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: Standard
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Etcd
+      spec:
+        controlPlaneHardwareSpeed: foo
+    expectedError: Unsupported value

--- a/operator/v1/types_etcd.go
+++ b/operator/v1/types_etcd.go
@@ -28,11 +28,40 @@ type Etcd struct {
 
 type EtcdSpec struct {
 	StaticPodOperatorSpec `json:",inline"`
+	// HardwareSpeed allows user to change the etcd tuning profile which configures
+	// the latency parameters for heartbeat interval and leader election timeouts
+	// allowing the cluster to tolerate longer round-trip-times between etcd members.
+	// Valid values are "", "Standard" and "Slower".
+	//	"" means no opinion and the platform is left to choose a reasonable default
+	//	which is subject to change without notice.
+	// +kubebuilder:validation:Optional
+	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
+	// +optional
+	HardwareSpeed ControlPlaneHardwareSpeed `json:"controlPlaneHardwareSpeed"`
 }
 
 type EtcdStatus struct {
 	StaticPodOperatorStatus `json:",inline"`
+	HardwareSpeed           ControlPlaneHardwareSpeed `json:"controlPlaneHardwareSpeed"`
 }
+
+const (
+	// StandardHardwareSpeed provides the normal tolerances for hardware speed and latency.
+	//	Currently sets (values subject to change at any time):
+	//		ETCD_HEARTBEAT_INTERVAL: 100ms
+	// 	ETCD_LEADER_ELECTION_TIMEOUT: 1000ms
+	StandardHardwareSpeed ControlPlaneHardwareSpeed = "Standard"
+	// SlowerHardwareSpeed provides more tolerance for slower hardware and/or higher latency networks.
+	// Sets (values subject to change):
+	//		ETCD_HEARTBEAT_INTERVAL: 5x Standard
+	// 	ETCD_LEADER_ELECTION_TIMEOUT: 2.5x Standard
+	SlowerHardwareSpeed ControlPlaneHardwareSpeed = "Slower"
+)
+
+// ControlPlaneHardwareSpeed declares valid hardware speed tolerance levels
+// +enum
+// +kubebuilder:validation:Enum:="";Standard;Slower
+type ControlPlaneHardwareSpeed string
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -686,6 +686,14 @@ func (EtcdList) SwaggerDoc() map[string]string {
 	return map_EtcdList
 }
 
+var map_EtcdSpec = map[string]string{
+	"controlPlaneHardwareSpeed": "HardwareSpeed allows user to change the etcd tuning profile which configures the latency parameters for heartbeat interval and leader election timeouts allowing the cluster to tolerate longer round-trip-times between etcd members. Valid values are \"\", \"Standard\" and \"Slower\".\n\t\"\" means no opinion and the platform is left to choose a reasonable default\n\twhich is subject to change without notice.",
+}
+
+func (EtcdSpec) SwaggerDoc() map[string]string {
+	return map_EtcdSpec
+}
+
 var map_AWSClassicLoadBalancerParameters = map[string]string{
 	"":                      "AWSClassicLoadBalancerParameters holds configuration parameters for an AWS Classic load balancer.",
 	"connectionIdleTimeout": "connectionIdleTimeout specifies the maximum time period that a connection may be idle before the load balancer closes the connection.  The value must be parseable as a time duration value; see <https://pkg.go.dev/time#ParseDuration>.  A nil or zero value means no opinion, in which case a default value is used.  The default value for this field is 60s.  This default is subject to change.",


### PR DESCRIPTION
Adds the techpreview API for etcd tuning profiles as will be outlined in https://github.com/openshift/enhancements/pull/1447

This will allow for limited user configuration of etcd's tolerated intervals/timeouts (heartbeat interval, leader election timeout)

Adds the API:
profiles.config.openshift.io/v1alpha1
Used to configure the tuning profiles in etcd

/cc @tjungblu @deads2k @hasbro17 @williamcaban 