### PR TITLE
Revert "Enable ValidatingAdmissionPolicy for tech preview."

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -163,7 +163,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		Disabled: []FeatureGateDescription{},
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
-		with(validatingAdmissionPolicy).
+		without(validatingAdmissionPolicy).
 		with(externalCloudProvider).
 		with(externalCloudProviderGCP).
 		with(csiDriverSharedResource).


### PR DESCRIPTION
This reverts commit 09a7011a2fdc7f9774c30f792f2f6a0cbf462931.

This commit is blocking a release blocker from merging in the cluster-config-operator. The associated pull request was reverted, so it should be safe to revert this one as well.

https://github.com/openshift/cluster-config-operator/pull/346

https://issues.redhat.com/browse/CCO-412