### PR TITLE
OCPBUGS-20164: Capability Annotation for Build CRD

### DIFF
--- a/config/v1/0000_10_config-operator_01_build.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_build.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    capability.openshift.io/name: Build
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/payload-command/empty-resources/0000_05_config-operator_02_build.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_build.cr.yaml
@@ -3,6 +3,7 @@ kind: Build
 metadata:
   name: cluster
   annotations:
+    capability.openshift.io/name: Build
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
Add missing `capability.openshift.io/name` annotation to the Build cluster configuration CRD. This will ensure that the config object for the Build sub-system is not created when the Build capability is not enabled.

JIRA ID: OCPBUGS-20164