### PR TITLE
Image and manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ _output/
 tests/bin/
 
 models-schema
+/render
+/write-available-featuresets

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -1,0 +1,35 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+WORKDIR /go/src/github.com/openshift/api
+COPY . .
+ENV GO_PACKAGE github.com/openshift/api
+RUN make build --warn-undefined-variables
+
+FROM registry.ci.openshift.org/ocp/4.14:base
+
+# copy the built binaries to /usr/bin
+COPY --from=builder /go/src/github.com/openshift/api/render /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/api/write-available-featuresets /usr/bin/
+
+# this directory is used to produce rendered manifests that the installer applies (but does not maintain) in bootkube
+RUN mkdir -p /usr/share/bootkube/manifests/manifests
+COPY config/v1/*_config-operator_*.yaml /usr/share/bootkube/manifests/manifests
+COPY quota/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
+COPY security/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
+COPY securityinternal/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
+COPY authorization/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
+COPY operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml /usr/share/bootkube/manifests/manifests
+
+# these are applied by the CVO
+COPY manifests /manifests
+# TODO copy these back when we're ready to make the switch from cluster-config-operator to here
+#COPY config/v1/*_config-operator_*.yaml /manifests
+#COPY quota/v1/*.crd.yaml /manifests
+#COPY security/v1/*.crd.yaml /manifests
+#COPY securityinternal/v1/*.crd.yaml /manifests
+#COPY authorization/v1/*.crd.yaml /manifests
+#COPY operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml /manifests
+#COPY operator/v1/0000_10_config-operator_*.yaml /manifests
+#COPY payload-command/empty-resources /manifests
+
+# TODO uncomment after all the other "add a new image" steps are complete.
+#LABEL io.openshift.release.operator true

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	golang.org/x/tools v0.8.0
 	k8s.io/api v0.28.2
 	k8s.io/apimachinery v0.28.2
+	k8s.io/klog/v2 v2.100.1
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -36,7 +37,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: api
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-api:v4.0

--- a/payload-command/cmd/render/main.go
+++ b/payload-command/cmd/render/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/openshift/api/payload-command/render"
+)
+
+// this command injects the initial FeatureGate.status and places some CRDs to be created by the installer during bootstrapping
+// remember that these manifests are not maintained in a running cluster.
+func main() {
+	o := &render.RenderOpts{}
+	o.AddFlags(flag.CommandLine)
+	flag.Parse()
+
+	if err := o.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+}

--- a/payload-command/cmd/write-available-featuresets/main.go
+++ b/payload-command/cmd/write-available-featuresets/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/openshift/api/payload-command/render"
+)
+
+// this command writes manifests for each available featureset so that the cluster-config-operator can read them
+// in order to maintain the list.
+func main() {
+	o := &render.WriteFeatureSets{}
+	o.AddFlags(flag.CommandLine)
+	flag.Parse()
+
+	if err := o.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+}

--- a/payload-command/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    # this flag is not set for a cluster coming from 4.5 via upgrade. Hence, 4.5 clusters will keep supporting non-sha256 tokens.
+    oauth-apiserver.openshift.io/secure-token-storage: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_build.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_build.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Build
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_console.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_console.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Console
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_dns.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_dns.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: DNS
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_image.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_image.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Infrastructure
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Ingress
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_network.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_network.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_project.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_project.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Project
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Proxy
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/empty-resources/0000_10_config-operator_02_node.cr.yaml
+++ b/payload-command/empty-resources/0000_10_config-operator_02_node.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/payload-command/render/config.go
+++ b/payload-command/render/config.go
@@ -1,0 +1,30 @@
+package render
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var (
+	configScheme = runtime.NewScheme()
+	configCodecs = serializer.NewCodecFactory(configScheme)
+)
+
+func init() {
+	utilruntime.Must(configv1.AddToScheme(configScheme))
+}
+
+func readFeatureGateV1OrDie(objBytes []byte) *configv1.FeatureGate {
+	requiredObj, err := runtime.Decode(configCodecs.UniversalDecoder(configv1.SchemeGroupVersion), objBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	return requiredObj.(*configv1.FeatureGate)
+}
+
+func writeFeatureGateV1OrDie(obj *configv1.FeatureGate) string {
+	return runtime.EncodeOrDie(configCodecs.LegacyCodec(configv1.SchemeGroupVersion), obj)
+}

--- a/payload-command/render/render.go
+++ b/payload-command/render/render.go
@@ -1,0 +1,193 @@
+package render
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	assets "github.com/openshift/api/payload-command/render/renderassets"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	// bootstrapManifestLocation is the location in the image that contains the manifests to copy into the bootstrap
+	// manifests that are created during bootkube.
+	bootstrapManifestLocation = "/usr/share/bootkube/manifests/manifests"
+)
+
+// RenderOpts holds values to drive the render command.
+type RenderOpts struct {
+	RenderedManifestInputFilename string
+	PayloadVersion                string
+	AssetOutputDir                string
+}
+
+func (o *RenderOpts) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&o.RenderedManifestInputFilename, "rendered-manifest-dir", o.RenderedManifestInputFilename,
+		"files or directories containing yaml or json manifests that will be created via cluster-bootstrapping.")
+	fs.StringVar(&o.PayloadVersion, "payload-version", o.PayloadVersion, "Version that will eventually be placed into ClusterOperator.status.  This normally comes from the CVO set via env var: OPERATOR_IMAGE_VERSION.")
+	fs.StringVar(&o.AssetOutputDir, "asset-output-dir", o.AssetOutputDir, "Output path for rendered manifests.")
+}
+
+// Validate verifies the inputs.
+func (o *RenderOpts) Validate() error {
+	return nil
+}
+
+// Complete fills in missing values before command execution.
+func (o *RenderOpts) Complete() error {
+	return nil
+}
+
+// Run contains the logic of the render command.
+func (o *RenderOpts) Run() error {
+	featureSet := ""
+	featureGateFiles, err := featureGateManifests([]string{o.RenderedManifestInputFilename})
+	if err != nil {
+		return fmt.Errorf("problem with featuregate manifests: %w", err)
+	}
+	for _, featureGateFile := range featureGateFiles {
+		featureGatesObj, err := featureGateFile.GetDecodedObj()
+		if err != nil {
+			return fmt.Errorf("error decoding FeatureGate: %w", err)
+		}
+		featureGates := featureGatesObj.(*configv1.FeatureGate)
+		currentDetails, err := FeaturesGateDetailsFromFeatureSets(configv1.FeatureSets, featureGates, o.PayloadVersion)
+		if err != nil {
+			return fmt.Errorf("error determining FeatureGates: %w", err)
+		}
+		featureGates.Status.FeatureGates = []configv1.FeatureGateDetails{*currentDetails}
+
+		featureGateOutBytes := writeFeatureGateV1OrDie(featureGates)
+		if err := os.WriteFile(featureGateFile.OriginalFilename, []byte(featureGateOutBytes), 0644); err != nil {
+			return fmt.Errorf("error writing FeatureGate manifest: %w", err)
+		}
+		featureSet = string(featureGates.Spec.FeatureSet)
+	}
+
+	err = assets.SubstituteAndCopyFiles(
+		bootstrapManifestLocation,
+		filepath.Join(o.AssetOutputDir, "manifests"),
+		featureSet,
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to substitute and copy files: %w", err)
+	}
+
+	return nil
+}
+
+func featureGateManifests(renderedManifestInputFilenames []string) (assets.RenderedManifests, error) {
+	if len(renderedManifestInputFilenames) == 0 {
+		return nil, fmt.Errorf("cannot return FeatureGate without rendered manifests")
+	}
+
+	inputManifests := assets.RenderedManifests{}
+	for _, filename := range renderedManifestInputFilenames {
+		manifestContent, err := assets.LoadFilesRecursively(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed loading rendered manifest inputs from %q: %w", filename, err)
+		}
+		for manifestFile, content := range manifestContent {
+			inputManifests = append(inputManifests, assets.RenderedManifest{
+				OriginalFilename: filepath.Join(filename, manifestFile),
+				Content:          content,
+			})
+		}
+	}
+	featureGates := inputManifests.ListManifestOfType(configv1.GroupVersion.WithKind("FeatureGate"))
+	if len(featureGates) == 0 {
+		return nil, fmt.Errorf("no FeatureGates found in manfest dir: %v", renderedManifestInputFilenames)
+	}
+
+	return featureGates, nil
+}
+
+func FeaturesGateDetailsFromFeatureSets(featureSetMap map[configv1.FeatureSet]*configv1.FeatureGateEnabledDisabled, featureGates *configv1.FeatureGate, currentVersion string) (*configv1.FeatureGateDetails, error) {
+	enabled, disabled, err := featuresGatesFromFeatureSets(featureSetMap, featureGates)
+	if err != nil {
+		return nil, err
+	}
+	currentDetails := configv1.FeatureGateDetails{
+		Version: currentVersion,
+	}
+	for _, gateName := range enabled {
+		currentDetails.Enabled = append(currentDetails.Enabled, configv1.FeatureGateAttributes{
+			Name: gateName,
+		})
+	}
+	for _, gateName := range disabled {
+		currentDetails.Disabled = append(currentDetails.Disabled, configv1.FeatureGateAttributes{
+			Name: gateName,
+		})
+	}
+
+	// sort for stability
+	sort.Sort(byName(currentDetails.Enabled))
+	sort.Sort(byName(currentDetails.Disabled))
+
+	return &currentDetails, nil
+}
+
+type byName []configv1.FeatureGateAttributes
+
+func (a byName) Len() int      { return len(a) }
+func (a byName) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a byName) Less(i, j int) bool {
+	if strings.Compare(string(a[i].Name), string(a[j].Name)) < 0 {
+		return true
+	}
+	return false
+}
+
+func featuresGatesFromFeatureSets(knownFeatureSets map[configv1.FeatureSet]*configv1.FeatureGateEnabledDisabled, featureGates *configv1.FeatureGate) ([]configv1.FeatureGateName, []configv1.FeatureGateName, error) {
+	if featureGates.Spec.FeatureSet == configv1.CustomNoUpgrade {
+		if featureGates.Spec.FeatureGateSelection.CustomNoUpgrade != nil {
+			completeEnabled, completeDisabled := completeFeatureGates(knownFeatureSets, featureGates.Spec.FeatureGateSelection.CustomNoUpgrade.Enabled, featureGates.Spec.FeatureGateSelection.CustomNoUpgrade.Disabled)
+			return completeEnabled, completeDisabled, nil
+		}
+		return []configv1.FeatureGateName{}, []configv1.FeatureGateName{}, nil
+	}
+
+	featureSet, ok := knownFeatureSets[featureGates.Spec.FeatureSet]
+	if !ok {
+		return []configv1.FeatureGateName{}, []configv1.FeatureGateName{}, fmt.Errorf(".spec.featureSet %q not found", featureSet)
+	}
+
+	completeEnabled, completeDisabled := completeFeatureGates(knownFeatureSets, toFeatureGateNames(featureSet.Enabled), toFeatureGateNames(featureSet.Disabled))
+	return completeEnabled, completeDisabled, nil
+}
+
+func toFeatureGateNames(in []configv1.FeatureGateDescription) []configv1.FeatureGateName {
+	out := []configv1.FeatureGateName{}
+	for _, curr := range in {
+		out = append(out, curr.FeatureGateAttributes.Name)
+	}
+
+	return out
+}
+
+// completeFeatureGates identifies every known feature and ensures that is explicitly on or explicitly off
+func completeFeatureGates(knownFeatureSets map[configv1.FeatureSet]*configv1.FeatureGateEnabledDisabled, enabled, disabled []configv1.FeatureGateName) ([]configv1.FeatureGateName, []configv1.FeatureGateName) {
+	specificallyEnabledFeatureGates := sets.New[configv1.FeatureGateName]()
+	specificallyEnabledFeatureGates.Insert(enabled...)
+
+	knownFeatureGates := sets.New[configv1.FeatureGateName]()
+	knownFeatureGates.Insert(enabled...)
+	knownFeatureGates.Insert(disabled...)
+	for _, known := range knownFeatureSets {
+		for _, curr := range known.Disabled {
+			knownFeatureGates.Insert(curr.FeatureGateAttributes.Name)
+		}
+		for _, curr := range known.Enabled {
+			knownFeatureGates.Insert(curr.FeatureGateAttributes.Name)
+		}
+	}
+
+	return enabled, knownFeatureGates.Difference(specificallyEnabledFeatureGates).UnsortedList()
+}

--- a/payload-command/render/renderassets/assets.go
+++ b/payload-command/render/renderassets/assets.go
@@ -1,0 +1,197 @@
+package assets
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/errors"
+)
+
+type Permission os.FileMode
+
+const (
+	PermissionDirectoryDefault Permission = 0755
+	PermissionFileDefault      Permission = 0644
+	PermissionFileRestricted   Permission = 0600
+)
+
+// Asset defines a single static asset.
+type Asset struct {
+	Name           string
+	FilePermission Permission
+	Data           []byte
+}
+
+// Assets is a list of assets.
+type Assets []Asset
+
+// New walks through a directory recursively and renders each file as asset. Only those files
+// are rendered that make all predicates true.
+func New(dir string, data interface{}, manifestPredicates []FileContentsPredicate, predicates ...FileInfoPredicate) (Assets, error) {
+	files, err := LoadFilesRecursively(dir, predicates...)
+	if err != nil {
+		return nil, err
+	}
+
+	var as Assets
+	var errs []error
+	for path, bs := range files {
+		a, err := assetFromTemplate(path, bs, data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to render %q: %v", path, err)
+		}
+
+		skipManifest := false
+		for _, manifestPredicate := range manifestPredicates {
+			shouldInclude, err := manifestPredicate(a.Data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to check manifest filter %q: %v", path, err)
+			}
+			if !shouldInclude {
+				skipManifest = true
+				break
+			}
+		}
+		if skipManifest {
+			continue
+		}
+
+		as = append(as, *a)
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.NewAggregate(errs)
+	}
+
+	return as, nil
+}
+
+// WriteFiles writes the assets to specified path.
+func (as Assets) WriteFiles(path string) error {
+	if err := os.MkdirAll(path, os.FileMode(PermissionDirectoryDefault)); err != nil {
+		return err
+	}
+	for _, asset := range as {
+		if _, err := os.Stat(path); os.IsExist(err) {
+			fmt.Printf("WARNING: File %s already exists, content will be replaced\n", path)
+		}
+		if err := asset.WriteFile(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteFile writes a single asset into specified path.
+func (a Asset) WriteFile(path string) error {
+	f := filepath.Join(path, a.Name)
+	perms := PermissionFileDefault
+	if err := os.MkdirAll(filepath.Dir(f), os.FileMode(PermissionDirectoryDefault)); err != nil {
+		return err
+	}
+	if a.FilePermission != 0 {
+		perms = a.FilePermission
+	}
+	fmt.Printf("Writing asset: %s\n", f)
+	return ioutil.WriteFile(f, a.Data, os.FileMode(perms))
+}
+
+// MustCreateAssetFromTemplate process the given template using and return an asset.
+func MustCreateAssetFromTemplate(name string, template []byte, config interface{}) Asset {
+	asset, err := assetFromTemplate(name, template, config)
+	if err != nil {
+		panic(err)
+	}
+	return *asset
+}
+
+func assetFromTemplate(name string, tb []byte, data interface{}) (*Asset, error) {
+	bs, err := renderFile(name, tb, data)
+	if err != nil {
+		return nil, err
+	}
+	return &Asset{Name: name, Data: bs}, nil
+}
+
+type FileInfoPredicate func(path string, info os.FileInfo) (bool, error)
+
+type FileContentsPredicate func(manifest []byte) (bool, error)
+
+// OnlyYaml is a predicate for LoadFilesRecursively filters out non-yaml files.
+func OnlyYaml(_ string, info os.FileInfo) (bool, error) {
+	return strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml"), nil
+}
+
+// InstallerFeatureSet returns a predicate for LoadFilesRecursively that filters manifests
+// based on the specified FeatureSet.
+func InstallerFeatureSet(featureSet string) FileContentsPredicate {
+	targetFeatureSet := "Default"
+	if len(featureSet) > 0 {
+		targetFeatureSet = featureSet
+	}
+	return func(manifest []byte) (bool, error) {
+		uncastObj, _, err := unstructured.UnstructuredJSONScheme.Decode(manifest, nil, &unstructured.Unstructured{})
+		if err != nil {
+			panic(fmt.Errorf("unable to decode: %w", err))
+		}
+
+		manifestFeatureSets := uncastObj.(*unstructured.Unstructured).GetAnnotations()["release.openshift.io/feature-set"]
+		if len(manifestFeatureSets) == 0 {
+			return true, nil
+		}
+		for _, manifestFeatureSet := range strings.Split(manifestFeatureSets, ",") {
+			if manifestFeatureSet == targetFeatureSet {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+}
+
+// LoadFilesRecursively returns a map from relative path names to file content.
+func LoadFilesRecursively(dir string, predicates ...FileInfoPredicate) (map[string][]byte, error) {
+	files := map[string][]byte{}
+	err := filepath.Walk(dir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+
+			for _, p := range predicates {
+				include, err := p(path, info)
+				if err != nil {
+					return err
+				}
+				if !include {
+					return nil
+				}
+			}
+
+			bs, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			// make path relative to dir
+			rel, err := filepath.Rel(dir, path)
+			if err != nil {
+				return err
+			}
+
+			files[rel] = bs
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}

--- a/payload-command/render/renderassets/rendered_manifests.go
+++ b/payload-command/render/renderassets/rendered_manifests.go
@@ -1,0 +1,90 @@
+package assets
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2"
+)
+
+type RenderedManifests []RenderedManifest
+
+type RenderedManifest struct {
+	OriginalFilename string
+	Content          []byte
+
+	// use GetDecodedObj to access
+	decodedObj runtime.Object
+}
+
+func (renderedManifests RenderedManifests) ListManifestOfType(gvk schema.GroupVersionKind) []RenderedManifest {
+	ret := []RenderedManifest{}
+	for i := range renderedManifests {
+		obj, err := renderedManifests[i].GetDecodedObj()
+		if err != nil {
+			klog.Warningf("failure to read %q: %v", renderedManifests[i].OriginalFilename, err)
+			continue
+		}
+		if obj.GetObjectKind().GroupVersionKind() == gvk {
+			ret = append(ret, renderedManifests[i])
+		}
+	}
+
+	return ret
+}
+
+func (renderedManifests RenderedManifests) GetManifest(gvk schema.GroupVersionKind, namespace, name string) (RenderedManifest, error) {
+	for i := range renderedManifests {
+		obj, err := renderedManifests[i].GetDecodedObj()
+		if err != nil {
+			klog.Warningf("failure to read %q: %v", renderedManifests[i].OriginalFilename, err)
+			continue
+		}
+		if obj.GetObjectKind().GroupVersionKind() != gvk {
+			continue
+		}
+		objMetadata, err := meta.Accessor(obj)
+		if err != nil {
+			klog.Warningf("failure to read metadata %q: %v", renderedManifests[i].OriginalFilename, err)
+			continue
+		}
+
+		// since validation requires that all of these are the same, it doesn't matterwhich one we return
+		if objMetadata.GetName() == name && objMetadata.GetNamespace() == namespace {
+			return renderedManifests[i], nil
+		}
+	}
+
+	return RenderedManifest{}, apierrors.NewNotFound(
+		schema.GroupResource{
+			Group:    gvk.Group,
+			Resource: gvk.Kind,
+		},
+		name)
+}
+
+func (renderedManifests RenderedManifests) GetObject(gvk schema.GroupVersionKind, namespace, name string) (runtime.Object, error) {
+	manifest, err := renderedManifests.GetManifest(gvk, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	return manifest.GetDecodedObj()
+}
+
+func (c *RenderedManifest) GetDecodedObj() (runtime.Object, error) {
+	if c.decodedObj != nil {
+		return c.decodedObj, nil
+	}
+
+	obj, _, err := unstructured.UnstructuredJSONScheme.Decode(c.Content, nil, &unstructured.Unstructured{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode %q: %w", c.OriginalFilename, err)
+	}
+	c.decodedObj = obj
+
+	return c.decodedObj, nil
+}

--- a/payload-command/render/renderassets/template.go
+++ b/payload-command/render/renderassets/template.go
@@ -1,0 +1,55 @@
+package assets
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+var templateFuncs = map[string]interface{}{
+	"base64": base64encode,
+	"indent": indent,
+	"load":   load,
+}
+
+func AddTemplateFunc(name string, fn interface{}) error {
+	if _, ok := templateFuncs[name]; ok {
+		return fmt.Errorf("%q already registered as template func", name)
+	}
+	templateFuncs[name] = fn
+	return nil
+}
+
+func AddTemplateFuncOrDie(name string, fn interface{}) {
+	err := AddTemplateFunc(name, fn)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func indent(indention int, v []byte) string {
+	newline := "\n" + strings.Repeat(" ", indention)
+	return strings.Replace(string(v), "\n", newline, -1)
+}
+
+func base64encode(v []byte) string {
+	return base64.StdEncoding.EncodeToString(v)
+}
+
+func load(n string, assets map[string][]byte) []byte {
+	return assets[n]
+}
+
+func renderFile(name string, tb []byte, data interface{}) ([]byte, error) {
+	tmpl, err := template.New(name).Funcs(templateFuncs).Parse(string(tb))
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/payload-command/render/renderassets/write.go
+++ b/payload-command/render/renderassets/write.go
@@ -1,0 +1,28 @@
+package assets
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// SubstituteAndCopyFiles read files from the input dir, selects some by predicate, transforms them, and writes the content to output dir.
+func SubstituteAndCopyFiles(assetInputDir, assetOutputDir, featureSet string, templateData interface{}, additionalPredicates ...FileInfoPredicate) error {
+	defaultPredicates := []FileInfoPredicate{OnlyYaml}
+	manifestPredicates := []FileContentsPredicate{InstallerFeatureSet(featureSet)}
+
+	// write assets
+	manifests, err := New(
+		assetInputDir,
+		templateData,
+		manifestPredicates,
+		append(additionalPredicates, defaultPredicates...)...,
+	)
+	if err != nil {
+		return fmt.Errorf("failed rendering assets: %v", err)
+	}
+	if err := manifests.WriteFiles(filepath.Join(assetOutputDir)); err != nil {
+		return fmt.Errorf("failed writing assets to %q: %v", filepath.Join(assetOutputDir), err)
+	}
+
+	return nil
+}

--- a/payload-command/render/write_featureset.go
+++ b/payload-command/render/write_featureset.go
@@ -1,0 +1,72 @@
+package render
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WriteFeatureSets holds values to drive the render command.
+type WriteFeatureSets struct {
+	PayloadVersion string
+	AssetOutputDir string
+}
+
+func (o *WriteFeatureSets) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&o.PayloadVersion, "payload-version", o.PayloadVersion, "Version that will eventually be placed into ClusterOperator.status.  This normally comes from the CVO set via env var: OPERATOR_IMAGE_VERSION.")
+	fs.StringVar(&o.AssetOutputDir, "asset-output-dir", o.AssetOutputDir, "Output path for rendered manifests.")
+}
+
+// Validate verifies the inputs.
+func (o *WriteFeatureSets) Validate() error {
+	return nil
+}
+
+// Complete fills in missing values before command execution.
+func (o *WriteFeatureSets) Complete() error {
+	return nil
+}
+
+// Run contains the logic of the render command.
+func (o *WriteFeatureSets) Run() error {
+	err := os.MkdirAll(o.AssetOutputDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	for featureSetName := range configv1.FeatureSets {
+		featureGates := &configv1.FeatureGate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster",
+			},
+			Spec: configv1.FeatureGateSpec{
+				FeatureGateSelection: configv1.FeatureGateSelection{
+					FeatureSet: featureSetName,
+				},
+			},
+		}
+
+		currentDetails, err := FeaturesGateDetailsFromFeatureSets(configv1.FeatureSets, featureGates, o.PayloadVersion)
+		if err != nil {
+			return fmt.Errorf("error determining FeatureGates: %w", err)
+		}
+		featureGates.Status.FeatureGates = []configv1.FeatureGateDetails{*currentDetails}
+
+		featureGateOutBytes := writeFeatureGateV1OrDie(featureGates)
+		featureSetFileName := fmt.Sprintf("featureGate-%s.yaml", featureSetName)
+		if len(featureSetName) == 0 {
+			featureSetFileName = fmt.Sprintf("featureGate-%s.yaml", "Default")
+		}
+
+		destFile := filepath.Join(o.AssetOutputDir, featureSetFileName)
+		if err := os.WriteFile(destFile, []byte(featureGateOutBytes), 0644); err != nil {
+			return fmt.Errorf("error writing FeatureGate manifest: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/vendor/k8s.io/apimachinery/pkg/api/errors/OWNERS
+++ b/vendor/k8s.io/apimachinery/pkg/api/errors/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - thockin
+  - smarterclayton
+  - wojtek-t
+  - deads2k
+  - derekwaynecarr
+  - caesarxuchao
+  - mikedanese
+  - liggitt
+  - saad-ali
+  - janetkuo
+  - tallclair
+  - dims
+  - cjcullen

--- a/vendor/k8s.io/apimachinery/pkg/api/errors/doc.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/errors/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package errors provides detailed error types for api field validation.
+package errors // import "k8s.io/apimachinery/pkg/api/errors"

--- a/vendor/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/vendor/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -1,0 +1,857 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// StatusError is an error intended for consumption by a REST API server; it can also be
+// reconstructed by clients from a REST response. Public to allow easy type switches.
+type StatusError struct {
+	ErrStatus metav1.Status
+}
+
+// APIStatus is exposed by errors that can be converted to an api.Status object
+// for finer grained details.
+type APIStatus interface {
+	Status() metav1.Status
+}
+
+var _ error = &StatusError{}
+
+var knownReasons = map[metav1.StatusReason]struct{}{
+	// metav1.StatusReasonUnknown : {}
+	metav1.StatusReasonUnauthorized:          {},
+	metav1.StatusReasonForbidden:             {},
+	metav1.StatusReasonNotFound:              {},
+	metav1.StatusReasonAlreadyExists:         {},
+	metav1.StatusReasonConflict:              {},
+	metav1.StatusReasonGone:                  {},
+	metav1.StatusReasonInvalid:               {},
+	metav1.StatusReasonServerTimeout:         {},
+	metav1.StatusReasonTimeout:               {},
+	metav1.StatusReasonTooManyRequests:       {},
+	metav1.StatusReasonBadRequest:            {},
+	metav1.StatusReasonMethodNotAllowed:      {},
+	metav1.StatusReasonNotAcceptable:         {},
+	metav1.StatusReasonRequestEntityTooLarge: {},
+	metav1.StatusReasonUnsupportedMediaType:  {},
+	metav1.StatusReasonInternalError:         {},
+	metav1.StatusReasonExpired:               {},
+	metav1.StatusReasonServiceUnavailable:    {},
+}
+
+// Error implements the Error interface.
+func (e *StatusError) Error() string {
+	return e.ErrStatus.Message
+}
+
+// Status allows access to e's status without having to know the detailed workings
+// of StatusError.
+func (e *StatusError) Status() metav1.Status {
+	return e.ErrStatus
+}
+
+// DebugError reports extended info about the error to debug output.
+func (e *StatusError) DebugError() (string, []interface{}) {
+	if out, err := json.MarshalIndent(e.ErrStatus, "", "  "); err == nil {
+		return "server response object: %s", []interface{}{string(out)}
+	}
+	return "server response object: %#v", []interface{}{e.ErrStatus}
+}
+
+// HasStatusCause returns true if the provided error has a details cause
+// with the provided type name.
+// It supports wrapped errors and returns false when the error is nil.
+func HasStatusCause(err error, name metav1.CauseType) bool {
+	_, ok := StatusCause(err, name)
+	return ok
+}
+
+// StatusCause returns the named cause from the provided error if it exists and
+// the error unwraps to the type APIStatus. Otherwise it returns false.
+func StatusCause(err error, name metav1.CauseType) (metav1.StatusCause, bool) {
+	status, ok := err.(APIStatus)
+	if (ok || errors.As(err, &status)) && status.Status().Details != nil {
+		for _, cause := range status.Status().Details.Causes {
+			if cause.Type == name {
+				return cause, true
+			}
+		}
+	}
+	return metav1.StatusCause{}, false
+}
+
+// UnexpectedObjectError can be returned by FromObject if it's passed a non-status object.
+type UnexpectedObjectError struct {
+	Object runtime.Object
+}
+
+// Error returns an error message describing 'u'.
+func (u *UnexpectedObjectError) Error() string {
+	return fmt.Sprintf("unexpected object: %v", u.Object)
+}
+
+// FromObject generates an StatusError from an metav1.Status, if that is the type of obj; otherwise,
+// returns an UnexpecteObjectError.
+func FromObject(obj runtime.Object) error {
+	switch t := obj.(type) {
+	case *metav1.Status:
+		return &StatusError{ErrStatus: *t}
+	case runtime.Unstructured:
+		var status metav1.Status
+		obj := t.UnstructuredContent()
+		if !reflect.DeepEqual(obj["kind"], "Status") {
+			break
+		}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(t.UnstructuredContent(), &status); err != nil {
+			return err
+		}
+		if status.APIVersion != "v1" && status.APIVersion != "meta.k8s.io/v1" {
+			break
+		}
+		return &StatusError{ErrStatus: status}
+	}
+	return &UnexpectedObjectError{obj}
+}
+
+// NewNotFound returns a new error which indicates that the resource of the kind and the name was not found.
+func NewNotFound(qualifiedResource schema.GroupResource, name string) *StatusError {
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusNotFound,
+		Reason: metav1.StatusReasonNotFound,
+		Details: &metav1.StatusDetails{
+			Group: qualifiedResource.Group,
+			Kind:  qualifiedResource.Resource,
+			Name:  name,
+		},
+		Message: fmt.Sprintf("%s %q not found", qualifiedResource.String(), name),
+	}}
+}
+
+// NewAlreadyExists returns an error indicating the item requested exists by that identifier.
+func NewAlreadyExists(qualifiedResource schema.GroupResource, name string) *StatusError {
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusConflict,
+		Reason: metav1.StatusReasonAlreadyExists,
+		Details: &metav1.StatusDetails{
+			Group: qualifiedResource.Group,
+			Kind:  qualifiedResource.Resource,
+			Name:  name,
+		},
+		Message: fmt.Sprintf("%s %q already exists", qualifiedResource.String(), name),
+	}}
+}
+
+// NewGenerateNameConflict returns an error indicating the server
+// was not able to generate a valid name for a resource.
+func NewGenerateNameConflict(qualifiedResource schema.GroupResource, name string, retryAfterSeconds int) *StatusError {
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusConflict,
+		Reason: metav1.StatusReasonAlreadyExists,
+		Details: &metav1.StatusDetails{
+			Group:             qualifiedResource.Group,
+			Kind:              qualifiedResource.Resource,
+			Name:              name,
+			RetryAfterSeconds: int32(retryAfterSeconds),
+		},
+		Message: fmt.Sprintf(
+			"%s %q already exists, the server was not able to generate a unique name for the object",
+			qualifiedResource.String(), name),
+	}}
+}
+
+// NewUnauthorized returns an error indicating the client is not authorized to perform the requested
+// action.
+func NewUnauthorized(reason string) *StatusError {
+	message := reason
+	if len(message) == 0 {
+		message = "not authorized"
+	}
+	return &StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusUnauthorized,
+		Reason:  metav1.StatusReasonUnauthorized,
+		Message: message,
+	}}
+}
+
+// NewForbidden returns an error indicating the requested action was forbidden
+func NewForbidden(qualifiedResource schema.GroupResource, name string, err error) *StatusError {
+	var message string
+	if qualifiedResource.Empty() {
+		message = fmt.Sprintf("forbidden: %v", err)
+	} else if name == "" {
+		message = fmt.Sprintf("%s is forbidden: %v", qualifiedResource.String(), err)
+	} else {
+		message = fmt.Sprintf("%s %q is forbidden: %v", qualifiedResource.String(), name, err)
+	}
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusForbidden,
+		Reason: metav1.StatusReasonForbidden,
+		Details: &metav1.StatusDetails{
+			Group: qualifiedResource.Group,
+			Kind:  qualifiedResource.Resource,
+			Name:  name,
+		},
+		Message: message,
+	}}
+}
+
+// NewConflict returns an error indicating the item can't be updated as provided.
+func NewConflict(qualifiedResource schema.GroupResource, name string, err error) *StatusError {
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusConflict,
+		Reason: metav1.StatusReasonConflict,
+		Details: &metav1.StatusDetails{
+			Group: qualifiedResource.Group,
+			Kind:  qualifiedResource.Resource,
+			Name:  name,
+		},
+		Message: fmt.Sprintf("Operation cannot be fulfilled on %s %q: %v", qualifiedResource.String(), name, err),
+	}}
+}
+
+// NewApplyConflict returns an error including details on the requests apply conflicts
+func NewApplyConflict(causes []metav1.StatusCause, message string) *StatusError {
+	return &StatusError{ErrStatus: metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusConflict,
+		Reason: metav1.StatusReasonConflict,
+		Details: &metav1.StatusDetails{
+			// TODO: Get obj details here?
+			Causes: causes,
+		},
+		Message: message,
+	}}
+}
+
+// NewGone returns an error indicating the item no longer available at the server and no forwarding address is known.
+// DEPRECATED: Please use NewResourceExpired instead.
+func NewGone(message string) *StatusError {
+	return &StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusGone,
+		Reason:  metav1.StatusReasonGone,
+		Message: message,
+	}}
+}
+
+// NewResourceExpired creates an error that indicates that the requested resource content has expired from
+// the server (usually due to a resourceVersion that is too old).
+func NewResourceExpired(message string) *StatusError {
+	return &StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusGone,
+		Reason:  metav1.StatusReasonExpired,
+		Message: message,
+	}}
+}
+
+// NewInvalid returns an error indicating the item is invalid and cannot be processed.
+func NewInvalid(qualifiedKind schema.GroupKind, name string, errs field.ErrorList) *StatusError {
+	causes := make([]metav1.StatusCause, 0, len(errs))
+	for i := range errs {
+		err := errs[i]
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseType(err.Type),
+			Message: err.ErrorBody(),
+			Field:   err.Field,
+		})
+	}
+	err := &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusUnprocessableEntity,
+		Reason: metav1.StatusReasonInvalid,
+		Details: &metav1.StatusDetails{
+			Group:  qualifiedKind.Group,
+			Kind:   qualifiedKind.Kind,
+			Name:   name,
+			Causes: causes,
+		},
+	}}
+	aggregatedErrs := errs.ToAggregate()
+	if aggregatedErrs == nil {
+		err.ErrStatus.Message = fmt.Sprintf("%s %q is invalid", qualifiedKind.String(), name)
+	} else {
+		err.ErrStatus.Message = fmt.Sprintf("%s %q is invalid: %v", qualifiedKind.String(), name, aggregatedErrs)
+	}
+	return err
+}
+
+// NewBadRequest creates an error that indicates that the request is invalid and can not be processed.
+func NewBadRequest(reason string) *StatusError {
+	return &StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusBadRequest,
+		Reason:  metav1.StatusReasonBadRequest,
+		Message: reason,
+	}}
+}
+
+// NewTooManyRequests creates an error that indicates that the client must try again later because
+// the specified endpoint is not accepting requests. More specific details should be provided
+// if client should know why the failure was limited.
+func NewTooManyRequests(message string, retryAfterSeconds int) *StatusError {
+	return &StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusTooManyRequests,
+		Reason:  metav1.StatusReasonTooManyRequests,
+		Message: message,
+		Details: &metav1.StatusDetails{
+			RetryAfterSeconds: int32(retryAfterSeconds),
+		},
+	}}
+}
+
+// NewServiceUnavailable creates an error that indicates that the requested service is unavailable.
+func NewServiceUnavailable(reason string) *StatusError {
+	return &StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusServiceUnavailable,
+		Reason:  metav1.StatusReasonServiceUnavailable,
+		Message: reason,
+	}}
+}
+
+// NewMethodNotSupported returns an error indicating the requested action is not supported on this kind.
+func NewMethodNotSupported(qualifiedResource schema.GroupResource, action string) *StatusError {
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusMethodNotAllowed,
+		Reason: metav1.StatusReasonMethodNotAllowed,
+		Details: &metav1.StatusDetails{
+			Group: qualifiedResource.Group,
+			Kind:  qualifiedResource.Resource,
+		},
+		Message: fmt.Sprintf("%s is not supported on resources of kind %q", action, qualifiedResource.String()),
+	}}
+}
+
+// NewServerTimeout returns an error indicating the requested action could not be completed due to a
+// transient error, and the client should try again.
+func NewServerTimeout(qualifiedResource schema.GroupResource, operation string, retryAfterSeconds int) *StatusError {
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusInternalServerError,
+		Reason: metav1.StatusReasonServerTimeout,
+		Details: &metav1.StatusDetails{
+			Group:             qualifiedResource.Group,
+			Kind:              qualifiedResource.Resource,
+			Name:              operation,
+			RetryAfterSeconds: int32(retryAfterSeconds),
+		},
+		Message: fmt.Sprintf("The %s operation against %s could not be completed at this time, please try again.", operation, qualifiedResource.String()),
+	}}
+}
+
+// NewServerTimeoutForKind should not exist.  Server timeouts happen when accessing resources, the Kind is just what we
+// happened to be looking at when the request failed.  This delegates to keep code sane, but we should work towards removing this.
+func NewServerTimeoutForKind(qualifiedKind schema.GroupKind, operation string, retryAfterSeconds int) *StatusError {
+	return NewServerTimeout(schema.GroupResource{Group: qualifiedKind.Group, Resource: qualifiedKind.Kind}, operation, retryAfterSeconds)
+}
+
+// NewInternalError returns an error indicating the item is invalid and cannot be processed.
+func NewInternalError(err error) *StatusError {
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   http.StatusInternalServerError,
+		Reason: metav1.StatusReasonInternalError,
+		Details: &metav1.StatusDetails{
+			Causes: []metav1.StatusCause{{Message: err.Error()}},
+		},
+		Message: fmt.Sprintf("Internal error occurred: %v", err),
+	}}
+}
+
+// NewTimeoutError returns an error indicating that a timeout occurred before the request
+// could be completed.  Clients may retry, but the operation may still complete.
+func NewTimeoutError(message string, retryAfterSeconds int) *StatusError {
+	return &StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusGatewayTimeout,
+		Reason:  metav1.StatusReasonTimeout,
+		Message: fmt.Sprintf("Timeout: %s", message),
+		Details: &metav1.StatusDetails{
+			RetryAfterSeconds: int32(retryAfterSeconds),
+		},
+	}}
+}
+
+// NewTooManyRequestsError returns an error indicating that the request was rejected because
+// the server has received too many requests. Client should wait and retry. But if the request
+// is perishable, then the client should not retry the request.
+func NewTooManyRequestsError(message string) *StatusError {
+	return &StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusTooManyRequests,
+		Reason:  metav1.StatusReasonTooManyRequests,
+		Message: fmt.Sprintf("Too many requests: %s", message),
+	}}
+}
+
+// NewRequestEntityTooLargeError returns an error indicating that the request
+// entity was too large.
+func NewRequestEntityTooLargeError(message string) *StatusError {
+	return &StatusError{metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    http.StatusRequestEntityTooLarge,
+		Reason:  metav1.StatusReasonRequestEntityTooLarge,
+		Message: fmt.Sprintf("Request entity too large: %s", message),
+	}}
+}
+
+// NewGenericServerResponse returns a new error for server responses that are not in a recognizable form.
+func NewGenericServerResponse(code int, verb string, qualifiedResource schema.GroupResource, name, serverMessage string, retryAfterSeconds int, isUnexpectedResponse bool) *StatusError {
+	reason := metav1.StatusReasonUnknown
+	message := fmt.Sprintf("the server responded with the status code %d but did not return more information", code)
+	switch code {
+	case http.StatusConflict:
+		if verb == "POST" {
+			reason = metav1.StatusReasonAlreadyExists
+		} else {
+			reason = metav1.StatusReasonConflict
+		}
+		message = "the server reported a conflict"
+	case http.StatusNotFound:
+		reason = metav1.StatusReasonNotFound
+		message = "the server could not find the requested resource"
+	case http.StatusBadRequest:
+		reason = metav1.StatusReasonBadRequest
+		message = "the server rejected our request for an unknown reason"
+	case http.StatusUnauthorized:
+		reason = metav1.StatusReasonUnauthorized
+		message = "the server has asked for the client to provide credentials"
+	case http.StatusForbidden:
+		reason = metav1.StatusReasonForbidden
+		// the server message has details about who is trying to perform what action.  Keep its message.
+		message = serverMessage
+	case http.StatusNotAcceptable:
+		reason = metav1.StatusReasonNotAcceptable
+		// the server message has details about what types are acceptable
+		if len(serverMessage) == 0 || serverMessage == "unknown" {
+			message = "the server was unable to respond with a content type that the client supports"
+		} else {
+			message = serverMessage
+		}
+	case http.StatusUnsupportedMediaType:
+		reason = metav1.StatusReasonUnsupportedMediaType
+		// the server message has details about what types are acceptable
+		message = serverMessage
+	case http.StatusMethodNotAllowed:
+		reason = metav1.StatusReasonMethodNotAllowed
+		message = "the server does not allow this method on the requested resource"
+	case http.StatusUnprocessableEntity:
+		reason = metav1.StatusReasonInvalid
+		message = "the server rejected our request due to an error in our request"
+	case http.StatusServiceUnavailable:
+		reason = metav1.StatusReasonServiceUnavailable
+		message = "the server is currently unable to handle the request"
+	case http.StatusGatewayTimeout:
+		reason = metav1.StatusReasonTimeout
+		message = "the server was unable to return a response in the time allotted, but may still be processing the request"
+	case http.StatusTooManyRequests:
+		reason = metav1.StatusReasonTooManyRequests
+		message = "the server has received too many requests and has asked us to try again later"
+	default:
+		if code >= 500 {
+			reason = metav1.StatusReasonInternalError
+			message = fmt.Sprintf("an error on the server (%q) has prevented the request from succeeding", serverMessage)
+		}
+	}
+	switch {
+	case !qualifiedResource.Empty() && len(name) > 0:
+		message = fmt.Sprintf("%s (%s %s %s)", message, strings.ToLower(verb), qualifiedResource.String(), name)
+	case !qualifiedResource.Empty():
+		message = fmt.Sprintf("%s (%s %s)", message, strings.ToLower(verb), qualifiedResource.String())
+	}
+	var causes []metav1.StatusCause
+	if isUnexpectedResponse {
+		causes = []metav1.StatusCause{
+			{
+				Type:    metav1.CauseTypeUnexpectedServerResponse,
+				Message: serverMessage,
+			},
+		}
+	} else {
+		causes = nil
+	}
+	return &StatusError{metav1.Status{
+		Status: metav1.StatusFailure,
+		Code:   int32(code),
+		Reason: reason,
+		Details: &metav1.StatusDetails{
+			Group: qualifiedResource.Group,
+			Kind:  qualifiedResource.Resource,
+			Name:  name,
+
+			Causes:            causes,
+			RetryAfterSeconds: int32(retryAfterSeconds),
+		},
+		Message: message,
+	}}
+}
+
+// IsNotFound returns true if the specified error was created by NewNotFound.
+// It supports wrapped errors and returns false when the error is nil.
+func IsNotFound(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonNotFound {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusNotFound {
+		return true
+	}
+	return false
+}
+
+// IsAlreadyExists determines if the err is an error which indicates that a specified resource already exists.
+// It supports wrapped errors and returns false when the error is nil.
+func IsAlreadyExists(err error) bool {
+	return ReasonForError(err) == metav1.StatusReasonAlreadyExists
+}
+
+// IsConflict determines if the err is an error which indicates the provided update conflicts.
+// It supports wrapped errors and returns false when the error is nil.
+func IsConflict(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonConflict {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusConflict {
+		return true
+	}
+	return false
+}
+
+// IsInvalid determines if the err is an error which indicates the provided resource is not valid.
+// It supports wrapped errors and returns false when the error is nil.
+func IsInvalid(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonInvalid {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusUnprocessableEntity {
+		return true
+	}
+	return false
+}
+
+// IsGone is true if the error indicates the requested resource is no longer available.
+// It supports wrapped errors and returns false when the error is nil.
+func IsGone(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonGone {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusGone {
+		return true
+	}
+	return false
+}
+
+// IsResourceExpired is true if the error indicates the resource has expired and the current action is
+// no longer possible.
+// It supports wrapped errors and returns false when the error is nil.
+func IsResourceExpired(err error) bool {
+	return ReasonForError(err) == metav1.StatusReasonExpired
+}
+
+// IsNotAcceptable determines if err is an error which indicates that the request failed due to an invalid Accept header
+// It supports wrapped errors and returns false when the error is nil.
+func IsNotAcceptable(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonNotAcceptable {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusNotAcceptable {
+		return true
+	}
+	return false
+}
+
+// IsUnsupportedMediaType determines if err is an error which indicates that the request failed due to an invalid Content-Type header
+// It supports wrapped errors and returns false when the error is nil.
+func IsUnsupportedMediaType(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonUnsupportedMediaType {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusUnsupportedMediaType {
+		return true
+	}
+	return false
+}
+
+// IsMethodNotSupported determines if the err is an error which indicates the provided action could not
+// be performed because it is not supported by the server.
+// It supports wrapped errors and returns false when the error is nil.
+func IsMethodNotSupported(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonMethodNotAllowed {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusMethodNotAllowed {
+		return true
+	}
+	return false
+}
+
+// IsServiceUnavailable is true if the error indicates the underlying service is no longer available.
+// It supports wrapped errors and returns false when the error is nil.
+func IsServiceUnavailable(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonServiceUnavailable {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusServiceUnavailable {
+		return true
+	}
+	return false
+}
+
+// IsBadRequest determines if err is an error which indicates that the request is invalid.
+// It supports wrapped errors and returns false when the error is nil.
+func IsBadRequest(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonBadRequest {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusBadRequest {
+		return true
+	}
+	return false
+}
+
+// IsUnauthorized determines if err is an error which indicates that the request is unauthorized and
+// requires authentication by the user.
+// It supports wrapped errors and returns false when the error is nil.
+func IsUnauthorized(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonUnauthorized {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusUnauthorized {
+		return true
+	}
+	return false
+}
+
+// IsForbidden determines if err is an error which indicates that the request is forbidden and cannot
+// be completed as requested.
+// It supports wrapped errors and returns false when the error is nil.
+func IsForbidden(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonForbidden {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusForbidden {
+		return true
+	}
+	return false
+}
+
+// IsTimeout determines if err is an error which indicates that request times out due to long
+// processing.
+// It supports wrapped errors and returns false when the error is nil.
+func IsTimeout(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonTimeout {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusGatewayTimeout {
+		return true
+	}
+	return false
+}
+
+// IsServerTimeout determines if err is an error which indicates that the request needs to be retried
+// by the client.
+// It supports wrapped errors and returns false when the error is nil.
+func IsServerTimeout(err error) bool {
+	// do not check the status code, because no https status code exists that can
+	// be scoped to retryable timeouts.
+	return ReasonForError(err) == metav1.StatusReasonServerTimeout
+}
+
+// IsInternalError determines if err is an error which indicates an internal server error.
+// It supports wrapped errors and returns false when the error is nil.
+func IsInternalError(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonInternalError {
+		return true
+	}
+	if _, ok := knownReasons[reason]; !ok && code == http.StatusInternalServerError {
+		return true
+	}
+	return false
+}
+
+// IsTooManyRequests determines if err is an error which indicates that there are too many requests
+// that the server cannot handle.
+// It supports wrapped errors and returns false when the error is nil.
+func IsTooManyRequests(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonTooManyRequests {
+		return true
+	}
+
+	// IsTooManyRequests' checking of code predates the checking of the code in
+	// the other Is* functions. In order to maintain backward compatibility, this
+	// does not check that the reason is unknown.
+	if code == http.StatusTooManyRequests {
+		return true
+	}
+	return false
+}
+
+// IsRequestEntityTooLargeError determines if err is an error which indicates
+// the request entity is too large.
+// It supports wrapped errors and returns false when the error is nil.
+func IsRequestEntityTooLargeError(err error) bool {
+	reason, code := reasonAndCodeForError(err)
+	if reason == metav1.StatusReasonRequestEntityTooLarge {
+		return true
+	}
+
+	// IsRequestEntityTooLargeError's checking of code predates the checking of
+	// the code in the other Is* functions. In order to maintain backward
+	// compatibility, this does not check that the reason is unknown.
+	if code == http.StatusRequestEntityTooLarge {
+		return true
+	}
+	return false
+}
+
+// IsUnexpectedServerError returns true if the server response was not in the expected API format,
+// and may be the result of another HTTP actor.
+// It supports wrapped errors and returns false when the error is nil.
+func IsUnexpectedServerError(err error) bool {
+	status, ok := err.(APIStatus)
+	if (ok || errors.As(err, &status)) && status.Status().Details != nil {
+		for _, cause := range status.Status().Details.Causes {
+			if cause.Type == metav1.CauseTypeUnexpectedServerResponse {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsUnexpectedObjectError determines if err is due to an unexpected object from the master.
+// It supports wrapped errors and returns false when the error is nil.
+func IsUnexpectedObjectError(err error) bool {
+	uoe, ok := err.(*UnexpectedObjectError)
+	return err != nil && (ok || errors.As(err, &uoe))
+}
+
+// SuggestsClientDelay returns true if this error suggests a client delay as well as the
+// suggested seconds to wait, or false if the error does not imply a wait. It does not
+// address whether the error *should* be retried, since some errors (like a 3xx) may
+// request delay without retry.
+// It supports wrapped errors and returns false when the error is nil.
+func SuggestsClientDelay(err error) (int, bool) {
+	t, ok := err.(APIStatus)
+	if (ok || errors.As(err, &t)) && t.Status().Details != nil {
+		switch t.Status().Reason {
+		// this StatusReason explicitly requests the caller to delay the action
+		case metav1.StatusReasonServerTimeout:
+			return int(t.Status().Details.RetryAfterSeconds), true
+		}
+		// If the client requests that we retry after a certain number of seconds
+		if t.Status().Details.RetryAfterSeconds > 0 {
+			return int(t.Status().Details.RetryAfterSeconds), true
+		}
+	}
+	return 0, false
+}
+
+// ReasonForError returns the HTTP status for a particular error.
+// It supports wrapped errors and returns StatusReasonUnknown when
+// the error is nil or doesn't have a status.
+func ReasonForError(err error) metav1.StatusReason {
+	if status, ok := err.(APIStatus); ok || errors.As(err, &status) {
+		return status.Status().Reason
+	}
+	return metav1.StatusReasonUnknown
+}
+
+func reasonAndCodeForError(err error) (metav1.StatusReason, int32) {
+	if status, ok := err.(APIStatus); ok || errors.As(err, &status) {
+		return status.Status().Reason, status.Status().Code
+	}
+	return metav1.StatusReasonUnknown, 0
+}
+
+// ErrorReporter converts generic errors into runtime.Object errors without
+// requiring the caller to take a dependency on meta/v1 (where Status lives).
+// This prevents circular dependencies in core watch code.
+type ErrorReporter struct {
+	code   int
+	verb   string
+	reason string
+}
+
+// NewClientErrorReporter will respond with valid v1.Status objects that report
+// unexpected server responses. Primarily used by watch to report errors when
+// we attempt to decode a response from the server and it is not in the form
+// we expect. Because watch is a dependency of the core api, we can't return
+// meta/v1.Status in that package and so much inject this interface to convert a
+// generic error as appropriate. The reason is passed as a unique status cause
+// on the returned status, otherwise the generic "ClientError" is returned.
+func NewClientErrorReporter(code int, verb string, reason string) *ErrorReporter {
+	return &ErrorReporter{
+		code:   code,
+		verb:   verb,
+		reason: reason,
+	}
+}
+
+// AsObject returns a valid error runtime.Object (a v1.Status) for the given
+// error, using the code and verb of the reporter type. The error is set to
+// indicate that this was an unexpected server response.
+func (r *ErrorReporter) AsObject(err error) runtime.Object {
+	status := NewGenericServerResponse(r.code, r.verb, schema.GroupResource{}, "", err.Error(), 0, true)
+	if status.ErrStatus.Details == nil {
+		status.ErrStatus.Details = &metav1.StatusDetails{}
+	}
+	reason := r.reason
+	if len(reason) == 0 {
+		reason = "ClientError"
+	}
+	status.ErrStatus.Details.Causes = append(status.ErrStatus.Details.Causes, metav1.StatusCause{
+		Type:    metav1.CauseType(reason),
+		Message: err.Error(),
+	})
+	return &status.ErrStatus
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -195,6 +195,7 @@ k8s.io/apimachinery/pkg/api/apitesting
 k8s.io/apimachinery/pkg/api/apitesting/fuzzer
 k8s.io/apimachinery/pkg/api/apitesting/roundtrip
 k8s.io/apimachinery/pkg/api/equality
+k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/apis/meta/fuzzer


### PR DESCRIPTION
Add new commands and a dockerfile to include in the payload so that config CRD manifests and FeatureGates are directly added to the payload once the PRs are merged.  Also adds command for use by the cluster-config-operator which maintains the FeatureGate at runtime.

Important!  This PR does not add dependencies to the modules depending on this one.  That's why the operator logic itself doesn't move here since it would create a cycle.


https://github.com/openshift/cluster-config-operator/pull/349 demonstrates the viability of using this image to be authoritative for CRD manifests and featuregates.  The merge order will have to look like

1. merge PR with dockerfile, not included in payload.  Nothing in image to conflict with existing payload images
2. create CI test for image and demonstrate that image creation is working
3. do whatever is needed for producing a valid image for nightlies (need to find docs)
4. update dockerfile to become part of the payload (might be switched with 3)
5. update the cluster-config-operator to read featuregates from this image
6. create and prove installer PR to use the api render command instead of the cluster-config-operator, but do not merge yet
7. update api image to include CRD manifests and near simultaneously stop providing CRD manifest from cluster-config-operator
8. merge installer PR to use the api render command instead of cluster-config-operator and near simultaneously remove API resources from cluster-config-operator render command.

