### PR TITLE
OCPBUGS-22364: Make MCO certificate observability fields optional for 4.15

### DIFF
--- a/machineconfiguration/v1/0000_80_controllerconfig.crd.yaml
+++ b/machineconfiguration/v1/0000_80_controllerconfig.crd.yaml
@@ -1224,8 +1224,6 @@ spec:
                     type: object
                     required:
                       - bundleFile
-                      - notAfter
-                      - notBefore
                       - signer
                       - subject
                     properties:

--- a/machineconfiguration/v1/0000_80_machineconfigpool.crd.yaml
+++ b/machineconfiguration/v1/0000_80_machineconfigpool.crd.yaml
@@ -227,7 +227,6 @@ spec:
                     type: object
                     required:
                       - bundle
-                      - expiry
                       - subject
                     properties:
                       bundle:

--- a/machineconfiguration/v1/types.go
+++ b/machineconfiguration/v1/types.go
@@ -210,11 +210,11 @@ type ControllerCertificate struct {
 	Signer string `json:"signer"`
 
 	// notBefore is the lower boundary for validity
-	// +kubebuilder:validation:Required
+	// +optional
 	NotBefore *metav1.Time `json:"notBefore"`
 
 	// notAfter is the upper boundary for validity
-	// +kubebuilder:validation:Required
+	// +optional
 	NotAfter *metav1.Time `json:"notAfter"`
 
 	// bundleFile is the larger bundle a cert comes from
@@ -445,7 +445,7 @@ type CertExpiry struct {
 	// +kubebuilder:validation:Required
 	Subject string `json:"subject"`
 	// expiry is the date after which the certificate will no longer be valid
-	// +kubebuilder:validation:Required
+	// +optional
 	Expiry *metav1.Time `json:"expiry"`
 }
 


### PR DESCRIPTION
Mistakes were made:
- we previously added some strings to the MCO that should have been `metav1.Time`
- we removed the fields from the MCO for 4.14: https://github.com/openshift/machine-config-operator/pull/3866 
- the fields were marked required after our API migration which merged for 4.15
- during upgrades, there is a race condition between when the ControllerConfig/MachineConfigPool CRDs get applied and when the "old"  (4.14) MCO controller pods get replaced during an upgrade 
- If we lose the race, this is breaking CI because the MCO goes `Available=False` when the "old" MCO render_controller [fails to supply the fields](https://github.com/openshift/machine-config-operator/blob/76e4c1867cbf37bd8ba9a953fa83623de817bb93/pkg/operator/sync.go#L1365C41-L1365C41) and returns an error

What this does:  
- makes these fields optional for 4.15 so the upgrades work properly and we unblock CI 
- (we intend to lock them back down to required in 4.16 for correctness ) 

Fixes: [OCPBUGS-22364](https://issues.redhat.com/browse/OCPBUGS-22364)