### PR TITLE
MON-3410: Add FeatureGate for MetricsServer

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -321,4 +321,14 @@ var (
 		ResponsiblePerson:   "vincepri",
 		OwningProduct:       ocpSpecific,
 	}
+
+	FeatureGateMetricsServer = FeatureGateName("MetricsServer")
+	metricsServer            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateMetricsServer,
+		},
+		OwningJiraComponent: "Monitoring",
+		ResponsiblePerson:   "slashpai",
+		OwningProduct:       ocpSpecific,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -183,6 +183,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(dnsNameResolver).
 		with(machineConfigNodes).
 		with(clusterAPIInstall).
+		with(metricsServer).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),


### PR DESCRIPTION
enhancement proposal: openshift/enhancements#1426

This feature will TechPreview in OCP 4.15 hence adding a feature gate where the feature is to be enabled only on TechPreview Clusters and not in standard cluster.

Goal is to disable the feature by default in 4.15 but enable it only in TechPreviewNoUpgrade clusters

cc: @simonpasquier 