### PR TITLE
STOR-1343: remove RetroactiveDefaultStorageClass feature gate

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -53,16 +53,6 @@ var (
 		OwningProduct:       ocpSpecific,
 	}
 
-	FeatureGateRetroactiveDefaultStorageClass = FeatureGateName("RetroactiveDefaultStorageClass")
-	retroactiveDefaultStorageClass            = FeatureGateDescription{
-		FeatureGateAttributes: FeatureGateAttributes{
-			Name: FeatureGateRetroactiveDefaultStorageClass,
-		},
-		OwningJiraComponent: "storage",
-		ResponsiblePerson:   "RomanBednar",
-		OwningProduct:       kubernetes,
-	}
-
 	FeatureGateExternalCloudProvider = FeatureGateName("ExternalCloudProvider")
 	externalCloudProvider            = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -168,7 +168,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(nodeSwap).
 		with(machineAPIProviderOpenStack).
 		with(insightsConfigAPI).
-		with(retroactiveDefaultStorageClass).
 		with(dynamicResourceAllocation).
 		with(gateGatewayAPI).
 		with(maxUnavailableStatefulSet).
@@ -200,9 +199,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		privateHostedZoneAWS,
 		buildCSIVolumes,
 	},
-	Disabled: []FeatureGateDescription{
-		retroactiveDefaultStorageClass,
-	},
+	Disabled: []FeatureGateDescription{},
 }
 
 type featureSetBuilder struct {


### PR DESCRIPTION
`RetroactiveDefaultStorageClass` moved to GA in 1.28 upstream: https://github.com/kubernetes/website/pull/41206

Feature gate is planned to be removed in 1.29: https://github.com/kubernetes/kubernetes/pull/120861

cc @openshift/storage 