### PR TITLE
OCPVE-672: feat: add the OLM as a capability

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion.crd.yaml
@@ -75,6 +75,7 @@ spec:
                           - Build
                           - DeploymentConfig
                           - ImageRegistry
+                          - OperatorLifecycleManager
                       x-kubernetes-list-type: atomic
                     baselineCapabilitySet:
                       description: baselineCapabilitySet selects an initial set of optional capabilities to enable, which can be extended via additionalEnabledCapabilities.  If unset, the cluster will choose a default, and the default may change over time. The current default is vCurrent.
@@ -201,6 +202,7 @@ spec:
                           - Build
                           - DeploymentConfig
                           - ImageRegistry
+                          - OperatorLifecycleManager
                       x-kubernetes-list-type: atomic
                     knownCapabilities:
                       description: knownCapabilities lists all the capabilities known to the current cluster.
@@ -221,6 +223,7 @@ spec:
                           - Build
                           - DeploymentConfig
                           - ImageRegistry
+                          - OperatorLifecycleManager
                       x-kubernetes-list-type: atomic
                 conditionalUpdates:
                   description: conditionalUpdates contains the list of updates that may be recommended for this cluster if it meets specific required conditions. Consumers interested in the set of updates that are actually recommended for this cluster should use availableUpdates. This list may be empty if no updates are recommended, if the update service is unavailable, or if an empty or invalid channel has been specified.
@@ -445,6 +448,8 @@ spec:
           x-kubernetes-validations:
             - rule: 'has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == ''None'' && ''baremetal'' in self.spec.capabilities.additionalEnabledCapabilities ? ''MachineAPI'' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && ''MachineAPI'' in self.status.capabilities.enabledCapabilities) : true'
               message: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
+            - rule: 'has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == ''None'' && ''marketplace'' in self.spec.capabilities.additionalEnabledCapabilities ? ''OperatorLifecycleManager'' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && ''OperatorLifecycleManager'' in self.status.capabilities.enabledCapabilities) : true'
+              message: the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability
       served: true
       storage: true
       subresources:

--- a/config/v1/stable.clusterversion.testsuite.yaml
+++ b/config/v1/stable.clusterversion.testsuite.yaml
@@ -130,6 +130,38 @@ tests:
           additionalEnabledCapabilities:
           - baremetal
     expectedError: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
+  - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities marketplace and OperatorLifecycleManager
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+          - OperatorLifecycleManager
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+          - OperatorLifecycleManager
+  - name: Should not be able to create a ClusterVersion with base capability None, and additional capabilities marketplace without OperatorLifecycleManager
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+    expectedError: the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability
   onUpdate:
   - name: Should not allow image to be set if architecture set
     initial: |
@@ -276,3 +308,111 @@ tests:
           additionalEnabledCapabilities:
           - baremetal
     expectedError: the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability
+  - name: Should be able to add the marketplace capability with a ClusterVersion with base capability None, and implicitly enabled OperatorLifecycleManager
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - OperatorLifecycleManager
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - OperatorLifecycleManager
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+      status:
+        desired:
+          version: foo
+          image: foo
+        observedGeneration: 1
+        versionHash: foo
+        availableUpdates:
+        - version: foo
+          image: foo
+        capabilities:
+          enabledCapabilities:
+          - OperatorLifecycleManager
+  - name: Should be able to add the marketplace capability with a ClusterVersion with base capability None, with the OperatorLifecycleManager capability
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+          - OperatorLifecycleManager
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+          - OperatorLifecycleManager
+  - name: Should not be able to add the marketplace capability with a ClusterVersion with base capability None, and without OperatorLifecycleManager
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      spec:
+        clusterID: foo
+        capabilities:
+          baselineCapabilitySet: None
+          additionalEnabledCapabilities:
+          - marketplace
+    expectedError: the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -14,6 +14,7 @@ import (
 // Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 // +openshift:compatibility-gen:level=1
 // +kubebuilder:validation:XValidation:rule="has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == 'None' && 'baremetal' in self.spec.capabilities.additionalEnabledCapabilities ? 'MachineAPI' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && 'MachineAPI' in self.status.capabilities.enabledCapabilities) : true",message="the `baremetal` capability requires the `MachineAPI` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `MachineAPI` capability"
+// +kubebuilder:validation:XValidation:rule="has(self.spec.capabilities) && has(self.spec.capabilities.additionalEnabledCapabilities) && self.spec.capabilities.baselineCapabilitySet == 'None' && 'marketplace' in self.spec.capabilities.additionalEnabledCapabilities ? 'OperatorLifecycleManager' in self.spec.capabilities.additionalEnabledCapabilities || (has(self.status) && has(self.status.capabilities) && has(self.status.capabilities.enabledCapabilities) && 'OperatorLifecycleManager' in self.status.capabilities.enabledCapabilities) : true",message="the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability"
 type ClusterVersion struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -248,7 +249,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry;OperatorLifecycleManager
 type ClusterVersionCapability string
 
 const (
@@ -267,6 +268,9 @@ const (
 	// ClusterVersionCapabilityMarketplace manages the Marketplace operator which
 	// supplies Operator Lifecycle Manager (OLM) users with default catalogs of
 	// "optional" operators.
+	//
+	// Note that Marketplace has a hard requirement on OLM. OLM can not be disabled
+	// while Marketplace is enabled.
 	ClusterVersionCapabilityMarketplace ClusterVersionCapability = "marketplace"
 
 	// ClusterVersionCapabilityConsole manages the Console operator which
@@ -331,9 +335,14 @@ const (
 	// The following resources are taken into account:
 	// - deploymentconfigs
 	ClusterVersionCapabilityDeploymentConfig ClusterVersionCapability = "DeploymentConfig"
+
 	// ClusterVersionCapabilityImageRegistry manages the image registry which
 	// allows to distribute Docker images
 	ClusterVersionCapabilityImageRegistry ClusterVersionCapability = "ImageRegistry"
+
+	// ClusterVersionCapabilityOperatorLifecycleManager manages the Operator Lifecycle Manager
+	// which itself manages the lifecycle of operators
+	ClusterVersionCapabilityOperatorLifecycleManager ClusterVersionCapability = "OperatorLifecycleManager"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -350,6 +359,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityBuild,
 	ClusterVersionCapabilityDeploymentConfig,
 	ClusterVersionCapabilityImageRegistry,
+	ClusterVersionCapabilityOperatorLifecycleManager,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
@@ -448,6 +458,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityBuild,
 		ClusterVersionCapabilityDeploymentConfig,
 		ClusterVersionCapabilityImageRegistry,
+		ClusterVersionCapabilityOperatorLifecycleManager,
 	},
 }
 


### PR DESCRIPTION
Add the OLM as a capability.

Note, that OLM and Marketplace have a dependency, the Marketplace should not be enabled and the OLM disabled. This enforcement will be done at the installer level similar to how we enforce [MachineAPI](https://github.com/openshift/installer/blob/7f49fee68faee3f4def8e0cbbf4c27efc3488859/pkg/types/validation/installconfig.go#L162)