### PR TITLE
NE-1303: Revert "cluster version: add ingress capability"

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -72,7 +72,6 @@ spec:
                           - CSISnapshot
                           - NodeTuning
                           - MachineAPI
-                          - Ingress
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -196,7 +195,6 @@ spec:
                           - CSISnapshot
                           - NodeTuning
                           - MachineAPI
-                          - Ingress
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -214,7 +212,6 @@ spec:
                           - CSISnapshot
                           - NodeTuning
                           - MachineAPI
-                          - Ingress
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -247,7 +247,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Ingress
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI
 type ClusterVersionCapability string
 
 const (
@@ -313,27 +313,12 @@ const (
 	// documentation. This is important part of openshift system
 	// and may cause cluster damage
 	ClusterVersionCapabilityMachineAPI ClusterVersionCapability = "MachineAPI"
-
-	// ClusterVersionCapabilityIngress manages the cluster ingress operator
-	// which is responsible for running the ingress controllers (including OpenShift router).
-	//
-	// The following CRDs are part of the capability as well:
-	// IngressController
-	// DNSRecord
-	// GatewayClass
-	// Gateway
-	// HTTPRoute
-	// ReferenceGrant
-	//
-	// WARNING: This capability cannot be disabled on the standalone OpenShift.
-	ClusterVersionCapabilityIngress ClusterVersionCapability = "Ingress"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
 var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityBaremetal,
 	ClusterVersionCapabilityConsole,
-	ClusterVersionCapabilityIngress,
 	ClusterVersionCapabilityInsights,
 	ClusterVersionCapabilityMarketplace,
 	ClusterVersionCapabilityStorage,
@@ -412,7 +397,6 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 	ClusterVersionCapabilitySet4_14: {
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityConsole,
-		ClusterVersionCapabilityIngress,
 		ClusterVersionCapabilityInsights,
 		ClusterVersionCapabilityMarketplace,
 		ClusterVersionCapabilityStorage,
@@ -424,7 +408,6 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 	ClusterVersionCapabilitySetCurrent: {
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityConsole,
-		ClusterVersionCapabilityIngress,
 		ClusterVersionCapabilityInsights,
 		ClusterVersionCapabilityMarketplace,
 		ClusterVersionCapabilityStorage,

--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/616
-    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/operatoringress/v1/0000_50_dns-record.yaml
+++ b/operatoringress/v1/0000_50_dns-record.yaml
@@ -7,7 +7,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Ingress
 spec:
   group: ingress.operator.openshift.io
   names:


### PR DESCRIPTION
This reverts commit ee31fd8914ccfc897fd7e9defbfd5c66cc047166.

The ingress capability has been deferred to OCP 4.15. Reverting the API change to not rush on the changes in the other repositories (cvo, installer, console operator).