### PR TITLE
Extend integration test timeout to 30m

### DIFF
--- a/tests/hack/test.sh
+++ b/tests/hack/test.sh
@@ -8,7 +8,7 @@ REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 OPENSHIFT_CI=${OPENSHIFT_CI:-""}
 ARTIFACT_DIR=${ARTIFACT_DIR:-""}
 GINKGO=${GINKGO:-"go run ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
-GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --randomize-all --randomize-suites --keep-going --timeout=15m"}
+GINKGO_ARGS=${GINKGO_ARGS:-"-r -v --randomize-all --randomize-suites --keep-going --timeout=30m"}
 GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}
 
 # Ensure that some home var is set and that it's not the root.


### PR DESCRIPTION
These tests are being added to and are starting to hit the 15m limit. Need to find a way to speed them up, but for now, lets just extend the timeout to give ourselves some headroom.