### PR TITLE
OCPCLOUD-2130: Allow missing failureDomains platform

### DIFF
--- a/machine/v1/0000_10_controlplanemachineset.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset.crd.yaml
@@ -157,8 +157,6 @@ spec:
                         failureDomains:
                           description: FailureDomains is the list of failure domains (sometimes called availability zones) in which the ControlPlaneMachineSet should balance the Control Plane Machines. This will be merged into the ProviderSpec given in the template. This field is optional on platforms that do not require placement information.
                           type: object
-                          required:
-                            - platform
                           properties:
                             aws:
                               description: AWS configures failure domain information for the AWS platform.

--- a/machine/v1/stable.controlplanemachineset.aws.testsuite.yaml
+++ b/machine/v1/stable.controlplanemachineset.aws.testsuite.yaml
@@ -48,7 +48,7 @@ tests:
               aws:
               - placement:
                   availabilityZone: foo
-    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform: Required value"
+    expectedError: "Invalid value: \"object\": aws configuration is required when platform is AWS, and forbidden otherwise"
   - name: Should reject an AWS configured failure domain with the wrong platform type
     initial: |
       apiVersion: machine.openshift.io/v1

--- a/machine/v1/stable.controlplanemachineset.azure.testsuite.yaml
+++ b/machine/v1/stable.controlplanemachineset.azure.testsuite.yaml
@@ -47,7 +47,7 @@ tests:
             failureDomains:
               azure:
               - zone: foo
-    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform: Required value"
+    expectedError: "Invalid value: \"object\": azure configuration is required when platform is Azure, and forbidden otherwise"
   - name: Should reject an Azure configured failure domain with the wrong platform type
     initial: |
       apiVersion: machine.openshift.io/v1

--- a/machine/v1/stable.controlplanemachineset.gcp.testsuite.yaml
+++ b/machine/v1/stable.controlplanemachineset.gcp.testsuite.yaml
@@ -45,9 +45,9 @@ tests:
             spec:
               providerSpec: {}
             failureDomains:
-              aws:
+              gcp:
               - zone: foo
-    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform: Required value"
+    expectedError: "Invalid value: \"object\": gcp configuration is required when platform is GCP, and forbidden otherwise"
   - name: Should reject an GCP configured failure domain with the wrong platform type
     initial: |
       apiVersion: machine.openshift.io/v1

--- a/machine/v1/stable.controlplanemachineset.openstack.testsuite.yaml
+++ b/machine/v1/stable.controlplanemachineset.openstack.testsuite.yaml
@@ -47,7 +47,7 @@ tests:
             failureDomains:
               openstack:
               - availabilityZone: foo
-    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform: Required value"
+    expectedError: "Invalid value: \"object\": openstack configuration is required when platform is OpenStack, and forbidden otherwise"
   - name: Should reject an OpenStack configured failure domain with an empty OpenStack config
     initial: |
       apiVersion: machine.openshift.io/v1

--- a/machine/v1/types_controlplanemachineset.go
+++ b/machine/v1/types_controlplanemachineset.go
@@ -235,8 +235,7 @@ type FailureDomains struct {
 	// Platform identifies the platform for which the FailureDomain represents.
 	// Currently supported values are AWS, Azure, and GCP.
 	// +unionDiscriminator
-	// +kubebuilder:validation:Required
-	Platform configv1.PlatformType `json:"platform"`
+	Platform configv1.PlatformType `json:"platform,omitempty"`
 
 	// AWS configures failure domain information for the AWS platform.
 	// +optional

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -30538,7 +30538,6 @@ func schema_openshift_api_machine_v1_FailureDomains(ref common.ReferenceCallback
 					"platform": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Platform identifies the platform for which the FailureDomain represents. Currently supported values are AWS, Azure, and GCP.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -30600,7 +30599,6 @@ func schema_openshift_api_machine_v1_FailureDomains(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"platform"},
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -17733,9 +17733,6 @@
     "com.github.openshift.api.machine.v1.FailureDomains": {
       "description": "FailureDomain represents the different configurations required to spread Machines across failure domains on different platforms.",
       "type": "object",
-      "required": [
-        "platform"
-      ],
       "properties": {
         "aws": {
           "description": "AWS configures failure domain information for the AWS platform.",
@@ -17771,8 +17768,7 @@
         },
         "platform": {
           "description": "Platform identifies the platform for which the FailureDomain represents. Currently supported values are AWS, Azure, and GCP.",
-          "type": "string",
-          "default": ""
+          "type": "string"
         }
       },
       "x-kubernetes-unions": [


### PR DESCRIPTION
Currently, when in an environment without failure domains, the platform field still needs to be set.
```
machines_v1beta1_machine_openshift_io:
  failuredomains:
    platform: ""
```

We already support the platform being set to "". But when not setting it at all, it gets rejected by the controller.
`E0912 04:23:44.246534       1 controller.go:324]  "msg"="Reconciler error" "error"="error reconciling control plane machine set: unable to create control plane machine set: unable to create control plane machine set: ControlPlaneMachineSet.machine.openshift.io \"cluster\" is invalid: [spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform: Required value, <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]" "controller"="controlplanemachinesetgenerator" "reconcileID"="1f6615e7-703e-4c8b-b1f7-edf77b7112f0"
 `
 
 The installer does not have this check before submitting, and it gets defaulted to the above example because of the missing omitempty.