### PR TITLE
Remove tech preview feature set annotation from existing non-techpreview crd

### DIFF
--- a/operator/v1/0000_12_etcd-operator_01_config-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/0000_12_etcd-operator_01_config-TechPreviewNoUpgrade.crd.yaml
@@ -6,7 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    release.openshift.io/feature-set: Default
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: etcds.operator.openshift.io
 spec:
   group: operator.openshift.io
@@ -37,6 +37,13 @@ spec:
             spec:
               type: object
               properties:
+                controlPlaneHardwareSpeed:
+                  description: HardwareSpeed allows user to change the etcd tuning profile which configures the latency parameters for heartbeat interval and leader election timeouts allowing the cluster to tolerate longer round-trip-times between etcd members. Valid values are "", "Standard" and "Slower". "" means no opinion and the platform is left to choose a reasonable default which is subject to change without notice.
+                  type: string
+                  enum:
+                    - ""
+                    - Standard
+                    - Slower
                 failedRevisionLimit:
                   description: failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)
                   type: integer

--- a/operator/v1/techpreview.etcd.testsuite.yaml
+++ b/operator/v1/techpreview.etcd.testsuite.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[TechPreview] Etcd"
-crd: 0000_12_etcd-operator_01_config.crd.yaml
+crd: 0000_12_etcd-operator_01_config-TechPreviewNoUpgrade.crd.yaml
 tests:
   onCreate:
   - name: Should be able to create with Standard hardware speed


### PR DESCRIPTION
I mistakenly added this while working on the tests for #1538, I think that it's causing this crd to not get laid down correctly which is causing etcd to not start properly.