### PR TITLE
OCPBUGS-17414: Limit header names to 255 characters

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -43726,7 +43726,7 @@ func schema_openshift_api_operator_v1_IngressControllerHTTPHeader(ref common.Ref
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.",
+							Description: "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53314,7 +53314,7 @@ func schema_openshift_api_route_v1_RouteHTTPHeader(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.",
+							Description: "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -25579,7 +25579,7 @@
           "$ref": "#/definitions/com.github.openshift.api.operator.v1.IngressControllerHTTPHeaderActionUnion"
         },
         "name": {
-          "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.",
+          "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
           "type": "string",
           "default": ""
         }
@@ -31438,7 +31438,7 @@
           "$ref": "#/definitions/com.github.openshift.api.route.v1.RouteHTTPHeaderActionUnion"
         },
         "name": {
-          "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.",
+          "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
           "type": "string",
           "default": ""
         }

--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -296,8 +296,8 @@ spec:
                                   - message: set is required when type is Set, and forbidden otherwise
                                     rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set) : !has(self.set)'
                               name:
-                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.'
-                                maxLength: 1024
+                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.'
+                                maxLength: 255
                                 minLength: 1
                                 pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
                                 type: string
@@ -356,8 +356,8 @@ spec:
                                   - message: set is required when type is Set, and forbidden otherwise
                                     rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set) : !has(self.set)'
                               name:
-                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.'
-                                maxLength: 1024
+                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.'
+                                maxLength: 255
                                 minLength: 1
                                 pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
                                 type: string

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -1473,11 +1473,11 @@ type IngressControllerHTTPHeader struct {
 	// The name must consist only of alphanumeric and the following special characters, "-!#$%&'*+.^_`".
 	// The following header names are reserved and may not be modified via this API:
 	// Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie.
-	// It must be no more than 1024 characters in length.
+	// It must be no more than 255 characters in length.
 	// Header name must be unique.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=1024
+	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:Pattern="^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$"
 	// +kubebuilder:validation:XValidation:rule="self.lowerAscii() != 'strict-transport-security'",message="strict-transport-security header may not be modified via header actions"
 	// +kubebuilder:validation:XValidation:rule="self.lowerAscii() != 'proxy'",message="proxy header may not be modified via header actions"

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -852,7 +852,7 @@ func (IngressControllerCaptureHTTPHeaders) SwaggerDoc() map[string]string {
 
 var map_IngressControllerHTTPHeader = map[string]string{
 	"":       "IngressControllerHTTPHeader specifies configuration for setting or deleting an HTTP header.",
-	"name":   "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.",
+	"name":   "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Host, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
 	"action": "action specifies actions to perform on headers, such as setting or deleting headers.",
 }
 

--- a/route/v1/generated.proto
+++ b/route/v1/generated.proto
@@ -72,11 +72,11 @@ message RouteHTTPHeader {
   // The name must consist only of alphanumeric and the following special characters, "-!#$%&'*+.^_`".
   // The following header names are reserved and may not be modified via this API:
   // Strict-Transport-Security, Proxy, Cookie, Set-Cookie.
-  // It must be no more than 1024 characters in length.
+  // It must be no more than 255 characters in length.
   // Header name must be unique.
   // +kubebuilder:validation:Required
   // +kubebuilder:validation:MinLength=1
-  // +kubebuilder:validation:MaxLength=1024
+  // +kubebuilder:validation:MaxLength=255
   // +kubebuilder:validation:Pattern="^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$"
   // +kubebuilder:validation:XValidation:rule="self.lowerAscii() != 'strict-transport-security'",message="strict-transport-security header may not be modified via header actions"
   // +kubebuilder:validation:XValidation:rule="self.lowerAscii() != 'proxy'",message="proxy header may not be modified via header actions"

--- a/route/v1/route-CustomNoUpgrade.crd.yaml
+++ b/route/v1/route-CustomNoUpgrade.crd.yaml
@@ -128,9 +128,9 @@ spec:
                                   - rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set) : !has(self.set)'
                                     message: set is required when type is Set, and forbidden otherwise
                               name:
-                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.'
+                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.'
                                 type: string
-                                maxLength: 1024
+                                maxLength: 255
                                 minLength: 1
                                 pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
                                 x-kubernetes-validations:
@@ -186,9 +186,9 @@ spec:
                                   - rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set) : !has(self.set)'
                                     message: set is required when type is Set, and forbidden otherwise
                               name:
-                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.'
+                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.'
                                 type: string
-                                maxLength: 1024
+                                maxLength: 255
                                 minLength: 1
                                 pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
                                 x-kubernetes-validations:

--- a/route/v1/route-TechPreviewNoUpgrade.crd.yaml
+++ b/route/v1/route-TechPreviewNoUpgrade.crd.yaml
@@ -128,9 +128,9 @@ spec:
                                   - rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set) : !has(self.set)'
                                     message: set is required when type is Set, and forbidden otherwise
                               name:
-                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.'
+                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.'
                                 type: string
-                                maxLength: 1024
+                                maxLength: 255
                                 minLength: 1
                                 pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
                                 x-kubernetes-validations:
@@ -186,9 +186,9 @@ spec:
                                   - rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set) : !has(self.set)'
                                     message: set is required when type is Set, and forbidden otherwise
                               name:
-                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.'
+                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.'
                                 type: string
-                                maxLength: 1024
+                                maxLength: 255
                                 minLength: 1
                                 pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
                                 x-kubernetes-validations:

--- a/route/v1/route.crd.yaml
+++ b/route/v1/route.crd.yaml
@@ -139,8 +139,8 @@ spec:
                                   - message: set is required when type is Set, and forbidden otherwise
                                     rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set) : !has(self.set)'
                               name:
-                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.'
-                                maxLength: 1024
+                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.'
+                                maxLength: 255
                                 minLength: 1
                                 pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
                                 type: string
@@ -197,8 +197,8 @@ spec:
                                   - message: set is required when type is Set, and forbidden otherwise
                                     rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set) : !has(self.set)'
                               name:
-                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.'
-                                maxLength: 1024
+                                description: 'name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, "-!#$%&''*+.^_`". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.'
+                                maxLength: 255
                                 minLength: 1
                                 pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
                                 type: string

--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -240,11 +240,11 @@ type RouteHTTPHeader struct {
 	// The name must consist only of alphanumeric and the following special characters, "-!#$%&'*+.^_`".
 	// The following header names are reserved and may not be modified via this API:
 	// Strict-Transport-Security, Proxy, Cookie, Set-Cookie.
-	// It must be no more than 1024 characters in length.
+	// It must be no more than 255 characters in length.
 	// Header name must be unique.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=1024
+	// +kubebuilder:validation:MaxLength=255
 	// +kubebuilder:validation:Pattern="^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$"
 	// +kubebuilder:validation:XValidation:rule="self.lowerAscii() != 'strict-transport-security'",message="strict-transport-security header may not be modified via header actions"
 	// +kubebuilder:validation:XValidation:rule="self.lowerAscii() != 'proxy'",message="proxy header may not be modified via header actions"

--- a/route/v1/zz_generated.swagger_doc_generated.go
+++ b/route/v1/zz_generated.swagger_doc_generated.go
@@ -33,7 +33,7 @@ func (Route) SwaggerDoc() map[string]string {
 
 var map_RouteHTTPHeader = map[string]string{
 	"":       "RouteHTTPHeader specifies configuration for setting or deleting an HTTP header.",
-	"name":   "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 1024 characters in length. Header name must be unique.",
+	"name":   "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header name as defined in RFC 2616 section 4.2. The name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\". The following header names are reserved and may not be modified via this API: Strict-Transport-Security, Proxy, Cookie, Set-Cookie. It must be no more than 255 characters in length. Header name must be unique.",
 	"action": "action specifies actions to perform on headers, such as setting or deleting headers.",
 }
 


### PR DESCRIPTION
The header name max size limit is changed to 255.
This was changed as haproxy does not allow more 255 bytes to be set for header name because of the reason mentioned here: https://jfrog.com/blog/critical-vulnerability-in-haproxy-cve-2021-40346-integer-overflow-enables-http-smuggling/
Issue link: https://issues.redhat.com/browse/OCPBUGS-17414
