### PR TITLE
OCPVE-631: add ImageRegistry capability

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -74,6 +74,7 @@ spec:
                           - MachineAPI
                           - Build
                           - DeploymentConfig
+                          - ImageRegistry
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -199,6 +200,7 @@ spec:
                           - MachineAPI
                           - Build
                           - DeploymentConfig
+                          - ImageRegistry
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -218,6 +220,7 @@ spec:
                           - MachineAPI
                           - Build
                           - DeploymentConfig
+                          - ImageRegistry
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -248,7 +248,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry
 type ClusterVersionCapability string
 
 const (
@@ -331,6 +331,9 @@ const (
 	// The following resources are taken into account:
 	// - deploymentconfigs
 	ClusterVersionCapabilityDeploymentConfig ClusterVersionCapability = "DeploymentConfig"
+	// ClusterVersionCapabilityImageRegistry manages the image registry which
+	// allows to distribute Docker images
+	ClusterVersionCapabilityImageRegistry ClusterVersionCapability = "ImageRegistry"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -346,6 +349,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityMachineAPI,
 	ClusterVersionCapabilityBuild,
 	ClusterVersionCapabilityDeploymentConfig,
+	ClusterVersionCapabilityImageRegistry,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
@@ -429,6 +433,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityMachineAPI,
 		ClusterVersionCapabilityBuild,
 		ClusterVersionCapabilityDeploymentConfig,
+		ClusterVersionCapabilityImageRegistry,
 	},
 	ClusterVersionCapabilitySetCurrent: {
 		ClusterVersionCapabilityBaremetal,
@@ -442,6 +447,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityMachineAPI,
 		ClusterVersionCapabilityBuild,
 		ClusterVersionCapabilityDeploymentConfig,
+		ClusterVersionCapabilityImageRegistry,
 	},
 }
 


### PR DESCRIPTION
Capability manages the image registry which allows to distribute Docker images