### PR TITLE
schemapatch: Print file path if unmarshal fails

### DIFF
--- a/tools/codegen/pkg/schemapatch/generator.go
+++ b/tools/codegen/pkg/schemapatch/generator.go
@@ -220,7 +220,7 @@ func loadSchemaPatchGenerationContextsForVersion(version generation.APIVersionCo
 
 		partialObject := &metav1.PartialObjectMetadata{}
 		if err := kyaml.Unmarshal(data, partialObject); err != nil {
-			errs = append(errs, fmt.Errorf("could not unmarshal YAML for type meta inspection: %v", err))
+			errs = append(errs, fmt.Errorf("could not unmarshal YAML in file %s for type meta inspection: %v", path, err))
 			continue
 		}
 


### PR DESCRIPTION
Expand the schemapatch generator's "could not unmarshal YAML" error message to reference the file path of the problematic yaml.

Before this change, the error output looked like this:

    F0803 04:00:17.068303 2579545 root.go:59] Error running codegen:
    error running generator schemapatch on group operator.openshift.io:
    	could not run schemapatch generator for group/version operator.openshift.io/v1:
    		could not load generation contexts:
    			could not unmarshal YAML for type meta inspection: error converting YAML to JSON: yaml: line 480: mapping values are not allowed in this context
    make: *** [Makefile:32: update-codegen-crds] Error 255

After this change, the error output looks like this:

    F0803 04:03:31.376213 2670287 root.go:59] Error running codegen:
    error running generator schemapatch on group operator.openshift.io:
    	could not run schemapatch generator for group/version operator.openshift.io/v1:
    		could not load generation contexts:
    			could not unmarshal YAML in file /home/mmasters/src/github.com/openshift/api/operator/v1/stable.ingresscontroller.testsuite.yaml for type meta inspection: error converting YAML to JSON: yaml: line 480: mapping values are not allowed in this context
    make: *** [Makefile:32: update-codegen-crds] Error 255

* `tools/codegen/pkg/schemapatch/generator.go` (`loadSchemaPatchGenerationContextsForVersion`): Include file path in the error message when unmarshalling fails.

---

I hope the more explicit error message will spare some future developer the hour it took me to realize I needed to fix the tests rather than the CRD.  