### PR TITLE
[WRKLDS-707] remove PDBUnhealthyPodEvictionPolicy feature gate from TechPreviewNoUpgrade

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -143,16 +143,6 @@ var (
 		OwningProduct:       ocpSpecific,
 	}
 
-	FeatureGatePDBUnhealthyPodEvictionPolicy = FeatureGateName("PDBUnhealthyPodEvictionPolicy")
-	pdbUnhealthyPodEvictionPolicy            = FeatureGateDescription{
-		FeatureGateAttributes: FeatureGateAttributes{
-			Name: FeatureGatePDBUnhealthyPodEvictionPolicy,
-		},
-		OwningJiraComponent: "apps",
-		ResponsiblePerson:   "atiratree",
-		OwningProduct:       kubernetes,
-	}
-
 	FeatureGateDynamicResourceAllocation = FeatureGateName("DynamicResourceAllocation")
 	dynamicResourceAllocation            = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -171,7 +171,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(machineAPIProviderOpenStack).
 		with(insightsConfigAPI).
 		with(retroactiveDefaultStorageClass).
-		with(pdbUnhealthyPodEvictionPolicy).
 		with(dynamicResourceAllocation).
 		with(admissionWebhookMatchConditions).
 		with(azureWorkloadIdentity).


### PR DESCRIPTION
It was promoted to beta and enabled by default in 1.27 upstream:
- https://github.com/kubernetes/kubernetes/pull/115363