### PR TITLE
Introduce ValidatingAdmissionPolicy gate as disabled.

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -23,6 +23,16 @@ var (
 )
 
 var (
+	FeatureGateValidatingAdmissionPolicy = FeatureGateName("ValidatingAdmissionPolicy")
+	validatingAdmissionPolicy            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateValidatingAdmissionPolicy,
+		},
+		OwningJiraComponent: "kube-apiserver",
+		ResponsiblePerson:   "benluddy",
+		OwningProduct:       kubernetes,
+	}
+
 	FeatureGateGatewayAPI = FeatureGateName("GatewayAPI")
 	gateGatewayAPI        = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -163,6 +163,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		Disabled: []FeatureGateDescription{},
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
+		without(validatingAdmissionPolicy).
 		with(externalCloudProvider).
 		with(externalCloudProviderGCP).
 		with(csiDriverSharedResource).


### PR DESCRIPTION
This feature is intentionally not enabled in an feature set since it depends on a change to the kube-apiserver operator. The kube-apiserver operator change can't merge (sans hack) until this feature is "known". So the intention is to introduce ValidatingAdmissionPolicy here, then merge the operator change, and finally add ValidatingAdmissionPolicy to the tech preview feature set.