### PR TITLE
CORS-2429: Update GCP PlatformStatus for user provided dns

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
@@ -646,6 +646,16 @@ spec:
                     gcp:
                       description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
                       properties:
+                        clusterHostedDNS:
+                          default: Disabled
+                          description: clusterHostedDNS indicates the type of DNS solution in use within the cluster. Its default value of "Disabled" indicates that the cluster's DNS is the default provided by the cloud platform. It can be "Enabled" during install to bypass the configuration of the cloud default DNS. When "Enabled", the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed. The cluster's use of the cloud's Load Balancers is unaffected by this setting. The value is immutable after it has been set at install time. Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS. Enabling this functionality allows the user to start their own DNS solution outside the cluster after installation is complete. The customer would be responsible for configuring this custom DNS solution, and it can be run in addition to the in-cluster DNS solution.
+                          enum:
+                            - Enabled
+                            - Disabled
+                          type: string
+                          x-kubernetes-validations:
+                            - message: clusterHostedDNS is immutable and may only be configured during installation
+                              rule: self == oldSelf
                         projectID:
                           description: resourceGroupName is the Project ID for new GCP resources created for the cluster.
                           type: string

--- a/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
@@ -646,6 +646,16 @@ spec:
                     gcp:
                       description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
                       properties:
+                        clusterHostedDNS:
+                          default: Disabled
+                          description: clusterHostedDNS indicates the type of DNS solution in use within the cluster. Its default value of "Disabled" indicates that the cluster's DNS is the default provided by the cloud platform. It can be "Enabled" during install to bypass the configuration of the cloud default DNS. When "Enabled", the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed. The cluster's use of the cloud's Load Balancers is unaffected by this setting. The value is immutable after it has been set at install time. Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS. Enabling this functionality allows the user to start their own DNS solution outside the cluster after installation is complete. The customer would be responsible for configuring this custom DNS solution, and it can be run in addition to the in-cluster DNS solution.
+                          enum:
+                            - Enabled
+                            - Disabled
+                          type: string
+                          x-kubernetes-validations:
+                            - message: clusterHostedDNS is immutable and may only be configured during installation
+                              rule: self == oldSelf
                         projectID:
                           description: resourceGroupName is the Project ID for new GCP resources created for the cluster.
                           type: string

--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -341,4 +341,14 @@ var (
 		ResponsiblePerson:   "padillon",
 		OwningProduct:       ocpSpecific,
 	}
+
+	FeatureGateGCPClusterHostedDNS = FeatureGateName("GCPClusterHostedDNS")
+	gcpClusterHostedDNS            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateGCPClusterHostedDNS,
+		},
+		OwningJiraComponent: "Installer",
+		ResponsiblePerson:   "barbacbd",
+		OwningProduct:       ocpSpecific,
+	}
 )

--- a/config/v1/techpreview.infrastructure.testsuite.yaml
+++ b/config/v1/techpreview.infrastructure.testsuite.yaml
@@ -517,3 +517,48 @@ tests:
             resourceTags:
               - {parentID: "test-project-123", key: "key", value: "value"}
     expectedStatusError: "status.platformStatus.gcp.resourceTags: Invalid value: \"array\": resourceTags are immutable and may only be configured during installation"
+  - name: Should not be able to modify the cluster hosted dns value for GCP Platform Status
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        controlPlaneTopology: "HighlyAvailable"
+        infrastructureTopology: "HighlyAvailable"
+        platform: GCP
+        platformStatus:
+          type: GCP
+          gcp:
+            clusterHostedDNS: "Enabled"
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        platform: GCP
+        platformStatus:
+          type: GCP
+          gcp:
+            clusterHostedDNS: "Disabled"
+    expectedStatusError: "status.platformStatus.gcp.clusterHostedDNS: Invalid value: \"string\": clusterHostedDNS is immutable and may only be configured during installation"
+  - name: Should not be able to remove GCP cluster hosted DNS from platformStatus.gcp
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        platform: GCP
+        platformStatus:
+          type: GCP
+          gcp:
+            clusterHostedDNS: "Enabled"
+    updated: |
+      apiVersion: config.openshift.io/v1
+      kind: Infrastructure
+      spec: {}
+      status:
+        platform: GCP
+        platformStatus:
+          type: GCP
+          gcp: {}
+    expectedStatusError: "status.platformStatus.gcp.clusterHostedDNS: Invalid value: \"string\": clusterHostedDNS is immutable and may only be configured during installation"

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -174,6 +174,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		without(eventedPleg).
 		with(sigstoreImageVerification).
 		with(gcpLabelsTags).
+		with(gcpClusterHostedDNS).
 		with(vSphereStaticIPs).
 		with(routeExternalCertificate).
 		with(automatedEtcdBackup).

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -229,6 +229,24 @@ const (
 	IBMCloudProviderTypeUPI IBMCloudProviderType = "UPI"
 )
 
+// ClusterHostedDNS indicates whether the cluster DNS is hosted by the cluster or Core DNS .
+type ClusterHostedDNS string
+
+const (
+	// EnabledClusterHostedDNS indicates that a DNS solution other than the default provided by the
+	// cloud platform is in use. In this mode, the cluster hosts a DNS solution during installation and the
+	// user is expected to provide their own DNS solution post-install.
+	// When "Enabled", the cluster will continue to use the default Load Balancers provided by the cloud
+	// platform.
+	EnabledClusterHostedDNS ClusterHostedDNS = "Enabled"
+
+	// DisabledClusterHostedDNS indicates that the cluster is using the default DNS solution for the
+	// cloud platform. OpenShift is responsible for all the LB and DNS configuration needed for the
+	// cluster to be functional with no intervention from the user. To accomplish this, OpenShift
+	// configures the default LB and DNS solutions provided by the underlying cloud.
+	DisabledClusterHostedDNS ClusterHostedDNS = "Disabled"
+)
+
 // ExternalPlatformSpec holds the desired state for the generic External infrastructure provider.
 type ExternalPlatformSpec struct {
 	// PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time.
@@ -610,6 +628,24 @@ type GCPPlatformStatus struct {
 	// +optional
 	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	ResourceTags []GCPResourceTag `json:"resourceTags,omitempty"`
+
+	// clusterHostedDNS indicates the type of DNS solution in use within the cluster. Its default value of
+	// "Disabled" indicates that the cluster's DNS is the default provided by the cloud platform. It can be
+	// "Enabled" during install to bypass the configuration of the cloud default DNS. When "Enabled", the
+	// cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed.
+	// The cluster's use of the cloud's Load Balancers is unaffected by this setting.
+	// The value is immutable after it has been set at install time.
+	// Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS.
+	// Enabling this functionality allows the user to start their own DNS solution outside the cluster after
+	// installation is complete. The customer would be responsible for configuring this custom DNS solution,
+	// and it can be run in addition to the in-cluster DNS solution.
+	// +kubebuilder:default:="Disabled"
+	// +default="Disabled"
+	// +kubebuilder:validation:Enum="Enabled";"Disabled"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusterHostedDNS is immutable and may only be configured during installation"
+	// +optional
+	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
+	ClusterHostedDNS ClusterHostedDNS `json:"clusterHostedDNS,omitempty"`
 }
 
 // GCPResourceLabel is a label to apply to GCP resources created for the cluster.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1310,11 +1310,12 @@ func (GCPPlatformSpec) SwaggerDoc() map[string]string {
 }
 
 var map_GCPPlatformStatus = map[string]string{
-	"":               "GCPPlatformStatus holds the current status of the Google Cloud Platform infrastructure provider.",
-	"projectID":      "resourceGroupName is the Project ID for new GCP resources created for the cluster.",
-	"region":         "region holds the region for new GCP resources created for the cluster.",
-	"resourceLabels": "resourceLabels is a list of additional labels to apply to GCP resources created for the cluster. See https://cloud.google.com/compute/docs/labeling-resources for information on labeling GCP resources. GCP supports a maximum of 64 labels per resource. OpenShift reserves 32 labels for internal use, allowing 32 labels for user configuration.",
-	"resourceTags":   "resourceTags is a list of additional tags to apply to GCP resources created for the cluster. See https://cloud.google.com/resource-manager/docs/tags/tags-overview for information on tagging GCP resources. GCP supports a maximum of 50 tags per resource.",
+	"":                 "GCPPlatformStatus holds the current status of the Google Cloud Platform infrastructure provider.",
+	"projectID":        "resourceGroupName is the Project ID for new GCP resources created for the cluster.",
+	"region":           "region holds the region for new GCP resources created for the cluster.",
+	"resourceLabels":   "resourceLabels is a list of additional labels to apply to GCP resources created for the cluster. See https://cloud.google.com/compute/docs/labeling-resources for information on labeling GCP resources. GCP supports a maximum of 64 labels per resource. OpenShift reserves 32 labels for internal use, allowing 32 labels for user configuration.",
+	"resourceTags":     "resourceTags is a list of additional tags to apply to GCP resources created for the cluster. See https://cloud.google.com/resource-manager/docs/tags/tags-overview for information on tagging GCP resources. GCP supports a maximum of 50 tags per resource.",
+	"clusterHostedDNS": "clusterHostedDNS indicates the type of DNS solution in use within the cluster. Its default value of \"Disabled\" indicates that the cluster's DNS is the default provided by the cloud platform. It can be \"Enabled\" during install to bypass the configuration of the cloud default DNS. When \"Enabled\", the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed. The cluster's use of the cloud's Load Balancers is unaffected by this setting. The value is immutable after it has been set at install time. Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS. Enabling this functionality allows the user to start their own DNS solution outside the cluster after installation is complete. The customer would be responsible for configuring this custom DNS solution, and it can be run in addition to the in-cluster DNS solution.",
 }
 
 func (GCPPlatformStatus) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -12043,6 +12043,14 @@ func schema_openshift_api_config_v1_GCPPlatformStatus(ref common.ReferenceCallba
 							},
 						},
 					},
+					"clusterHostedDNS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "clusterHostedDNS indicates the type of DNS solution in use within the cluster. Its default value of \"Disabled\" indicates that the cluster's DNS is the default provided by the cloud platform. It can be \"Enabled\" during install to bypass the configuration of the cloud default DNS. When \"Enabled\", the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed. The cluster's use of the cloud's Load Balancers is unaffected by this setting. The value is immutable after it has been set at install time. Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS. Enabling this functionality allows the user to start their own DNS solution outside the cluster after installation is complete. The customer would be responsible for configuring this custom DNS solution, and it can be run in addition to the in-cluster DNS solution.",
+							Default:     "Disabled",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"projectID", "region"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -6260,6 +6260,11 @@
         "region"
       ],
       "properties": {
+        "clusterHostedDNS": {
+          "description": "clusterHostedDNS indicates the type of DNS solution in use within the cluster. Its default value of \"Disabled\" indicates that the cluster's DNS is the default provided by the cloud platform. It can be \"Enabled\" during install to bypass the configuration of the cloud default DNS. When \"Enabled\", the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed. The cluster's use of the cloud's Load Balancers is unaffected by this setting. The value is immutable after it has been set at install time. Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS. Enabling this functionality allows the user to start their own DNS solution outside the cluster after installation is complete. The customer would be responsible for configuring this custom DNS solution, and it can be run in addition to the in-cluster DNS solution.",
+          "type": "string",
+          "default": "Disabled"
+        },
         "projectID": {
           "description": "resourceGroupName is the Project ID for new GCP resources created for the cluster.",
           "type": "string",


### PR DESCRIPTION
This feature attempts to provide a DNS alternative to customers that have specific restrictions around using the cloud provider default DNS.

These API changes are being introduced to indicate the state and type of DNS solution used within the cluster. Currently, this feature applies to AWS, Azure and GCP platforms, but this PR only focuses on GCP support. This new status field indicates in its default state that the OpenShift cluster is using the DNS solution provided by default by the underlying cloud platform. For example, that would be Route53 in the case of the AWS platform.

When Enabled by the Installer, this status field indicates that the default Cloud DNS is not in use. The cluster utilizes a self-hosted DNS solution to achieve a successful cluster installation. The user then has an option of additionally using a custom DNS solution outside the cluster. This custom DNS solution has to be completely managed by the user.

This PR supports the [Openshift Installer Epic](https://issues.redhat.com/projects/CORS/issues/CORS-2460). 