### PR TITLE
Fix default comment policy, set to Enforce

### DIFF
--- a/insights/v1alpha1/types_insights.go
+++ b/insights/v1alpha1/types_insights.go
@@ -14,7 +14,10 @@ import (
 // Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
 // +openshift:compatibility-gen:level=4
 type DataGather struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// spec holds user settable values for configuration
@@ -25,6 +28,7 @@ type DataGather struct {
 	Status DataGatherStatus `json:"status"`
 }
 
+// DataGatherSpec contains the configuration for the DataGather.
 type DataGatherSpec struct {
 	// dataPolicy allows user to enable additional global obfuscation of the IP addresses and base domain
 	// in the Insights archive data. Valid values are "ClearText" and "ObfuscateNetworking".
@@ -91,6 +95,7 @@ type GathererConfig struct {
 // +kubebuilder:validation:XValidation:rule="!(oldSelf == 'Failed' && self == 'Running')", message="dataGatherState cannot transition from Failed to Running"
 type DataGatherState string
 
+// DataGatherStatus contains information relating to the DataGather state.
 // +kubebuilder:validation:XValidation:rule="(!has(oldSelf.insightsRequestID) || has(self.insightsRequestID))",message="cannot remove insightsRequestID attribute from status"
 // +kubebuilder:validation:XValidation:rule="(!has(oldSelf.startTime) || has(self.startTime))",message="cannot remove startTime attribute from status"
 // +kubebuilder:validation:XValidation:rule="(!has(oldSelf.finishTime) || has(self.finishTime))",message="cannot remove finishTime attribute from status"
@@ -250,6 +255,11 @@ type ObjectReference struct {
 // +openshift:compatibility-gen:level=4
 type DataGatherList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata is the standard list's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ListMeta `json:"metadata"`
-	Items           []DataGather `json:"items"`
+
+	// items contains a list of DataGather resources.
+	Items []DataGather `json:"items"`
 }

--- a/insights/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/insights/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -12,9 +12,10 @@ package v1alpha1
 
 // AUTO-GENERATED FUNCTIONS START HERE
 var map_DataGather = map[string]string{
-	"":       "\n\nDataGather provides data gather configuration options and status for the particular Insights data gathering.\n\nCompatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
-	"spec":   "spec holds user settable values for configuration",
-	"status": "status holds observed values from the cluster. They may not be overridden.",
+	"":         "\n\nDataGather provides data gather configuration options and status for the particular Insights data gathering.\n\nCompatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+	"metadata": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "spec holds user settable values for configuration",
+	"status":   "status holds observed values from the cluster. They may not be overridden.",
 }
 
 func (DataGather) SwaggerDoc() map[string]string {
@@ -22,7 +23,9 @@ func (DataGather) SwaggerDoc() map[string]string {
 }
 
 var map_DataGatherList = map[string]string{
-	"": "DataGatherList is a collection of items\n\nCompatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+	"":         "DataGatherList is a collection of items\n\nCompatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
+	"metadata": "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"items":    "items contains a list of DataGather resources.",
 }
 
 func (DataGatherList) SwaggerDoc() map[string]string {
@@ -30,6 +33,7 @@ func (DataGatherList) SwaggerDoc() map[string]string {
 }
 
 var map_DataGatherSpec = map[string]string{
+	"":           "DataGatherSpec contains the configuration for the DataGather.",
 	"dataPolicy": "dataPolicy allows user to enable additional global obfuscation of the IP addresses and base domain in the Insights archive data. Valid values are \"ClearText\" and \"ObfuscateNetworking\". When set to ClearText the data is not obfuscated. When set to ObfuscateNetworking the IP addresses and the cluster domain name are obfuscated. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is ClearText.",
 	"gatherers":  "gatherers is a list of gatherers configurations. The particular gatherers IDs can be found at https://github.com/openshift/insights-operator/blob/master/docs/gathered-data.md. Run the following command to get the names of last active gatherers: \"oc get insightsoperators.operator.openshift.io cluster -o json | jq '.status.gatherStatus.gatherers[].name'\"",
 }
@@ -39,6 +43,7 @@ func (DataGatherSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DataGatherStatus = map[string]string{
+	"":                  "DataGatherStatus contains information relating to the DataGather state.",
 	"conditions":        "conditions provide details on the status of the gatherer job.",
 	"dataGatherState":   "dataGatherState reflects the current state of the data gathering process.",
 	"gatherers":         "gatherers is a list of active gatherers (and their statuses) in the last gathering.",

--- a/machineconfiguration/.codegen.yaml
+++ b/machineconfiguration/.codegen.yaml
@@ -1,0 +1,2 @@
+swaggerdocs:
+  commentPolicy: Warn

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -23714,8 +23714,9 @@ func schema_openshift_api_insights_v1alpha1_DataGather(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Description: "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
@@ -23764,13 +23765,15 @@ func schema_openshift_api_insights_v1alpha1_DataGatherList(ref common.ReferenceC
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Description: "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"array"},
+							Description: "items contains a list of DataGather resources.",
+							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -23794,7 +23797,8 @@ func schema_openshift_api_insights_v1alpha1_DataGatherSpec(ref common.ReferenceC
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "DataGatherSpec contains the configuration for the DataGather.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"dataPolicy": {
 						SchemaProps: spec.SchemaProps{
@@ -23830,7 +23834,8 @@ func schema_openshift_api_insights_v1alpha1_DataGatherStatus(ref common.Referenc
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "DataGatherStatus contains information relating to the DataGather state.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -13340,6 +13340,7 @@
           "type": "string"
         },
         "metadata": {
+          "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
           "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
         },
@@ -13368,6 +13369,7 @@
           "type": "string"
         },
         "items": {
+          "description": "items contains a list of DataGather resources.",
           "type": "array",
           "items": {
             "default": {},
@@ -13379,12 +13381,14 @@
           "type": "string"
         },
         "metadata": {
+          "description": "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
           "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
         }
       }
     },
     "com.github.openshift.api.insights.v1alpha1.DataGatherSpec": {
+      "description": "DataGatherSpec contains the configuration for the DataGather.",
       "type": "object",
       "properties": {
         "dataPolicy": {
@@ -13403,6 +13407,7 @@
       }
     },
     "com.github.openshift.api.insights.v1alpha1.DataGatherStatus": {
+      "description": "DataGatherStatus contains information relating to the DataGather state.",
       "type": "object",
       "properties": {
         "conditions": {

--- a/tools/codegen/cmd/swaggerdocs.go
+++ b/tools/codegen/cmd/swaggerdocs.go
@@ -11,7 +11,7 @@ import (
 var (
 	swaggerOutputFileName string
 
-	swaggerCommentPolicy = swaggerdocs.CommentPolicyWarn
+	swaggerCommentPolicy = swaggerdocs.CommentPolicyEnforce
 )
 
 // swaggerDocsCmd represents the swaggerdocs command
@@ -44,7 +44,7 @@ func init() {
 	rootCmd.AddCommand(swaggerDocsCmd)
 
 	rootCmd.PersistentFlags().StringVar(&swaggerOutputFileName, "swagger:output-file-name", swaggerdocs.DefaultOutputFileName, "Defines the file name to use for the swagger generated docs for each group version.")
-	rootCmd.PersistentFlags().Var(newEnum(&swaggerCommentPolicy, swaggerdocs.CommentPolicyIgnore, swaggerdocs.CommentPolicyWarn, swaggerdocs.CommentPolicyEnforce), "swagger:comment-policy", "Defines the policy to use when a field is missing documentation. Valid values are 'Ignore', 'Warn' and 'Enforce'. The default policy is 'Warn'. Missing comments will be ignored when the policy is set to 'Ignore', a warning will be produced when the policy is set to 'Warn', the generator will fail when the policy is set to 'Enforce'.")
+	rootCmd.PersistentFlags().Var(newEnum(&swaggerCommentPolicy, swaggerdocs.CommentPolicyIgnore, swaggerdocs.CommentPolicyWarn, swaggerdocs.CommentPolicyEnforce), "swagger:comment-policy", "Defines the policy to use when a field is missing documentation. Valid values are 'Ignore', 'Warn' and 'Enforce'. The default policy is 'Enforce'. Missing comments will be ignored when the policy is set to 'Ignore', a warning will be produced when the policy is set to 'Warn', the generator will fail when the policy is set to 'Enforce'.")
 }
 
 // newSwaggerDocsGenerator builds a new swaggerdocs generator.


### PR DESCRIPTION
We had intended to change the default comment policy to Enforce to make sure that all fields and structs that are exposed via APIs have complete documentation. This wasn't done correctly as I forgot to update the default flag value.

This updates the default flag value and corrects a handful of missing comments that were failing when making this change