### PR TITLE
NP-793: SDN live migration

### DIFF
--- a/config/v1/0000_10_config-operator_01_network-CustomNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,211 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: networks.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc. Please view network.spec for an explanation on what applies when configuring this resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs. This field is immutable after installation.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                externalIP:
+                  description: externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.
+                  type: object
+                  properties:
+                    autoAssignCIDRs:
+                      description: autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called "IngressIPs". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.
+                      type: array
+                      items:
+                        type: string
+                    policy:
+                      description: policy is a set of restrictions applied to the ExternalIP field. If nil or empty, then ExternalIP is not allowed to be set.
+                      type: object
+                      properties:
+                        allowedCIDRs:
+                          description: allowedCIDRs is the list of allowed CIDRs.
+                          type: array
+                          items:
+                            type: string
+                        rejectedCIDRs:
+                          description: rejectedCIDRs is the list of disallowed CIDRs. These take precedence over allowedCIDRs.
+                          type: array
+                          items:
+                            type: string
+                networkType:
+                  description: 'NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.'
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.
+                  type: array
+                  items:
+                    type: string
+                serviceNodePortRange:
+                  description: The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.
+                  type: string
+                  pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                clusterNetworkMTU:
+                  description: ClusterNetworkMTU is the MTU for inter-pod networking.
+                  type: integer
+                conditions:
+                  description: 'conditions represents the observations of a network.config current state. Known .status.conditions.type are: "NetworkTypeMigrationInProgress", "NetworkTypeMigrationMTUReady", "NetworkTypeMigrationTargetCNIAvailable", "NetworkTypeMigrationTargetCNIInUse" and "NetworkTypeMigrationOriginalCNIPurged"'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                migration:
+                  description: Migration contains the cluster network migration configuration.
+                  type: object
+                  properties:
+                    mtu:
+                      description: MTU contains the MTU migration configuration.
+                      type: object
+                      properties:
+                        machine:
+                          description: Machine contains MTU migration configuration for the machine's uplink.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                        network:
+                          description: Network contains MTU migration configuration for the default network.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                    networkType:
+                      description: 'NetworkType is the target plugin that is to be deployed. Currently supported values are: OpenShiftSDN, OVNKubernetes'
+                      type: string
+                      enum:
+                        - OpenShiftSDN
+                        - OVNKubernetes
+                networkType:
+                  description: NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here.
+                  type: array
+                  items:
+                    type: string
+      served: true
+      storage: true

--- a/config/v1/0000_10_config-operator_01_network-Default.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network-Default.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
   name: networks.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/0000_10_config-operator_01_network-Default.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network-Default.crd.yaml
@@ -110,53 +110,6 @@ spec:
                 clusterNetworkMTU:
                   description: ClusterNetworkMTU is the MTU for inter-pod networking.
                   type: integer
-                conditions:
-                  description: 'conditions represents the observations of a network.config current state. Known .status.conditions.type are: "NetworkTypeMigrationInProgress", "NetworkTypeMigrationMTUReady", "NetworkTypeMigrationTargetCNIAvailable", "NetworkTypeMigrationTargetCNIInUse" and "NetworkTypeMigrationOriginalCNIPurged"'
-                  type: array
-                  items:
-                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                    type: object
-                    required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
-                    properties:
-                      lastTransitionTime:
-                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        type: string
-                        format: date-time
-                      message:
-                        description: message is a human readable message indicating details about the transition. This may be an empty string.
-                        type: string
-                        maxLength: 32768
-                      observedGeneration:
-                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                        type: integer
-                        format: int64
-                        minimum: 0
-                      reason:
-                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                        type: string
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        type: string
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        type: string
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
                 migration:
                   description: Migration contains the cluster network migration configuration.
                   type: object

--- a/config/v1/0000_10_config-operator_01_network-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,211 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: networks.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc. Please view network.spec for an explanation on what applies when configuring this resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs. This field is immutable after installation.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                externalIP:
+                  description: externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.
+                  type: object
+                  properties:
+                    autoAssignCIDRs:
+                      description: autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called "IngressIPs". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.
+                      type: array
+                      items:
+                        type: string
+                    policy:
+                      description: policy is a set of restrictions applied to the ExternalIP field. If nil or empty, then ExternalIP is not allowed to be set.
+                      type: object
+                      properties:
+                        allowedCIDRs:
+                          description: allowedCIDRs is the list of allowed CIDRs.
+                          type: array
+                          items:
+                            type: string
+                        rejectedCIDRs:
+                          description: rejectedCIDRs is the list of disallowed CIDRs. These take precedence over allowedCIDRs.
+                          type: array
+                          items:
+                            type: string
+                networkType:
+                  description: 'NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.'
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.
+                  type: array
+                  items:
+                    type: string
+                serviceNodePortRange:
+                  description: The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.
+                  type: string
+                  pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                clusterNetworkMTU:
+                  description: ClusterNetworkMTU is the MTU for inter-pod networking.
+                  type: integer
+                conditions:
+                  description: 'conditions represents the observations of a network.config current state. Known .status.conditions.type are: "NetworkTypeMigrationInProgress", "NetworkTypeMigrationMTUReady", "NetworkTypeMigrationTargetCNIAvailable", "NetworkTypeMigrationTargetCNIInUse" and "NetworkTypeMigrationOriginalCNIPurged"'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                migration:
+                  description: Migration contains the cluster network migration configuration.
+                  type: object
+                  properties:
+                    mtu:
+                      description: MTU contains the MTU migration configuration.
+                      type: object
+                      properties:
+                        machine:
+                          description: Machine contains MTU migration configuration for the machine's uplink.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                        network:
+                          description: Network contains MTU migration configuration for the default network.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                    networkType:
+                      description: 'NetworkType is the target plugin that is to be deployed. Currently supported values are: OpenShiftSDN, OVNKubernetes'
+                      type: string
+                      enum:
+                        - OpenShiftSDN
+                        - OVNKubernetes
+                networkType:
+                  description: NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here.
+                  type: array
+                  items:
+                    type: string
+      served: true
+      storage: true

--- a/config/v1/0000_10_config-operator_01_network.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_network.crd.yaml
@@ -109,6 +109,53 @@ spec:
                 clusterNetworkMTU:
                   description: ClusterNetworkMTU is the MTU for inter-pod networking.
                   type: integer
+                conditions:
+                  description: 'conditions represents the observations of a network.config current state. Known .status.conditions.type are: "NetworkTypeMigrationInProgress", "NetworkTypeMigrationMTUReady", "NetworkTypeMigrationTargetCNIAvailable", "NetworkTypeMigrationTargetCNIInUse" and "NetworkTypeMigrationOriginalCNIPurged"'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
                 migration:
                   description: Migration contains the cluster network migration configuration.
                   type: object

--- a/config/v1/custom.network.testsuite.yaml
+++ b/config/v1/custom.network.testsuite.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[CustomNoUpgrade] Network"
+crd: 0000_10_config-operator_01_network-CustomNoUpgrade.crd.yaml
+tests:
+  onCreate:
+    - name: Should be able to set status conditions
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Network
+        spec: {} # No spec is required for a Network
+        status:
+          conditions:
+            - type: NetworkTypeMigrationInProgress
+              status: "False"
+              reason: "Reason"
+              message: "Message"
+              lastTransitionTime: "2023-10-25T12:00:00Z"
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Network
+        spec: {}
+        status:
+          conditions:
+            - type: NetworkTypeMigrationInProgress
+              status: "False"
+              reason: "Reason"
+              message: "Message"
+              lastTransitionTime: "2023-10-25T12:00:00Z"

--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -262,6 +262,16 @@ var (
 		OwningProduct:       ocpSpecific,
 	}
 
+	FeatureGateNetworkLiveMigration = FeatureGateName("NetworkLiveMigration")
+	sdnLiveMigration                = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateNetworkLiveMigration,
+		},
+		OwningJiraComponent: "Networking/ovn-kubernetes",
+		ResponsiblePerson:   "pliu",
+		OwningProduct:       ocpSpecific,
+	}
+
 	FeatureGateAutomatedEtcdBackup = FeatureGateName("AutomatedEtcdBackup")
 	automatedEtcdBackup            = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{

--- a/config/v1/stable.network.testsuite.yaml
+++ b/config/v1/stable.network.testsuite.yaml
@@ -12,3 +12,20 @@ tests:
       apiVersion: config.openshift.io/v1
       kind: Network
       spec: {}
+  - name: Should not be able to set status conditions
+    initial: |
+      apiVersion: config.openshift.io/v1
+      kind: Network
+      spec: {} # No spec is required for a Network
+      status:
+        conditions:
+          - type: NetworkTypeMigrationInProgress
+            status: "False"
+            reason: "Reason"
+            message: "Message"
+            lastTransitionTime: "2023-10-25T12:00:00Z"
+    expected: |
+      apiVersion: config.openshift.io/v1
+      kind: Network
+      spec: {}
+      status: {}

--- a/config/v1/stable.network.testsuite.yaml
+++ b/config/v1/stable.network.testsuite.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[Stable] Network"
-crd: 0000_10_config-operator_01_network.crd.yaml
+crd: 0000_10_config-operator_01_network-Default.crd.yaml
 tests:
   onCreate:
   - name: Should be able to create a minimal Network

--- a/config/v1/techpreview.network.testsuite.yaml
+++ b/config/v1/techpreview.network.testsuite.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[TechPreviewNoUpgrade] Network"
+crd: 0000_10_config-operator_01_network-TechPreviewNoUpgrade.crd.yaml
+tests:
+  onCreate:
+    - name: Should be able to set status conditions
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Network
+        spec: {} # No spec is required for a Network
+        status:
+          conditions:
+            - type: NetworkTypeMigrationInProgress
+              status: "False"
+              reason: "Reason"
+              message: "Message"
+              lastTransitionTime: "2023-10-25T12:00:00Z"
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Network
+        spec: {}
+        status:
+          conditions:
+            - type: NetworkTypeMigrationInProgress
+              status: "False"
+              reason: "Reason"
+              message: "Message"
+              lastTransitionTime: "2023-10-25T12:00:00Z"

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -186,6 +186,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(metricsServer).
 		with(installAlternateInfrastructureAWS).
 		without(clusterAPIInstall).
+		with(sdnLiveMigration).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),

--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -85,6 +85,17 @@ type NetworkStatus struct {
 
 	// Migration contains the cluster network migration configuration.
 	Migration *NetworkMigration `json:"migration,omitempty"`
+
+	// conditions represents the observations of a network.config current state.
+	// Known .status.conditions.type are: "NetworkTypeMigrationInProgress", "NetworkTypeMigrationMTUReady",
+	// "NetworkTypeMigrationTargetCNIAvailable", "NetworkTypeMigrationTargetCNIInUse"
+	// and "NetworkTypeMigrationOriginalCNIPurged"
+	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs

--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -95,6 +95,7 @@ type NetworkStatus struct {
 	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
+	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 

--- a/config/v1/zz_generated.deepcopy.go
+++ b/config/v1/zz_generated.deepcopy.go
@@ -3631,6 +3631,13 @@ func (in *NetworkStatus) DeepCopyInto(out *NetworkStatus) {
 		*out = new(NetworkMigration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1958,6 +1958,7 @@ var map_NetworkStatus = map[string]string{
 	"networkType":       "NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).",
 	"clusterNetworkMTU": "ClusterNetworkMTU is the MTU for inter-pod networking.",
 	"migration":         "Migration contains the cluster network migration configuration.",
+	"conditions":        "conditions represents the observations of a network.config current state. Known .status.conditions.type are: \"NetworkTypeMigrationInProgress\", \"NetworkTypeMigrationMTUReady\", \"NetworkTypeMigrationTargetCNIAvailable\", \"NetworkTypeMigrationTargetCNIInUse\" and \"NetworkTypeMigrationOriginalCNIPurged\"",
 }
 
 func (NetworkStatus) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -48119,6 +48119,14 @@ func schema_openshift_api_operator_v1_NetworkMigration(ref common.ReferenceCallb
 							Ref:         ref("github.com/openshift/api/operator/v1.FeaturesMigration"),
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "mode indicates the mode of network migration. The supported values are \"Live\", \"Offline\" and omitted. A \"Live\" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An \"Offline\" migration operation will cause service interruption. During an \"Offline\" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is \"Offline\".",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -14906,11 +14906,35 @@ func schema_openshift_api_config_v1_NetworkStatus(ref common.ReferenceCallback) 
 							Ref:         ref("github.com/openshift/api/config/v1.NetworkMigration"),
 						},
 					},
+					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type":       "map",
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Description: "conditions represents the observations of a network.config current state. Known .status.conditions.type are: \"NetworkTypeMigrationInProgress\", \"NetworkTypeMigrationMTUReady\", \"NetworkTypeMigrationTargetCNIAvailable\", \"NetworkTypeMigrationTargetCNIInUse\" and \"NetworkTypeMigrationOriginalCNIPurged\"",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/openshift/api/config/v1.ClusterNetworkEntry", "github.com/openshift/api/config/v1.NetworkMigration"},
+			"github.com/openshift/api/config/v1.ClusterNetworkEntry", "github.com/openshift/api/config/v1.NetworkMigration", "k8s.io/apimachinery/pkg/apis/meta/v1.Condition"},
 	}
 }
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -7980,6 +7980,20 @@
           "type": "integer",
           "format": "int32"
         },
+        "conditions": {
+          "description": "conditions represents the observations of a network.config current state. Known .status.conditions.type are: \"NetworkTypeMigrationInProgress\", \"NetworkTypeMigrationMTUReady\", \"NetworkTypeMigrationTargetCNIAvailable\", \"NetworkTypeMigrationTargetCNIInUse\" and \"NetworkTypeMigrationOriginalCNIPurged\"",
+          "type": "array",
+          "items": {
+            "default": {},
+            "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Condition"
+          },
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
         "migration": {
           "description": "Migration contains the cluster network migration configuration.",
           "$ref": "#/definitions/com.github.openshift.api.config.v1.NetworkMigration"

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -28192,6 +28192,11 @@
           "description": "features contains the features migration configuration. Set this to migrate feature configuration when changing the cluster default network provider. if unset, the default operation is to migrate all the configuration of supported features.",
           "$ref": "#/definitions/com.github.openshift.api.operator.v1.FeaturesMigration"
         },
+        "mode": {
+          "description": "mode indicates the mode of network migration. The supported values are \"Live\", \"Offline\" and omitted. A \"Live\" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An \"Offline\" migration operation will cause service interruption. During an \"Offline\" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is \"Offline\".",
+          "type": "string",
+          "default": ""
+        },
         "mtu": {
           "description": "mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.",
           "$ref": "#/definitions/com.github.openshift.api.operator.v1.MTUMigration"

--- a/operator/v1/0000_70_cluster-network-operator_01-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-CustomNoUpgrade.crd.yaml
@@ -494,6 +494,9 @@ spec:
                     networkType:
                       description: networkType is the target type of network migration. Set this to the target network type to allow changing the default network. If unset, the operation of changing cluster default network plugin will be rejected. The supported values are OpenShiftSDN, OVNKubernetes
                       type: string
+                  x-kubernetes-validations:
+                    - rule: '!has(self.mtu) || !has(self.networkType) || self.networkType == '''' || has(self.mode) && self.mode == ''Live'''
+                      message: networkType migration in mode other than 'Live' may not be configured at the same time as mtu migration
                 observedConfig:
                   description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
                   type: object

--- a/operator/v1/0000_70_cluster-network-operator_01-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,585 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: networks.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Network describes the cluster's desired network configuration. It is consumed by the cluster-network-operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NetworkSpec is the top-level network configuration object.
+              type: object
+              properties:
+                additionalNetworks:
+                  description: additionalNetworks is a list of extra networks to make available to pods when multiple networks are enabled.
+                  type: array
+                  items:
+                    description: AdditionalNetworkDefinition configures an extra network that is available but not created by default. Instead, pods must request them by name. type must be specified, along with exactly one "Config" that matches the type.
+                    type: object
+                    properties:
+                      name:
+                        description: name is the name of the network. This will be populated in the resulting CRD This must be unique.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the network. This will be populated in the resulting CRD If not given the network will be created in the default namespace.
+                        type: string
+                      rawCNIConfig:
+                        description: rawCNIConfig is the raw CNI configuration json to create in the NetworkAttachmentDefinition CRD
+                        type: string
+                      simpleMacvlanConfig:
+                        description: SimpleMacvlanConfig configures the macvlan interface in case of type:NetworkTypeSimpleMacvlan
+                        type: object
+                        properties:
+                          ipamConfig:
+                            description: IPAMConfig configures IPAM module will be used for IP Address Management (IPAM).
+                            type: object
+                            properties:
+                              staticIPAMConfig:
+                                description: StaticIPAMConfig configures the static IP address in case of type:IPAMTypeStatic
+                                type: object
+                                properties:
+                                  addresses:
+                                    description: Addresses configures IP address for the interface
+                                    type: array
+                                    items:
+                                      description: StaticIPAMAddresses provides IP address and Gateway for static IPAM addresses
+                                      type: object
+                                      properties:
+                                        address:
+                                          description: Address is the IP address in CIDR format
+                                          type: string
+                                        gateway:
+                                          description: Gateway is IP inside of subnet to designate as the gateway
+                                          type: string
+                                  dns:
+                                    description: DNS configures DNS for the interface
+                                    type: object
+                                    properties:
+                                      domain:
+                                        description: Domain configures the domainname the local domain used for short hostname lookups
+                                        type: string
+                                      nameservers:
+                                        description: Nameservers points DNS servers for IP lookup
+                                        type: array
+                                        items:
+                                          type: string
+                                      search:
+                                        description: Search configures priority ordered search domains for short hostname lookups
+                                        type: array
+                                        items:
+                                          type: string
+                                  routes:
+                                    description: Routes configures IP routes for the interface
+                                    type: array
+                                    items:
+                                      description: StaticIPAMRoutes provides Destination/Gateway pairs for static IPAM routes
+                                      type: object
+                                      properties:
+                                        destination:
+                                          description: Destination points the IP route destination
+                                          type: string
+                                        gateway:
+                                          description: Gateway is the route's next-hop IP address If unset, a default gateway is assumed (as determined by the CNI plugin).
+                                          type: string
+                              type:
+                                description: Type is the type of IPAM module will be used for IP Address Management(IPAM). The supported values are IPAMTypeDHCP, IPAMTypeStatic
+                                type: string
+                          master:
+                            description: master is the host interface to create the macvlan interface from. If not specified, it will be default route interface
+                            type: string
+                          mode:
+                            description: 'mode is the macvlan mode: bridge, private, vepa, passthru. The default is bridge'
+                            type: string
+                          mtu:
+                            description: mtu is the mtu to use for the macvlan interface. if unset, host's kernel will select the value.
+                            type: integer
+                            format: int32
+                            minimum: 0
+                      type:
+                        description: type is the type of network The supported values are NetworkTypeRaw, NetworkTypeSimpleMacvlan
+                        type: string
+                clusterNetwork:
+                  description: clusterNetwork is the IP address pool to use for pod IPs. Some network providers, e.g. OpenShift SDN, support multiple ClusterNetworks. Others only support one. This is equivalent to the cluster-cidr.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks
+                    type: object
+                    properties:
+                      cidr:
+                        type: string
+                      hostPrefix:
+                        type: integer
+                        format: int32
+                        minimum: 0
+                defaultNetwork:
+                  description: defaultNetwork is the "default" network that all pods will receive
+                  type: object
+                  properties:
+                    kuryrConfig:
+                      description: KuryrConfig configures the kuryr plugin
+                      type: object
+                      properties:
+                        controllerProbesPort:
+                          description: The port kuryr-controller will listen for readiness and liveness requests.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        daemonProbesPort:
+                          description: The port kuryr-daemon will listen for readiness and liveness requests.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        enablePortPoolsPrepopulation:
+                          description: enablePortPoolsPrepopulation when true will make Kuryr prepopulate each newly created port pool with a minimum number of ports. Kuryr uses Neutron port pooling to fight the fact that it takes a significant amount of time to create one. It creates a number of ports when the first pod that is configured to use the dedicated network for pods is created in a namespace, and keeps them ready to be attached to pods. Port prepopulation is disabled by default.
+                          type: boolean
+                        mtu:
+                          description: mtu is the MTU that Kuryr should use when creating pod networks in Neutron. The value has to be lower or equal to the MTU of the nodes network and Neutron has to allow creation of tenant networks with such MTU. If unset Pod networks will be created with the same MTU as the nodes network has. This also affects the services network created by cluster-network-operator.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        openStackServiceNetwork:
+                          description: openStackServiceNetwork contains the CIDR of network from which to allocate IPs for OpenStack Octavia's Amphora VMs. Please note that with Amphora driver Octavia uses two IPs from that network for each loadbalancer - one given by OpenShift and second for VRRP connections. As the first one is managed by OpenShift's and second by Neutron's IPAMs, those need to come from different pools. Therefore `openStackServiceNetwork` needs to be at least twice the size of `serviceNetwork`, and whole `serviceNetwork` must be overlapping with `openStackServiceNetwork`. cluster-network-operator will then make sure VRRP IPs are taken from the ranges inside `openStackServiceNetwork` that are not overlapping with `serviceNetwork`, effectivly preventing conflicts. If not set cluster-network-operator will use `serviceNetwork` expanded by decrementing the prefix size by 1.
+                          type: string
+                        poolBatchPorts:
+                          description: poolBatchPorts sets a number of ports that should be created in a single batch request to extend the port pool. The default is 3. For more information about port pools see enablePortPoolsPrepopulation setting.
+                          type: integer
+                          minimum: 0
+                        poolMaxPorts:
+                          description: poolMaxPorts sets a maximum number of free ports that are being kept in a port pool. If the number of ports exceeds this setting, free ports will get deleted. Setting 0 will disable this upper bound, effectively preventing pools from shrinking and this is the default value. For more information about port pools see enablePortPoolsPrepopulation setting.
+                          type: integer
+                          minimum: 0
+                        poolMinPorts:
+                          description: poolMinPorts sets a minimum number of free ports that should be kept in a port pool. If the number of ports is lower than this setting, new ports will get created and added to pool. The default is 1. For more information about port pools see enablePortPoolsPrepopulation setting.
+                          type: integer
+                          minimum: 1
+                    openshiftSDNConfig:
+                      description: openShiftSDNConfig configures the openshift-sdn plugin
+                      type: object
+                      properties:
+                        enableUnidling:
+                          description: enableUnidling controls whether or not the service proxy will support idling and unidling of services. By default, unidling is enabled.
+                          type: boolean
+                        mode:
+                          description: mode is one of "Multitenant", "Subnet", or "NetworkPolicy"
+                          type: string
+                        mtu:
+                          description: mtu is the mtu to use for the tunnel interface. Defaults to 1450 if unset. This must be 50 bytes smaller than the machine's uplink.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        useExternalOpenvswitch:
+                          description: 'useExternalOpenvswitch used to control whether the operator would deploy an OVS DaemonSet itself or expect someone else to start OVS. As of 4.6, OVS is always run as a system service, and this flag is ignored. DEPRECATED: non-functional as of 4.6'
+                          type: boolean
+                        vxlanPort:
+                          description: vxlanPort is the port to use for all vxlan packets. The default is 4789.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                    ovnKubernetesConfig:
+                      description: ovnKubernetesConfig configures the ovn-kubernetes plugin.
+                      type: object
+                      properties:
+                        egressIPConfig:
+                          description: egressIPConfig holds the configuration for EgressIP options.
+                          type: object
+                          properties:
+                            reachabilityTotalTimeoutSeconds:
+                              description: reachabilityTotalTimeout configures the EgressIP node reachability check total timeout in seconds. If the EgressIP node cannot be reached within this timeout, the node is declared down. Setting a large value may cause the EgressIP feature to react slowly to node changes. In particular, it may react slowly for EgressIP nodes that really have a genuine problem and are unreachable. When omitted, this means the user has no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is 1 second. A value of 0 disables the EgressIP node's reachability check.
+                              type: integer
+                              format: int32
+                              maximum: 60
+                              minimum: 0
+                        gatewayConfig:
+                          description: gatewayConfig holds the configuration for node gateway options.
+                          type: object
+                          properties:
+                            ipForwarding:
+                              description: IPForwarding controls IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is set to Restricted, and Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by the OCP node. If there is a desire to allow the host to forward traffic across OVN-Kubernetes managed interfaces, then set this field to "Global". The supported values are "Restricted" and "Global".
+                              type: string
+                            ipv4:
+                              description: ipv4 allows users to configure IP settings for IPv4 connections. When omitted, this means no opinion and the default configuration is used. Check individual members fields within ipv4 for details of default values.
+                              type: object
+                              properties:
+                                internalMasqueradeSubnet:
+                                  description: internalMasqueradeSubnet contains the masquerade addresses in IPV4 CIDR format used internally by ovn-kubernetes to enable host to service traffic. Each host in the cluster is configured with these addresses, as well as the shared gateway bridge interface. The values can be changed after installation. The subnet chosen should not overlap with other networks specified for OVN-Kubernetes as well as other networks used on the host. Additionally the subnet must be large enough to accommodate 6 IPs (maximum prefix length /29). When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default subnet is 169.254.169.0/29 The value must be in proper IPV4 CIDR format
+                                  type: string
+                                  maxLength: 18
+                                  x-kubernetes-validations:
+                                    - rule: self.indexOf('/') == self.lastIndexOf('/')
+                                      message: CIDR format must contain exactly one '/'
+                                    - rule: '[int(self.split(''/'')[1])].all(x, x <= 29 && x >= 0)'
+                                      message: subnet must be in the range /0 to /29 inclusive
+                                    - rule: self.split('/')[0].split('.').size() == 4
+                                      message: a valid IPv4 address must contain 4 octets
+                                    - rule: '[self.findAll(''[0-9]+'')[0]].all(x, x != ''0'' && int(x) <= 255 && !x.startsWith(''0''))'
+                                      message: first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255
+                                    - rule: '[self.findAll(''[0-9]+'')[1], self.findAll(''[0-9]+'')[2], self.findAll(''[0-9]+'')[3]].all(x, int(x) <= 255 && (x == ''0'' || !x.startsWith(''0'')))'
+                                      message: IP address octets must not contain leading zeros, and must be less or equal to 255
+                            ipv6:
+                              description: ipv6 allows users to configure IP settings for IPv6 connections. When omitted, this means no opinion and the default configuration is used. Check individual members fields within ipv6 for details of default values.
+                              type: object
+                              properties:
+                                internalMasqueradeSubnet:
+                                  description: internalMasqueradeSubnet contains the masquerade addresses in IPV6 CIDR format used internally by ovn-kubernetes to enable host to service traffic. Each host in the cluster is configured with these addresses, as well as the shared gateway bridge interface. The values can be changed after installation. The subnet chosen should not overlap with other networks specified for OVN-Kubernetes as well as other networks used on the host. Additionally the subnet must be large enough to accommodate 6 IPs (maximum prefix length /125). When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default subnet is fd69::/125 Note that IPV6 dual addresses are not permitted
+                                  type: string
+                                  x-kubernetes-validations:
+                                    - rule: self.indexOf('/') == self.lastIndexOf('/')
+                                      message: CIDR format must contain exactly one '/'
+                                    - rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x, x <= 125 && x >= 0)
+                                      message: subnet must be in the range /0 to /125 inclusive
+                                    - rule: self.indexOf('::') == self.lastIndexOf('::')
+                                      message: IPv6 addresses must contain at most one '::' and may only be shortened once
+                                    - rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size() <= 8 : self.split(''/'')[0].split('':'').size() == 8'
+                                      message: a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=1 ? [self.split(''/'')[0].split('':'', 8)[0]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 1
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=2 ? [self.split(''/'')[0].split('':'', 8)[1]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 2
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=3 ? [self.split(''/'')[0].split('':'', 8)[2]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 3
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=4 ? [self.split(''/'')[0].split('':'', 8)[3]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 4
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=5 ? [self.split(''/'')[0].split('':'', 8)[4]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 5
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=6 ? [self.split(''/'')[0].split('':'', 8)[5]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 6
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=7 ? [self.split(''/'')[0].split('':'', 8)[6]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 7
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=8 ? [self.split(''/'')[0].split('':'', 8)[7]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 8
+                                    - rule: '!self.contains(''.'')'
+                                      message: IPv6 dual addresses are not permitted, value should not contain `.` characters
+                            routingViaHost:
+                              description: RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.
+                              type: boolean
+                              default: false
+                        genevePort:
+                          description: geneve port is the UDP port to be used by geneve encapulation. Default is 6081
+                          type: integer
+                          format: int32
+                          minimum: 1
+                        hybridOverlayConfig:
+                          description: HybridOverlayConfig configures an additional overlay network for peers that are not using OVN.
+                          type: object
+                          properties:
+                            hybridClusterNetwork:
+                              description: HybridClusterNetwork defines a network space given to nodes on an additional overlay network.
+                              type: array
+                              items:
+                                description: ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  hostPrefix:
+                                    type: integer
+                                    format: int32
+                                    minimum: 0
+                            hybridOverlayVXLANPort:
+                              description: HybridOverlayVXLANPort defines the VXLAN port number to be used by the additional overlay network. Default is 4789
+                              type: integer
+                              format: int32
+                        ipsecConfig:
+                          description: ipsecConfig enables and configures IPsec for pods on the pod network within the cluster.
+                          type: object
+                        mtu:
+                          description: mtu is the MTU to use for the tunnel interface. This must be 100 bytes smaller than the uplink mtu. Default is 1400
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        policyAuditConfig:
+                          description: policyAuditConfig is the configuration for network policy audit events. If unset, reported defaults are used.
+                          type: object
+                          properties:
+                            destination:
+                              description: 'destination is the location for policy log messages. Regardless of this config, persistent logs will always be dumped to the host at /var/log/ovn/ however Additionally syslog output may be configured as follows. Valid values are: - "libc" -> to use the libc syslog() function of the host node''s journdald process - "udp:host:port" -> for sending syslog over UDP - "unix:file" -> for using the UNIX domain socket directly - "null" -> to discard all messages logged to syslog The default is "null"'
+                              type: string
+                              default: "null"
+                            maxFileSize:
+                              description: maxFilesSize is the max size an ACL_audit log file is allowed to reach before rotation occurs Units are in MB and the Default is 50MB
+                              type: integer
+                              format: int32
+                              default: 50
+                              minimum: 1
+                            maxLogFiles:
+                              description: maxLogFiles specifies the maximum number of ACL_audit log files that can be present.
+                              type: integer
+                              format: int32
+                              default: 5
+                              minimum: 1
+                            rateLimit:
+                              description: rateLimit is the approximate maximum number of messages to generate per-second per-node. If unset the default of 20 msg/sec is used.
+                              type: integer
+                              format: int32
+                              default: 20
+                              minimum: 1
+                            syslogFacility:
+                              description: syslogFacility the RFC5424 facility for generated messages, e.g. "kern". Default is "local0"
+                              type: string
+                              default: local0
+                        v4InternalSubnet:
+                          description: v4InternalSubnet is a v4 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is 100.64.0.0/16
+                          type: string
+                        v6InternalSubnet:
+                          description: v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is fd98::/48
+                          type: string
+                    type:
+                      description: type is the type of network All NetworkTypes are supported except for NetworkTypeRaw
+                      type: string
+                deployKubeProxy:
+                  description: deployKubeProxy specifies whether or not a standalone kube-proxy should be deployed by the operator. Some network providers include kube-proxy or similar functionality. If unset, the plugin will attempt to select the correct value, which is false when OpenShift SDN and ovn-kubernetes are used and true otherwise.
+                  type: boolean
+                disableMultiNetwork:
+                  description: disableMultiNetwork specifies whether or not multiple pod network support should be disabled. If unset, this property defaults to 'false' and multiple network support is enabled.
+                  type: boolean
+                disableNetworkDiagnostics:
+                  description: disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck CRs from a test pod to every node, apiserver and LB should be disabled or not. If unset, this property defaults to 'false' and network diagnostics is enabled. Setting this to 'true' would reduce the additional load of the pods performing the checks.
+                  type: boolean
+                  default: false
+                exportNetworkFlows:
+                  description: exportNetworkFlows enables and configures the export of network flow metadata from the pod network by using protocols NetFlow, SFlow or IPFIX. Currently only supported on OVN-Kubernetes plugin. If unset, flows will not be exported to any collector.
+                  type: object
+                  properties:
+                    ipfix:
+                      description: ipfix defines IPFIX configuration.
+                      type: object
+                      properties:
+                        collectors:
+                          description: ipfixCollectors is list of strings formatted as ip:port with a maximum of ten items
+                          type: array
+                          maxItems: 10
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                    netFlow:
+                      description: netFlow defines the NetFlow configuration.
+                      type: object
+                      properties:
+                        collectors:
+                          description: netFlow defines the NetFlow collectors that will consume the flow data exported from OVS. It is a list of strings formatted as ip:port with a maximum of ten items
+                          type: array
+                          maxItems: 10
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                    sFlow:
+                      description: sFlow defines the SFlow configuration.
+                      type: object
+                      properties:
+                        collectors:
+                          description: sFlowCollectors is list of strings formatted as ip:port with a maximum of ten items
+                          type: array
+                          maxItems: 10
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                kubeProxyConfig:
+                  description: kubeProxyConfig lets us configure desired proxy configuration. If not specified, sensible defaults will be chosen by OpenShift directly. Not consumed by all network providers - currently only openshift-sdn.
+                  type: object
+                  properties:
+                    bindAddress:
+                      description: The address to "bind" on Defaults to 0.0.0.0
+                      type: string
+                    iptablesSyncPeriod:
+                      description: 'An internal kube-proxy parameter. In older releases of OCP, this sometimes needed to be adjusted in large clusters for performance reasons, but this is no longer necessary, and there is no reason to change this from the default value. Default: 30s'
+                      type: string
+                    proxyArguments:
+                      description: Any additional arguments to pass to the kubeproxy process
+                      type: object
+                      additionalProperties:
+                        description: ProxyArgumentList is a list of arguments to pass to the kubeproxy process
+                        type: array
+                        items:
+                          type: string
+                logLevel:
+                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                  type: string
+                  default: Normal
+                  enum:
+                    - ""
+                    - Normal
+                    - Debug
+                    - Trace
+                    - TraceAll
+                managementState:
+                  description: managementState indicates whether and how the operator should manage the component
+                  type: string
+                  pattern: ^(Managed|Unmanaged|Force|Removed)$
+                migration:
+                  description: migration enables and configures the cluster network migration. The migration procedure allows to change the network type and the MTU.
+                  type: object
+                  properties:
+                    features:
+                      description: features contains the features migration configuration. Set this to migrate feature configuration when changing the cluster default network provider. if unset, the default operation is to migrate all the configuration of supported features.
+                      type: object
+                      properties:
+                        egressFirewall:
+                          description: egressFirewall specifies whether or not the Egress Firewall configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and Egress Firewall configure is migrated.
+                          type: boolean
+                          default: true
+                        egressIP:
+                          description: egressIP specifies whether or not the Egress IP configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and Egress IP configure is migrated.
+                          type: boolean
+                          default: true
+                        multicast:
+                          description: multicast specifies whether or not the multicast configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and multicast configure is migrated.
+                          type: boolean
+                          default: true
+                    mode:
+                      description: mode indicates the mode of network migration. The supported values are "Live", "Offline" and omitted. A "Live" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is "Offline".
+                      type: string
+                      enum:
+                        - Live
+                        - Offline
+                        - ""
+                    mtu:
+                      description: mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.
+                      type: object
+                      properties:
+                        machine:
+                          description: machine contains MTU migration configuration for the machine's uplink. Needs to be migrated along with the default network MTU unless the current uplink MTU already accommodates the default network MTU.
+                          type: object
+                          properties:
+                            from:
+                              description: from is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: to is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                        network:
+                          description: network contains information about MTU migration for the default network. Migrations are only allowed to MTU values lower than the machine's uplink MTU by the minimum appropriate offset.
+                          type: object
+                          properties:
+                            from:
+                              description: from is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: to is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                    networkType:
+                      description: networkType is the target type of network migration. Set this to the target network type to allow changing the default network. If unset, the operation of changing cluster default network plugin will be rejected. The supported values are OpenShiftSDN, OVNKubernetes
+                      type: string
+                observedConfig:
+                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                operatorLogLevel:
+                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                  type: string
+                  default: Normal
+                  enum:
+                    - ""
+                    - Normal
+                    - Debug
+                    - Trace
+                    - TraceAll
+                serviceNetwork:
+                  description: serviceNetwork is the ip address pool to use for Service IPs Currently, all existing network providers only support a single value here, but this is an array to allow for growth.
+                  type: array
+                  items:
+                    type: string
+                unsupportedConfigOverrides:
+                  description: unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                useMultiNetworkPolicy:
+                  description: useMultiNetworkPolicy enables a controller which allows for MultiNetworkPolicy objects to be used on additional networks as created by Multus CNI. MultiNetworkPolicy are similar to NetworkPolicy objects, but NetworkPolicy objects only apply to the primary interface. With MultiNetworkPolicy, you can control the traffic that a pod can receive over the secondary interfaces. If unset, this property defaults to 'false' and MultiNetworkPolicy objects are ignored. If 'disableMultiNetwork' is 'true' then the value of this field is ignored.
+                  type: boolean
+            status:
+              description: NetworkStatus is detailed operator status, which is distilled up to the Network clusteroperator object.
+              type: object
+              properties:
+                conditions:
+                  description: conditions is a list of conditions and their status
+                  type: array
+                  items:
+                    description: OperatorCondition is just the standard condition fields.
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                generations:
+                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                  type: array
+                  items:
+                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the thing you're tracking
+                        type: string
+                      hash:
+                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
+                        type: string
+                      lastGeneration:
+                        description: lastGeneration is the last generation of the workload controller involved
+                        type: integer
+                        format: int64
+                      name:
+                        description: name is the name of the thing you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the thing you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the thing you're tracking
+                        type: string
+                observedGeneration:
+                  description: observedGeneration is the last generation change you've dealt with
+                  type: integer
+                  format: int64
+                readyReplicas:
+                  description: readyReplicas indicates how many replicas are ready and at the desired state
+                  type: integer
+                  format: int32
+                version:
+                  description: version is the level this availability applies to
+                  type: string
+      served: true
+      storage: true

--- a/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
@@ -1,0 +1,585 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/475
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
+  name: networks.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Network describes the cluster's desired network configuration. It is consumed by the cluster-network-operator. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NetworkSpec is the top-level network configuration object.
+              type: object
+              properties:
+                additionalNetworks:
+                  description: additionalNetworks is a list of extra networks to make available to pods when multiple networks are enabled.
+                  type: array
+                  items:
+                    description: AdditionalNetworkDefinition configures an extra network that is available but not created by default. Instead, pods must request them by name. type must be specified, along with exactly one "Config" that matches the type.
+                    type: object
+                    properties:
+                      name:
+                        description: name is the name of the network. This will be populated in the resulting CRD This must be unique.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the network. This will be populated in the resulting CRD If not given the network will be created in the default namespace.
+                        type: string
+                      rawCNIConfig:
+                        description: rawCNIConfig is the raw CNI configuration json to create in the NetworkAttachmentDefinition CRD
+                        type: string
+                      simpleMacvlanConfig:
+                        description: SimpleMacvlanConfig configures the macvlan interface in case of type:NetworkTypeSimpleMacvlan
+                        type: object
+                        properties:
+                          ipamConfig:
+                            description: IPAMConfig configures IPAM module will be used for IP Address Management (IPAM).
+                            type: object
+                            properties:
+                              staticIPAMConfig:
+                                description: StaticIPAMConfig configures the static IP address in case of type:IPAMTypeStatic
+                                type: object
+                                properties:
+                                  addresses:
+                                    description: Addresses configures IP address for the interface
+                                    type: array
+                                    items:
+                                      description: StaticIPAMAddresses provides IP address and Gateway for static IPAM addresses
+                                      type: object
+                                      properties:
+                                        address:
+                                          description: Address is the IP address in CIDR format
+                                          type: string
+                                        gateway:
+                                          description: Gateway is IP inside of subnet to designate as the gateway
+                                          type: string
+                                  dns:
+                                    description: DNS configures DNS for the interface
+                                    type: object
+                                    properties:
+                                      domain:
+                                        description: Domain configures the domainname the local domain used for short hostname lookups
+                                        type: string
+                                      nameservers:
+                                        description: Nameservers points DNS servers for IP lookup
+                                        type: array
+                                        items:
+                                          type: string
+                                      search:
+                                        description: Search configures priority ordered search domains for short hostname lookups
+                                        type: array
+                                        items:
+                                          type: string
+                                  routes:
+                                    description: Routes configures IP routes for the interface
+                                    type: array
+                                    items:
+                                      description: StaticIPAMRoutes provides Destination/Gateway pairs for static IPAM routes
+                                      type: object
+                                      properties:
+                                        destination:
+                                          description: Destination points the IP route destination
+                                          type: string
+                                        gateway:
+                                          description: Gateway is the route's next-hop IP address If unset, a default gateway is assumed (as determined by the CNI plugin).
+                                          type: string
+                              type:
+                                description: Type is the type of IPAM module will be used for IP Address Management(IPAM). The supported values are IPAMTypeDHCP, IPAMTypeStatic
+                                type: string
+                          master:
+                            description: master is the host interface to create the macvlan interface from. If not specified, it will be default route interface
+                            type: string
+                          mode:
+                            description: 'mode is the macvlan mode: bridge, private, vepa, passthru. The default is bridge'
+                            type: string
+                          mtu:
+                            description: mtu is the mtu to use for the macvlan interface. if unset, host's kernel will select the value.
+                            type: integer
+                            format: int32
+                            minimum: 0
+                      type:
+                        description: type is the type of network The supported values are NetworkTypeRaw, NetworkTypeSimpleMacvlan
+                        type: string
+                clusterNetwork:
+                  description: clusterNetwork is the IP address pool to use for pod IPs. Some network providers, e.g. OpenShift SDN, support multiple ClusterNetworks. Others only support one. This is equivalent to the cluster-cidr.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks
+                    type: object
+                    properties:
+                      cidr:
+                        type: string
+                      hostPrefix:
+                        type: integer
+                        format: int32
+                        minimum: 0
+                defaultNetwork:
+                  description: defaultNetwork is the "default" network that all pods will receive
+                  type: object
+                  properties:
+                    kuryrConfig:
+                      description: KuryrConfig configures the kuryr plugin
+                      type: object
+                      properties:
+                        controllerProbesPort:
+                          description: The port kuryr-controller will listen for readiness and liveness requests.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        daemonProbesPort:
+                          description: The port kuryr-daemon will listen for readiness and liveness requests.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        enablePortPoolsPrepopulation:
+                          description: enablePortPoolsPrepopulation when true will make Kuryr prepopulate each newly created port pool with a minimum number of ports. Kuryr uses Neutron port pooling to fight the fact that it takes a significant amount of time to create one. It creates a number of ports when the first pod that is configured to use the dedicated network for pods is created in a namespace, and keeps them ready to be attached to pods. Port prepopulation is disabled by default.
+                          type: boolean
+                        mtu:
+                          description: mtu is the MTU that Kuryr should use when creating pod networks in Neutron. The value has to be lower or equal to the MTU of the nodes network and Neutron has to allow creation of tenant networks with such MTU. If unset Pod networks will be created with the same MTU as the nodes network has. This also affects the services network created by cluster-network-operator.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        openStackServiceNetwork:
+                          description: openStackServiceNetwork contains the CIDR of network from which to allocate IPs for OpenStack Octavia's Amphora VMs. Please note that with Amphora driver Octavia uses two IPs from that network for each loadbalancer - one given by OpenShift and second for VRRP connections. As the first one is managed by OpenShift's and second by Neutron's IPAMs, those need to come from different pools. Therefore `openStackServiceNetwork` needs to be at least twice the size of `serviceNetwork`, and whole `serviceNetwork` must be overlapping with `openStackServiceNetwork`. cluster-network-operator will then make sure VRRP IPs are taken from the ranges inside `openStackServiceNetwork` that are not overlapping with `serviceNetwork`, effectivly preventing conflicts. If not set cluster-network-operator will use `serviceNetwork` expanded by decrementing the prefix size by 1.
+                          type: string
+                        poolBatchPorts:
+                          description: poolBatchPorts sets a number of ports that should be created in a single batch request to extend the port pool. The default is 3. For more information about port pools see enablePortPoolsPrepopulation setting.
+                          type: integer
+                          minimum: 0
+                        poolMaxPorts:
+                          description: poolMaxPorts sets a maximum number of free ports that are being kept in a port pool. If the number of ports exceeds this setting, free ports will get deleted. Setting 0 will disable this upper bound, effectively preventing pools from shrinking and this is the default value. For more information about port pools see enablePortPoolsPrepopulation setting.
+                          type: integer
+                          minimum: 0
+                        poolMinPorts:
+                          description: poolMinPorts sets a minimum number of free ports that should be kept in a port pool. If the number of ports is lower than this setting, new ports will get created and added to pool. The default is 1. For more information about port pools see enablePortPoolsPrepopulation setting.
+                          type: integer
+                          minimum: 1
+                    openshiftSDNConfig:
+                      description: openShiftSDNConfig configures the openshift-sdn plugin
+                      type: object
+                      properties:
+                        enableUnidling:
+                          description: enableUnidling controls whether or not the service proxy will support idling and unidling of services. By default, unidling is enabled.
+                          type: boolean
+                        mode:
+                          description: mode is one of "Multitenant", "Subnet", or "NetworkPolicy"
+                          type: string
+                        mtu:
+                          description: mtu is the mtu to use for the tunnel interface. Defaults to 1450 if unset. This must be 50 bytes smaller than the machine's uplink.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        useExternalOpenvswitch:
+                          description: 'useExternalOpenvswitch used to control whether the operator would deploy an OVS DaemonSet itself or expect someone else to start OVS. As of 4.6, OVS is always run as a system service, and this flag is ignored. DEPRECATED: non-functional as of 4.6'
+                          type: boolean
+                        vxlanPort:
+                          description: vxlanPort is the port to use for all vxlan packets. The default is 4789.
+                          type: integer
+                          format: int32
+                          minimum: 0
+                    ovnKubernetesConfig:
+                      description: ovnKubernetesConfig configures the ovn-kubernetes plugin.
+                      type: object
+                      properties:
+                        egressIPConfig:
+                          description: egressIPConfig holds the configuration for EgressIP options.
+                          type: object
+                          properties:
+                            reachabilityTotalTimeoutSeconds:
+                              description: reachabilityTotalTimeout configures the EgressIP node reachability check total timeout in seconds. If the EgressIP node cannot be reached within this timeout, the node is declared down. Setting a large value may cause the EgressIP feature to react slowly to node changes. In particular, it may react slowly for EgressIP nodes that really have a genuine problem and are unreachable. When omitted, this means the user has no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is 1 second. A value of 0 disables the EgressIP node's reachability check.
+                              type: integer
+                              format: int32
+                              maximum: 60
+                              minimum: 0
+                        gatewayConfig:
+                          description: gatewayConfig holds the configuration for node gateway options.
+                          type: object
+                          properties:
+                            ipForwarding:
+                              description: IPForwarding controls IP forwarding for all traffic on OVN-Kubernetes managed interfaces (such as br-ex). By default this is set to Restricted, and Kubernetes related traffic is still forwarded appropriately, but other IP traffic will not be routed by the OCP node. If there is a desire to allow the host to forward traffic across OVN-Kubernetes managed interfaces, then set this field to "Global". The supported values are "Restricted" and "Global".
+                              type: string
+                            ipv4:
+                              description: ipv4 allows users to configure IP settings for IPv4 connections. When omitted, this means no opinion and the default configuration is used. Check individual members fields within ipv4 for details of default values.
+                              type: object
+                              properties:
+                                internalMasqueradeSubnet:
+                                  description: internalMasqueradeSubnet contains the masquerade addresses in IPV4 CIDR format used internally by ovn-kubernetes to enable host to service traffic. Each host in the cluster is configured with these addresses, as well as the shared gateway bridge interface. The values can be changed after installation. The subnet chosen should not overlap with other networks specified for OVN-Kubernetes as well as other networks used on the host. Additionally the subnet must be large enough to accommodate 6 IPs (maximum prefix length /29). When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default subnet is 169.254.169.0/29 The value must be in proper IPV4 CIDR format
+                                  type: string
+                                  maxLength: 18
+                                  x-kubernetes-validations:
+                                    - rule: self.indexOf('/') == self.lastIndexOf('/')
+                                      message: CIDR format must contain exactly one '/'
+                                    - rule: '[int(self.split(''/'')[1])].all(x, x <= 29 && x >= 0)'
+                                      message: subnet must be in the range /0 to /29 inclusive
+                                    - rule: self.split('/')[0].split('.').size() == 4
+                                      message: a valid IPv4 address must contain 4 octets
+                                    - rule: '[self.findAll(''[0-9]+'')[0]].all(x, x != ''0'' && int(x) <= 255 && !x.startsWith(''0''))'
+                                      message: first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255
+                                    - rule: '[self.findAll(''[0-9]+'')[1], self.findAll(''[0-9]+'')[2], self.findAll(''[0-9]+'')[3]].all(x, int(x) <= 255 && (x == ''0'' || !x.startsWith(''0'')))'
+                                      message: IP address octets must not contain leading zeros, and must be less or equal to 255
+                            ipv6:
+                              description: ipv6 allows users to configure IP settings for IPv6 connections. When omitted, this means no opinion and the default configuration is used. Check individual members fields within ipv6 for details of default values.
+                              type: object
+                              properties:
+                                internalMasqueradeSubnet:
+                                  description: internalMasqueradeSubnet contains the masquerade addresses in IPV6 CIDR format used internally by ovn-kubernetes to enable host to service traffic. Each host in the cluster is configured with these addresses, as well as the shared gateway bridge interface. The values can be changed after installation. The subnet chosen should not overlap with other networks specified for OVN-Kubernetes as well as other networks used on the host. Additionally the subnet must be large enough to accommodate 6 IPs (maximum prefix length /125). When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default subnet is fd69::/125 Note that IPV6 dual addresses are not permitted
+                                  type: string
+                                  x-kubernetes-validations:
+                                    - rule: self.indexOf('/') == self.lastIndexOf('/')
+                                      message: CIDR format must contain exactly one '/'
+                                    - rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x, x <= 125 && x >= 0)
+                                      message: subnet must be in the range /0 to /125 inclusive
+                                    - rule: self.indexOf('::') == self.lastIndexOf('::')
+                                      message: IPv6 addresses must contain at most one '::' and may only be shortened once
+                                    - rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size() <= 8 : self.split(''/'')[0].split('':'').size() == 8'
+                                      message: a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=1 ? [self.split(''/'')[0].split('':'', 8)[0]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 1
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=2 ? [self.split(''/'')[0].split('':'', 8)[1]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 2
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=3 ? [self.split(''/'')[0].split('':'', 8)[2]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 3
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=4 ? [self.split(''/'')[0].split('':'', 8)[3]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 4
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=5 ? [self.split(''/'')[0].split('':'', 8)[4]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 5
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=6 ? [self.split(''/'')[0].split('':'', 8)[5]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 6
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=7 ? [self.split(''/'')[0].split('':'', 8)[6]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 7
+                                    - rule: 'self.split(''/'')[0].split('':'').size() >=8 ? [self.split(''/'')[0].split('':'', 8)[7]].all(x, x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$'')) && size(x)<5 ) : true'
+                                      message: each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 8
+                                    - rule: '!self.contains(''.'')'
+                                      message: IPv6 dual addresses are not permitted, value should not contain `.` characters
+                            routingViaHost:
+                              description: RoutingViaHost allows pod egress traffic to exit via the ovn-k8s-mp0 management port into the host before sending it out. If this is not set, traffic will always egress directly from OVN to outside without touching the host stack. Setting this to true means hardware offload will not be supported. Default is false if GatewayConfig is specified.
+                              type: boolean
+                              default: false
+                        genevePort:
+                          description: geneve port is the UDP port to be used by geneve encapulation. Default is 6081
+                          type: integer
+                          format: int32
+                          minimum: 1
+                        hybridOverlayConfig:
+                          description: HybridOverlayConfig configures an additional overlay network for peers that are not using OVN.
+                          type: object
+                          properties:
+                            hybridClusterNetwork:
+                              description: HybridClusterNetwork defines a network space given to nodes on an additional overlay network.
+                              type: array
+                              items:
+                                description: ClusterNetworkEntry is a subnet from which to allocate PodIPs. A network of size HostPrefix (in CIDR notation) will be allocated when nodes join the cluster. If the HostPrefix field is not used by the plugin, it can be left unset. Not all network providers support multiple ClusterNetworks
+                                type: object
+                                properties:
+                                  cidr:
+                                    type: string
+                                  hostPrefix:
+                                    type: integer
+                                    format: int32
+                                    minimum: 0
+                            hybridOverlayVXLANPort:
+                              description: HybridOverlayVXLANPort defines the VXLAN port number to be used by the additional overlay network. Default is 4789
+                              type: integer
+                              format: int32
+                        ipsecConfig:
+                          description: ipsecConfig enables and configures IPsec for pods on the pod network within the cluster.
+                          type: object
+                        mtu:
+                          description: mtu is the MTU to use for the tunnel interface. This must be 100 bytes smaller than the uplink mtu. Default is 1400
+                          type: integer
+                          format: int32
+                          minimum: 0
+                        policyAuditConfig:
+                          description: policyAuditConfig is the configuration for network policy audit events. If unset, reported defaults are used.
+                          type: object
+                          properties:
+                            destination:
+                              description: 'destination is the location for policy log messages. Regardless of this config, persistent logs will always be dumped to the host at /var/log/ovn/ however Additionally syslog output may be configured as follows. Valid values are: - "libc" -> to use the libc syslog() function of the host node''s journdald process - "udp:host:port" -> for sending syslog over UDP - "unix:file" -> for using the UNIX domain socket directly - "null" -> to discard all messages logged to syslog The default is "null"'
+                              type: string
+                              default: "null"
+                            maxFileSize:
+                              description: maxFilesSize is the max size an ACL_audit log file is allowed to reach before rotation occurs Units are in MB and the Default is 50MB
+                              type: integer
+                              format: int32
+                              default: 50
+                              minimum: 1
+                            maxLogFiles:
+                              description: maxLogFiles specifies the maximum number of ACL_audit log files that can be present.
+                              type: integer
+                              format: int32
+                              default: 5
+                              minimum: 1
+                            rateLimit:
+                              description: rateLimit is the approximate maximum number of messages to generate per-second per-node. If unset the default of 20 msg/sec is used.
+                              type: integer
+                              format: int32
+                              default: 20
+                              minimum: 1
+                            syslogFacility:
+                              description: syslogFacility the RFC5424 facility for generated messages, e.g. "kern". Default is "local0"
+                              type: string
+                              default: local0
+                        v4InternalSubnet:
+                          description: v4InternalSubnet is a v4 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is 100.64.0.0/16
+                          type: string
+                        v6InternalSubnet:
+                          description: v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the default one is being already used by something else. It must not overlap with any other subnet being used by OpenShift or by the node network. The size of the subnet must be larger than the number of nodes. The value cannot be changed after installation. Default is fd98::/48
+                          type: string
+                    type:
+                      description: type is the type of network All NetworkTypes are supported except for NetworkTypeRaw
+                      type: string
+                deployKubeProxy:
+                  description: deployKubeProxy specifies whether or not a standalone kube-proxy should be deployed by the operator. Some network providers include kube-proxy or similar functionality. If unset, the plugin will attempt to select the correct value, which is false when OpenShift SDN and ovn-kubernetes are used and true otherwise.
+                  type: boolean
+                disableMultiNetwork:
+                  description: disableMultiNetwork specifies whether or not multiple pod network support should be disabled. If unset, this property defaults to 'false' and multiple network support is enabled.
+                  type: boolean
+                disableNetworkDiagnostics:
+                  description: disableNetworkDiagnostics specifies whether or not PodNetworkConnectivityCheck CRs from a test pod to every node, apiserver and LB should be disabled or not. If unset, this property defaults to 'false' and network diagnostics is enabled. Setting this to 'true' would reduce the additional load of the pods performing the checks.
+                  type: boolean
+                  default: false
+                exportNetworkFlows:
+                  description: exportNetworkFlows enables and configures the export of network flow metadata from the pod network by using protocols NetFlow, SFlow or IPFIX. Currently only supported on OVN-Kubernetes plugin. If unset, flows will not be exported to any collector.
+                  type: object
+                  properties:
+                    ipfix:
+                      description: ipfix defines IPFIX configuration.
+                      type: object
+                      properties:
+                        collectors:
+                          description: ipfixCollectors is list of strings formatted as ip:port with a maximum of ten items
+                          type: array
+                          maxItems: 10
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                    netFlow:
+                      description: netFlow defines the NetFlow configuration.
+                      type: object
+                      properties:
+                        collectors:
+                          description: netFlow defines the NetFlow collectors that will consume the flow data exported from OVS. It is a list of strings formatted as ip:port with a maximum of ten items
+                          type: array
+                          maxItems: 10
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                    sFlow:
+                      description: sFlow defines the SFlow configuration.
+                      type: object
+                      properties:
+                        collectors:
+                          description: sFlowCollectors is list of strings formatted as ip:port with a maximum of ten items
+                          type: array
+                          maxItems: 10
+                          minItems: 1
+                          items:
+                            type: string
+                            pattern: ^(([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]):([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+                kubeProxyConfig:
+                  description: kubeProxyConfig lets us configure desired proxy configuration. If not specified, sensible defaults will be chosen by OpenShift directly. Not consumed by all network providers - currently only openshift-sdn.
+                  type: object
+                  properties:
+                    bindAddress:
+                      description: The address to "bind" on Defaults to 0.0.0.0
+                      type: string
+                    iptablesSyncPeriod:
+                      description: 'An internal kube-proxy parameter. In older releases of OCP, this sometimes needed to be adjusted in large clusters for performance reasons, but this is no longer necessary, and there is no reason to change this from the default value. Default: 30s'
+                      type: string
+                    proxyArguments:
+                      description: Any additional arguments to pass to the kubeproxy process
+                      type: object
+                      additionalProperties:
+                        description: ProxyArgumentList is a list of arguments to pass to the kubeproxy process
+                        type: array
+                        items:
+                          type: string
+                logLevel:
+                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                  type: string
+                  default: Normal
+                  enum:
+                    - ""
+                    - Normal
+                    - Debug
+                    - Trace
+                    - TraceAll
+                managementState:
+                  description: managementState indicates whether and how the operator should manage the component
+                  type: string
+                  pattern: ^(Managed|Unmanaged|Force|Removed)$
+                migration:
+                  description: migration enables and configures the cluster network migration. The migration procedure allows to change the network type and the MTU.
+                  type: object
+                  properties:
+                    features:
+                      description: features contains the features migration configuration. Set this to migrate feature configuration when changing the cluster default network provider. if unset, the default operation is to migrate all the configuration of supported features.
+                      type: object
+                      properties:
+                        egressFirewall:
+                          description: egressFirewall specifies whether or not the Egress Firewall configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and Egress Firewall configure is migrated.
+                          type: boolean
+                          default: true
+                        egressIP:
+                          description: egressIP specifies whether or not the Egress IP configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and Egress IP configure is migrated.
+                          type: boolean
+                          default: true
+                        multicast:
+                          description: multicast specifies whether or not the multicast configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and multicast configure is migrated.
+                          type: boolean
+                          default: true
+                    mode:
+                      description: mode indicates the mode of network migration. The supported values are "Live", "Offline" and omitted. A "Live" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is "Offline".
+                      type: string
+                      enum:
+                        - Live
+                        - Offline
+                        - ""
+                    mtu:
+                      description: mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.
+                      type: object
+                      properties:
+                        machine:
+                          description: machine contains MTU migration configuration for the machine's uplink. Needs to be migrated along with the default network MTU unless the current uplink MTU already accommodates the default network MTU.
+                          type: object
+                          properties:
+                            from:
+                              description: from is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: to is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                        network:
+                          description: network contains information about MTU migration for the default network. Migrations are only allowed to MTU values lower than the machine's uplink MTU by the minimum appropriate offset.
+                          type: object
+                          properties:
+                            from:
+                              description: from is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: to is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                    networkType:
+                      description: networkType is the target type of network migration. Set this to the target network type to allow changing the default network. If unset, the operation of changing cluster default network plugin will be rejected. The supported values are OpenShiftSDN, OVNKubernetes
+                      type: string
+                observedConfig:
+                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                operatorLogLevel:
+                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                  type: string
+                  default: Normal
+                  enum:
+                    - ""
+                    - Normal
+                    - Debug
+                    - Trace
+                    - TraceAll
+                serviceNetwork:
+                  description: serviceNetwork is the ip address pool to use for Service IPs Currently, all existing network providers only support a single value here, but this is an array to allow for growth.
+                  type: array
+                  items:
+                    type: string
+                unsupportedConfigOverrides:
+                  description: unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                useMultiNetworkPolicy:
+                  description: useMultiNetworkPolicy enables a controller which allows for MultiNetworkPolicy objects to be used on additional networks as created by Multus CNI. MultiNetworkPolicy are similar to NetworkPolicy objects, but NetworkPolicy objects only apply to the primary interface. With MultiNetworkPolicy, you can control the traffic that a pod can receive over the secondary interfaces. If unset, this property defaults to 'false' and MultiNetworkPolicy objects are ignored. If 'disableMultiNetwork' is 'true' then the value of this field is ignored.
+                  type: boolean
+            status:
+              description: NetworkStatus is detailed operator status, which is distilled up to the Network clusteroperator object.
+              type: object
+              properties:
+                conditions:
+                  description: conditions is a list of conditions and their status
+                  type: array
+                  items:
+                    description: OperatorCondition is just the standard condition fields.
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                generations:
+                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                  type: array
+                  items:
+                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the thing you're tracking
+                        type: string
+                      hash:
+                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
+                        type: string
+                      lastGeneration:
+                        description: lastGeneration is the last generation of the workload controller involved
+                        type: integer
+                        format: int64
+                      name:
+                        description: name is the name of the thing you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the thing you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the thing you're tracking
+                        type: string
+                observedGeneration:
+                  description: observedGeneration is the last generation change you've dealt with
+                  type: integer
+                  format: int64
+                readyReplicas:
+                  description: readyReplicas indicates how many replicas are ready and at the desired state
+                  type: integer
+                  format: int32
+                version:
+                  description: version is the level this availability applies to
+                  type: string
+      served: true
+      storage: true

--- a/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
@@ -452,13 +452,6 @@ spec:
                           description: multicast specifies whether or not the multicast configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and multicast configure is migrated.
                           type: boolean
                           default: true
-                    mode:
-                      description: mode indicates the mode of network migration. The supported values are "Live", "Offline" and omitted. A "Live" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is "Offline".
-                      type: string
-                      enum:
-                        - Live
-                        - Offline
-                        - ""
                     mtu:
                       description: mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.
                       type: object

--- a/operator/v1/0000_70_cluster-network-operator_01-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-TechPreviewNoUpgrade.crd.yaml
@@ -494,6 +494,9 @@ spec:
                     networkType:
                       description: networkType is the target type of network migration. Set this to the target network type to allow changing the default network. If unset, the operation of changing cluster default network plugin will be rejected. The supported values are OpenShiftSDN, OVNKubernetes
                       type: string
+                  x-kubernetes-validations:
+                    - rule: '!has(self.mtu) || !has(self.networkType) || self.networkType == '''' || has(self.mode) && self.mode == ''Live'''
+                      message: networkType migration in mode other than 'Live' may not be configured at the same time as mtu migration
                 observedConfig:
                   description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
                   type: object

--- a/operator/v1/0000_70_cluster-network-operator_01-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-TechPreviewNoUpgrade.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: networks.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01.crd.yaml
@@ -451,6 +451,13 @@ spec:
                           description: multicast specifies whether or not the multicast configuration is migrated automatically when changing the cluster default network provider. If unset, this property defaults to 'true' and multicast configure is migrated.
                           type: boolean
                           default: true
+                    mode:
+                      description: mode indicates the mode of network migration. The supported values are "Live", "Offline" and omitted. A "Live" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is "Offline".
+                      type: string
+                      enum:
+                        - Live
+                        - Offline
+                        - ""
                     mtu:
                       description: mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.
                       type: object

--- a/operator/v1/custom.network.testsuite.yaml
+++ b/operator/v1/custom.network.testsuite.yaml
@@ -7,7 +7,7 @@ tests:
       initial: |
         apiVersion: operator.openshift.io/v1
         kind: Network
-        spec: 
+        spec:
           migration:
             mode: Live
       expected: |
@@ -19,4 +19,82 @@ tests:
           operatorLogLevel: Normal
           migration:
             mode: Live
-
+    - name: Should be able to create mtu migration without setting the migration mode
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        spec:
+          migration:
+            mtu:
+              network:
+                from: 1450
+                to: 1400
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        spec:
+          disableNetworkDiagnostics: false
+          logLevel: Normal
+          operatorLogLevel: Normal
+          migration:
+            mtu:
+              network:
+                from: 1450
+                to: 1400
+    - name: Should be able to create networkType migration in in offline migration mode
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        spec:
+          migration:
+            networkType: OVNKubernetes
+            mode: Offline
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        spec:
+          disableNetworkDiagnostics: false
+          logLevel: Normal
+          operatorLogLevel: Normal
+          migration:
+            networkType: OVNKubernetes
+            mode: Offline
+    - name: Should throw an error when mtu and networkType migration is created in offline migration mode
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        spec:
+          migration:
+            networkType: OVNKubernetes
+            mtu:
+              network:
+                from: 1450
+                to: 1400
+            mode: Offline
+      expectedError: "networkType migration in mode other than 'Live' may not be configured at the same time as mtu migration"
+    - name: Should be able to create mtu and networkType migration in live migration mode
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        spec:
+          migration:
+            networkType: OVNKubernetes
+            mtu:
+              network:
+                from: 1450
+                to: 1400
+            mode: Live
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        spec:
+          disableNetworkDiagnostics: false
+          logLevel: Normal
+          operatorLogLevel: Normal
+          migration:
+            networkType: OVNKubernetes
+            mtu:
+              network:
+                from: 1450
+                to: 1400
+            mode: Live

--- a/operator/v1/custom.network.testsuite.yaml
+++ b/operator/v1/custom.network.testsuite.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[CustomNoUpgrade] Network"
+crd: 0000_70_cluster-network-operator_01-CustomNoUpgrade.crd.yaml
+tests:
+  onCreate:
+    - name: Should be able to create migration mode
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        spec: 
+          migration:
+            mode: Live
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: Network
+        spec:
+          disableNetworkDiagnostics: false
+          logLevel: Normal
+          operatorLogLevel: Normal
+          migration:
+            mode: Live
+

--- a/operator/v1/stable.network.testsuite.yaml
+++ b/operator/v1/stable.network.testsuite.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[Stable] Network"
-crd: 0000_70_cluster-network-operator_01.crd.yaml
+crd: 0000_70_cluster-network-operator_01-Default.crd.yaml
 tests:
   onCreate:
   - name: Should be able to create a minimal Network

--- a/operator/v1/stable.network.testsuite.yaml
+++ b/operator/v1/stable.network.testsuite.yaml
@@ -249,4 +249,18 @@ tests:
               ipv6:
                 internalMasqueradeSubnet: "abcd:eff01:2345:6789::2345:6789/20"
     expectedError: "Invalid value: \"string\": each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 2"
-    
+  - name: Should not be able to create migration mode
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec: 
+        migration:
+          mode: Live
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+        disableNetworkDiagnostics: false
+        logLevel: Normal
+        operatorLogLevel: Normal
+        migration: {}

--- a/operator/v1/techpreview.network.testsuite.yaml
+++ b/operator/v1/techpreview.network.testsuite.yaml
@@ -19,4 +19,82 @@ tests:
         operatorLogLevel: Normal
         migration:
           mode: Live
-
+  - name: Should be able to create mtu migration without setting the migration mode
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+        migration:
+          mtu:
+            network:
+              from: 1450
+              to: 1400
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+        disableNetworkDiagnostics: false
+        logLevel: Normal
+        operatorLogLevel: Normal
+        migration:
+          mtu:
+            network:
+              from: 1450
+              to: 1400
+  - name: Should be able to create networkType migration in in offline migration mode
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+        migration:
+          networkType: OVNKubernetes
+          mode: Offline
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+        disableNetworkDiagnostics: false
+        logLevel: Normal
+        operatorLogLevel: Normal
+        migration:
+          networkType: OVNKubernetes
+          mode: Offline
+  - name: Should throw an error when mtu and networkType migration is created in offline migration mode
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+        migration:
+          networkType: OVNKubernetes
+          mtu:
+            network:
+              from: 1450
+              to: 1400
+          mode: Offline
+    expectedError: "networkType migration in mode other than 'Live' may not be configured at the same time as mtu migration"
+  - name: Should be able to create mtu and networkType migration in live migration mode
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+        migration:
+          networkType: OVNKubernetes
+          mtu:
+            network:
+              from: 1450
+              to: 1400
+          mode: Live
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+        disableNetworkDiagnostics: false
+        logLevel: Normal
+        operatorLogLevel: Normal
+        migration:
+          networkType: OVNKubernetes
+          mtu:
+            network:
+              from: 1450
+              to: 1400
+          mode: Live

--- a/operator/v1/techpreview.network.testsuite.yaml
+++ b/operator/v1/techpreview.network.testsuite.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "[TechPreviewNoUpgrade] Network"
+crd: 0000_70_cluster-network-operator_01-TechPreviewNoUpgrade.crd.yaml
+tests:
+  onCreate:
+  - name: Should be able to create migration mode
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec: 
+        migration:
+          mode: Live
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+        disableNetworkDiagnostics: false
+        logLevel: Normal
+        operatorLogLevel: Normal
+        migration:
+          mode: Live
+

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -116,6 +116,18 @@ type NetworkSpec struct {
 	Migration *NetworkMigration `json:"migration,omitempty"`
 }
 
+// NetworkMigrationMode is an enumeration of the possible mode of the network migration
+// Valid values are "Live", "Offline" and omitted.
+// +kubebuilder:validation:Enum:=Live;Offline;""
+type NetworkMigrationMode string
+
+const (
+	// A "Live" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration.
+	LiveNetworkMigrationMode NetworkMigrationMode = "Live"
+	// An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration.
+	OfflineNetworkMigrationMode NetworkMigrationMode = "Offline"
+)
+
 // NetworkMigration represents the cluster network configuration.
 type NetworkMigration struct {
 	// networkType is the target type of network migration. Set this to the
@@ -137,6 +149,15 @@ type NetworkMigration struct {
 	// supported features.
 	// +optional
 	Features *FeaturesMigration `json:"features,omitempty"`
+
+	// mode indicates the mode of network migration.
+	// The supported values are "Live", "Offline" and omitted.
+	// A "Live" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration.
+	// An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration.
+	// When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time.
+	// The current default value is "Offline".
+	// +optional
+	Mode NetworkMigrationMode `json:"mode"`
 }
 
 type FeaturesMigration struct {

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -156,6 +156,7 @@ type NetworkMigration struct {
 	// An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration.
 	// When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time.
 	// The current default value is "Offline".
+	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	// +optional
 	Mode NetworkMigrationMode `json:"mode"`
 }

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -129,6 +129,7 @@ const (
 )
 
 // NetworkMigration represents the cluster network configuration.
+// +openshift:validation:FeatureSetAwareXValidation:featureSet=CustomNoUpgrade;TechPreviewNoUpgrade,rule="!has(self.mtu) || !has(self.networkType) || self.networkType == '' || has(self.mode) && self.mode == 'Live'",message="networkType migration in mode other than 'Live' may not be configured at the same time as mtu migration"
 type NetworkMigration struct {
 	// networkType is the target type of network migration. Set this to the
 	// target network type to allow changing the default network. If unset, the

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1460,6 +1460,7 @@ var map_NetworkMigration = map[string]string{
 	"networkType": "networkType is the target type of network migration. Set this to the target network type to allow changing the default network. If unset, the operation of changing cluster default network plugin will be rejected. The supported values are OpenShiftSDN, OVNKubernetes",
 	"mtu":         "mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.",
 	"features":    "features contains the features migration configuration. Set this to migrate feature configuration when changing the cluster default network provider. if unset, the default operation is to migrate all the configuration of supported features.",
+	"mode":        "mode indicates the mode of network migration. The supported values are \"Live\", \"Offline\" and omitted. A \"Live\" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An \"Offline\" migration operation will cause service interruption. During an \"Offline\" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is \"Offline\".",
 }
 
 func (NetworkMigration) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Enhancement: https://github.com/openshift/enhancements/pull/1064

Changes include:
- Add new 'mode' flag to 'spec.Migration' in Networks.operator.openshift.io
- Add status.conditions to networks.config.openshift.io
- Restrict the newly added fields to TechPreview


This PR is based on https://github.com/openshift/api/pull/1546 and https://github.com/openshift/api/pull/1560 with minor changes.