### PR TITLE
STOR-1182: set PersistentVolumeLastPhaseTransitionTime feature as TechPreview

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -53,6 +53,16 @@ var (
 		OwningProduct:       ocpSpecific,
 	}
 
+	FeatureGatePersistentVolumeLastPhaseTransitionTime = FeatureGateName("PersistentVolumeLastPhaseTransitionTime")
+	persistentVolumeLastPhaseTransitionTime            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGatePersistentVolumeLastPhaseTransitionTime,
+		},
+		OwningJiraComponent: "storage",
+		ResponsiblePerson:   "RomanBednar",
+		OwningProduct:       kubernetes,
+	}
+
 	FeatureGateRetroactiveDefaultStorageClass = FeatureGateName("RetroactiveDefaultStorageClass")
 	retroactiveDefaultStorageClass            = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -170,6 +170,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(nodeSwap).
 		with(machineAPIProviderOpenStack).
 		with(insightsConfigAPI).
+		with(persistentVolumeLastPhaseTransitionTime).
 		with(retroactiveDefaultStorageClass).
 		with(dynamicResourceAllocation).
 		with(admissionWebhookMatchConditions).
@@ -200,6 +201,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		buildCSIVolumes,
 	},
 	Disabled: []FeatureGateDescription{
+		persistentVolumeLastPhaseTransitionTime,
 		retroactiveDefaultStorageClass,
 	},
 }


### PR DESCRIPTION
We want to release PersistentVolumeLastPhaseTransitionTime as TechPreview in 4.15.

KEP: https://github.com/kubernetes/enhancements/issues/3762

cc @openshift/storage 