### PR TITLE
OCPBUGS-17851: AzureMachineProviderSpec convert zone to non-pointer

### DIFF
--- a/machine/v1beta1/types_azureprovider.go
+++ b/machine/v1beta1/types_azureprovider.go
@@ -95,7 +95,7 @@ type AzureMachineProviderSpec struct {
 	// Availability Zone for the virtual machine.
 	// If nil, the virtual machine should be deployed to no zone
 	// +optional
-	Zone *string `json:"zone,omitempty"`
+	Zone string `json:"zone,omitempty"`
 	// NetworkResourceGroup is the resource group for the virtual machine's network
 	// +optional
 	NetworkResourceGroup string `json:"networkResourceGroup,omitempty"`

--- a/machine/v1beta1/zz_generated.deepcopy.go
+++ b/machine/v1beta1/zz_generated.deepcopy.go
@@ -303,11 +303,6 @@ func (in *AzureMachineProviderSpec) DeepCopyInto(out *AzureMachineProviderSpec) 
 		*out = new(int64)
 		**out = **in
 	}
-	if in.Zone != nil {
-		in, out := &in.Zone, &out.Zone
-		*out = new(string)
-		**out = **in
-	}
 	if in.SpotVMOptions != nil {
 		in, out := &in.SpotVMOptions, &out.SpotVMOptions
 		*out = new(SpotVMOptions)


### PR DESCRIPTION
This PR removes pointer from the zone field in `AzureMachineProviderSpec` to simplify conversion between it and CPMS's Azure failure domain that already uses a non-pointer Zone. 
This change will be a no-op in terms of the data stored in etcd since the type is unstructured anyway. I'll update all the users of this API. (MAPZ, installer, CPMSO)