### PR TITLE
CCO-412: Promote azureWorkloadIdentity to defaultFeatures.

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -173,7 +173,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(retroactiveDefaultStorageClass).
 		with(dynamicResourceAllocation).
 		with(admissionWebhookMatchConditions).
-		with(azureWorkloadIdentity).
 		with(gateGatewayAPI).
 		with(maxUnavailableStatefulSet).
 		without(eventedPleg).
@@ -193,6 +192,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 	Enabled: []FeatureGateDescription{
 		openShiftPodSecurityAdmission,
 		alibabaPlatform, // This is a bug, it should be TechPreviewNoUpgrade. This must be downgraded before 4.14 is shipped.
+		azureWorkloadIdentity,
 		cloudDualStackNodeIPs,
 		externalCloudProviderAzure,
 		externalCloudProviderExternal,


### PR DESCRIPTION
Promote the azureWorkloadIdentity feature from the TechPreviewNoUpgrade featureSet to defaultFeatures.

Corresponding cluster-config-operator pr: https://github.com/openshift/cluster-config-operator/pull/345

Feature periodic: https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-cloud-credential-operator-release-4.14-periodics-e2e-azure-manual-oidc