### PR TITLE
OCPBUGS-21781: Rectify Infrastructure GCP label key validation check

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
@@ -655,7 +655,7 @@ spec:
                                 description: key is the key part of the label. A label key can have a maximum of 63 characters and cannot be empty. Label key must begin with a lowercase letter, and must contain only lowercase letters, numeric characters, and the following special characters `_-`. Label key must not have the reserved prefixes `kubernetes-io` and `openshift-io`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[a-z][0-9a-z_-]+$
+                                pattern: ^[a-z][0-9a-z_-]{0,62}$
                                 type: string
                                 x-kubernetes-validations:
                                   - message: label keys must not start with either `openshift-io` or `kubernetes-io`
@@ -664,7 +664,7 @@ spec:
                                 description: value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty. Value must contain only lowercase letters, numeric characters, and the following special characters `_-`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[0-9a-z_-]+$
+                                pattern: ^[0-9a-z_-]{1,63}$
                                 type: string
                             required:
                               - key

--- a/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
@@ -655,7 +655,7 @@ spec:
                                 description: key is the key part of the label. A label key can have a maximum of 63 characters and cannot be empty. Label key must begin with a lowercase letter, and must contain only lowercase letters, numeric characters, and the following special characters `_-`. Label key must not have the reserved prefixes `kubernetes-io` and `openshift-io`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[a-z][0-9a-z_-]+$
+                                pattern: ^[a-z][0-9a-z_-]{0,62}$
                                 type: string
                                 x-kubernetes-validations:
                                   - message: label keys must not start with either `openshift-io` or `kubernetes-io`
@@ -664,7 +664,7 @@ spec:
                                 description: value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty. Value must contain only lowercase letters, numeric characters, and the following special characters `_-`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[0-9a-z_-]+$
+                                pattern: ^[0-9a-z_-]{1,63}$
                                 type: string
                             required:
                               - key

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -622,7 +622,7 @@ type GCPResourceLabel struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=`^[a-z][0-9a-z_-]+$`
+	// +kubebuilder:validation:Pattern=`^[a-z][0-9a-z_-]{0,62}$`
 	Key string `json:"key"`
 
 	// value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty.
@@ -630,7 +630,7 @@ type GCPResourceLabel struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=`^[0-9a-z_-]+$`
+	// +kubebuilder:validation:Pattern=`^[0-9a-z_-]{1,63}$`
 	Value string `json:"value"`
 }
 


### PR DESCRIPTION
Regex check used for validating GCP label key configured in Infrastructure expects minimum two characters for the key, which is corrected to accept minimum 1 character and maximum of 63 characters.