### PR TITLE
Add an owning-component annotation.

### DIFF
--- a/annotations/annotations.go
+++ b/annotations/annotations.go
@@ -25,4 +25,10 @@ const (
 
 	// OpenShiftLongDescriptionAnnotation is a resource's long description
 	OpenShiftLongDescriptionAnnotation = "openshift.io/long-description"
+
+	// OpenShiftComponent is a common, optional annotation that stores the owning component for a resource.
+	// The component is for whatever bug tracker we're using.  That used to be bugzilla, now it is
+	// a jira component and subcomponent in OCPBUGS.
+	// For example, "Etcd" or "Networking / ovn-kubernetes"
+	OpenShiftComponent = "openshift.io/owning-component"
 )


### PR DESCRIPTION
Given the large number of resources we have, it is useful to have a mechanism to determine which component to contact when a particular one needs attention.  The first direct usage will be for recording who is responsible for in-cluster secrets and configmaps that contain certs, keys, and CA bundles.