### PR TITLE
add featuregate for MachineConfigNodes

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -311,4 +311,14 @@ var (
 		ResponsiblePerson:   "rvanderp3",
 		OwningProduct:       ocpSpecific,
 	}
+
+	FeatureGateMachineConfigNodes = FeatureGateName("MachineConfigNodes")
+	machineConfigNodes            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateMachineConfigNodes,
+		},
+		OwningJiraComponent: "MachineConfigOperator",
+		ResponsiblePerson:   "cdoern",
+		OwningProduct:       ocpSpecific,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -182,6 +182,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		without(machineAPIOperatorDisableMachineHealthCheckController).
 		with(adminNetworkPolicy).
 		with(dnsNameResolver).
+		with(machineConfigNodes).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),


### PR DESCRIPTION
This adds a featuegate for the work on openshift/api#1596 which I will then bring into the MCO. Keeping this separate as it can merge before the types get into the API.