### PR TITLE
Split CRD schema check into separate Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,17 @@ verify-scripts:
 	bash -x hack/verify-integration-tests.sh
 	bash -x hack/verify-group-versions.sh
 	bash -x hack/verify-prerelease-lifecycle-gen.sh
-	bash -x hack/verify-crd-schema-checker.sh
 
 .PHONY: verify
-verify: verify-scripts verify-codegen-crds
+verify: verify-scripts verify-crd-schema verify-codegen-crds
 
 .PHONY: verify-codegen-crds
 verify-codegen-crds:
 	bash -x hack/verify-codegen-crds.sh
+
+.PHONY: verify-crd-schema
+verify-crd-schema:
+	bash -x hack/verify-crd-schema-checker.sh
 
 .PHONY: verify-%
 verify-%:


### PR DESCRIPTION
When the schema check fails, it may need to be overridden. By splitting into it's own target, make will continue to execute other dependencies, but report only the failure of verify-crd-schema.

Presently if it fails, it reports that verify-scripts failed, which is not ideal, since we require this to pass.

I would like to have a separate status check on GitHub for the two sets, those that must pass and those that may not, so will sort that once this is merged. But the intention is that `make verify` still works locally for devs