### PR TITLE
add feature gate for MCO boot images updates

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -371,4 +371,14 @@ var (
 		ResponsiblePerson:   "titzhak",
 		OwningProduct:       ocpSpecific,
 	}
+
+	FeatureGateManagedBootImages = FeatureGateName("ManagedBootImages")
+	managedBootImages            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateManagedBootImages,
+		},
+		OwningJiraComponent: "MachineConfigOperator",
+		ResponsiblePerson:   "djoshy",
+		OwningProduct:       ocpSpecific,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -188,6 +188,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		without(clusterAPIInstall).
 		with(sdnLiveMigration).
 		with(mixedCPUsAllocation).
+		with(managedBootImages).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),


### PR DESCRIPTION
This adds a feature gate for the implementation of [openshift/enhancements#1496](https://github.com/openshift/enhancements/pull/1496) by the MCO team.  This feature is planned to be released in 4.15 as TechPreview.