### PR TITLE
SPLAT-1172: Enhance machine status relating to IPAddressClaimed

### DIFF
--- a/machine/v1beta1/types_provider.go
+++ b/machine/v1beta1/types_provider.go
@@ -185,6 +185,8 @@ const (
 	// WaitingForIPAddressReason is set to indicate that a machine is
 	// currently waiting for an IP address to be provisioned.
 	WaitingForIPAddressReason string = "WaitingForIPAddress"
+	// IPAddressClaimedReason is set to indicate the machine was able to claim an IP address during provisioning.
+	IPAddressClaimedReason string = "IPAddressesClaimed"
 )
 
 // Condition defines an observation of a Machine API resource operational state.


### PR DESCRIPTION
Enhancements have been made to the provider status field for machines relating to assignment of static IPs.  Currently the fields are a little confusing and need some clarity.