### PR TITLE
OCPBUGS-18454: Match restrictions on ConditionalUpdateRisk name with Condition reason

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -341,9 +341,11 @@ spec:
                               type: string
                               minLength: 1
                             name:
-                              description: name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state.
+                              description: name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state. Can be used as a reason in a Condition.
                               type: string
+                              maxLength: 1024
                               minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                             url:
                               description: url contains information about this risk.
                               type: string

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -644,9 +644,11 @@ type ConditionalUpdateRisk struct {
 
 	// name is the CamelCase reason for not recommending a
 	// conditional update, in the event that matchingRules match the
-	// cluster state.
+	// cluster state. Can be used as a reason in a Condition.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=1024
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
 	// +required
 	Name string `json:"name"`
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -643,7 +643,7 @@ func (ConditionalUpdate) SwaggerDoc() map[string]string {
 var map_ConditionalUpdateRisk = map[string]string{
 	"":              "ConditionalUpdateRisk represents a reason and cluster-state for not recommending a conditional update.",
 	"url":           "url contains information about this risk.",
-	"name":          "name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state.",
+	"name":          "name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state. Can be used as a reason in a Condition.",
 	"message":       "message provides additional information about the risk of updating, in the event that matchingRules match the cluster state. This is only to be consumed by humans. It may contain Line Feed characters (U+000A), which should be rendered as new lines.",
 	"matchingRules": "matchingRules is a slice of conditions for deciding which clusters match the risk and which do not. The slice is ordered by decreasing precedence. The cluster-version operator will walk the slice in order, and stop after the first it can successfully evaluate. If no condition can be successfully evaluated, the update will not be recommended.",
 }

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -10605,7 +10605,7 @@ func schema_openshift_api_config_v1_ConditionalUpdateRisk(ref common.ReferenceCa
 					},
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state.",
+							Description: "name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state. Can be used as a reason in a Condition.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -5498,7 +5498,7 @@
           "default": ""
         },
         "name": {
-          "description": "name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state.",
+          "description": "name is the CamelCase reason for not recommending a conditional update, in the event that matchingRules match the cluster state. Can be used as a reason in a Condition.",
           "type": "string",
           "default": ""
         },


### PR DESCRIPTION
Conditional risk names are used as a `Reason` field values when the risk
applies and CVO sets up the `Recommended` condition. Hence, the risk
names need to be valid [Reason field values](https://github.com/openshift/api/blob/8891815aa476232109dccf6c11b8611d209445d9/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L1515C4-L1520).

xref: https://github.com/openshift/cincinnati-graph-data/pull/4059
