### PR TITLE
Add payload manifests dir

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -12,22 +12,11 @@ COPY --from=builder /go/src/github.com/openshift/api/write-available-featuresets
 
 # this directory is used to produce rendered manifests that the installer applies (but does not maintain) in bootkube
 RUN mkdir -p /usr/share/bootkube/manifests/manifests
-COPY config/v1/*_config-operator_*.yaml /usr/share/bootkube/manifests/manifests
-COPY quota/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
-COPY security/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
-COPY securityinternal/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
-COPY authorization/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
-COPY operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml /usr/share/bootkube/manifests/manifests
+COPY payload-manifests/crds/* /usr/share/bootkube/manifests/manifests
 
 # these are applied by the CVO
 COPY manifests /manifests
-COPY config/v1/*_config-operator_*.yaml /manifests
-COPY quota/v1/*.crd.yaml /manifests
-COPY security/v1/*.crd.yaml /manifests
-COPY securityinternal/v1/*.crd.yaml /manifests
-COPY authorization/v1/*.crd.yaml /manifests
-COPY operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml /manifests
-COPY operator/v1/0000_10_config-operator_*.yaml /manifests
+COPY payload-manifests/crds/* /manifests
 COPY payload-command/empty-resources /manifests
 
 LABEL io.openshift.release.operator true

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ verify-scripts:
 	bash -x hack/verify-integration-tests.sh
 	bash -x hack/verify-group-versions.sh
 	bash -x hack/verify-prerelease-lifecycle-gen.sh
+	hack/verify-payload-crds.sh
 
 .PHONY: verify
 verify: verify-scripts verify-crd-schema verify-codegen-crds
@@ -76,7 +77,7 @@ verify-%:
 ################################################################################################
 
 .PHONY: update-scripts
-update-scripts: update-compatibility update-openapi update-deepcopy update-protobuf update-swagger-docs tests-vendor update-prerelease-lifecycle-gen
+update-scripts: update-compatibility update-openapi update-deepcopy update-protobuf update-swagger-docs tests-vendor update-prerelease-lifecycle-gen update-payload-crds
 
 .PHONY: update-compatibility
 update-compatibility:
@@ -101,6 +102,10 @@ update-swagger-docs:
 .PHONY: update-prerelease-lifecycle-gen
 update-prerelease-lifecycle-gen:
 	hack/update-prerelease-lifecycle-gen.sh
+
+.PHONY: update-payload-crds
+update-payload-crds:
+	hack/update-payload-crds.sh
 
 #####################
 #

--- a/hack/update-payload-crds.sh
+++ b/hack/update-payload-crds.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+crd_globs="\
+    config/v1/*_config-operator_*.crd*yaml\
+    quota/v1/*.crd*yaml\
+    security/v1/*.crd*yaml\
+    securityinternal/v1/*.crd*yaml\
+    authorization/v1/*.crd*yaml\
+    operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd*yaml\
+    operator/v1/0000_10_config-operator_*.yaml
+    "
+
+# To allow the crd_globs to be sourced in the verify script,
+# wrap the copy action to prevent it running when sourced.
+if [ "$0" = "$BASH_SOURCE" ] ; then
+    for f in ${crd_globs}; do
+        cp "$f" "${SCRIPT_ROOT}/payload-manifests/crds/"
+    done
+fi

--- a/hack/verify-payload-crds.sh
+++ b/hack/verify-payload-crds.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+source "$(dirname "${BASH_SOURCE}")/update-payload-crds.sh"
+
+files=""
+
+# Check there's no diff between the files in their canonical location
+# and the payload-manifests location.
+for f in ${crd_globs}; do
+    basename=$(basename "${f}")
+    files+=${basename},
+    echo "Verifying diff on ${basename}"
+    diff "$f" "${SCRIPT_ROOT}/payload-manifests/crds/${basename}"
+done
+	
+files=$(echo "${files}" | tr "," "\n")
+
+# Check that we haven't accidentally added any files that aren't tracked
+# by the crd_globs into the payload CRDs folder.
+for f in "${SCRIPT_ROOT}/payload-manifests/crds/"*; do
+    basename=$(basename "${f}")
+    if ! echo "${files}" | grep -F -q -x "${basename}"; then
+        echo "Found untracked file ${basename} in payload CRD manifests.  Please add the file to crd_globs in hack/update-payload-crds.sh."
+        exit 1
+    fi
+done

--- a/payload-manifests/crds/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
+++ b/payload-manifests/crds/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
@@ -1,0 +1,158 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: rolebindingrestrictions.authorization.openshift.io
+spec:
+  group: authorization.openshift.io
+  names:
+    kind: RoleBindingRestriction
+    listKind: RoleBindingRestrictionList
+    plural: rolebindingrestrictions
+    singular: rolebindingrestriction
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "RoleBindingRestriction is an object that can be matched against a subject (user, group, or service account) to determine whether rolebindings on that subject are allowed in the namespace to which the RoleBindingRestriction belongs.  If any one of those RoleBindingRestriction objects matches a subject, rolebindings on that subject in the namespace are allowed. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the matcher.
+              type: object
+              properties:
+                grouprestriction:
+                  description: GroupRestriction matches against group subjects.
+                  type: object
+                  properties:
+                    groups:
+                      description: Groups is a list of groups used to match against an individual user's groups. If the user is a member of one of the whitelisted groups, the user is allowed to be bound to a role.
+                      type: array
+                      items:
+                        type: string
+                      nullable: true
+                    labels:
+                      description: Selectors specifies a list of label selectors over group labels.
+                      type: array
+                      items:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        type: object
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            type: array
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              type: object
+                              required:
+                                - key
+                                - operator
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                            additionalProperties:
+                              type: string
+                        x-kubernetes-map-type: atomic
+                      nullable: true
+                  nullable: true
+                serviceaccountrestriction:
+                  description: ServiceAccountRestriction matches against service-account subjects.
+                  type: object
+                  properties:
+                    namespaces:
+                      description: Namespaces specifies a list of literal namespace names.
+                      type: array
+                      items:
+                        type: string
+                    serviceaccounts:
+                      description: ServiceAccounts specifies a list of literal service-account names.
+                      type: array
+                      items:
+                        description: ServiceAccountReference specifies a service account and namespace by their names.
+                        type: object
+                        properties:
+                          name:
+                            description: Name is the name of the service account.
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the service account.  Service accounts from inside the whitelisted namespaces are allowed to be bound to roles.  If Namespace is empty, then the namespace of the RoleBindingRestriction in which the ServiceAccountReference is embedded is used.
+                            type: string
+                  nullable: true
+                userrestriction:
+                  description: UserRestriction matches against user subjects.
+                  type: object
+                  properties:
+                    groups:
+                      description: Groups specifies a list of literal group names.
+                      type: array
+                      items:
+                        type: string
+                      nullable: true
+                    labels:
+                      description: Selectors specifies a list of label selectors over user labels.
+                      type: array
+                      items:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        type: object
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            type: array
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              type: object
+                              required:
+                                - key
+                                - operator
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                            additionalProperties:
+                              type: string
+                        x-kubernetes-map-type: atomic
+                      nullable: true
+                    users:
+                      description: Users specifies a list of literal user names.
+                      type: array
+                      items:
+                        type: string
+                  nullable: true
+      served: true
+      storage: true

--- a/payload-manifests/crds/0000_03_config-operator_01_proxy.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_proxy.crd.yaml
@@ -1,0 +1,78 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: proxies.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Proxy
+    listKind: ProxyList
+    plural: proxies
+    singular: proxy
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Proxy holds cluster-wide information on how to configure default proxies for the cluster. The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds user-settable values for the proxy configuration
+              type: object
+              properties:
+                httpProxy:
+                  description: httpProxy is the URL of the proxy for HTTP requests.  Empty means unset and will not result in an env var.
+                  type: string
+                httpsProxy:
+                  description: httpsProxy is the URL of the proxy for HTTPS requests.  Empty means unset and will not result in an env var.
+                  type: string
+                noProxy:
+                  description: noProxy is a comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used. Empty means unset and will not result in an env var.
+                  type: string
+                readinessEndpoints:
+                  description: readinessEndpoints is a list of endpoints used to verify readiness of the proxy.
+                  type: array
+                  items:
+                    type: string
+                trustedCA:
+                  description: "trustedCA is a reference to a ConfigMap containing a CA certificate bundle. The trustedCA field should only be consumed by a proxy validator. The validator is responsible for reading the certificate bundle from the required key \"ca-bundle.crt\", merging it with the system default trust bundle, and writing the merged trust bundle to a ConfigMap named \"trusted-ca-bundle\" in the \"openshift-config-managed\" namespace. Clients that expect to make proxy connections must use the trusted-ca-bundle for all HTTPS requests to the proxy, and may use the trusted-ca-bundle for non-proxy HTTPS requests as well. \n The namespace for the ConfigMap referenced by trustedCA is \"openshift-config\". Here is an example ConfigMap (in yaml): \n apiVersion: v1 kind: ConfigMap metadata: name: user-ca-bundle namespace: openshift-config data: ca-bundle.crt: | -----BEGIN CERTIFICATE----- Custom CA certificate bundle. -----END CERTIFICATE-----"
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                httpProxy:
+                  description: httpProxy is the URL of the proxy for HTTP requests.
+                  type: string
+                httpsProxy:
+                  description: httpsProxy is the URL of the proxy for HTTPS requests.
+                  type: string
+                noProxy:
+                  description: noProxy is a comma-separated list of hostnames and/or CIDRs for which the proxy should not be used.
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
+++ b/payload-manifests/crds/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
@@ -1,0 +1,197 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: clusterresourcequotas.quota.openshift.io
+spec:
+  group: quota.openshift.io
+  names:
+    kind: ClusterResourceQuota
+    listKind: ClusterResourceQuotaList
+    plural: clusterresourcequotas
+    singular: clusterresourcequota
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "ClusterResourceQuota mirrors ResourceQuota at a cluster scope.  This object is easily convertible to synthetic ResourceQuota object to allow quota evaluation re-use. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired quota
+              type: object
+              required:
+                - quota
+                - selector
+              properties:
+                quota:
+                  description: Quota defines the desired quota
+                  type: object
+                  properties:
+                    hard:
+                      description: 'hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                      type: object
+                      additionalProperties:
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                    scopeSelector:
+                      description: scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: A list of scope selector requirements by scope of the resources.
+                          type: array
+                          items:
+                            description: A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
+                            type: object
+                            required:
+                              - operator
+                              - scopeName
+                            properties:
+                              operator:
+                                description: Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                                type: string
+                              scopeName:
+                                description: The name of the scope that the selector applies to.
+                                type: string
+                              values:
+                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                type: array
+                                items:
+                                  type: string
+                      x-kubernetes-map-type: atomic
+                    scopes:
+                      description: A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
+                      type: array
+                      items:
+                        description: A ResourceQuotaScope defines a filter that must match each object tracked by a quota
+                        type: string
+                selector:
+                  description: Selector is the selector used to match projects. It should only select active projects on the scale of dozens (though it can select many more less active projects).  These projects will contend on object creation through this resource.
+                  type: object
+                  properties:
+                    annotations:
+                      description: AnnotationSelector is used to select projects by annotation.
+                      type: object
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                    labels:
+                      description: LabelSelector is used to select projects by label.
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          type: array
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            type: object
+                            required:
+                              - key
+                              - operator
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                          additionalProperties:
+                            type: string
+                      nullable: true
+                      x-kubernetes-map-type: atomic
+            status:
+              description: Status defines the actual enforced quota and its current usage
+              type: object
+              required:
+                - total
+              properties:
+                namespaces:
+                  description: Namespaces slices the usage by project.  This division allows for quick resolution of deletion reconciliation inside of a single project without requiring a recalculation across all projects.  This can be used to pull the deltas for a given project.
+                  type: array
+                  items:
+                    description: ResourceQuotaStatusByNamespace gives status for a particular project
+                    type: object
+                    required:
+                      - namespace
+                      - status
+                    properties:
+                      namespace:
+                        description: Namespace the project this status applies to
+                        type: string
+                      status:
+                        description: Status indicates how many resources have been consumed by this project
+                        type: object
+                        properties:
+                          hard:
+                            description: 'Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                            type: object
+                            additionalProperties:
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                          used:
+                            description: Used is the current observed total usage of the resource in the namespace.
+                            type: object
+                            additionalProperties:
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                  nullable: true
+                total:
+                  description: Total defines the actual enforced quota and its current usage across all projects
+                  type: object
+                  properties:
+                    hard:
+                      description: 'Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                      type: object
+                      additionalProperties:
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                    used:
+                      description: Used is the current observed total usage of the resource in the namespace.
+                      type: object
+                      additionalProperties:
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_03_security-openshift_01_scc.crd.yaml
+++ b/payload-manifests/crds/0000_03_security-openshift_01_scc.crd.yaml
@@ -1,0 +1,279 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: securitycontextconstraints.security.openshift.io
+spec:
+  group: security.openshift.io
+  names:
+    kind: SecurityContextConstraints
+    listKind: SecurityContextConstraintsList
+    plural: securitycontextconstraints
+    singular: securitycontextconstraints
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Determines if a container can request to be run as privileged
+          jsonPath: .allowPrivilegedContainer
+          name: Priv
+          type: string
+        - description: A list of capabilities that can be requested to add to the container
+          jsonPath: .allowedCapabilities
+          name: Caps
+          type: string
+        - description: Strategy that will dictate what labels will be set in the SecurityContext
+          jsonPath: .seLinuxContext.type
+          name: SELinux
+          type: string
+        - description: Strategy that will dictate what RunAsUser is used in the SecurityContext
+          jsonPath: .runAsUser.type
+          name: RunAsUser
+          type: string
+        - description: Strategy that will dictate what fs group is used by the SecurityContext
+          jsonPath: .fsGroup.type
+          name: FSGroup
+          type: string
+        - description: Strategy that will dictate what supplemental groups are used by the SecurityContext
+          jsonPath: .supplementalGroups.type
+          name: SupGroup
+          type: string
+        - description: Sort order of SCCs
+          jsonPath: .priority
+          name: Priority
+          type: string
+        - description: Force containers to run with a read only root file system
+          jsonPath: .readOnlyRootFilesystem
+          name: ReadOnlyRootFS
+          type: string
+        - description: White list of allowed volume plugins
+          jsonPath: .volumes
+          name: Volumes
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: "SecurityContextConstraints governs the ability to make requests that affect the SecurityContext that will be applied to a container. For historical reasons SCC was exposed under the core Kubernetes API group. That exposure is deprecated and will be removed in a future release - users should instead use the security.openshift.io group to manage SecurityContextConstraints. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - allowHostDirVolumePlugin
+            - allowHostIPC
+            - allowHostNetwork
+            - allowHostPID
+            - allowHostPorts
+            - allowPrivilegedContainer
+            - allowedCapabilities
+            - defaultAddCapabilities
+            - priority
+            - readOnlyRootFilesystem
+            - requiredDropCapabilities
+            - volumes
+          properties:
+            allowHostDirVolumePlugin:
+              description: AllowHostDirVolumePlugin determines if the policy allow containers to use the HostDir volume plugin
+              type: boolean
+            allowHostIPC:
+              description: AllowHostIPC determines if the policy allows host ipc in the containers.
+              type: boolean
+            allowHostNetwork:
+              description: AllowHostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+              type: boolean
+            allowHostPID:
+              description: AllowHostPID determines if the policy allows host pid in the containers.
+              type: boolean
+            allowHostPorts:
+              description: AllowHostPorts determines if the policy allows host ports in the containers.
+              type: boolean
+            allowPrivilegeEscalation:
+              description: AllowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.
+              type: boolean
+              nullable: true
+            allowPrivilegedContainer:
+              description: AllowPrivilegedContainer determines if a container can request to be run as privileged.
+              type: boolean
+            allowedCapabilities:
+              description: AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field maybe added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities. To allow all capabilities you may use '*'.
+              type: array
+              items:
+                description: Capability represent POSIX capabilities type
+                type: string
+              nullable: true
+            allowedFlexVolumes:
+              description: AllowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the "Volumes" field.
+              type: array
+              items:
+                description: AllowedFlexVolume represents a single Flexvolume that is allowed to be used.
+                type: object
+                required:
+                  - driver
+                properties:
+                  driver:
+                    description: Driver is the name of the Flexvolume driver.
+                    type: string
+              nullable: true
+            allowedUnsafeSysctls:
+              description: "AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection. \n Examples: e.g. \"foo/*\" allows \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" allows \"foo.bar\", \"foo.baz\", etc."
+              type: array
+              items:
+                type: string
+              nullable: true
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            defaultAddCapabilities:
+              description: DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.
+              type: array
+              items:
+                description: Capability represent POSIX capabilities type
+                type: string
+              nullable: true
+            defaultAllowPrivilegeEscalation:
+              description: DefaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.
+              type: boolean
+              nullable: true
+            forbiddenSysctls:
+              description: "ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in \"*\" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden. \n Examples: e.g. \"foo/*\" forbids \"foo/bar\", \"foo/baz\", etc. e.g. \"foo.*\" forbids \"foo.bar\", \"foo.baz\", etc."
+              type: array
+              items:
+                type: string
+              nullable: true
+            fsGroup:
+              description: FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+              type: object
+              properties:
+                ranges:
+                  description: Ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.
+                  type: array
+                  items:
+                    description: 'IDRange provides a min/max of an allowed range of IDs. TODO: this could be reused for UIDs.'
+                    type: object
+                    properties:
+                      max:
+                        description: Max is the end of the range, inclusive.
+                        type: integer
+                        format: int64
+                      min:
+                        description: Min is the start of the range, inclusive.
+                        type: integer
+                        format: int64
+                type:
+                  description: Type is the strategy that will dictate what FSGroup is used in the SecurityContext.
+                  type: string
+              nullable: true
+            groups:
+              description: The groups that have permission to use this security context constraints
+              type: array
+              items:
+                type: string
+              nullable: true
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            priority:
+              description: Priority influences the sort order of SCCs when evaluating which SCCs to try first for a given pod request based on access in the Users and Groups fields.  The higher the int, the higher priority. An unset value is considered a 0 priority. If scores for multiple SCCs are equal they will be sorted from most restrictive to least restrictive. If both priorities and restrictions are equal the SCCs will be sorted by name.
+              type: integer
+              format: int32
+              nullable: true
+            readOnlyRootFilesystem:
+              description: ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the SCC should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.
+              type: boolean
+            requiredDropCapabilities:
+              description: RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.
+              type: array
+              items:
+                description: Capability represent POSIX capabilities type
+                type: string
+              nullable: true
+            runAsUser:
+              description: RunAsUser is the strategy that will dictate what RunAsUser is used in the SecurityContext.
+              type: object
+              properties:
+                type:
+                  description: Type is the strategy that will dictate what RunAsUser is used in the SecurityContext.
+                  type: string
+                uid:
+                  description: UID is the user id that containers must run as.  Required for the MustRunAs strategy if not using namespace/service account allocated uids.
+                  type: integer
+                  format: int64
+                uidRangeMax:
+                  description: UIDRangeMax defines the max value for a strategy that allocates by range.
+                  type: integer
+                  format: int64
+                uidRangeMin:
+                  description: UIDRangeMin defines the min value for a strategy that allocates by range.
+                  type: integer
+                  format: int64
+              nullable: true
+            seLinuxContext:
+              description: SELinuxContext is the strategy that will dictate what labels will be set in the SecurityContext.
+              type: object
+              properties:
+                seLinuxOptions:
+                  description: seLinuxOptions required to run as; required for MustRunAs
+                  type: object
+                  properties:
+                    level:
+                      description: Level is SELinux level label that applies to the container.
+                      type: string
+                    role:
+                      description: Role is a SELinux role label that applies to the container.
+                      type: string
+                    type:
+                      description: Type is a SELinux type label that applies to the container.
+                      type: string
+                    user:
+                      description: User is a SELinux user label that applies to the container.
+                      type: string
+                type:
+                  description: Type is the strategy that will dictate what SELinux context is used in the SecurityContext.
+                  type: string
+              nullable: true
+            seccompProfiles:
+              description: "SeccompProfiles lists the allowed profiles that may be set for the pod or container's seccomp annotations.  An unset (nil) or empty value means that no profiles may be specifid by the pod or container.\tThe wildcard '*' may be used to allow all profiles.  When used to generate a value for a pod the first non-wildcard profile will be used as the default."
+              type: array
+              items:
+                type: string
+              nullable: true
+            supplementalGroups:
+              description: SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+              type: object
+              properties:
+                ranges:
+                  description: Ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.
+                  type: array
+                  items:
+                    description: 'IDRange provides a min/max of an allowed range of IDs. TODO: this could be reused for UIDs.'
+                    type: object
+                    properties:
+                      max:
+                        description: Max is the end of the range, inclusive.
+                        type: integer
+                        format: int64
+                      min:
+                        description: Min is the start of the range, inclusive.
+                        type: integer
+                        format: int64
+                type:
+                  description: Type is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+                  type: string
+              nullable: true
+            users:
+              description: The users who have permissions to use this security context constraints
+              type: array
+              items:
+                type: string
+              nullable: true
+            volumes:
+              description: Volumes is a white list of allowed volume plugins.  FSType corresponds directly with the field names of a VolumeSource (azureFile, configMap, emptyDir).  To allow all volumes you may use "*". To allow no volumes, set to ["none"].
+              type: array
+              items:
+                description: FS Type gives strong typing to different file systems that are used by volumes.
+                type: string
+              nullable: true
+      served: true
+      storage: true

--- a/payload-manifests/crds/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
+++ b/payload-manifests/crds/0000_03_securityinternal-openshift_02_rangeallocation.crd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/751
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: rangeallocations.security.internal.openshift.io
+spec:
+  group: security.internal.openshift.io
+  names:
+    kind: RangeAllocation
+    listKind: RangeAllocationList
+    plural: rangeallocations
+    singular: rangeallocation
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "RangeAllocation is used so we can easily expose a RangeAllocation typed for security group This is an internal API, not intended for external consumption. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            data:
+              description: data is a byte array representing the serialized state of a range allocation.  It is a bitmap with each bit set to one to represent a range is taken.
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            range:
+              description: range is a string representing a unique label for a range of uids, "1000000000-2000000000/10000".
+              type: string
+          type: object
+      served: true
+      storage: true

--- a/payload-manifests/crds/0000_10_config-operator_01_apiserver-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiserver-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,179 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: apiservers.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: APIServer
+    listKind: APIServerList
+    plural: apiservers
+    singular: apiserver
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "APIServer holds configuration (like serving certificates, client CA and CORS domains) shared by all API servers in the system, among them especially kube-apiserver and openshift-apiserver. The canonical name of an instance is 'cluster'. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                additionalCORSAllowedOrigins:
+                  description: additionalCORSAllowedOrigins lists additional, user-defined regular expressions describing hosts for which the API server allows access using the CORS headers. This may be needed to access the API and the integrated OAuth server from JavaScript applications. The values are regular expressions that correspond to the Golang regular expression language.
+                  type: array
+                  items:
+                    type: string
+                audit:
+                  description: audit specifies the settings for audit configuration to be applied to all OpenShift-provided API servers in the cluster.
+                  type: object
+                  default:
+                    profile: Default
+                  properties:
+                    customRules:
+                      description: customRules specify profiles per group. These profile take precedence over the top-level profile field if they apply. They are evaluation from top to bottom and the first one that matches, applies.
+                      type: array
+                      items:
+                        description: AuditCustomRule describes a custom rule for an audit profile that takes precedence over the top-level profile.
+                        type: object
+                        required:
+                          - group
+                          - profile
+                        properties:
+                          group:
+                            description: group is a name of group a request user must be member of in order to this profile to apply.
+                            type: string
+                            minLength: 1
+                          profile:
+                            description: "profile specifies the name of the desired audit policy configuration to be deployed to all OpenShift-provided API servers in the cluster. \n The following profiles are provided: - Default: the existing default policy. - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n If unset, the 'Default' profile is used as the default."
+                            type: string
+                            enum:
+                              - Default
+                              - WriteRequestBodies
+                              - AllRequestBodies
+                              - None
+                      x-kubernetes-list-map-keys:
+                        - group
+                      x-kubernetes-list-type: map
+                    profile:
+                      description: "profile specifies the name of the desired top-level audit profile to be applied to all requests sent to any of the OpenShift-provided API servers in the cluster (kube-apiserver, openshift-apiserver and oauth-apiserver), with the exception of those requests that match one or more of the customRules. \n The following profiles are provided: - Default: default policy which means MetaData level logging with the exception of events (not logged at all), oauthaccesstokens and oauthauthorizetokens (both logged at RequestBody level). - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n Warning: It is not recommended to disable audit logging by using the `None` profile unless you are fully aware of the risks of not logging data that can be beneficial when troubleshooting issues. If you disable audit logging and a support situation arises, you might need to enable audit logging and reproduce the issue in order to troubleshoot properly. \n If unset, the 'Default' profile is used as the default."
+                      type: string
+                      default: Default
+                      enum:
+                        - Default
+                        - WriteRequestBodies
+                        - AllRequestBodies
+                        - None
+                clientCA:
+                  description: 'clientCA references a ConfigMap containing a certificate bundle for the signers that will be recognized for incoming client certificates in addition to the operator managed signers. If this is empty, then only operator managed signers are valid. You usually only have to set this if you have your own PKI you wish to honor client certificates from. The ConfigMap must exist in the openshift-config namespace and contain the following required fields: - ConfigMap.Data["ca-bundle.crt"] - CA bundle.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                encryption:
+                  description: encryption allows the configuration of encryption of resources at the datastore layer.
+                  type: object
+                  properties:
+                    type:
+                      description: "type defines what encryption type should be used to encrypt resources at the datastore layer. When this field is unset (i.e. when it is set to the empty string), identity is implied. The behavior of unset can and will change over time.  Even if encryption is enabled by default, the meaning of unset may change to a different encryption type based on changes in best practices. \n When encryption is enabled, all sensitive resources shipped with the platform are encrypted. This list of sensitive resources can and will change over time.  The current authoritative list is: \n 1. secrets 2. configmaps 3. routes.route.openshift.io 4. oauthaccesstokens.oauth.openshift.io 5. oauthauthorizetokens.oauth.openshift.io"
+                      type: string
+                      enum:
+                        - ""
+                        - identity
+                        - aescbc
+                        - aesgcm
+                servingCerts:
+                  description: servingCert is the TLS cert info for serving secure traffic. If not specified, operator managed certificates will be used for serving secure traffic.
+                  type: object
+                  properties:
+                    namedCertificates:
+                      description: namedCertificates references secrets containing the TLS cert info for serving secure traffic to specific hostnames. If no named certificates are provided, or no named certificates match the server name as understood by a client, the defaultServingCertificate will be used.
+                      type: array
+                      items:
+                        description: APIServerNamedServingCert maps a server DNS name, as understood by a client, to a certificate.
+                        type: object
+                        properties:
+                          names:
+                            description: names is a optional list of explicit DNS names (leading wildcards allowed) that should use this certificate to serve secure traffic. If no names are provided, the implicit names will be extracted from the certificates. Exact names trump over wildcard names. Explicit names defined here trump over extracted implicit names.
+                            type: array
+                            items:
+                              type: string
+                          servingCertificate:
+                            description: 'servingCertificate references a kubernetes.io/tls type secret containing the TLS cert info for serving secure traffic. The secret must exist in the openshift-config namespace and contain the following required fields: - Secret.Data["tls.key"] - TLS private key. - Secret.Data["tls.crt"] - TLS certificate.'
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                tlsSecurityProfile:
+                  description: "tlsSecurityProfile specifies settings for TLS connections for externally exposed servers. \n If unset, a default (which may change between releases) is chosen. Note that only Old, Intermediate and Custom profiles are currently supported, and the maximum available minTLSVersion is VersionTLS12."
+                  type: object
+                  properties:
+                    custom:
+                      description: "custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion: VersionTLS11"
+                      type: object
+                      properties:
+                        ciphers:
+                          description: "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA"
+                          type: array
+                          items:
+                            type: string
+                        minTLSVersion:
+                          description: "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion: VersionTLS11 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12"
+                          type: string
+                          enum:
+                            - VersionTLS10
+                            - VersionTLS11
+                            - VersionTLS12
+                            - VersionTLS13
+                      nullable: true
+                    intermediate:
+                      description: "intermediate is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 minTLSVersion: VersionTLS12"
+                      type: object
+                      nullable: true
+                    modern:
+                      description: "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 minTLSVersion: VersionTLS13 \n NOTE: Currently unsupported."
+                      type: object
+                      nullable: true
+                    old:
+                      description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256 - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA - ECDHE-RSA-AES128-SHA - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384 - ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256 - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384 - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA - DES-CBC3-SHA minTLSVersion: VersionTLS10"
+                      type: object
+                      nullable: true
+                    type:
+                      description: "type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations \n The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. \n Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries."
+                      type: string
+                      enum:
+                        - Old
+                        - Intermediate
+                        - Modern
+                        - Custom
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_apiserver-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiserver-Default.crd.yaml
@@ -1,0 +1,179 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
+  name: apiservers.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: APIServer
+    listKind: APIServerList
+    plural: apiservers
+    singular: apiserver
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "APIServer holds configuration (like serving certificates, client CA and CORS domains) shared by all API servers in the system, among them especially kube-apiserver and openshift-apiserver. The canonical name of an instance is 'cluster'. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                additionalCORSAllowedOrigins:
+                  description: additionalCORSAllowedOrigins lists additional, user-defined regular expressions describing hosts for which the API server allows access using the CORS headers. This may be needed to access the API and the integrated OAuth server from JavaScript applications. The values are regular expressions that correspond to the Golang regular expression language.
+                  type: array
+                  items:
+                    type: string
+                audit:
+                  description: audit specifies the settings for audit configuration to be applied to all OpenShift-provided API servers in the cluster.
+                  type: object
+                  default:
+                    profile: Default
+                  properties:
+                    customRules:
+                      description: customRules specify profiles per group. These profile take precedence over the top-level profile field if they apply. They are evaluation from top to bottom and the first one that matches, applies.
+                      type: array
+                      items:
+                        description: AuditCustomRule describes a custom rule for an audit profile that takes precedence over the top-level profile.
+                        type: object
+                        required:
+                          - group
+                          - profile
+                        properties:
+                          group:
+                            description: group is a name of group a request user must be member of in order to this profile to apply.
+                            type: string
+                            minLength: 1
+                          profile:
+                            description: "profile specifies the name of the desired audit policy configuration to be deployed to all OpenShift-provided API servers in the cluster. \n The following profiles are provided: - Default: the existing default policy. - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n If unset, the 'Default' profile is used as the default."
+                            type: string
+                            enum:
+                              - Default
+                              - WriteRequestBodies
+                              - AllRequestBodies
+                              - None
+                      x-kubernetes-list-map-keys:
+                        - group
+                      x-kubernetes-list-type: map
+                    profile:
+                      description: "profile specifies the name of the desired top-level audit profile to be applied to all requests sent to any of the OpenShift-provided API servers in the cluster (kube-apiserver, openshift-apiserver and oauth-apiserver), with the exception of those requests that match one or more of the customRules. \n The following profiles are provided: - Default: default policy which means MetaData level logging with the exception of events (not logged at all), oauthaccesstokens and oauthauthorizetokens (both logged at RequestBody level). - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n Warning: It is not recommended to disable audit logging by using the `None` profile unless you are fully aware of the risks of not logging data that can be beneficial when troubleshooting issues. If you disable audit logging and a support situation arises, you might need to enable audit logging and reproduce the issue in order to troubleshoot properly. \n If unset, the 'Default' profile is used as the default."
+                      type: string
+                      default: Default
+                      enum:
+                        - Default
+                        - WriteRequestBodies
+                        - AllRequestBodies
+                        - None
+                clientCA:
+                  description: 'clientCA references a ConfigMap containing a certificate bundle for the signers that will be recognized for incoming client certificates in addition to the operator managed signers. If this is empty, then only operator managed signers are valid. You usually only have to set this if you have your own PKI you wish to honor client certificates from. The ConfigMap must exist in the openshift-config namespace and contain the following required fields: - ConfigMap.Data["ca-bundle.crt"] - CA bundle.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                encryption:
+                  description: encryption allows the configuration of encryption of resources at the datastore layer.
+                  type: object
+                  properties:
+                    type:
+                      description: "type defines what encryption type should be used to encrypt resources at the datastore layer. When this field is unset (i.e. when it is set to the empty string), identity is implied. The behavior of unset can and will change over time.  Even if encryption is enabled by default, the meaning of unset may change to a different encryption type based on changes in best practices. \n When encryption is enabled, all sensitive resources shipped with the platform are encrypted. This list of sensitive resources can and will change over time.  The current authoritative list is: \n 1. secrets 2. configmaps 3. routes.route.openshift.io 4. oauthaccesstokens.oauth.openshift.io 5. oauthauthorizetokens.oauth.openshift.io"
+                      type: string
+                      enum:
+                        - ""
+                        - identity
+                        - aescbc
+                        - aesgcm
+                servingCerts:
+                  description: servingCert is the TLS cert info for serving secure traffic. If not specified, operator managed certificates will be used for serving secure traffic.
+                  type: object
+                  properties:
+                    namedCertificates:
+                      description: namedCertificates references secrets containing the TLS cert info for serving secure traffic to specific hostnames. If no named certificates are provided, or no named certificates match the server name as understood by a client, the defaultServingCertificate will be used.
+                      type: array
+                      items:
+                        description: APIServerNamedServingCert maps a server DNS name, as understood by a client, to a certificate.
+                        type: object
+                        properties:
+                          names:
+                            description: names is a optional list of explicit DNS names (leading wildcards allowed) that should use this certificate to serve secure traffic. If no names are provided, the implicit names will be extracted from the certificates. Exact names trump over wildcard names. Explicit names defined here trump over extracted implicit names.
+                            type: array
+                            items:
+                              type: string
+                          servingCertificate:
+                            description: 'servingCertificate references a kubernetes.io/tls type secret containing the TLS cert info for serving secure traffic. The secret must exist in the openshift-config namespace and contain the following required fields: - Secret.Data["tls.key"] - TLS private key. - Secret.Data["tls.crt"] - TLS certificate.'
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                tlsSecurityProfile:
+                  description: "tlsSecurityProfile specifies settings for TLS connections for externally exposed servers. \n If unset, a default (which may change between releases) is chosen. Note that only Old, Intermediate and Custom profiles are currently supported, and the maximum available minTLSVersion is VersionTLS12."
+                  type: object
+                  properties:
+                    custom:
+                      description: "custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion: VersionTLS11"
+                      type: object
+                      properties:
+                        ciphers:
+                          description: "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA"
+                          type: array
+                          items:
+                            type: string
+                        minTLSVersion:
+                          description: "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion: VersionTLS11 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12"
+                          type: string
+                          enum:
+                            - VersionTLS10
+                            - VersionTLS11
+                            - VersionTLS12
+                            - VersionTLS13
+                      nullable: true
+                    intermediate:
+                      description: "intermediate is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 minTLSVersion: VersionTLS12"
+                      type: object
+                      nullable: true
+                    modern:
+                      description: "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 minTLSVersion: VersionTLS13 \n NOTE: Currently unsupported."
+                      type: object
+                      nullable: true
+                    old:
+                      description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256 - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA - ECDHE-RSA-AES128-SHA - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384 - ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256 - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384 - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA - DES-CBC3-SHA minTLSVersion: VersionTLS10"
+                      type: object
+                      nullable: true
+                    type:
+                      description: "type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations \n The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. \n Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries."
+                      type: string
+                      enum:
+                        - Old
+                        - Intermediate
+                        - Modern
+                        - Custom
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_apiserver-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiserver-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,179 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: apiservers.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: APIServer
+    listKind: APIServerList
+    plural: apiservers
+    singular: apiserver
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "APIServer holds configuration (like serving certificates, client CA and CORS domains) shared by all API servers in the system, among them especially kube-apiserver and openshift-apiserver. The canonical name of an instance is 'cluster'. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                additionalCORSAllowedOrigins:
+                  description: additionalCORSAllowedOrigins lists additional, user-defined regular expressions describing hosts for which the API server allows access using the CORS headers. This may be needed to access the API and the integrated OAuth server from JavaScript applications. The values are regular expressions that correspond to the Golang regular expression language.
+                  type: array
+                  items:
+                    type: string
+                audit:
+                  description: audit specifies the settings for audit configuration to be applied to all OpenShift-provided API servers in the cluster.
+                  type: object
+                  default:
+                    profile: Default
+                  properties:
+                    customRules:
+                      description: customRules specify profiles per group. These profile take precedence over the top-level profile field if they apply. They are evaluation from top to bottom and the first one that matches, applies.
+                      type: array
+                      items:
+                        description: AuditCustomRule describes a custom rule for an audit profile that takes precedence over the top-level profile.
+                        type: object
+                        required:
+                          - group
+                          - profile
+                        properties:
+                          group:
+                            description: group is a name of group a request user must be member of in order to this profile to apply.
+                            type: string
+                            minLength: 1
+                          profile:
+                            description: "profile specifies the name of the desired audit policy configuration to be deployed to all OpenShift-provided API servers in the cluster. \n The following profiles are provided: - Default: the existing default policy. - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n If unset, the 'Default' profile is used as the default."
+                            type: string
+                            enum:
+                              - Default
+                              - WriteRequestBodies
+                              - AllRequestBodies
+                              - None
+                      x-kubernetes-list-map-keys:
+                        - group
+                      x-kubernetes-list-type: map
+                    profile:
+                      description: "profile specifies the name of the desired top-level audit profile to be applied to all requests sent to any of the OpenShift-provided API servers in the cluster (kube-apiserver, openshift-apiserver and oauth-apiserver), with the exception of those requests that match one or more of the customRules. \n The following profiles are provided: - Default: default policy which means MetaData level logging with the exception of events (not logged at all), oauthaccesstokens and oauthauthorizetokens (both logged at RequestBody level). - WriteRequestBodies: like 'Default', but logs request and response HTTP payloads for write requests (create, update, patch). - AllRequestBodies: like 'WriteRequestBodies', but also logs request and response HTTP payloads for read requests (get, list). - None: no requests are logged at all, not even oauthaccesstokens and oauthauthorizetokens. \n Warning: It is not recommended to disable audit logging by using the `None` profile unless you are fully aware of the risks of not logging data that can be beneficial when troubleshooting issues. If you disable audit logging and a support situation arises, you might need to enable audit logging and reproduce the issue in order to troubleshoot properly. \n If unset, the 'Default' profile is used as the default."
+                      type: string
+                      default: Default
+                      enum:
+                        - Default
+                        - WriteRequestBodies
+                        - AllRequestBodies
+                        - None
+                clientCA:
+                  description: 'clientCA references a ConfigMap containing a certificate bundle for the signers that will be recognized for incoming client certificates in addition to the operator managed signers. If this is empty, then only operator managed signers are valid. You usually only have to set this if you have your own PKI you wish to honor client certificates from. The ConfigMap must exist in the openshift-config namespace and contain the following required fields: - ConfigMap.Data["ca-bundle.crt"] - CA bundle.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                encryption:
+                  description: encryption allows the configuration of encryption of resources at the datastore layer.
+                  type: object
+                  properties:
+                    type:
+                      description: "type defines what encryption type should be used to encrypt resources at the datastore layer. When this field is unset (i.e. when it is set to the empty string), identity is implied. The behavior of unset can and will change over time.  Even if encryption is enabled by default, the meaning of unset may change to a different encryption type based on changes in best practices. \n When encryption is enabled, all sensitive resources shipped with the platform are encrypted. This list of sensitive resources can and will change over time.  The current authoritative list is: \n 1. secrets 2. configmaps 3. routes.route.openshift.io 4. oauthaccesstokens.oauth.openshift.io 5. oauthauthorizetokens.oauth.openshift.io"
+                      type: string
+                      enum:
+                        - ""
+                        - identity
+                        - aescbc
+                        - aesgcm
+                servingCerts:
+                  description: servingCert is the TLS cert info for serving secure traffic. If not specified, operator managed certificates will be used for serving secure traffic.
+                  type: object
+                  properties:
+                    namedCertificates:
+                      description: namedCertificates references secrets containing the TLS cert info for serving secure traffic to specific hostnames. If no named certificates are provided, or no named certificates match the server name as understood by a client, the defaultServingCertificate will be used.
+                      type: array
+                      items:
+                        description: APIServerNamedServingCert maps a server DNS name, as understood by a client, to a certificate.
+                        type: object
+                        properties:
+                          names:
+                            description: names is a optional list of explicit DNS names (leading wildcards allowed) that should use this certificate to serve secure traffic. If no names are provided, the implicit names will be extracted from the certificates. Exact names trump over wildcard names. Explicit names defined here trump over extracted implicit names.
+                            type: array
+                            items:
+                              type: string
+                          servingCertificate:
+                            description: 'servingCertificate references a kubernetes.io/tls type secret containing the TLS cert info for serving secure traffic. The secret must exist in the openshift-config namespace and contain the following required fields: - Secret.Data["tls.key"] - TLS private key. - Secret.Data["tls.crt"] - TLS certificate.'
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                tlsSecurityProfile:
+                  description: "tlsSecurityProfile specifies settings for TLS connections for externally exposed servers. \n If unset, a default (which may change between releases) is chosen. Note that only Old, Intermediate and Custom profiles are currently supported, and the maximum available minTLSVersion is VersionTLS12."
+                  type: object
+                  properties:
+                    custom:
+                      description: "custom is a user-defined TLS security profile. Be extremely careful using a custom profile as invalid configurations can be catastrophic. An example custom profile looks like this: \n ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion: VersionTLS11"
+                      type: object
+                      properties:
+                        ciphers:
+                          description: "ciphers is used to specify the cipher algorithms that are negotiated during the TLS handshake.  Operators may remove entries their operands do not support.  For example, to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA"
+                          type: array
+                          items:
+                            type: string
+                        minTLSVersion:
+                          description: "minTLSVersion is used to specify the minimal version of the TLS protocol that is negotiated during the TLS handshake. For example, to use TLS versions 1.1, 1.2 and 1.3 (yaml): \n minTLSVersion: VersionTLS11 \n NOTE: currently the highest minTLSVersion allowed is VersionTLS12"
+                          type: string
+                          enum:
+                            - VersionTLS10
+                            - VersionTLS11
+                            - VersionTLS12
+                            - VersionTLS13
+                      nullable: true
+                    intermediate:
+                      description: "intermediate is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29 \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 minTLSVersion: VersionTLS12"
+                      type: object
+                      nullable: true
+                    modern:
+                      description: "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 minTLSVersion: VersionTLS13 \n NOTE: Currently unsupported."
+                      type: object
+                      nullable: true
+                    old:
+                      description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility \n and looks like this (yaml): \n ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 - TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 - ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 - ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 - DHE-RSA-AES256-GCM-SHA384 - DHE-RSA-CHACHA20-POLY1305 - ECDHE-ECDSA-AES128-SHA256 - ECDHE-RSA-AES128-SHA256 - ECDHE-ECDSA-AES128-SHA - ECDHE-RSA-AES128-SHA - ECDHE-ECDSA-AES256-SHA384 - ECDHE-RSA-AES256-SHA384 - ECDHE-ECDSA-AES256-SHA - ECDHE-RSA-AES256-SHA - DHE-RSA-AES128-SHA256 - DHE-RSA-AES256-SHA256 - AES128-GCM-SHA256 - AES256-GCM-SHA384 - AES128-SHA256 - AES256-SHA256 - AES128-SHA - AES256-SHA - DES-CBC3-SHA minTLSVersion: VersionTLS10"
+                      type: object
+                      nullable: true
+                    type:
+                      description: "type is one of Old, Intermediate, Modern or Custom. Custom provides the ability to specify individual TLS security profile parameters. Old, Intermediate and Modern are TLS security profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations \n The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be reduced. \n Note that the Modern profile is currently not supported because it is not yet well adopted by common software libraries."
+                      type: string
+                      enum:
+                        - Old
+                        - Intermediate
+                        - Modern
+                        - Custom
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
@@ -1,0 +1,374 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      "schema":
+        "openAPIV3Schema":
+          description: "Authentication specifies cluster-wide settings for authentication (like OAuth and webhook token authenticators). The canonical name of an instance is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                oauthMetadata:
+                  description: 'oauthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for an external OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 If oauthMetadata.name is non-empty, this value has precedence over any metadata reference stored in status. The key "oauthMetadata" is used to locate the data. If specified and the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                oidcProviders:
+                  description: "OIDCProviders are OIDC identity providers that can issue tokens for this cluster Can only be set if \"Type\" is set to \"OIDC\". \n At most one provider can be configured."
+                  type: array
+                  maxItems: 1
+                  items:
+                    type: object
+                    required:
+                      - issuer
+                      - name
+                    properties:
+                      claimMappings:
+                        description: ClaimMappings describes rules on how to transform information from an ID token into a cluster identity
+                        type: object
+                        properties:
+                          groups:
+                            description: Groups is a name of the claim that should be used to construct groups for the cluster identity. The referenced claim must use array of strings values.
+                            type: object
+                            required:
+                              - claim
+                            properties:
+                              claim:
+                                description: Claim is a JWT token claim to be used in the mapping
+                                type: string
+                              prefix:
+                                description: "Prefix is a string to prefix the value from the token in the result of the claim mapping. \n By default, no prefixing occurs. \n Example: if `prefix` is set to \"myoidc:\"\" and the `claim` in JWT contains an array of strings \"a\", \"b\" and  \"c\", the mapping will result in an array of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                                type: string
+                          username:
+                            description: "Username is a name of the claim that should be used to construct usernames for the cluster identity. \n Default value: \"sub\""
+                            type: object
+                            required:
+                              - claim
+                            properties:
+                              claim:
+                                description: Claim is a JWT token claim to be used in the mapping
+                                type: string
+                              prefix:
+                                type: object
+                                required:
+                                  - prefixString
+                                properties:
+                                  prefixString:
+                                    type: string
+                                    minLength: 1
+                              prefixPolicy:
+                                description: "PrefixPolicy specifies how a prefix should apply. \n By default, claims other than `email` will be prefixed with the issuer URL to prevent naming clashes with other plugins. \n Set to \"NoPrefix\" to disable prefixing. \n Example: (1) `prefix` is set to \"myoidc:\" and `claim` is set to \"username\". If the JWT claim `username` contains value `userA`, the resulting mapped value will be \"myoidc:userA\". (2) `prefix` is set to \"myoidc:\" and `claim` is set to \"email\". If the JWT `email` claim contains value \"userA@myoidc.tld\", the resulting mapped value will be \"myoidc:userA@myoidc.tld\". (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`, the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\", and `claim` is set to: (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\" (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                                type: string
+                                enum:
+                                  - ""
+                                  - NoPrefix
+                                  - Prefix
+                            x-kubernetes-validations:
+                              - rule: 'has(self.prefixPolicy) && self.prefixPolicy == ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString) > 0) : !has(self.prefix)'
+                                message: prefix must be set if prefixPolicy is 'Prefix', but must remain unset otherwise
+                      claimValidationRules:
+                        description: ClaimValidationRules are rules that are applied to validate token claims to authenticate users.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            requiredClaim:
+                              description: RequiredClaim allows configuring a required claim name and its expected value
+                              type: object
+                              required:
+                                - claim
+                                - requiredValue
+                              properties:
+                                claim:
+                                  description: Claim is a name of a required claim. Only claims with string values are supported.
+                                  type: string
+                                  minLength: 1
+                                requiredValue:
+                                  description: RequiredValue is the required value for the claim.
+                                  type: string
+                                  minLength: 1
+                            type:
+                              description: Type sets the type of the validation rule
+                              type: string
+                              default: RequiredClaim
+                              enum:
+                                - RequiredClaim
+                        x-kubernetes-list-type: atomic
+                      issuer:
+                        description: Issuer describes atributes of the OIDC token issuer
+                        type: object
+                        required:
+                          - audiences
+                          - issuerURL
+                        properties:
+                          audiences:
+                            description: Audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their "aud" claim. Must be set to exactly one value.
+                            type: array
+                            maxItems: 1
+                            items:
+                              type: string
+                              minLength: 1
+                            x-kubernetes-list-type: set
+                          issuerCertificateAuthority:
+                            description: CertificateAuthority is a reference to a config map in the configuration namespace. The .data of the configMap must contain the "ca-bundle.crt" key. If unset, system trust is used instead.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced config map
+                                type: string
+                          issuerURL:
+                            description: URL is the serving URL of the token issuer. Must use the https:// scheme.
+                            type: string
+                            pattern: ^https:\/\/[^\s]
+                      name:
+                        description: Name of the OIDC provider
+                        type: string
+                        minLength: 1
+                      oidcClients:
+                        description: OIDCClients contains configuration for the platform's clients that need to request tokens from the issuer
+                        type: array
+                        maxItems: 20
+                        items:
+                          type: object
+                          required:
+                            - clientID
+                            - componentName
+                            - componentNamespace
+                          properties:
+                            clientID:
+                              description: ClientID is the identifier of the OIDC client from the OIDC provider
+                              type: string
+                              minLength: 1
+                            clientSecret:
+                              description: ClientSecret refers to a secret in the `openshift-config` namespace that contains the client secret in the `clientSecret` key of the `.data` field
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  description: name is the metadata.name of the referenced secret
+                                  type: string
+                            componentName:
+                              description: ComponentName is the name of the component that is supposed to consume this client configuration
+                              type: string
+                              maxLength: 256
+                              minLength: 1
+                            componentNamespace:
+                              description: ComponentNamespace is the namespace of the component that is supposed to consume this client configuration
+                              type: string
+                              maxLength: 63
+                              minLength: 1
+                            extraScopes:
+                              description: ExtraScopes is an optional set of scopes to request tokens with.
+                              type: array
+                              items:
+                                type: string
+                              x-kubernetes-list-type: set
+                        x-kubernetes-list-map-keys:
+                          - componentNamespace
+                          - componentName
+                        x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                serviceAccountIssuer:
+                  description: 'serviceAccountIssuer is the identifier of the bound service account token issuer. The default is https://kubernetes.default.svc WARNING: Updating this field will not result in immediate invalidation of all bound tokens with the previous issuer value. Instead, the tokens issued by previous service account issuer will continue to be trusted for a time period chosen by the platform (currently set to 24h). This time period is subject to change over time. This allows internal components to transition to use new service account issuer without service distruption.'
+                  type: string
+                type:
+                  description: type identifies the cluster managed, user facing authentication mode in use. Specifically, it manages the component that responds to login attempts. The default is IntegratedOAuth.
+                  type: string
+                webhookTokenAuthenticator:
+                  description: "webhookTokenAuthenticator configures a remote token reviewer. These remote authentication webhooks can be used to verify bearer tokens via the tokenreviews.authentication.k8s.io REST API. This is required to honor bearer tokens that are provisioned by an external authentication service. \n Can only be set if \"Type\" is set to \"None\"."
+                  type: object
+                  required:
+                    - kubeConfig
+                  properties:
+                    kubeConfig:
+                      description: "kubeConfig references a secret that contains kube config file data which describes how to access the remote webhook service. The namespace for the referenced secret is openshift-config. \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication \n The key \"kubeConfig\" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored."
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced secret
+                          type: string
+                webhookTokenAuthenticators:
+                  description: webhookTokenAuthenticators is DEPRECATED, setting it has no effect.
+                  type: array
+                  items:
+                    description: deprecatedWebhookTokenAuthenticator holds the necessary configuration options for a remote token authenticator. It's the same as WebhookTokenAuthenticator but it's missing the 'required' validation on KubeConfig field.
+                    type: object
+                    properties:
+                      kubeConfig:
+                        description: 'kubeConfig contains kube config file data which describes how to access the remote webhook service. For further details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication The key "kubeConfig" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored. The namespace for this secret is determined by the point of use.'
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced secret
+                            type: string
+                  x-kubernetes-list-type: atomic
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                integratedOAuthMetadata:
+                  description: 'integratedOAuthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for the in-cluster integrated OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 This contains the observed value based on cluster state. An explicitly set value in spec.oauthMetadata has precedence over this field. This field has no meaning if authentication spec.type is not set to IntegratedOAuth. The key "oauthMetadata" is used to locate the data. If the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config-managed.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                oidcClients:
+                  description: OIDCClients is where participating operators place the current OIDC client status for OIDC clients that can be customized by the cluster-admin.
+                  type: array
+                  maxItems: 20
+                  items:
+                    type: object
+                    required:
+                      - componentName
+                      - componentNamespace
+                    properties:
+                      componentName:
+                        description: ComponentName is the name of the component that will consume a client configuration.
+                        type: string
+                        maxLength: 256
+                        minLength: 1
+                      componentNamespace:
+                        description: ComponentNamespace is the namespace of the component that will consume a client configuration.
+                        type: string
+                        maxLength: 63
+                        minLength: 1
+                      conditions:
+                        description: "Conditions are used to communicate the state of the `oidcClients` entry. \n Supported conditions include Available, Degraded and Progressing. \n If Available is true, the component is successfully using the configured client. If Degraded is true, that means something has gone wrong trying to handle the client configuration. If Progressing is true, that means the component is taking some action related to the `oidcClients` entry."
+                        type: array
+                        items:
+                          description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                          type: object
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          properties:
+                            lastTransitionTime:
+                              description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              type: string
+                              format: date-time
+                            message:
+                              description: message is a human readable message indicating details about the transition. This may be an empty string.
+                              type: string
+                              maxLength: 32768
+                            observedGeneration:
+                              description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                              type: integer
+                              format: int64
+                              minimum: 0
+                            reason:
+                              description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                              type: string
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              type: string
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                              type: string
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      consumingUsers:
+                        description: ConsumingUsers is a slice of ServiceAccounts that need to have read permission on the `clientSecret` secret.
+                        type: array
+                        maxItems: 5
+                        items:
+                          description: ConsumingUser is an alias for string which we add validation to. Currently only service accounts are supported.
+                          type: string
+                          maxLength: 512
+                          minLength: 1
+                          pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        x-kubernetes-list-type: set
+                      currentOIDCClients:
+                        description: CurrentOIDCClients is a list of clients that the component is currently using.
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - clientID
+                            - issuerURL
+                            - oidcProviderName
+                          properties:
+                            clientID:
+                              description: ClientID is the identifier of the OIDC client from the OIDC provider
+                              type: string
+                              minLength: 1
+                            issuerURL:
+                              description: URL is the serving URL of the token issuer. Must use the https:// scheme.
+                              type: string
+                              pattern: ^https:\/\/[^\s]
+                            oidcProviderName:
+                              description: OIDCName refers to the `name` of the provider from `oidcProviders`
+                              type: string
+                              minLength: 1
+                        x-kubernetes-list-map-keys:
+                          - issuerURL
+                          - clientID
+                        x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - componentNamespace
+                    - componentName
+                  x-kubernetes-list-type: map
+          x-kubernetes-validations:
+            - rule: '!has(self.spec.oidcProviders) || self.spec.oidcProviders.all(p, !has(p.oidcClients) || p.oidcClients.all(specC, self.status.oidcClients.exists(statusC, statusC.componentNamespace == specC.componentNamespace && statusC.componentName == specC.componentName) || (has(oldSelf.spec.oidcProviders) && oldSelf.spec.oidcProviders.exists(oldP, oldP.name == p.name && has(oldP.oidcClients) && oldP.oidcClients.exists(oldC, oldC.componentNamespace == specC.componentNamespace && oldC.componentName == specC.componentName)))))'
+              message: all oidcClients in the oidcProviders must match their componentName and componentNamespace to either a previously configured oidcClient or they must exist in the status.oidcClients

--- a/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
@@ -1,0 +1,374 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      "schema":
+        "openAPIV3Schema":
+          description: "Authentication specifies cluster-wide settings for authentication (like OAuth and webhook token authenticators). The canonical name of an instance is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                oauthMetadata:
+                  description: 'oauthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for an external OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 If oauthMetadata.name is non-empty, this value has precedence over any metadata reference stored in status. The key "oauthMetadata" is used to locate the data. If specified and the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                oidcProviders:
+                  description: "OIDCProviders are OIDC identity providers that can issue tokens for this cluster Can only be set if \"Type\" is set to \"OIDC\". \n At most one provider can be configured."
+                  type: array
+                  maxItems: 1
+                  items:
+                    type: object
+                    required:
+                      - issuer
+                      - name
+                    properties:
+                      claimMappings:
+                        description: ClaimMappings describes rules on how to transform information from an ID token into a cluster identity
+                        type: object
+                        properties:
+                          groups:
+                            description: Groups is a name of the claim that should be used to construct groups for the cluster identity. The referenced claim must use array of strings values.
+                            type: object
+                            required:
+                              - claim
+                            properties:
+                              claim:
+                                description: Claim is a JWT token claim to be used in the mapping
+                                type: string
+                              prefix:
+                                description: "Prefix is a string to prefix the value from the token in the result of the claim mapping. \n By default, no prefixing occurs. \n Example: if `prefix` is set to \"myoidc:\"\" and the `claim` in JWT contains an array of strings \"a\", \"b\" and  \"c\", the mapping will result in an array of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                                type: string
+                          username:
+                            description: "Username is a name of the claim that should be used to construct usernames for the cluster identity. \n Default value: \"sub\""
+                            type: object
+                            required:
+                              - claim
+                            properties:
+                              claim:
+                                description: Claim is a JWT token claim to be used in the mapping
+                                type: string
+                              prefix:
+                                type: object
+                                required:
+                                  - prefixString
+                                properties:
+                                  prefixString:
+                                    type: string
+                                    minLength: 1
+                              prefixPolicy:
+                                description: "PrefixPolicy specifies how a prefix should apply. \n By default, claims other than `email` will be prefixed with the issuer URL to prevent naming clashes with other plugins. \n Set to \"NoPrefix\" to disable prefixing. \n Example: (1) `prefix` is set to \"myoidc:\" and `claim` is set to \"username\". If the JWT claim `username` contains value `userA`, the resulting mapped value will be \"myoidc:userA\". (2) `prefix` is set to \"myoidc:\" and `claim` is set to \"email\". If the JWT `email` claim contains value \"userA@myoidc.tld\", the resulting mapped value will be \"myoidc:userA@myoidc.tld\". (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`, the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\", and `claim` is set to: (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\" (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                                type: string
+                                enum:
+                                  - ""
+                                  - NoPrefix
+                                  - Prefix
+                            x-kubernetes-validations:
+                              - rule: 'has(self.prefixPolicy) && self.prefixPolicy == ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString) > 0) : !has(self.prefix)'
+                                message: prefix must be set if prefixPolicy is 'Prefix', but must remain unset otherwise
+                      claimValidationRules:
+                        description: ClaimValidationRules are rules that are applied to validate token claims to authenticate users.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            requiredClaim:
+                              description: RequiredClaim allows configuring a required claim name and its expected value
+                              type: object
+                              required:
+                                - claim
+                                - requiredValue
+                              properties:
+                                claim:
+                                  description: Claim is a name of a required claim. Only claims with string values are supported.
+                                  type: string
+                                  minLength: 1
+                                requiredValue:
+                                  description: RequiredValue is the required value for the claim.
+                                  type: string
+                                  minLength: 1
+                            type:
+                              description: Type sets the type of the validation rule
+                              type: string
+                              default: RequiredClaim
+                              enum:
+                                - RequiredClaim
+                        x-kubernetes-list-type: atomic
+                      issuer:
+                        description: Issuer describes atributes of the OIDC token issuer
+                        type: object
+                        required:
+                          - audiences
+                          - issuerURL
+                        properties:
+                          audiences:
+                            description: Audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their "aud" claim. Must be set to exactly one value.
+                            type: array
+                            maxItems: 1
+                            items:
+                              type: string
+                              minLength: 1
+                            x-kubernetes-list-type: set
+                          issuerCertificateAuthority:
+                            description: CertificateAuthority is a reference to a config map in the configuration namespace. The .data of the configMap must contain the "ca-bundle.crt" key. If unset, system trust is used instead.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced config map
+                                type: string
+                          issuerURL:
+                            description: URL is the serving URL of the token issuer. Must use the https:// scheme.
+                            type: string
+                            pattern: ^https:\/\/[^\s]
+                      name:
+                        description: Name of the OIDC provider
+                        type: string
+                        minLength: 1
+                      oidcClients:
+                        description: OIDCClients contains configuration for the platform's clients that need to request tokens from the issuer
+                        type: array
+                        maxItems: 20
+                        items:
+                          type: object
+                          required:
+                            - clientID
+                            - componentName
+                            - componentNamespace
+                          properties:
+                            clientID:
+                              description: ClientID is the identifier of the OIDC client from the OIDC provider
+                              type: string
+                              minLength: 1
+                            clientSecret:
+                              description: ClientSecret refers to a secret in the `openshift-config` namespace that contains the client secret in the `clientSecret` key of the `.data` field
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  description: name is the metadata.name of the referenced secret
+                                  type: string
+                            componentName:
+                              description: ComponentName is the name of the component that is supposed to consume this client configuration
+                              type: string
+                              maxLength: 256
+                              minLength: 1
+                            componentNamespace:
+                              description: ComponentNamespace is the namespace of the component that is supposed to consume this client configuration
+                              type: string
+                              maxLength: 63
+                              minLength: 1
+                            extraScopes:
+                              description: ExtraScopes is an optional set of scopes to request tokens with.
+                              type: array
+                              items:
+                                type: string
+                              x-kubernetes-list-type: set
+                        x-kubernetes-list-map-keys:
+                          - componentNamespace
+                          - componentName
+                        x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                serviceAccountIssuer:
+                  description: 'serviceAccountIssuer is the identifier of the bound service account token issuer. The default is https://kubernetes.default.svc WARNING: Updating this field will not result in immediate invalidation of all bound tokens with the previous issuer value. Instead, the tokens issued by previous service account issuer will continue to be trusted for a time period chosen by the platform (currently set to 24h). This time period is subject to change over time. This allows internal components to transition to use new service account issuer without service distruption.'
+                  type: string
+                type:
+                  description: type identifies the cluster managed, user facing authentication mode in use. Specifically, it manages the component that responds to login attempts. The default is IntegratedOAuth.
+                  type: string
+                webhookTokenAuthenticator:
+                  description: "webhookTokenAuthenticator configures a remote token reviewer. These remote authentication webhooks can be used to verify bearer tokens via the tokenreviews.authentication.k8s.io REST API. This is required to honor bearer tokens that are provisioned by an external authentication service. \n Can only be set if \"Type\" is set to \"None\"."
+                  type: object
+                  required:
+                    - kubeConfig
+                  properties:
+                    kubeConfig:
+                      description: "kubeConfig references a secret that contains kube config file data which describes how to access the remote webhook service. The namespace for the referenced secret is openshift-config. \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication \n The key \"kubeConfig\" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored."
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced secret
+                          type: string
+                webhookTokenAuthenticators:
+                  description: webhookTokenAuthenticators is DEPRECATED, setting it has no effect.
+                  type: array
+                  items:
+                    description: deprecatedWebhookTokenAuthenticator holds the necessary configuration options for a remote token authenticator. It's the same as WebhookTokenAuthenticator but it's missing the 'required' validation on KubeConfig field.
+                    type: object
+                    properties:
+                      kubeConfig:
+                        description: 'kubeConfig contains kube config file data which describes how to access the remote webhook service. For further details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication The key "kubeConfig" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored. The namespace for this secret is determined by the point of use.'
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced secret
+                            type: string
+                  x-kubernetes-list-type: atomic
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                integratedOAuthMetadata:
+                  description: 'integratedOAuthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for the in-cluster integrated OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 This contains the observed value based on cluster state. An explicitly set value in spec.oauthMetadata has precedence over this field. This field has no meaning if authentication spec.type is not set to IntegratedOAuth. The key "oauthMetadata" is used to locate the data. If the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config-managed.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                oidcClients:
+                  description: OIDCClients is where participating operators place the current OIDC client status for OIDC clients that can be customized by the cluster-admin.
+                  type: array
+                  maxItems: 20
+                  items:
+                    type: object
+                    required:
+                      - componentName
+                      - componentNamespace
+                    properties:
+                      componentName:
+                        description: ComponentName is the name of the component that will consume a client configuration.
+                        type: string
+                        maxLength: 256
+                        minLength: 1
+                      componentNamespace:
+                        description: ComponentNamespace is the namespace of the component that will consume a client configuration.
+                        type: string
+                        maxLength: 63
+                        minLength: 1
+                      conditions:
+                        description: "Conditions are used to communicate the state of the `oidcClients` entry. \n Supported conditions include Available, Degraded and Progressing. \n If Available is true, the component is successfully using the configured client. If Degraded is true, that means something has gone wrong trying to handle the client configuration. If Progressing is true, that means the component is taking some action related to the `oidcClients` entry."
+                        type: array
+                        items:
+                          description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                          type: object
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          properties:
+                            lastTransitionTime:
+                              description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              type: string
+                              format: date-time
+                            message:
+                              description: message is a human readable message indicating details about the transition. This may be an empty string.
+                              type: string
+                              maxLength: 32768
+                            observedGeneration:
+                              description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                              type: integer
+                              format: int64
+                              minimum: 0
+                            reason:
+                              description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                              type: string
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              type: string
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                              type: string
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      consumingUsers:
+                        description: ConsumingUsers is a slice of ServiceAccounts that need to have read permission on the `clientSecret` secret.
+                        type: array
+                        maxItems: 5
+                        items:
+                          description: ConsumingUser is an alias for string which we add validation to. Currently only service accounts are supported.
+                          type: string
+                          maxLength: 512
+                          minLength: 1
+                          pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        x-kubernetes-list-type: set
+                      currentOIDCClients:
+                        description: CurrentOIDCClients is a list of clients that the component is currently using.
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - clientID
+                            - issuerURL
+                            - oidcProviderName
+                          properties:
+                            clientID:
+                              description: ClientID is the identifier of the OIDC client from the OIDC provider
+                              type: string
+                              minLength: 1
+                            issuerURL:
+                              description: URL is the serving URL of the token issuer. Must use the https:// scheme.
+                              type: string
+                              pattern: ^https:\/\/[^\s]
+                            oidcProviderName:
+                              description: OIDCName refers to the `name` of the provider from `oidcProviders`
+                              type: string
+                              minLength: 1
+                        x-kubernetes-list-map-keys:
+                          - issuerURL
+                          - clientID
+                        x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - componentNamespace
+                    - componentName
+                  x-kubernetes-list-type: map
+          x-kubernetes-validations:
+            - rule: '!has(self.spec.oidcProviders) || self.spec.oidcProviders.all(p, !has(p.oidcClients) || p.oidcClients.all(specC, self.status.oidcClients.exists(statusC, statusC.componentNamespace == specC.componentNamespace && statusC.componentName == specC.componentName) || (has(oldSelf.spec.oidcProviders) && oldSelf.spec.oidcProviders.exists(oldP, oldP.name == p.name && has(oldP.oidcClients) && oldP.oidcClients.exists(oldC, oldC.componentNamespace == specC.componentNamespace && oldC.componentName == specC.componentName)))))'
+              message: all oidcClients in the oidcProviders must match their componentName and componentNamespace to either a previously configured oidcClient or they must exist in the status.oidcClients

--- a/payload-manifests/crds/0000_10_config-operator_01_authentication.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentication.crd.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Authentication specifies cluster-wide settings for authentication (like OAuth and webhook token authenticators). The canonical name of an instance is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                oauthMetadata:
+                  description: 'oauthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for an external OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 If oauthMetadata.name is non-empty, this value has precedence over any metadata reference stored in status. The key "oauthMetadata" is used to locate the data. If specified and the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                serviceAccountIssuer:
+                  description: 'serviceAccountIssuer is the identifier of the bound service account token issuer. The default is https://kubernetes.default.svc WARNING: Updating this field will not result in immediate invalidation of all bound tokens with the previous issuer value. Instead, the tokens issued by previous service account issuer will continue to be trusted for a time period chosen by the platform (currently set to 24h). This time period is subject to change over time. This allows internal components to transition to use new service account issuer without service distruption.'
+                  type: string
+                type:
+                  description: type identifies the cluster managed, user facing authentication mode in use. Specifically, it manages the component that responds to login attempts. The default is IntegratedOAuth.
+                  type: string
+                webhookTokenAuthenticator:
+                  description: "webhookTokenAuthenticator configures a remote token reviewer. These remote authentication webhooks can be used to verify bearer tokens via the tokenreviews.authentication.k8s.io REST API. This is required to honor bearer tokens that are provisioned by an external authentication service. \n Can only be set if \"Type\" is set to \"None\"."
+                  type: object
+                  required:
+                    - kubeConfig
+                  properties:
+                    kubeConfig:
+                      description: "kubeConfig references a secret that contains kube config file data which describes how to access the remote webhook service. The namespace for the referenced secret is openshift-config. \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication \n The key \"kubeConfig\" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored."
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced secret
+                          type: string
+                webhookTokenAuthenticators:
+                  description: webhookTokenAuthenticators is DEPRECATED, setting it has no effect.
+                  type: array
+                  items:
+                    description: deprecatedWebhookTokenAuthenticator holds the necessary configuration options for a remote token authenticator. It's the same as WebhookTokenAuthenticator but it's missing the 'required' validation on KubeConfig field.
+                    type: object
+                    properties:
+                      kubeConfig:
+                        description: 'kubeConfig contains kube config file data which describes how to access the remote webhook service. For further details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication The key "kubeConfig" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored. The namespace for this secret is determined by the point of use.'
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced secret
+                            type: string
+                  x-kubernetes-list-type: atomic
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                integratedOAuthMetadata:
+                  description: 'integratedOAuthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for the in-cluster integrated OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 This contains the observed value based on cluster state. An explicitly set value in spec.oauthMetadata has precedence over this field. This field has no meaning if authentication spec.type is not set to IntegratedOAuth. The key "oauthMetadata" is used to locate the data. If the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config-managed.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_config.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_config.crd.yaml
@@ -1,0 +1,136 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/612
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: configs.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    categories:
+      - coreoperators
+    kind: Config
+    plural: configs
+    singular: config
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Config specifies the behavior of the config operator which is responsible for creating the initial configuration of other components on the cluster.  The operator also handles installation, migration or synchronization of cloud configurations for AWS and Azure cloud based clusters \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec is the specification of the desired behavior of the Config Operator.
+              type: object
+              properties:
+                logLevel:
+                  description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                  type: string
+                  default: Normal
+                  enum:
+                    - ""
+                    - Normal
+                    - Debug
+                    - Trace
+                    - TraceAll
+                managementState:
+                  description: managementState indicates whether and how the operator should manage the component
+                  type: string
+                  pattern: ^(Managed|Unmanaged|Force|Removed)$
+                observedConfig:
+                  description: observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+                operatorLogLevel:
+                  description: "operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for themselves. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                  type: string
+                  default: Normal
+                  enum:
+                    - ""
+                    - Normal
+                    - Debug
+                    - Trace
+                    - TraceAll
+                unsupportedConfigOverrides:
+                  description: unsupportedConfigOverrides overrides the final configuration that was computed by the operator. Red Hat does not support the use of this field. Misuse of this field could lead to unexpected behavior or conflict with other configuration options. Seek guidance from the Red Hat support before using this field. Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.
+                  type: object
+                  nullable: true
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: status defines the observed status of the Config Operator.
+              type: object
+              properties:
+                conditions:
+                  description: conditions is a list of conditions and their status
+                  type: array
+                  items:
+                    description: OperatorCondition is just the standard condition fields.
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                generations:
+                  description: generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
+                  type: array
+                  items:
+                    description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
+                    type: object
+                    properties:
+                      group:
+                        description: group is the group of the thing you're tracking
+                        type: string
+                      hash:
+                        description: hash is an optional field set for resources without generation that are content sensitive like secrets and configmaps
+                        type: string
+                      lastGeneration:
+                        description: lastGeneration is the last generation of the workload controller involved
+                        type: integer
+                        format: int64
+                      name:
+                        description: name is the name of the thing you're tracking
+                        type: string
+                      namespace:
+                        description: namespace is where the thing you're tracking is
+                        type: string
+                      resource:
+                        description: resource is the resource type of the thing you're tracking
+                        type: string
+                observedGeneration:
+                  description: observedGeneration is the last generation change you've dealt with
+                  type: integer
+                  format: int64
+                readyReplicas:
+                  description: readyReplicas indicates how many replicas are ready and at the desired state
+                  type: integer
+                  format: int32
+                version:
+                  description: version is the level this availability applies to
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_console.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_console.crd.yaml
@@ -1,0 +1,57 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: consoles.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Console
+    listKind: ConsoleList
+    plural: consoles
+    singular: console
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Console holds cluster-wide configuration for the web console, including the logout URL, and reports the public URL of the console. The canonical name is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                authentication:
+                  description: ConsoleAuthentication defines a list of optional configuration for console authentication.
+                  type: object
+                  properties:
+                    logoutRedirect:
+                      description: 'An optional, absolute URL to redirect web browsers to after logging out of the console. If not specified, it will redirect to the default login page. This is required when using an identity provider that supports single sign-on (SSO) such as: - OpenID (Keycloak, Azure) - RequestHeader (GSSAPI, SSPI, SAML) - OAuth (GitHub, GitLab, Google) Logging out of the console will destroy the user''s token. The logoutRedirect provides the user the option to perform single logout (SLO) through the identity provider to destroy their single sign-on session.'
+                      type: string
+                      pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                consoleURL:
+                  description: The URL for the console. This will be derived from the host for the route that is created for the console.
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_dns-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_dns-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,114 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: dnses.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: DNS
+    listKind: DNSList
+    plural: dnses
+    singular: dns
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "DNS holds cluster-wide information about DNS. The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                baseDomain:
+                  description: "baseDomain is the base domain of the cluster. All managed DNS records will be sub-domains of this base. \n For example, given the base domain `openshift.example.com`, an API server DNS record may be created for `cluster-api.openshift.example.com`. \n Once set, this field cannot be changed."
+                  type: string
+                platform:
+                  description: platform holds configuration specific to the underlying infrastructure provider for DNS. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.
+                  type: object
+                  required:
+                    - type
+                  properties:
+                    aws:
+                      description: aws contains DNS configuration specific to the Amazon Web Services cloud provider.
+                      type: object
+                      properties:
+                        privateZoneIAMRole:
+                          description: privateZoneIAMRole contains the ARN of an IAM role that should be assumed when performing operations on the cluster's private hosted zone specified in the cluster DNS config. When left empty, no role should be assumed.
+                          type: string
+                          pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                    type:
+                      description: "type is the underlying infrastructure provider for the cluster. Allowed values: \"\", \"AWS\". \n Individual components may not support all platforms, and must handle unrecognized platforms with best-effort defaults."
+                      type: string
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                      x-kubernetes-validations:
+                        - rule: self in ['','AWS']
+                          message: allowed values are '' and 'AWS'
+                  x-kubernetes-validations:
+                    - rule: 'has(self.type) && self.type == ''AWS'' ?  has(self.aws) : !has(self.aws)'
+                      message: aws configuration is required when platform is AWS, and forbidden otherwise
+                privateZone:
+                  description: "privateZone is the location where all the DNS records that are only available internally to the cluster exist. \n If this field is nil, no private records should be created. \n Once set, this field cannot be changed."
+                  type: object
+                  properties:
+                    id:
+                      description: "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                      type: string
+                    tags:
+                      description: "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                      type: object
+                      additionalProperties:
+                        type: string
+                publicZone:
+                  description: "publicZone is the location where all the DNS records that are publicly accessible to the internet exist. \n If this field is nil, no public records should be created. \n Once set, this field cannot be changed."
+                  type: object
+                  properties:
+                    id:
+                      description: "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                      type: string
+                    tags:
+                      description: "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                      type: object
+                      additionalProperties:
+                        type: string
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_dns-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_dns-Default.crd.yaml
@@ -1,0 +1,114 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
+  name: dnses.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: DNS
+    listKind: DNSList
+    plural: dnses
+    singular: dns
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "DNS holds cluster-wide information about DNS. The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                baseDomain:
+                  description: "baseDomain is the base domain of the cluster. All managed DNS records will be sub-domains of this base. \n For example, given the base domain `openshift.example.com`, an API server DNS record may be created for `cluster-api.openshift.example.com`. \n Once set, this field cannot be changed."
+                  type: string
+                platform:
+                  description: platform holds configuration specific to the underlying infrastructure provider for DNS. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.
+                  type: object
+                  required:
+                    - type
+                  properties:
+                    aws:
+                      description: aws contains DNS configuration specific to the Amazon Web Services cloud provider.
+                      type: object
+                      properties:
+                        privateZoneIAMRole:
+                          description: privateZoneIAMRole contains the ARN of an IAM role that should be assumed when performing operations on the cluster's private hosted zone specified in the cluster DNS config. When left empty, no role should be assumed.
+                          type: string
+                          pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                    type:
+                      description: "type is the underlying infrastructure provider for the cluster. Allowed values: \"\", \"AWS\". \n Individual components may not support all platforms, and must handle unrecognized platforms with best-effort defaults."
+                      type: string
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                      x-kubernetes-validations:
+                        - rule: self in ['','AWS']
+                          message: allowed values are '' and 'AWS'
+                  x-kubernetes-validations:
+                    - rule: 'has(self.type) && self.type == ''AWS'' ?  has(self.aws) : !has(self.aws)'
+                      message: aws configuration is required when platform is AWS, and forbidden otherwise
+                privateZone:
+                  description: "privateZone is the location where all the DNS records that are only available internally to the cluster exist. \n If this field is nil, no private records should be created. \n Once set, this field cannot be changed."
+                  type: object
+                  properties:
+                    id:
+                      description: "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                      type: string
+                    tags:
+                      description: "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                      type: object
+                      additionalProperties:
+                        type: string
+                publicZone:
+                  description: "publicZone is the location where all the DNS records that are publicly accessible to the internet exist. \n If this field is nil, no public records should be created. \n Once set, this field cannot be changed."
+                  type: object
+                  properties:
+                    id:
+                      description: "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                      type: string
+                    tags:
+                      description: "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                      type: object
+                      additionalProperties:
+                        type: string
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_dns-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_dns-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,114 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: dnses.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: DNS
+    listKind: DNSList
+    plural: dnses
+    singular: dns
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "DNS holds cluster-wide information about DNS. The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                baseDomain:
+                  description: "baseDomain is the base domain of the cluster. All managed DNS records will be sub-domains of this base. \n For example, given the base domain `openshift.example.com`, an API server DNS record may be created for `cluster-api.openshift.example.com`. \n Once set, this field cannot be changed."
+                  type: string
+                platform:
+                  description: platform holds configuration specific to the underlying infrastructure provider for DNS. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.
+                  type: object
+                  required:
+                    - type
+                  properties:
+                    aws:
+                      description: aws contains DNS configuration specific to the Amazon Web Services cloud provider.
+                      type: object
+                      properties:
+                        privateZoneIAMRole:
+                          description: privateZoneIAMRole contains the ARN of an IAM role that should be assumed when performing operations on the cluster's private hosted zone specified in the cluster DNS config. When left empty, no role should be assumed.
+                          type: string
+                          pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                    type:
+                      description: "type is the underlying infrastructure provider for the cluster. Allowed values: \"\", \"AWS\". \n Individual components may not support all platforms, and must handle unrecognized platforms with best-effort defaults."
+                      type: string
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                      x-kubernetes-validations:
+                        - rule: self in ['','AWS']
+                          message: allowed values are '' and 'AWS'
+                  x-kubernetes-validations:
+                    - rule: 'has(self.type) && self.type == ''AWS'' ?  has(self.aws) : !has(self.aws)'
+                      message: aws configuration is required when platform is AWS, and forbidden otherwise
+                privateZone:
+                  description: "privateZone is the location where all the DNS records that are only available internally to the cluster exist. \n If this field is nil, no private records should be created. \n Once set, this field cannot be changed."
+                  type: object
+                  properties:
+                    id:
+                      description: "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                      type: string
+                    tags:
+                      description: "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                      type: object
+                      additionalProperties:
+                        type: string
+                publicZone:
+                  description: "publicZone is the location where all the DNS records that are publicly accessible to the internet exist. \n If this field is nil, no public records should be created. \n Once set, this field cannot be changed."
+                  type: object
+                  properties:
+                    id:
+                      description: "id is the identifier that can be used to find the DNS hosted zone. \n on AWS zone can be fetched using `ID` as id in [1] on Azure zone can be fetched using `ID` as a pre-determined name in [2], on GCP zone can be fetched using `ID` as a pre-determined name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                      type: string
+                    tags:
+                      description: "tags can be used to query the DNS hosted zone. \n on AWS, resourcegroupstaggingapi [1] can be used to fetch a zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                      type: object
+                      additionalProperties:
+                        type: string
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_featuregate.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_featuregate.crd.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: featuregates.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: FeatureGate
+    listKind: FeatureGateList
+    plural: featuregates
+    singular: featuregate
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Feature holds cluster-wide information about feature gates.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                customNoUpgrade:
+                  description: customNoUpgrade allows the enabling or disabling of any feature. Turning this feature set on IS NOT SUPPORTED, CANNOT BE UNDONE, and PREVENTS UPGRADES. Because of its nature, this setting cannot be validated.  If you have any typos or accidentally apply invalid combinations your cluster may fail in an unrecoverable way.  featureSet must equal "CustomNoUpgrade" must be set to use this field.
+                  type: object
+                  properties:
+                    disabled:
+                      description: disabled is a list of all feature gates that you want to force off
+                      type: array
+                      items:
+                        description: FeatureGateName is a string to enforce patterns on the name of a FeatureGate
+                        type: string
+                        pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                    enabled:
+                      description: enabled is a list of all feature gates that you want to force on
+                      type: array
+                      items:
+                        description: FeatureGateName is a string to enforce patterns on the name of a FeatureGate
+                        type: string
+                        pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                  nullable: true
+                featureSet:
+                  description: featureSet changes the list of features in the cluster.  The default is empty.  Be very careful adjusting this setting. Turning on or off features may cause irreversible changes in your cluster which cannot be undone.
+                  type: string
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                conditions:
+                  description: 'conditions represent the observations of the current state. Known .status.conditions.type are: "DeterminationDegraded"'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                featureGates:
+                  description: featureGates contains a list of enabled and disabled featureGates that are keyed by payloadVersion. Operators other than the CVO and cluster-config-operator, must read the .status.featureGates, locate the version they are managing, find the enabled/disabled featuregates and make the operand and operator match. The enabled/disabled values for a particular version may change during the life of the cluster as various .spec.featureSet values are selected. Operators may choose to restart their processes to pick up these changes, but remembering past enable/disable lists is beyond the scope of this API and is the responsibility of individual operators. Only featureGates with .version in the ClusterVersion.status will be present in this list.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - version
+                    properties:
+                      disabled:
+                        description: disabled is a list of all feature gates that are disabled in the cluster for the named version.
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: name is the name of the FeatureGate.
+                              type: string
+                              pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                      enabled:
+                        description: enabled is a list of all feature gates that are enabled in the cluster for the named version.
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: name is the name of the FeatureGate.
+                              type: string
+                              pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                      version:
+                        description: version matches the version provided by the ClusterVersion and in the ClusterOperator.Status.Versions field.
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - version
+                  x-kubernetes-list-type: map
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_image.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_image.crd.yaml
@@ -1,0 +1,108 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: images.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Image
+    listKind: ImageList
+    plural: images
+    singular: image
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Image governs policies related to imagestream imports and runtime configuration for external registries. It allows cluster admins to configure which registries OpenShift is allowed to import images from, extra CA trust bundles for external registries, and policies to block or allow registry hostnames. When exposing OpenShift's image registry to the public, this also lets cluster admins specify the external hostname. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                additionalTrustedCA:
+                  description: additionalTrustedCA is a reference to a ConfigMap containing additional CAs that should be trusted during imagestream import, pod image pull, build image pull, and imageregistry pullthrough. The namespace for this config map is openshift-config.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                allowedRegistriesForImport:
+                  description: allowedRegistriesForImport limits the container image registries that normal users may import images from. Set this list to the registries that you trust to contain valid Docker images and that you want applications to be able to import from. Users with permission to create Images or ImageStreamMappings via the API are not affected by this policy - typically only administrators or system integrations will have those permissions.
+                  type: array
+                  items:
+                    description: RegistryLocation contains a location of the registry specified by the registry domain name. The domain name might include wildcards, like '*' or '??'.
+                    type: object
+                    properties:
+                      domainName:
+                        description: domainName specifies a domain name for the registry In case the registry use non-standard (80 or 443) port, the port should be included in the domain name as well.
+                        type: string
+                      insecure:
+                        description: insecure indicates whether the registry is secure (https) or insecure (http) By default (if not specified) the registry is assumed as secure.
+                        type: boolean
+                externalRegistryHostnames:
+                  description: externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in "hostname[:port]" format.
+                  type: array
+                  items:
+                    type: string
+                registrySources:
+                  description: registrySources contains configuration that determines how the container runtime should treat individual registries when accessing images for builds+pods. (e.g. whether or not to allow insecure access).  It does not contain configuration for the internal cluster registry.
+                  type: object
+                  properties:
+                    allowedRegistries:
+                      description: "allowedRegistries are the only registries permitted for image pull and push actions. All other registries are denied. \n Only one of BlockedRegistries or AllowedRegistries may be set."
+                      type: array
+                      items:
+                        type: string
+                    blockedRegistries:
+                      description: "blockedRegistries cannot be used for image pull and push actions. All other registries are permitted. \n Only one of BlockedRegistries or AllowedRegistries may be set."
+                      type: array
+                      items:
+                        type: string
+                    containerRuntimeSearchRegistries:
+                      description: 'containerRuntimeSearchRegistries are registries that will be searched when pulling images that do not have fully qualified domains in their pull specs. Registries will be searched in the order provided in the list. Note: this search list only works with the container runtime, i.e CRI-O. Will NOT work with builds or imagestream imports.'
+                      type: array
+                      format: hostname
+                      minItems: 1
+                      items:
+                        type: string
+                      x-kubernetes-list-type: set
+                    insecureRegistries:
+                      description: insecureRegistries are registries which do not have a valid TLS certificates or only support HTTP connections.
+                      type: array
+                      items:
+                        type: string
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                externalRegistryHostnames:
+                  description: externalRegistryHostnames provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in 'publicDockerImageRepository' field in ImageStreams. The value must be in "hostname[:port]" format.
+                  type: array
+                  items:
+                    type: string
+                internalRegistryHostname:
+                  description: internalRegistryHostname sets the hostname for the default internal image registry. The value must be in "hostname[:port]" format. This value is set by the image registry operator which controls the internal registry hostname.
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_imagecontentpolicy.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagecontentpolicy.crd.yaml
@@ -1,0 +1,68 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/874
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: imagecontentpolicies.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: ImageContentPolicy
+    listKind: ImageContentPolicyList
+    plural: imagecontentpolicies
+    singular: imagecontentpolicy
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "ImageContentPolicy holds cluster-wide information about how to handle registry mirror rules. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                repositoryDigestMirrors:
+                  description: "repositoryDigestMirrors allows images referenced by image digests in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in RepositoryDigestMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. To pull image from mirrors by tags, should set the \"allowMirrorByTags\". \n Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified."
+                  type: array
+                  items:
+                    description: RepositoryDigestMirrors holds cluster-wide information about how to handle mirrors in the registries config.
+                    type: object
+                    required:
+                      - source
+                    properties:
+                      allowMirrorByTags:
+                        description: allowMirrorByTags if true, the mirrors can be used to pull the images that are referenced by their tags. Default is false, the mirrors only work when pulling the images that are referenced by their digests. Pulling images by tag can potentially yield different images, depending on which endpoint we pull from. Forcing digest-pulls for mirrors avoids that issue.
+                        type: boolean
+                      mirrors:
+                        description: mirrors is zero or more repositories that may also contain the same images. If the "mirrors" is not specified, the image will continue to be pulled from the specified repository in the pull spec. No mirror will be configured. The order of mirrors in this list is treated as the user's desired priority, while source is by default considered lower priority than all mirrors. Other cluster configuration, including (but not limited to) other repositoryDigestMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering.
+                        type: array
+                        items:
+                          type: string
+                          pattern: ^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])(:[0-9]+)?(\/[^\/:\n]+)*(\/[^\/:\n]+((:[^\/:\n]+)|(@[^\n]+)))?$
+                        x-kubernetes-list-type: set
+                      source:
+                        description: source is the repository that users refer to, e.g. in image pull specifications.
+                        type: string
+                        pattern: ^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])(:[0-9]+)?(\/[^\/:\n]+)*(\/[^\/:\n]+((:[^\/:\n]+)|(@[^\n]+)))?$
+                  x-kubernetes-list-map-keys:
+                    - source
+                  x-kubernetes-list-type: map
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml
@@ -1,0 +1,59 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: imagecontentsourcepolicies.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: ImageContentSourcePolicy
+    listKind: ImageContentSourcePolicyList
+    plural: imagecontentsourcepolicies
+    singular: imagecontentsourcepolicy
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: "ImageContentSourcePolicy holds cluster-wide information about how to handle registry mirror rules. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                repositoryDigestMirrors:
+                  description: "repositoryDigestMirrors allows images referenced by image digests in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in RepositoryDigestMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. Only image pull specifications that have an image digest will have this behavior applied to them - tags will continue to be pulled from the specified repository in the pull spec. \n Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified."
+                  type: array
+                  items:
+                    description: 'RepositoryDigestMirrors holds cluster-wide information about how to handle mirros in the registries config. Note: the mirrors only work when pulling the images that are referenced by their digests.'
+                    type: object
+                    required:
+                      - source
+                    properties:
+                      mirrors:
+                        description: mirrors is one or more repositories that may also contain the same images. The order of mirrors in this list is treated as the user's desired priority, while source is by default considered lower priority than all mirrors. Other cluster configuration, including (but not limited to) other repositoryDigestMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering.
+                        type: array
+                        items:
+                          type: string
+                      source:
+                        description: source is the repository that users refer to, e.g. in image pull specifications.
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_imagedigestmirrorset.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagedigestmirrorset.crd.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1126
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: imagedigestmirrorsets.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: ImageDigestMirrorSet
+    listKind: ImageDigestMirrorSetList
+    plural: imagedigestmirrorsets
+    shortNames:
+      - idms
+    singular: imagedigestmirrorset
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "ImageDigestMirrorSet holds cluster-wide information about how to handle registry mirror rules on using digest pull specification. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                imageDigestMirrors:
+                  description: "imageDigestMirrors allows images referenced by image digests in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in imageDigestMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. To use mirrors to pull images using tag specification, users should configure a list of mirrors using \"ImageTagMirrorSet\" CRD. \n If the image pull specification matches the repository of \"source\" in multiple imagedigestmirrorset objects, only the objects which define the most specific namespace match will be used. For example, if there are objects using quay.io/libpod and quay.io/libpod/busybox as the \"source\", only the objects using quay.io/libpod/busybox are going to apply for pull specification quay.io/libpod/busybox. Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified. Users who want to use a specific order of mirrors, should configure them into one list of mirrors using the expected order."
+                  type: array
+                  items:
+                    description: ImageDigestMirrors holds cluster-wide information about how to handle mirrors in the registries config.
+                    type: object
+                    required:
+                      - source
+                    properties:
+                      mirrorSourcePolicy:
+                        description: mirrorSourcePolicy defines the fallback policy if fails to pull image from the mirrors. If unset, the image will continue to be pulled from the the repository in the pull spec. sourcePolicy is valid configuration only when one or more mirrors are in the mirror list.
+                        type: string
+                        enum:
+                          - NeverContactSource
+                          - AllowContactingSource
+                      mirrors:
+                        description: 'mirrors is zero or more locations that may also contain the same images. No mirror will be configured if not specified. Images can be pulled from these mirrors only if they are referenced by their digests. The mirrored location is obtained by replacing the part of the input reference that matches source by the mirrors entry, e.g. for registry.redhat.io/product/repo reference, a (source, mirror) pair *.redhat.io, mirror.local/redhat causes a mirror.local/redhat/product/repo repository to be used. The order of mirrors in this list is treated as the user''s desired priority, while source is by default considered lower priority than all mirrors. If no mirror is specified or all image pulls from the mirror list fail, the image will continue to be pulled from the repository in the pull spec unless explicitly prohibited by "mirrorSourcePolicy" Other cluster configuration, including (but not limited to) other imageDigestMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering. "mirrors" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
+                        type: array
+                        items:
+                          type: string
+                          pattern: ^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
+                        x-kubernetes-list-type: set
+                      source:
+                        description: 'source matches the repository that users refer to, e.g. in image pull specifications. Setting source to a registry hostname e.g. docker.io. quay.io, or registry.redhat.io, will match the image pull specification of corressponding registry. "source" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo [*.]host for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
+                        type: string
+                        pattern: ^\*(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$|^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
+                  x-kubernetes-list-type: atomic
+            status:
+              description: status contains the observed state of the resource.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_imagetagmirrorset.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagetagmirrorset.crd.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1126
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: imagetagmirrorsets.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: ImageTagMirrorSet
+    listKind: ImageTagMirrorSetList
+    plural: imagetagmirrorsets
+    shortNames:
+      - itms
+    singular: imagetagmirrorset
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "ImageTagMirrorSet holds cluster-wide information about how to handle registry mirror rules on using tag pull specification. When multiple policies are defined, the outcome of the behavior is defined on each field. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                imageTagMirrors:
+                  description: "imageTagMirrors allows images referenced by image tags in pods to be pulled from alternative mirrored repository locations. The image pull specification provided to the pod will be compared to the source locations described in imageTagMirrors and the image may be pulled down from any of the mirrors in the list instead of the specified repository allowing administrators to choose a potentially faster mirror. To use mirrors to pull images using digest specification only, users should configure a list of mirrors using \"ImageDigestMirrorSet\" CRD. \n If the image pull specification matches the repository of \"source\" in multiple imagetagmirrorset objects, only the objects which define the most specific namespace match will be used. For example, if there are objects using quay.io/libpod and quay.io/libpod/busybox as the \"source\", only the objects using quay.io/libpod/busybox are going to apply for pull specification quay.io/libpod/busybox. Each “source” repository is treated independently; configurations for different “source” repositories don’t interact. \n If the \"mirrors\" is not specified, the image will continue to be pulled from the specified repository in the pull spec. \n When multiple policies are defined for the same “source” repository, the sets of defined mirrors will be merged together, preserving the relative order of the mirrors, if possible. For example, if policy A has mirrors `a, b, c` and policy B has mirrors `c, d, e`, the mirrors will be used in the order `a, b, c, d, e`.  If the orders of mirror entries conflict (e.g. `a, b` vs. `b, a`) the configuration is not rejected but the resulting order is unspecified. Users who want to use a deterministic order of mirrors, should configure them into one list of mirrors using the expected order."
+                  type: array
+                  items:
+                    description: ImageTagMirrors holds cluster-wide information about how to handle mirrors in the registries config.
+                    type: object
+                    required:
+                      - source
+                    properties:
+                      mirrorSourcePolicy:
+                        description: mirrorSourcePolicy defines the fallback policy if fails to pull image from the mirrors. If unset, the image will continue to be pulled from the repository in the pull spec. sourcePolicy is valid configuration only when one or more mirrors are in the mirror list.
+                        type: string
+                        enum:
+                          - NeverContactSource
+                          - AllowContactingSource
+                      mirrors:
+                        description: 'mirrors is zero or more locations that may also contain the same images. No mirror will be configured if not specified. Images can be pulled from these mirrors only if they are referenced by their tags. The mirrored location is obtained by replacing the part of the input reference that matches source by the mirrors entry, e.g. for registry.redhat.io/product/repo reference, a (source, mirror) pair *.redhat.io, mirror.local/redhat causes a mirror.local/redhat/product/repo repository to be used. Pulling images by tag can potentially yield different images, depending on which endpoint we pull from. Configuring a list of mirrors using "ImageDigestMirrorSet" CRD and forcing digest-pulls for mirrors avoids that issue. The order of mirrors in this list is treated as the user''s desired priority, while source is by default considered lower priority than all mirrors. If no mirror is specified or all image pulls from the mirror list fail, the image will continue to be pulled from the repository in the pull spec unless explicitly prohibited by "mirrorSourcePolicy". Other cluster configuration, including (but not limited to) other imageTagMirrors objects, may impact the exact order mirrors are contacted in, or some mirrors may be contacted in parallel, so this should be considered a preference rather than a guarantee of ordering. "mirrors" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
+                        type: array
+                        items:
+                          type: string
+                          pattern: ^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
+                        x-kubernetes-list-type: set
+                      source:
+                        description: 'source matches the repository that users refer to, e.g. in image pull specifications. Setting source to a registry hostname e.g. docker.io. quay.io, or registry.redhat.io, will match the image pull specification of corressponding registry. "source" uses one of the following formats: host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo [*.]host for more information about the format, see the document about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
+                        type: string
+                        pattern: ^\*(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$|^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
+                  x-kubernetes-list-type: atomic
+            status:
+              description: status contains the observed state of the resource.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,1150 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: infrastructures.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Infrastructure
+    listKind: InfrastructureList
+    plural: infrastructures
+    singular: infrastructure
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Infrastructure holds cluster-wide information about Infrastructure.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              properties:
+                cloudConfig:
+                  description: "cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config. \n cloudConfig should only be consumed by the kube_cloud_config controller. The controller is responsible for using the user configuration in the spec for various platforms and combining that with the user provided ConfigMap in this field to create a stitched kube cloud config. The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace with the kube cloud config is stored in `cloud.conf` key. All the clients are expected to use the generated ConfigMap only."
+                  properties:
+                    key:
+                      description: Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.
+                      type: string
+                    name:
+                      type: string
+                  type: object
+                platformSpec:
+                  description: platformSpec holds desired information specific to the underlying infrastructure provider.
+                  properties:
+                    alibabaCloud:
+                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
+                      type: object
+                    aws:
+                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
+                      properties:
+                        serviceEndpoints:
+                          description: serviceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
+                          items:
+                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
+                            properties:
+                              name:
+                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                pattern: ^https://
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    azure:
+                      description: Azure contains settings specific to the Azure infrastructure provider.
+                      type: object
+                    baremetal:
+                      description: BareMetal contains settings specific to the BareMetal platform.
+                      type: object
+                    equinixMetal:
+                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
+                      type: object
+                    external:
+                      description: ExternalPlatformType represents generic infrastructure provider. Platform-specific components should be supplemented separately.
+                      properties:
+                        platformName:
+                          default: Unknown
+                          description: PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time. This field is solely for informational and reporting purposes and is not expected to be used for decision-making.
+                          type: string
+                          x-kubernetes-validations:
+                            - message: platform name cannot be changed once set
+                              rule: oldSelf == 'Unknown' || self == oldSelf
+                      type: object
+                    gcp:
+                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
+                      type: object
+                    ibmcloud:
+                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
+                      type: object
+                    kubevirt:
+                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
+                      type: object
+                    nutanix:
+                      description: Nutanix contains settings specific to the Nutanix infrastructure provider.
+                      properties:
+                        failureDomains:
+                          description: failureDomains configures failure domains information for the Nutanix platform. When set, the failure domains defined here may be used to spread Machines across prism element clusters to improve fault tolerance of the cluster.
+                          items:
+                            description: NutanixFailureDomain configures failure domain information for the Nutanix platform.
+                            properties:
+                              cluster:
+                                description: cluster is to identify the cluster (the Prism Element under management of the Prism Central), in which the Machine's VM will be created. The cluster identifier (uuid or name) can be obtained from the Prism Central console or using the prism_central API.
+                                properties:
+                                  name:
+                                    description: name is the resource name in the PC. It cannot be empty if the type is Name.
+                                    type: string
+                                  type:
+                                    description: type is the identifier type to use for this resource.
+                                    enum:
+                                      - UUID
+                                      - Name
+                                    type: string
+                                  uuid:
+                                    description: uuid is the UUID of the resource in the PC. It cannot be empty if the type is UUID.
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                                x-kubernetes-validations:
+                                  - message: uuid configuration is required when type is UUID, and forbidden otherwise
+                                    rule: 'has(self.type) && self.type == ''UUID'' ?  has(self.uuid) : !has(self.uuid)'
+                                  - message: name configuration is required when type is Name, and forbidden otherwise
+                                    rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name) : !has(self.name)'
+                              name:
+                                description: name defines the unique name of a failure domain. Name is required and must be at most 64 characters in length. It must consist of only lower case alphanumeric characters and hyphens (-). It must start and end with an alphanumeric character. This value is arbitrary and is used to identify the failure domain within the platform.
+                                maxLength: 64
+                                minLength: 1
+                                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                                type: string
+                              subnets:
+                                description: subnets holds a list of identifiers (one or more) of the cluster's network subnets for the Machine's VM to connect to. The subnet identifiers (uuid or name) can be obtained from the Prism Central console or using the prism_central API.
+                                items:
+                                  description: NutanixResourceIdentifier holds the identity of a Nutanix PC resource (cluster, image, subnet, etc.)
+                                  properties:
+                                    name:
+                                      description: name is the resource name in the PC. It cannot be empty if the type is Name.
+                                      type: string
+                                    type:
+                                      description: type is the identifier type to use for this resource.
+                                      enum:
+                                        - UUID
+                                        - Name
+                                      type: string
+                                    uuid:
+                                      description: uuid is the UUID of the resource in the PC. It cannot be empty if the type is UUID.
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                  x-kubernetes-validations:
+                                    - message: uuid configuration is required when type is UUID, and forbidden otherwise
+                                      rule: 'has(self.type) && self.type == ''UUID'' ?  has(self.uuid) : !has(self.uuid)'
+                                    - message: name configuration is required when type is Name, and forbidden otherwise
+                                      rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name) : !has(self.name)'
+                                maxItems: 1
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - type
+                                x-kubernetes-list-type: map
+                            required:
+                              - cluster
+                              - name
+                              - subnets
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        prismCentral:
+                          description: prismCentral holds the endpoint address and port to access the Nutanix Prism Central. When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
+                          properties:
+                            address:
+                              description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
+                              maxLength: 256
+                              type: string
+                            port:
+                              description: port is the port number to access the Nutanix Prism Central or Element (cluster)
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                            - address
+                            - port
+                          type: object
+                        prismElements:
+                          description: prismElements holds one or more endpoint address and port data to access the Nutanix Prism Elements (clusters) of the Nutanix Prism Central. Currently we only support one Prism Element (cluster) for an OpenShift cluster, where all the Nutanix resources (VMs, subnets, volumes, etc.) used in the OpenShift cluster are located. In the future, we may support Nutanix resources (VMs, etc.) spread over multiple Prism Elements (clusters) of the Prism Central.
+                          items:
+                            description: NutanixPrismElementEndpoint holds the name and endpoint data for a Prism Element (cluster)
+                            properties:
+                              endpoint:
+                                description: endpoint holds the endpoint address and port data of the Prism Element (cluster). When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
+                                properties:
+                                  address:
+                                    description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
+                                    maxLength: 256
+                                    type: string
+                                  port:
+                                    description: port is the port number to access the Nutanix Prism Central or Element (cluster)
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                  - address
+                                  - port
+                                type: object
+                              name:
+                                description: name is the name of the Prism Element (cluster). This value will correspond with the cluster field configured on other resources (eg Machines, PVCs, etc).
+                                maxLength: 256
+                                type: string
+                            required:
+                              - endpoint
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      required:
+                        - prismCentral
+                        - prismElements
+                      type: object
+                    openstack:
+                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
+                      type: object
+                    ovirt:
+                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
+                      type: object
+                    powervs:
+                      description: PowerVS contains settings specific to the IBM Power Systems Virtual Servers infrastructure provider.
+                      properties:
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
+                          items:
+                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
+                            properties:
+                              name:
+                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                format: uri
+                                pattern: ^https://
+                                type: string
+                            required:
+                              - name
+                              - url
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    type:
+                      description: type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud", "Nutanix" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                      type: string
+                    vsphere:
+                      description: VSphere contains settings specific to the VSphere infrastructure provider.
+                      properties:
+                        failureDomains:
+                          description: failureDomains contains the definition of region, zone and the vCenter topology. If this is omitted failure domains (regions and zones) will not be used.
+                          items:
+                            description: VSpherePlatformFailureDomainSpec holds the region and zone failure domain and the vCenter topology of that failure domain.
+                            properties:
+                              name:
+                                description: name defines the arbitrary but unique name of a failure domain.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              region:
+                                description: region defines the name of a region tag that will be attached to a vCenter datacenter. The tag category in vCenter must be named openshift-region.
+                                maxLength: 80
+                                minLength: 1
+                                type: string
+                              server:
+                                anyOf:
+                                  - format: ipv4
+                                  - format: ipv6
+                                  - format: hostname
+                                description: server is the fully-qualified domain name or the IP address of the vCenter server. ---
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                              topology:
+                                description: Topology describes a given failure domain using vSphere constructs
+                                properties:
+                                  computeCluster:
+                                    description: computeCluster the absolute path of the vCenter cluster in which virtual machine will be located. The absolute path is of the form /<datacenter>/host/<cluster>. The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/host/.*?
+                                    type: string
+                                  datacenter:
+                                    description: datacenter is the name of vCenter datacenter in which virtual machines will be located. The maximum length of the datacenter name is 80 characters.
+                                    maxLength: 80
+                                    type: string
+                                  datastore:
+                                    description: datastore is the absolute path of the datastore in which the virtual machine is located. The absolute path is of the form /<datacenter>/datastore/<datastore> The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/datastore/.*?
+                                    type: string
+                                  folder:
+                                    description: folder is the absolute path of the folder where virtual machines are located. The absolute path is of the form /<datacenter>/vm/<folder>. The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/vm/.*?
+                                    type: string
+                                  networks:
+                                    description: networks is the list of port group network names within this failure domain. Currently, we only support a single interface per RHCOS virtual machine. The available networks (port groups) can be listed using `govc ls 'network/*'` The single interface should be the absolute path of the form /<datacenter>/network/<portgroup>.
+                                    items:
+                                      type: string
+                                    maxItems: 1
+                                    minItems: 1
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resourcePool:
+                                    description: resourcePool is the absolute path of the resource pool where virtual machines will be created. The absolute path is of the form /<datacenter>/host/<cluster>/Resources/<resourcepool>. The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/host/.*?/Resources.*
+                                    type: string
+                                  template:
+                                    description: "template is the full inventory path of the virtual machine or template that will be cloned when creating new machines in this failure domain. The maximum length of the path is 2048 characters. \n When omitted, the template will be calculated by the control plane machineset operator based on the region and zone defined in VSpherePlatformFailureDomainSpec. For example, for zone=zonea, region=region1, and infrastructure name=test, the template path would be calculated as /<datacenter>/vm/test-rhcos-region1-zonea."
+                                    maxLength: 2048
+                                    minLength: 1
+                                    pattern: ^/.*?/vm/.*?
+                                    type: string
+                                required:
+                                  - computeCluster
+                                  - datacenter
+                                  - datastore
+                                  - networks
+                                type: object
+                              zone:
+                                description: zone defines the name of a zone tag that will be attached to a vCenter cluster. The tag category in vCenter must be named openshift-zone.
+                                maxLength: 80
+                                minLength: 1
+                                type: string
+                            required:
+                              - name
+                              - region
+                              - server
+                              - topology
+                              - zone
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        nodeNetworking:
+                          description: nodeNetworking contains the definition of internal and external network constraints for assigning the node's networking. If this field is omitted, networking defaults to the legacy address selection behavior which is to only support a single address and return the first one found.
+                          properties:
+                            external:
+                              description: external represents the network configuration of the node that is externally routable.
+                              properties:
+                                excludeNetworkSubnetCidr:
+                                  description: excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting the IP address from the VirtualMachine's VM for use in the status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                network:
+                                  description: network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`
+                                  type: string
+                                networkSubnetCidr:
+                                  description: networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs that will be used in respective status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              type: object
+                            internal:
+                              description: internal represents the network configuration of the node that is routable only within the cluster.
+                              properties:
+                                excludeNetworkSubnetCidr:
+                                  description: excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting the IP address from the VirtualMachine's VM for use in the status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                network:
+                                  description: network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`
+                                  type: string
+                                networkSubnetCidr:
+                                  description: networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs that will be used in respective status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              type: object
+                          type: object
+                        vcenters:
+                          description: vcenters holds the connection details for services to communicate with vCenter. Currently, only a single vCenter is supported. ---
+                          items:
+                            description: VSpherePlatformVCenterSpec stores the vCenter connection fields. This is used by the vSphere CCM.
+                            properties:
+                              datacenters:
+                                description: The vCenter Datacenters in which the RHCOS vm guests are located. This field will be used by the Cloud Controller Manager. Each datacenter listed here should be used within a topology.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: set
+                              port:
+                                description: port is the TCP port that will be used to communicate to the vCenter endpoint. When omitted, this means the user has no opinion and it is up to the platform to choose a sensible default, which is subject to change over time.
+                                format: int32
+                                maximum: 32767
+                                minimum: 1
+                                type: integer
+                              server:
+                                anyOf:
+                                  - format: ipv4
+                                  - format: ipv6
+                                  - format: hostname
+                                description: server is the fully-qualified domain name or the IP address of the vCenter server. ---
+                                maxLength: 255
+                                type: string
+                            required:
+                              - datacenters
+                              - server
+                            type: object
+                          maxItems: 1
+                          minItems: 0
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              properties:
+                apiServerInternalURI:
+                  description: apiServerInternalURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.
+                  type: string
+                apiServerURL:
+                  description: apiServerURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.
+                  type: string
+                controlPlaneTopology:
+                  default: HighlyAvailable
+                  description: controlPlaneTopology expresses the expectations for operands that normally run on control nodes. The default is 'HighlyAvailable', which represents the behavior operators have in a "normal" cluster. The 'SingleReplica' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation The 'External' mode indicates that the control plane is hosted externally to the cluster and that its components are not visible within the cluster.
+                  enum:
+                    - HighlyAvailable
+                    - SingleReplica
+                    - External
+                  type: string
+                cpuPartitioning:
+                  default: None
+                  description: cpuPartitioning expresses if CPU partitioning is a currently enabled feature in the cluster. CPU Partitioning means that this cluster can support partitioning workloads to specific CPU Sets. Valid values are "None" and "AllNodes". When omitted, the default value is "None". The default value of "None" indicates that no nodes will be setup with CPU partitioning. The "AllNodes" value indicates that all nodes have been setup with CPU partitioning, and can then be further configured via the PerformanceProfile API.
+                  enum:
+                    - None
+                    - AllNodes
+                  type: string
+                etcdDiscoveryDomain:
+                  description: 'etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery deprecated: as of 4.7, this field is no longer set or honored.  It will be removed in a future release.'
+                  type: string
+                infrastructureName:
+                  description: infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.
+                  type: string
+                infrastructureTopology:
+                  default: HighlyAvailable
+                  description: 'infrastructureTopology expresses the expectations for infrastructure services that do not run on control plane nodes, usually indicated by a node selector for a `role` value other than `master`. The default is ''HighlyAvailable'', which represents the behavior operators have in a "normal" cluster. The ''SingleReplica'' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation NOTE: External topology mode is not applicable for this field.'
+                  enum:
+                    - HighlyAvailable
+                    - SingleReplica
+                  type: string
+                platform:
+                  description: "platform is the underlying infrastructure provider for the cluster. \n Deprecated: Use platformStatus.type instead."
+                  enum:
+                    - ""
+                    - AWS
+                    - Azure
+                    - BareMetal
+                    - GCP
+                    - Libvirt
+                    - OpenStack
+                    - None
+                    - VSphere
+                    - oVirt
+                    - IBMCloud
+                    - KubeVirt
+                    - EquinixMetal
+                    - PowerVS
+                    - AlibabaCloud
+                    - Nutanix
+                    - External
+                  type: string
+                platformStatus:
+                  description: platformStatus holds status information specific to the underlying infrastructure provider.
+                  properties:
+                    alibabaCloud:
+                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
+                      properties:
+                        region:
+                          description: region specifies the region for Alibaba Cloud resources created for the cluster.
+                          pattern: ^[0-9A-Za-z-]+$
+                          type: string
+                        resourceGroupID:
+                          description: resourceGroupID is the ID of the resource group for the cluster.
+                          pattern: ^(rg-[0-9A-Za-z]+)?$
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.
+                          items:
+                            description: AlibabaCloudResourceTag is the set of tags to add to apply to resources.
+                            properties:
+                              key:
+                                description: key is the key of the tag.
+                                maxLength: 128
+                                minLength: 1
+                                type: string
+                              value:
+                                description: value is the value of the tag.
+                                maxLength: 128
+                                minLength: 1
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 20
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                      required:
+                        - region
+                      type: object
+                    aws:
+                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
+                      properties:
+                        region:
+                          description: region holds the default AWS region for new AWS resources created by the cluster.
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.
+                          items:
+                            description: AWSResourceTag is a tag to apply to AWS resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key of the tag
+                                maxLength: 128
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                type: string
+                              value:
+                                description: value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 25
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        serviceEndpoints:
+                          description: ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
+                          items:
+                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
+                            properties:
+                              name:
+                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                pattern: ^https://
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    azure:
+                      description: Azure contains settings specific to the Azure infrastructure provider.
+                      properties:
+                        armEndpoint:
+                          description: armEndpoint specifies a URL to use for resource management in non-soverign clouds such as Azure Stack.
+                          type: string
+                        cloudName:
+                          description: cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the value is equal to `AzurePublicCloud`.
+                          enum:
+                            - ""
+                            - AzurePublicCloud
+                            - AzureUSGovernmentCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureStackCloud
+                          type: string
+                        networkResourceGroupName:
+                          description: networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster. If empty, the value is same as ResourceGroupName.
+                          type: string
+                        resourceGroupName:
+                          description: resourceGroupName is the Resource Group for new Azure resources created for the cluster.
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to Azure resources created for the cluster. See https://docs.microsoft.com/en-us/rest/api/resources/tags for information on tagging Azure resources. Due to limitations on Automation, Content Delivery Network, DNS Azure resources, a maximum of 15 tags may be applied. OpenShift reserves 5 tags for internal use, allowing 10 tags for user configuration.
+                          items:
+                            description: AzureResourceTag is a tag to apply to Azure resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key part of the tag. A tag key can have a maximum of 128 characters and cannot be empty. Key must begin with a letter, end with a letter, number or underscore, and must contain only alphanumeric characters and the following special characters `_ . -`.
+                                maxLength: 128
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([0-9A-Za-z_.-]*[0-9A-Za-z_])?$
+                                type: string
+                              value:
+                                description: 'value is the value part of the tag. A tag value can have a maximum of 256 characters and cannot be empty. Value must contain only alphanumeric characters and the following special characters `_ + , - . / : ; < = > ? @`.'
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.=+-@]+$
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 10
+                          type: array
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                            - message: resourceTags are immutable and may only be configured during installation
+                              rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                      type: object
+                      x-kubernetes-validations:
+                        - message: resourceTags may only be configured during installation
+                          rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags) || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                    baremetal:
+                      description: BareMetal contains settings specific to the BareMetal platform.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on BareMetal platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for BareMetal deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                      type: object
+                    equinixMetal:
+                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                      type: object
+                    external:
+                      description: External contains settings specific to the generic External infrastructure provider.
+                      properties:
+                        cloudControllerManager:
+                          description: cloudControllerManager contains settings specific to the external Cloud Controller Manager (a.k.a. CCM or CPI). When omitted, new nodes will be not tainted and no extra initialization from the cloud controller manager is expected.
+                          properties:
+                            state:
+                              description: "state determines whether or not an external Cloud Controller Manager is expected to be installed within the cluster. https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager \n Valid values are \"External\", \"None\" and omitted. When set to \"External\", new nodes will be tainted as uninitialized when created, preventing them from running workloads until they are initialized by the cloud controller manager. When omitted or set to \"None\", new nodes will be not tainted and no extra initialization from the cloud controller manager is expected."
+                              enum:
+                                - ""
+                                - External
+                                - None
+                              type: string
+                              x-kubernetes-validations:
+                                - message: state is immutable once set
+                                  rule: self == oldSelf
+                          type: object
+                          x-kubernetes-validations:
+                            - message: state may not be added or removed once set
+                              rule: (has(self.state) == has(oldSelf.state)) || (!has(oldSelf.state) && self.state != "External")
+                      type: object
+                      x-kubernetes-validations:
+                        - message: cloudControllerManager may not be added or removed once set
+                          rule: has(self.cloudControllerManager) == has(oldSelf.cloudControllerManager)
+                    gcp:
+                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
+                      properties:
+                        clusterHostedDNS:
+                          default: Disabled
+                          description: clusterHostedDNS indicates the type of DNS solution in use within the cluster. Its default value of "Disabled" indicates that the cluster's DNS is the default provided by the cloud platform. It can be "Enabled" during install to bypass the configuration of the cloud default DNS. When "Enabled", the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed. The cluster's use of the cloud's Load Balancers is unaffected by this setting. The value is immutable after it has been set at install time. Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS. Enabling this functionality allows the user to start their own DNS solution outside the cluster after installation is complete. The customer would be responsible for configuring this custom DNS solution, and it can be run in addition to the in-cluster DNS solution.
+                          enum:
+                            - Enabled
+                            - Disabled
+                          type: string
+                          x-kubernetes-validations:
+                            - message: clusterHostedDNS is immutable and may only be configured during installation
+                              rule: self == oldSelf
+                        projectID:
+                          description: resourceGroupName is the Project ID for new GCP resources created for the cluster.
+                          type: string
+                        region:
+                          description: region holds the region for new GCP resources created for the cluster.
+                          type: string
+                        resourceLabels:
+                          description: resourceLabels is a list of additional labels to apply to GCP resources created for the cluster. See https://cloud.google.com/compute/docs/labeling-resources for information on labeling GCP resources. GCP supports a maximum of 64 labels per resource. OpenShift reserves 32 labels for internal use, allowing 32 labels for user configuration.
+                          items:
+                            description: GCPResourceLabel is a label to apply to GCP resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key part of the label. A label key can have a maximum of 63 characters and cannot be empty. Label key must begin with a lowercase letter, and must contain only lowercase letters, numeric characters, and the following special characters `_-`. Label key must not have the reserved prefixes `kubernetes-io` and `openshift-io`.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z][0-9a-z_-]{0,62}$
+                                type: string
+                                x-kubernetes-validations:
+                                  - message: label keys must not start with either `openshift-io` or `kubernetes-io`
+                                    rule: '!self.startsWith(''openshift-io'') && !self.startsWith(''kubernetes-io'')'
+                              value:
+                                description: value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty. Value must contain only lowercase letters, numeric characters, and the following special characters `_-`.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[0-9a-z_-]{1,63}$
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                          x-kubernetes-validations:
+                            - message: resourceLabels are immutable and may only be configured during installation
+                              rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to GCP resources created for the cluster. See https://cloud.google.com/resource-manager/docs/tags/tags-overview for information on tagging GCP resources. GCP supports a maximum of 50 tags per resource.
+                          items:
+                            description: GCPResourceTag is a tag to apply to GCP resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key part of the tag. A tag key can have a maximum of 63 characters and cannot be empty. Tag key must begin and end with an alphanumeric character, and must contain only uppercase, lowercase alphanumeric characters, and the following special characters `._-`.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.-]{0,61}[a-zA-Z0-9])?$
+                                type: string
+                              parentID:
+                                description: 'parentID is the ID of the hierarchical resource where the tags are defined, e.g. at the Organization or the Project level. To find the Organization or Project ID refer to the following pages: https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id, https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects. An OrganizationID must consist of decimal numbers, and cannot have leading zeroes. A ProjectID must be 6 to 30 characters in length, can only contain lowercase letters, numbers, and hyphens, and must start with a letter, and cannot end with a hyphen.'
+                                maxLength: 32
+                                minLength: 1
+                                pattern: (^[1-9][0-9]{0,31}$)|(^[a-z][a-z0-9-]{4,28}[a-z0-9]$)
+                                type: string
+                              value:
+                                description: value is the value part of the tag. A tag value can have a maximum of 63 characters and cannot be empty. Tag value must begin and end with an alphanumeric character, and must contain only uppercase, lowercase alphanumeric characters, and the following special characters `_-.@%=+:,*#&(){}[]` and spaces.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.@%=+:,*#&()\[\]{}\-\s]{0,61}[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                              - key
+                              - parentID
+                              - value
+                            type: object
+                          maxItems: 50
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                          x-kubernetes-validations:
+                            - message: resourceTags are immutable and may only be configured during installation
+                              rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                      type: object
+                      x-kubernetes-validations:
+                        - message: resourceLabels may only be configured during installation
+                          rule: '!has(oldSelf.resourceLabels) && !has(self.resourceLabels) || has(oldSelf.resourceLabels) && has(self.resourceLabels)'
+                        - message: resourceTags may only be configured during installation
+                          rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags) || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                    ibmcloud:
+                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
+                      properties:
+                        cisInstanceCRN:
+                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        dnsInstanceCRN:
+                          description: DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        location:
+                          description: Location is where the cluster has been deployed
+                          type: string
+                        providerType:
+                          description: ProviderType indicates the type of cluster that was created
+                          type: string
+                        resourceGroupName:
+                          description: ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.
+                          type: string
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM Cloud service. These endpoints are consumed by components within the cluster to reach the respective IBM Cloud Services.
+                          items:
+                            description: IBMCloudServiceEndpoint stores the configuration of a custom url to override existing defaults of IBM Cloud Services.
+                            properties:
+                              name:
+                                description: 'name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`'
+                                enum:
+                                  - CIS
+                                  - COS
+                                  - DNSServices
+                                  - GlobalSearch
+                                  - GlobalTagging
+                                  - HyperProtect
+                                  - IAM
+                                  - KeyProtect
+                                  - ResourceController
+                                  - ResourceManager
+                                  - VPC
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                type: string
+                                x-kubernetes-validations:
+                                  - message: url must be a valid absolute URL
+                                    rule: isURL(self)
+                            required:
+                              - name
+                              - url
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    kubevirt:
+                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                      type: object
+                    nutanix:
+                      description: Nutanix contains settings specific to the Nutanix infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on Nutanix platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                      type: object
+                    openstack:
+                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        cloudName:
+                          description: cloudName is the name of the desired OpenStack cloud in the client configuration file (`clouds.yaml`).
+                          type: string
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on OpenStack platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for OpenStack deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                      type: object
+                    ovirt:
+                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on Ovirt platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                        nodeDNSIP:
+                          description: 'deprecated: as of 4.6, this field is no longer set or honored.  It will be removed in a future release.'
+                          type: string
+                      type: object
+                    powervs:
+                      description: PowerVS contains settings specific to the Power Systems Virtual Servers infrastructure provider.
+                      properties:
+                        cisInstanceCRN:
+                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        dnsInstanceCRN:
+                          description: DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        region:
+                          description: region holds the default Power VS region for new Power VS resources created by the cluster.
+                          type: string
+                        resourceGroup:
+                          description: 'resourceGroup is the resource group name for new IBMCloud resources created for a cluster. The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry. More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs. When omitted, the image registry operator won''t be able to configure storage, which results in the image registry cluster operator not being in an available state.'
+                          maxLength: 40
+                          pattern: ^[a-zA-Z0-9-_ ]+$
+                          type: string
+                          x-kubernetes-validations:
+                            - message: resourceGroup is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
+                          items:
+                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
+                            properties:
+                              name:
+                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                format: uri
+                                pattern: ^https://
+                                type: string
+                            required:
+                              - name
+                              - url
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        zone:
+                          description: 'zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported'
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: cannot unset resourceGroup once set
+                          rule: '!has(oldSelf.resourceGroup) || has(self.resourceGroup)'
+                    type:
+                      description: "type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform. \n This value will be synced with to the `status.platform` and `status.platformStatus.type`. Currently this value cannot be changed once set."
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                      type: string
+                    vsphere:
+                      description: VSphere contains settings specific to the VSphere infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on VSphere platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for vSphere deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                      type: object
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructure-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructure-Default.crd.yaml
@@ -1,0 +1,997 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
+  name: infrastructures.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Infrastructure
+    listKind: InfrastructureList
+    plural: infrastructures
+    singular: infrastructure
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Infrastructure holds cluster-wide information about Infrastructure.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              properties:
+                cloudConfig:
+                  description: "cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config. \n cloudConfig should only be consumed by the kube_cloud_config controller. The controller is responsible for using the user configuration in the spec for various platforms and combining that with the user provided ConfigMap in this field to create a stitched kube cloud config. The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace with the kube cloud config is stored in `cloud.conf` key. All the clients are expected to use the generated ConfigMap only."
+                  properties:
+                    key:
+                      description: Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.
+                      type: string
+                    name:
+                      type: string
+                  type: object
+                platformSpec:
+                  description: platformSpec holds desired information specific to the underlying infrastructure provider.
+                  properties:
+                    alibabaCloud:
+                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
+                      type: object
+                    aws:
+                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
+                      properties:
+                        serviceEndpoints:
+                          description: serviceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
+                          items:
+                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
+                            properties:
+                              name:
+                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                pattern: ^https://
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    azure:
+                      description: Azure contains settings specific to the Azure infrastructure provider.
+                      type: object
+                    baremetal:
+                      description: BareMetal contains settings specific to the BareMetal platform.
+                      type: object
+                    equinixMetal:
+                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
+                      type: object
+                    external:
+                      description: ExternalPlatformType represents generic infrastructure provider. Platform-specific components should be supplemented separately.
+                      properties:
+                        platformName:
+                          default: Unknown
+                          description: PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time. This field is solely for informational and reporting purposes and is not expected to be used for decision-making.
+                          type: string
+                          x-kubernetes-validations:
+                            - message: platform name cannot be changed once set
+                              rule: oldSelf == 'Unknown' || self == oldSelf
+                      type: object
+                    gcp:
+                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
+                      type: object
+                    ibmcloud:
+                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
+                      type: object
+                    kubevirt:
+                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
+                      type: object
+                    nutanix:
+                      description: Nutanix contains settings specific to the Nutanix infrastructure provider.
+                      properties:
+                        failureDomains:
+                          description: failureDomains configures failure domains information for the Nutanix platform. When set, the failure domains defined here may be used to spread Machines across prism element clusters to improve fault tolerance of the cluster.
+                          items:
+                            description: NutanixFailureDomain configures failure domain information for the Nutanix platform.
+                            properties:
+                              cluster:
+                                description: cluster is to identify the cluster (the Prism Element under management of the Prism Central), in which the Machine's VM will be created. The cluster identifier (uuid or name) can be obtained from the Prism Central console or using the prism_central API.
+                                properties:
+                                  name:
+                                    description: name is the resource name in the PC. It cannot be empty if the type is Name.
+                                    type: string
+                                  type:
+                                    description: type is the identifier type to use for this resource.
+                                    enum:
+                                      - UUID
+                                      - Name
+                                    type: string
+                                  uuid:
+                                    description: uuid is the UUID of the resource in the PC. It cannot be empty if the type is UUID.
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                                x-kubernetes-validations:
+                                  - message: uuid configuration is required when type is UUID, and forbidden otherwise
+                                    rule: 'has(self.type) && self.type == ''UUID'' ?  has(self.uuid) : !has(self.uuid)'
+                                  - message: name configuration is required when type is Name, and forbidden otherwise
+                                    rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name) : !has(self.name)'
+                              name:
+                                description: name defines the unique name of a failure domain. Name is required and must be at most 64 characters in length. It must consist of only lower case alphanumeric characters and hyphens (-). It must start and end with an alphanumeric character. This value is arbitrary and is used to identify the failure domain within the platform.
+                                maxLength: 64
+                                minLength: 1
+                                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                                type: string
+                              subnets:
+                                description: subnets holds a list of identifiers (one or more) of the cluster's network subnets for the Machine's VM to connect to. The subnet identifiers (uuid or name) can be obtained from the Prism Central console or using the prism_central API.
+                                items:
+                                  description: NutanixResourceIdentifier holds the identity of a Nutanix PC resource (cluster, image, subnet, etc.)
+                                  properties:
+                                    name:
+                                      description: name is the resource name in the PC. It cannot be empty if the type is Name.
+                                      type: string
+                                    type:
+                                      description: type is the identifier type to use for this resource.
+                                      enum:
+                                        - UUID
+                                        - Name
+                                      type: string
+                                    uuid:
+                                      description: uuid is the UUID of the resource in the PC. It cannot be empty if the type is UUID.
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                  x-kubernetes-validations:
+                                    - message: uuid configuration is required when type is UUID, and forbidden otherwise
+                                      rule: 'has(self.type) && self.type == ''UUID'' ?  has(self.uuid) : !has(self.uuid)'
+                                    - message: name configuration is required when type is Name, and forbidden otherwise
+                                      rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name) : !has(self.name)'
+                                maxItems: 1
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - type
+                                x-kubernetes-list-type: map
+                            required:
+                              - cluster
+                              - name
+                              - subnets
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        prismCentral:
+                          description: prismCentral holds the endpoint address and port to access the Nutanix Prism Central. When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
+                          properties:
+                            address:
+                              description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
+                              maxLength: 256
+                              type: string
+                            port:
+                              description: port is the port number to access the Nutanix Prism Central or Element (cluster)
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                            - address
+                            - port
+                          type: object
+                        prismElements:
+                          description: prismElements holds one or more endpoint address and port data to access the Nutanix Prism Elements (clusters) of the Nutanix Prism Central. Currently we only support one Prism Element (cluster) for an OpenShift cluster, where all the Nutanix resources (VMs, subnets, volumes, etc.) used in the OpenShift cluster are located. In the future, we may support Nutanix resources (VMs, etc.) spread over multiple Prism Elements (clusters) of the Prism Central.
+                          items:
+                            description: NutanixPrismElementEndpoint holds the name and endpoint data for a Prism Element (cluster)
+                            properties:
+                              endpoint:
+                                description: endpoint holds the endpoint address and port data of the Prism Element (cluster). When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
+                                properties:
+                                  address:
+                                    description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
+                                    maxLength: 256
+                                    type: string
+                                  port:
+                                    description: port is the port number to access the Nutanix Prism Central or Element (cluster)
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                  - address
+                                  - port
+                                type: object
+                              name:
+                                description: name is the name of the Prism Element (cluster). This value will correspond with the cluster field configured on other resources (eg Machines, PVCs, etc).
+                                maxLength: 256
+                                type: string
+                            required:
+                              - endpoint
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      required:
+                        - prismCentral
+                        - prismElements
+                      type: object
+                    openstack:
+                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
+                      type: object
+                    ovirt:
+                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
+                      type: object
+                    powervs:
+                      description: PowerVS contains settings specific to the IBM Power Systems Virtual Servers infrastructure provider.
+                      properties:
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
+                          items:
+                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
+                            properties:
+                              name:
+                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                format: uri
+                                pattern: ^https://
+                                type: string
+                            required:
+                              - name
+                              - url
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    type:
+                      description: type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud", "Nutanix" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                      type: string
+                    vsphere:
+                      description: VSphere contains settings specific to the VSphere infrastructure provider.
+                      properties:
+                        failureDomains:
+                          description: failureDomains contains the definition of region, zone and the vCenter topology. If this is omitted failure domains (regions and zones) will not be used.
+                          items:
+                            description: VSpherePlatformFailureDomainSpec holds the region and zone failure domain and the vCenter topology of that failure domain.
+                            properties:
+                              name:
+                                description: name defines the arbitrary but unique name of a failure domain.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              region:
+                                description: region defines the name of a region tag that will be attached to a vCenter datacenter. The tag category in vCenter must be named openshift-region.
+                                maxLength: 80
+                                minLength: 1
+                                type: string
+                              server:
+                                anyOf:
+                                  - format: ipv4
+                                  - format: ipv6
+                                  - format: hostname
+                                description: server is the fully-qualified domain name or the IP address of the vCenter server. ---
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                              topology:
+                                description: Topology describes a given failure domain using vSphere constructs
+                                properties:
+                                  computeCluster:
+                                    description: computeCluster the absolute path of the vCenter cluster in which virtual machine will be located. The absolute path is of the form /<datacenter>/host/<cluster>. The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/host/.*?
+                                    type: string
+                                  datacenter:
+                                    description: datacenter is the name of vCenter datacenter in which virtual machines will be located. The maximum length of the datacenter name is 80 characters.
+                                    maxLength: 80
+                                    type: string
+                                  datastore:
+                                    description: datastore is the absolute path of the datastore in which the virtual machine is located. The absolute path is of the form /<datacenter>/datastore/<datastore> The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/datastore/.*?
+                                    type: string
+                                  folder:
+                                    description: folder is the absolute path of the folder where virtual machines are located. The absolute path is of the form /<datacenter>/vm/<folder>. The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/vm/.*?
+                                    type: string
+                                  networks:
+                                    description: networks is the list of port group network names within this failure domain. Currently, we only support a single interface per RHCOS virtual machine. The available networks (port groups) can be listed using `govc ls 'network/*'` The single interface should be the absolute path of the form /<datacenter>/network/<portgroup>.
+                                    items:
+                                      type: string
+                                    maxItems: 1
+                                    minItems: 1
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resourcePool:
+                                    description: resourcePool is the absolute path of the resource pool where virtual machines will be created. The absolute path is of the form /<datacenter>/host/<cluster>/Resources/<resourcepool>. The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/host/.*?/Resources.*
+                                    type: string
+                                required:
+                                  - computeCluster
+                                  - datacenter
+                                  - datastore
+                                  - networks
+                                type: object
+                              zone:
+                                description: zone defines the name of a zone tag that will be attached to a vCenter cluster. The tag category in vCenter must be named openshift-zone.
+                                maxLength: 80
+                                minLength: 1
+                                type: string
+                            required:
+                              - name
+                              - region
+                              - server
+                              - topology
+                              - zone
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        nodeNetworking:
+                          description: nodeNetworking contains the definition of internal and external network constraints for assigning the node's networking. If this field is omitted, networking defaults to the legacy address selection behavior which is to only support a single address and return the first one found.
+                          properties:
+                            external:
+                              description: external represents the network configuration of the node that is externally routable.
+                              properties:
+                                excludeNetworkSubnetCidr:
+                                  description: excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting the IP address from the VirtualMachine's VM for use in the status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                network:
+                                  description: network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`
+                                  type: string
+                                networkSubnetCidr:
+                                  description: networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs that will be used in respective status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              type: object
+                            internal:
+                              description: internal represents the network configuration of the node that is routable only within the cluster.
+                              properties:
+                                excludeNetworkSubnetCidr:
+                                  description: excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting the IP address from the VirtualMachine's VM for use in the status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                network:
+                                  description: network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`
+                                  type: string
+                                networkSubnetCidr:
+                                  description: networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs that will be used in respective status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              type: object
+                          type: object
+                        vcenters:
+                          description: vcenters holds the connection details for services to communicate with vCenter. Currently, only a single vCenter is supported. ---
+                          items:
+                            description: VSpherePlatformVCenterSpec stores the vCenter connection fields. This is used by the vSphere CCM.
+                            properties:
+                              datacenters:
+                                description: The vCenter Datacenters in which the RHCOS vm guests are located. This field will be used by the Cloud Controller Manager. Each datacenter listed here should be used within a topology.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: set
+                              port:
+                                description: port is the TCP port that will be used to communicate to the vCenter endpoint. When omitted, this means the user has no opinion and it is up to the platform to choose a sensible default, which is subject to change over time.
+                                format: int32
+                                maximum: 32767
+                                minimum: 1
+                                type: integer
+                              server:
+                                anyOf:
+                                  - format: ipv4
+                                  - format: ipv6
+                                  - format: hostname
+                                description: server is the fully-qualified domain name or the IP address of the vCenter server. ---
+                                maxLength: 255
+                                type: string
+                            required:
+                              - datacenters
+                              - server
+                            type: object
+                          maxItems: 1
+                          minItems: 0
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              properties:
+                apiServerInternalURI:
+                  description: apiServerInternalURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.
+                  type: string
+                apiServerURL:
+                  description: apiServerURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.
+                  type: string
+                controlPlaneTopology:
+                  default: HighlyAvailable
+                  description: controlPlaneTopology expresses the expectations for operands that normally run on control nodes. The default is 'HighlyAvailable', which represents the behavior operators have in a "normal" cluster. The 'SingleReplica' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation The 'External' mode indicates that the control plane is hosted externally to the cluster and that its components are not visible within the cluster.
+                  enum:
+                    - HighlyAvailable
+                    - SingleReplica
+                    - External
+                  type: string
+                cpuPartitioning:
+                  default: None
+                  description: cpuPartitioning expresses if CPU partitioning is a currently enabled feature in the cluster. CPU Partitioning means that this cluster can support partitioning workloads to specific CPU Sets. Valid values are "None" and "AllNodes". When omitted, the default value is "None". The default value of "None" indicates that no nodes will be setup with CPU partitioning. The "AllNodes" value indicates that all nodes have been setup with CPU partitioning, and can then be further configured via the PerformanceProfile API.
+                  enum:
+                    - None
+                    - AllNodes
+                  type: string
+                etcdDiscoveryDomain:
+                  description: 'etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery deprecated: as of 4.7, this field is no longer set or honored.  It will be removed in a future release.'
+                  type: string
+                infrastructureName:
+                  description: infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.
+                  type: string
+                infrastructureTopology:
+                  default: HighlyAvailable
+                  description: 'infrastructureTopology expresses the expectations for infrastructure services that do not run on control plane nodes, usually indicated by a node selector for a `role` value other than `master`. The default is ''HighlyAvailable'', which represents the behavior operators have in a "normal" cluster. The ''SingleReplica'' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation NOTE: External topology mode is not applicable for this field.'
+                  enum:
+                    - HighlyAvailable
+                    - SingleReplica
+                  type: string
+                platform:
+                  description: "platform is the underlying infrastructure provider for the cluster. \n Deprecated: Use platformStatus.type instead."
+                  enum:
+                    - ""
+                    - AWS
+                    - Azure
+                    - BareMetal
+                    - GCP
+                    - Libvirt
+                    - OpenStack
+                    - None
+                    - VSphere
+                    - oVirt
+                    - IBMCloud
+                    - KubeVirt
+                    - EquinixMetal
+                    - PowerVS
+                    - AlibabaCloud
+                    - Nutanix
+                    - External
+                  type: string
+                platformStatus:
+                  description: platformStatus holds status information specific to the underlying infrastructure provider.
+                  properties:
+                    alibabaCloud:
+                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
+                      properties:
+                        region:
+                          description: region specifies the region for Alibaba Cloud resources created for the cluster.
+                          pattern: ^[0-9A-Za-z-]+$
+                          type: string
+                        resourceGroupID:
+                          description: resourceGroupID is the ID of the resource group for the cluster.
+                          pattern: ^(rg-[0-9A-Za-z]+)?$
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.
+                          items:
+                            description: AlibabaCloudResourceTag is the set of tags to add to apply to resources.
+                            properties:
+                              key:
+                                description: key is the key of the tag.
+                                maxLength: 128
+                                minLength: 1
+                                type: string
+                              value:
+                                description: value is the value of the tag.
+                                maxLength: 128
+                                minLength: 1
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 20
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                      required:
+                        - region
+                      type: object
+                    aws:
+                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
+                      properties:
+                        region:
+                          description: region holds the default AWS region for new AWS resources created by the cluster.
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.
+                          items:
+                            description: AWSResourceTag is a tag to apply to AWS resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key of the tag
+                                maxLength: 128
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                type: string
+                              value:
+                                description: value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 25
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        serviceEndpoints:
+                          description: ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
+                          items:
+                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
+                            properties:
+                              name:
+                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                pattern: ^https://
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    azure:
+                      description: Azure contains settings specific to the Azure infrastructure provider.
+                      properties:
+                        armEndpoint:
+                          description: armEndpoint specifies a URL to use for resource management in non-soverign clouds such as Azure Stack.
+                          type: string
+                        cloudName:
+                          description: cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the value is equal to `AzurePublicCloud`.
+                          enum:
+                            - ""
+                            - AzurePublicCloud
+                            - AzureUSGovernmentCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureStackCloud
+                          type: string
+                        networkResourceGroupName:
+                          description: networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster. If empty, the value is same as ResourceGroupName.
+                          type: string
+                        resourceGroupName:
+                          description: resourceGroupName is the Resource Group for new Azure resources created for the cluster.
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to Azure resources created for the cluster. See https://docs.microsoft.com/en-us/rest/api/resources/tags for information on tagging Azure resources. Due to limitations on Automation, Content Delivery Network, DNS Azure resources, a maximum of 15 tags may be applied. OpenShift reserves 5 tags for internal use, allowing 10 tags for user configuration.
+                          items:
+                            description: AzureResourceTag is a tag to apply to Azure resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key part of the tag. A tag key can have a maximum of 128 characters and cannot be empty. Key must begin with a letter, end with a letter, number or underscore, and must contain only alphanumeric characters and the following special characters `_ . -`.
+                                maxLength: 128
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([0-9A-Za-z_.-]*[0-9A-Za-z_])?$
+                                type: string
+                              value:
+                                description: 'value is the value part of the tag. A tag value can have a maximum of 256 characters and cannot be empty. Value must contain only alphanumeric characters and the following special characters `_ + , - . / : ; < = > ? @`.'
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.=+-@]+$
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 10
+                          type: array
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                            - message: resourceTags are immutable and may only be configured during installation
+                              rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                      type: object
+                      x-kubernetes-validations:
+                        - message: resourceTags may only be configured during installation
+                          rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags) || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                    baremetal:
+                      description: BareMetal contains settings specific to the BareMetal platform.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for BareMetal deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                      type: object
+                    equinixMetal:
+                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                      type: object
+                    external:
+                      description: External contains settings specific to the generic External infrastructure provider.
+                      properties:
+                        cloudControllerManager:
+                          description: cloudControllerManager contains settings specific to the external Cloud Controller Manager (a.k.a. CCM or CPI). When omitted, new nodes will be not tainted and no extra initialization from the cloud controller manager is expected.
+                          properties:
+                            state:
+                              description: "state determines whether or not an external Cloud Controller Manager is expected to be installed within the cluster. https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager \n Valid values are \"External\", \"None\" and omitted. When set to \"External\", new nodes will be tainted as uninitialized when created, preventing them from running workloads until they are initialized by the cloud controller manager. When omitted or set to \"None\", new nodes will be not tainted and no extra initialization from the cloud controller manager is expected."
+                              enum:
+                                - ""
+                                - External
+                                - None
+                              type: string
+                              x-kubernetes-validations:
+                                - message: state is immutable once set
+                                  rule: self == oldSelf
+                          type: object
+                          x-kubernetes-validations:
+                            - message: state may not be added or removed once set
+                              rule: (has(self.state) == has(oldSelf.state)) || (!has(oldSelf.state) && self.state != "External")
+                      type: object
+                      x-kubernetes-validations:
+                        - message: cloudControllerManager may not be added or removed once set
+                          rule: has(self.cloudControllerManager) == has(oldSelf.cloudControllerManager)
+                    gcp:
+                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
+                      properties:
+                        projectID:
+                          description: resourceGroupName is the Project ID for new GCP resources created for the cluster.
+                          type: string
+                        region:
+                          description: region holds the region for new GCP resources created for the cluster.
+                          type: string
+                      type: object
+                    ibmcloud:
+                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
+                      properties:
+                        cisInstanceCRN:
+                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        dnsInstanceCRN:
+                          description: DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        location:
+                          description: Location is where the cluster has been deployed
+                          type: string
+                        providerType:
+                          description: ProviderType indicates the type of cluster that was created
+                          type: string
+                        resourceGroupName:
+                          description: ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.
+                          type: string
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM Cloud service. These endpoints are consumed by components within the cluster to reach the respective IBM Cloud Services.
+                          items:
+                            description: IBMCloudServiceEndpoint stores the configuration of a custom url to override existing defaults of IBM Cloud Services.
+                            properties:
+                              name:
+                                description: 'name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`'
+                                enum:
+                                  - CIS
+                                  - COS
+                                  - DNSServices
+                                  - GlobalSearch
+                                  - GlobalTagging
+                                  - HyperProtect
+                                  - IAM
+                                  - KeyProtect
+                                  - ResourceController
+                                  - ResourceManager
+                                  - VPC
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                type: string
+                                x-kubernetes-validations:
+                                  - message: url must be a valid absolute URL
+                                    rule: isURL(self)
+                            required:
+                              - name
+                              - url
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    kubevirt:
+                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                      type: object
+                    nutanix:
+                      description: Nutanix contains settings specific to the Nutanix infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                      type: object
+                    openstack:
+                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        cloudName:
+                          description: cloudName is the name of the desired OpenStack cloud in the client configuration file (`clouds.yaml`).
+                          type: string
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on OpenStack platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for OpenStack deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                      type: object
+                    ovirt:
+                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        nodeDNSIP:
+                          description: 'deprecated: as of 4.6, this field is no longer set or honored.  It will be removed in a future release.'
+                          type: string
+                      type: object
+                    powervs:
+                      description: PowerVS contains settings specific to the Power Systems Virtual Servers infrastructure provider.
+                      properties:
+                        cisInstanceCRN:
+                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        dnsInstanceCRN:
+                          description: DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        region:
+                          description: region holds the default Power VS region for new Power VS resources created by the cluster.
+                          type: string
+                        resourceGroup:
+                          description: 'resourceGroup is the resource group name for new IBMCloud resources created for a cluster. The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry. More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs. When omitted, the image registry operator won''t be able to configure storage, which results in the image registry cluster operator not being in an available state.'
+                          maxLength: 40
+                          pattern: ^[a-zA-Z0-9-_ ]+$
+                          type: string
+                          x-kubernetes-validations:
+                            - message: resourceGroup is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
+                          items:
+                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
+                            properties:
+                              name:
+                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                format: uri
+                                pattern: ^https://
+                                type: string
+                            required:
+                              - name
+                              - url
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        zone:
+                          description: 'zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported'
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: cannot unset resourceGroup once set
+                          rule: '!has(oldSelf.resourceGroup) || has(self.resourceGroup)'
+                    type:
+                      description: "type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform. \n This value will be synced with to the `status.platform` and `status.platformStatus.type`. Currently this value cannot be changed once set."
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                      type: string
+                    vsphere:
+                      description: VSphere contains settings specific to the VSphere infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for vSphere deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                      type: object
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,1150 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: infrastructures.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Infrastructure
+    listKind: InfrastructureList
+    plural: infrastructures
+    singular: infrastructure
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Infrastructure holds cluster-wide information about Infrastructure.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              properties:
+                cloudConfig:
+                  description: "cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config. \n cloudConfig should only be consumed by the kube_cloud_config controller. The controller is responsible for using the user configuration in the spec for various platforms and combining that with the user provided ConfigMap in this field to create a stitched kube cloud config. The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace with the kube cloud config is stored in `cloud.conf` key. All the clients are expected to use the generated ConfigMap only."
+                  properties:
+                    key:
+                      description: Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.
+                      type: string
+                    name:
+                      type: string
+                  type: object
+                platformSpec:
+                  description: platformSpec holds desired information specific to the underlying infrastructure provider.
+                  properties:
+                    alibabaCloud:
+                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
+                      type: object
+                    aws:
+                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
+                      properties:
+                        serviceEndpoints:
+                          description: serviceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
+                          items:
+                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
+                            properties:
+                              name:
+                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                pattern: ^https://
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    azure:
+                      description: Azure contains settings specific to the Azure infrastructure provider.
+                      type: object
+                    baremetal:
+                      description: BareMetal contains settings specific to the BareMetal platform.
+                      type: object
+                    equinixMetal:
+                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
+                      type: object
+                    external:
+                      description: ExternalPlatformType represents generic infrastructure provider. Platform-specific components should be supplemented separately.
+                      properties:
+                        platformName:
+                          default: Unknown
+                          description: PlatformName holds the arbitrary string representing the infrastructure provider name, expected to be set at the installation time. This field is solely for informational and reporting purposes and is not expected to be used for decision-making.
+                          type: string
+                          x-kubernetes-validations:
+                            - message: platform name cannot be changed once set
+                              rule: oldSelf == 'Unknown' || self == oldSelf
+                      type: object
+                    gcp:
+                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
+                      type: object
+                    ibmcloud:
+                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
+                      type: object
+                    kubevirt:
+                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
+                      type: object
+                    nutanix:
+                      description: Nutanix contains settings specific to the Nutanix infrastructure provider.
+                      properties:
+                        failureDomains:
+                          description: failureDomains configures failure domains information for the Nutanix platform. When set, the failure domains defined here may be used to spread Machines across prism element clusters to improve fault tolerance of the cluster.
+                          items:
+                            description: NutanixFailureDomain configures failure domain information for the Nutanix platform.
+                            properties:
+                              cluster:
+                                description: cluster is to identify the cluster (the Prism Element under management of the Prism Central), in which the Machine's VM will be created. The cluster identifier (uuid or name) can be obtained from the Prism Central console or using the prism_central API.
+                                properties:
+                                  name:
+                                    description: name is the resource name in the PC. It cannot be empty if the type is Name.
+                                    type: string
+                                  type:
+                                    description: type is the identifier type to use for this resource.
+                                    enum:
+                                      - UUID
+                                      - Name
+                                    type: string
+                                  uuid:
+                                    description: uuid is the UUID of the resource in the PC. It cannot be empty if the type is UUID.
+                                    type: string
+                                required:
+                                  - type
+                                type: object
+                                x-kubernetes-validations:
+                                  - message: uuid configuration is required when type is UUID, and forbidden otherwise
+                                    rule: 'has(self.type) && self.type == ''UUID'' ?  has(self.uuid) : !has(self.uuid)'
+                                  - message: name configuration is required when type is Name, and forbidden otherwise
+                                    rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name) : !has(self.name)'
+                              name:
+                                description: name defines the unique name of a failure domain. Name is required and must be at most 64 characters in length. It must consist of only lower case alphanumeric characters and hyphens (-). It must start and end with an alphanumeric character. This value is arbitrary and is used to identify the failure domain within the platform.
+                                maxLength: 64
+                                minLength: 1
+                                pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                                type: string
+                              subnets:
+                                description: subnets holds a list of identifiers (one or more) of the cluster's network subnets for the Machine's VM to connect to. The subnet identifiers (uuid or name) can be obtained from the Prism Central console or using the prism_central API.
+                                items:
+                                  description: NutanixResourceIdentifier holds the identity of a Nutanix PC resource (cluster, image, subnet, etc.)
+                                  properties:
+                                    name:
+                                      description: name is the resource name in the PC. It cannot be empty if the type is Name.
+                                      type: string
+                                    type:
+                                      description: type is the identifier type to use for this resource.
+                                      enum:
+                                        - UUID
+                                        - Name
+                                      type: string
+                                    uuid:
+                                      description: uuid is the UUID of the resource in the PC. It cannot be empty if the type is UUID.
+                                      type: string
+                                  required:
+                                    - type
+                                  type: object
+                                  x-kubernetes-validations:
+                                    - message: uuid configuration is required when type is UUID, and forbidden otherwise
+                                      rule: 'has(self.type) && self.type == ''UUID'' ?  has(self.uuid) : !has(self.uuid)'
+                                    - message: name configuration is required when type is Name, and forbidden otherwise
+                                      rule: 'has(self.type) && self.type == ''Name'' ?  has(self.name) : !has(self.name)'
+                                maxItems: 1
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - type
+                                x-kubernetes-list-type: map
+                            required:
+                              - cluster
+                              - name
+                              - subnets
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        prismCentral:
+                          description: prismCentral holds the endpoint address and port to access the Nutanix Prism Central. When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
+                          properties:
+                            address:
+                              description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
+                              maxLength: 256
+                              type: string
+                            port:
+                              description: port is the port number to access the Nutanix Prism Central or Element (cluster)
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                            - address
+                            - port
+                          type: object
+                        prismElements:
+                          description: prismElements holds one or more endpoint address and port data to access the Nutanix Prism Elements (clusters) of the Nutanix Prism Central. Currently we only support one Prism Element (cluster) for an OpenShift cluster, where all the Nutanix resources (VMs, subnets, volumes, etc.) used in the OpenShift cluster are located. In the future, we may support Nutanix resources (VMs, etc.) spread over multiple Prism Elements (clusters) of the Prism Central.
+                          items:
+                            description: NutanixPrismElementEndpoint holds the name and endpoint data for a Prism Element (cluster)
+                            properties:
+                              endpoint:
+                                description: endpoint holds the endpoint address and port data of the Prism Element (cluster). When a cluster-wide proxy is installed, by default, this endpoint will be accessed via the proxy. Should you wish for communication with this endpoint not to be proxied, please add the endpoint to the proxy spec.noProxy list.
+                                properties:
+                                  address:
+                                    description: address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
+                                    maxLength: 256
+                                    type: string
+                                  port:
+                                    description: port is the port number to access the Nutanix Prism Central or Element (cluster)
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                  - address
+                                  - port
+                                type: object
+                              name:
+                                description: name is the name of the Prism Element (cluster). This value will correspond with the cluster field configured on other resources (eg Machines, PVCs, etc).
+                                maxLength: 256
+                                type: string
+                            required:
+                              - endpoint
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      required:
+                        - prismCentral
+                        - prismElements
+                      type: object
+                    openstack:
+                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
+                      type: object
+                    ovirt:
+                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
+                      type: object
+                    powervs:
+                      description: PowerVS contains settings specific to the IBM Power Systems Virtual Servers infrastructure provider.
+                      properties:
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
+                          items:
+                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
+                            properties:
+                              name:
+                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                format: uri
+                                pattern: ^https://
+                                type: string
+                            required:
+                              - name
+                              - url
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    type:
+                      description: type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud", "Nutanix" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                      type: string
+                    vsphere:
+                      description: VSphere contains settings specific to the VSphere infrastructure provider.
+                      properties:
+                        failureDomains:
+                          description: failureDomains contains the definition of region, zone and the vCenter topology. If this is omitted failure domains (regions and zones) will not be used.
+                          items:
+                            description: VSpherePlatformFailureDomainSpec holds the region and zone failure domain and the vCenter topology of that failure domain.
+                            properties:
+                              name:
+                                description: name defines the arbitrary but unique name of a failure domain.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              region:
+                                description: region defines the name of a region tag that will be attached to a vCenter datacenter. The tag category in vCenter must be named openshift-region.
+                                maxLength: 80
+                                minLength: 1
+                                type: string
+                              server:
+                                anyOf:
+                                  - format: ipv4
+                                  - format: ipv6
+                                  - format: hostname
+                                description: server is the fully-qualified domain name or the IP address of the vCenter server. ---
+                                maxLength: 255
+                                minLength: 1
+                                type: string
+                              topology:
+                                description: Topology describes a given failure domain using vSphere constructs
+                                properties:
+                                  computeCluster:
+                                    description: computeCluster the absolute path of the vCenter cluster in which virtual machine will be located. The absolute path is of the form /<datacenter>/host/<cluster>. The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/host/.*?
+                                    type: string
+                                  datacenter:
+                                    description: datacenter is the name of vCenter datacenter in which virtual machines will be located. The maximum length of the datacenter name is 80 characters.
+                                    maxLength: 80
+                                    type: string
+                                  datastore:
+                                    description: datastore is the absolute path of the datastore in which the virtual machine is located. The absolute path is of the form /<datacenter>/datastore/<datastore> The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/datastore/.*?
+                                    type: string
+                                  folder:
+                                    description: folder is the absolute path of the folder where virtual machines are located. The absolute path is of the form /<datacenter>/vm/<folder>. The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/vm/.*?
+                                    type: string
+                                  networks:
+                                    description: networks is the list of port group network names within this failure domain. Currently, we only support a single interface per RHCOS virtual machine. The available networks (port groups) can be listed using `govc ls 'network/*'` The single interface should be the absolute path of the form /<datacenter>/network/<portgroup>.
+                                    items:
+                                      type: string
+                                    maxItems: 1
+                                    minItems: 1
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resourcePool:
+                                    description: resourcePool is the absolute path of the resource pool where virtual machines will be created. The absolute path is of the form /<datacenter>/host/<cluster>/Resources/<resourcepool>. The maximum length of the path is 2048 characters.
+                                    maxLength: 2048
+                                    pattern: ^/.*?/host/.*?/Resources.*
+                                    type: string
+                                  template:
+                                    description: "template is the full inventory path of the virtual machine or template that will be cloned when creating new machines in this failure domain. The maximum length of the path is 2048 characters. \n When omitted, the template will be calculated by the control plane machineset operator based on the region and zone defined in VSpherePlatformFailureDomainSpec. For example, for zone=zonea, region=region1, and infrastructure name=test, the template path would be calculated as /<datacenter>/vm/test-rhcos-region1-zonea."
+                                    maxLength: 2048
+                                    minLength: 1
+                                    pattern: ^/.*?/vm/.*?
+                                    type: string
+                                required:
+                                  - computeCluster
+                                  - datacenter
+                                  - datastore
+                                  - networks
+                                type: object
+                              zone:
+                                description: zone defines the name of a zone tag that will be attached to a vCenter cluster. The tag category in vCenter must be named openshift-zone.
+                                maxLength: 80
+                                minLength: 1
+                                type: string
+                            required:
+                              - name
+                              - region
+                              - server
+                              - topology
+                              - zone
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        nodeNetworking:
+                          description: nodeNetworking contains the definition of internal and external network constraints for assigning the node's networking. If this field is omitted, networking defaults to the legacy address selection behavior which is to only support a single address and return the first one found.
+                          properties:
+                            external:
+                              description: external represents the network configuration of the node that is externally routable.
+                              properties:
+                                excludeNetworkSubnetCidr:
+                                  description: excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting the IP address from the VirtualMachine's VM for use in the status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                network:
+                                  description: network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`
+                                  type: string
+                                networkSubnetCidr:
+                                  description: networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs that will be used in respective status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              type: object
+                            internal:
+                              description: internal represents the network configuration of the node that is routable only within the cluster.
+                              properties:
+                                excludeNetworkSubnetCidr:
+                                  description: excludeNetworkSubnetCidr IP addresses in subnet ranges will be excluded when selecting the IP address from the VirtualMachine's VM for use in the status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                network:
+                                  description: network VirtualMachine's VM Network names that will be used to when searching for status.addresses fields. Note that if internal.networkSubnetCIDR and external.networkSubnetCIDR are not set, then the vNIC associated to this network must only have a single IP address assigned to it. The available networks (port groups) can be listed using `govc ls 'network/*'`
+                                  type: string
+                                networkSubnetCidr:
+                                  description: networkSubnetCidr IP address on VirtualMachine's network interfaces included in the fields' CIDRs that will be used in respective status.addresses fields. ---
+                                  items:
+                                    format: cidr
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: set
+                              type: object
+                          type: object
+                        vcenters:
+                          description: vcenters holds the connection details for services to communicate with vCenter. Currently, only a single vCenter is supported. ---
+                          items:
+                            description: VSpherePlatformVCenterSpec stores the vCenter connection fields. This is used by the vSphere CCM.
+                            properties:
+                              datacenters:
+                                description: The vCenter Datacenters in which the RHCOS vm guests are located. This field will be used by the Cloud Controller Manager. Each datacenter listed here should be used within a topology.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                                x-kubernetes-list-type: set
+                              port:
+                                description: port is the TCP port that will be used to communicate to the vCenter endpoint. When omitted, this means the user has no opinion and it is up to the platform to choose a sensible default, which is subject to change over time.
+                                format: int32
+                                maximum: 32767
+                                minimum: 1
+                                type: integer
+                              server:
+                                anyOf:
+                                  - format: ipv4
+                                  - format: ipv6
+                                  - format: hostname
+                                description: server is the fully-qualified domain name or the IP address of the vCenter server. ---
+                                maxLength: 255
+                                type: string
+                            required:
+                              - datacenters
+                              - server
+                            type: object
+                          maxItems: 1
+                          minItems: 0
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              properties:
+                apiServerInternalURI:
+                  description: apiServerInternalURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.
+                  type: string
+                apiServerURL:
+                  description: apiServerURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.
+                  type: string
+                controlPlaneTopology:
+                  default: HighlyAvailable
+                  description: controlPlaneTopology expresses the expectations for operands that normally run on control nodes. The default is 'HighlyAvailable', which represents the behavior operators have in a "normal" cluster. The 'SingleReplica' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation The 'External' mode indicates that the control plane is hosted externally to the cluster and that its components are not visible within the cluster.
+                  enum:
+                    - HighlyAvailable
+                    - SingleReplica
+                    - External
+                  type: string
+                cpuPartitioning:
+                  default: None
+                  description: cpuPartitioning expresses if CPU partitioning is a currently enabled feature in the cluster. CPU Partitioning means that this cluster can support partitioning workloads to specific CPU Sets. Valid values are "None" and "AllNodes". When omitted, the default value is "None". The default value of "None" indicates that no nodes will be setup with CPU partitioning. The "AllNodes" value indicates that all nodes have been setup with CPU partitioning, and can then be further configured via the PerformanceProfile API.
+                  enum:
+                    - None
+                    - AllNodes
+                  type: string
+                etcdDiscoveryDomain:
+                  description: 'etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery deprecated: as of 4.7, this field is no longer set or honored.  It will be removed in a future release.'
+                  type: string
+                infrastructureName:
+                  description: infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.
+                  type: string
+                infrastructureTopology:
+                  default: HighlyAvailable
+                  description: 'infrastructureTopology expresses the expectations for infrastructure services that do not run on control plane nodes, usually indicated by a node selector for a `role` value other than `master`. The default is ''HighlyAvailable'', which represents the behavior operators have in a "normal" cluster. The ''SingleReplica'' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation NOTE: External topology mode is not applicable for this field.'
+                  enum:
+                    - HighlyAvailable
+                    - SingleReplica
+                  type: string
+                platform:
+                  description: "platform is the underlying infrastructure provider for the cluster. \n Deprecated: Use platformStatus.type instead."
+                  enum:
+                    - ""
+                    - AWS
+                    - Azure
+                    - BareMetal
+                    - GCP
+                    - Libvirt
+                    - OpenStack
+                    - None
+                    - VSphere
+                    - oVirt
+                    - IBMCloud
+                    - KubeVirt
+                    - EquinixMetal
+                    - PowerVS
+                    - AlibabaCloud
+                    - Nutanix
+                    - External
+                  type: string
+                platformStatus:
+                  description: platformStatus holds status information specific to the underlying infrastructure provider.
+                  properties:
+                    alibabaCloud:
+                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
+                      properties:
+                        region:
+                          description: region specifies the region for Alibaba Cloud resources created for the cluster.
+                          pattern: ^[0-9A-Za-z-]+$
+                          type: string
+                        resourceGroupID:
+                          description: resourceGroupID is the ID of the resource group for the cluster.
+                          pattern: ^(rg-[0-9A-Za-z]+)?$
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.
+                          items:
+                            description: AlibabaCloudResourceTag is the set of tags to add to apply to resources.
+                            properties:
+                              key:
+                                description: key is the key of the tag.
+                                maxLength: 128
+                                minLength: 1
+                                type: string
+                              value:
+                                description: value is the value of the tag.
+                                maxLength: 128
+                                minLength: 1
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 20
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                      required:
+                        - region
+                      type: object
+                    aws:
+                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
+                      properties:
+                        region:
+                          description: region holds the default AWS region for new AWS resources created by the cluster.
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.
+                          items:
+                            description: AWSResourceTag is a tag to apply to AWS resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key of the tag
+                                maxLength: 128
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                type: string
+                              value:
+                                description: value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 25
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        serviceEndpoints:
+                          description: ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
+                          items:
+                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
+                            properties:
+                              name:
+                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                pattern: ^https://
+                                type: string
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    azure:
+                      description: Azure contains settings specific to the Azure infrastructure provider.
+                      properties:
+                        armEndpoint:
+                          description: armEndpoint specifies a URL to use for resource management in non-soverign clouds such as Azure Stack.
+                          type: string
+                        cloudName:
+                          description: cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the value is equal to `AzurePublicCloud`.
+                          enum:
+                            - ""
+                            - AzurePublicCloud
+                            - AzureUSGovernmentCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureStackCloud
+                          type: string
+                        networkResourceGroupName:
+                          description: networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster. If empty, the value is same as ResourceGroupName.
+                          type: string
+                        resourceGroupName:
+                          description: resourceGroupName is the Resource Group for new Azure resources created for the cluster.
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to Azure resources created for the cluster. See https://docs.microsoft.com/en-us/rest/api/resources/tags for information on tagging Azure resources. Due to limitations on Automation, Content Delivery Network, DNS Azure resources, a maximum of 15 tags may be applied. OpenShift reserves 5 tags for internal use, allowing 10 tags for user configuration.
+                          items:
+                            description: AzureResourceTag is a tag to apply to Azure resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key part of the tag. A tag key can have a maximum of 128 characters and cannot be empty. Key must begin with a letter, end with a letter, number or underscore, and must contain only alphanumeric characters and the following special characters `_ . -`.
+                                maxLength: 128
+                                minLength: 1
+                                pattern: ^[a-zA-Z]([0-9A-Za-z_.-]*[0-9A-Za-z_])?$
+                                type: string
+                              value:
+                                description: 'value is the value part of the tag. A tag value can have a maximum of 256 characters and cannot be empty. Value must contain only alphanumeric characters and the following special characters `_ + , - . / : ; < = > ? @`.'
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.=+-@]+$
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 10
+                          type: array
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                            - message: resourceTags are immutable and may only be configured during installation
+                              rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                      type: object
+                      x-kubernetes-validations:
+                        - message: resourceTags may only be configured during installation
+                          rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags) || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                    baremetal:
+                      description: BareMetal contains settings specific to the BareMetal platform.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on BareMetal platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for BareMetal deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                      type: object
+                    equinixMetal:
+                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                      type: object
+                    external:
+                      description: External contains settings specific to the generic External infrastructure provider.
+                      properties:
+                        cloudControllerManager:
+                          description: cloudControllerManager contains settings specific to the external Cloud Controller Manager (a.k.a. CCM or CPI). When omitted, new nodes will be not tainted and no extra initialization from the cloud controller manager is expected.
+                          properties:
+                            state:
+                              description: "state determines whether or not an external Cloud Controller Manager is expected to be installed within the cluster. https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager \n Valid values are \"External\", \"None\" and omitted. When set to \"External\", new nodes will be tainted as uninitialized when created, preventing them from running workloads until they are initialized by the cloud controller manager. When omitted or set to \"None\", new nodes will be not tainted and no extra initialization from the cloud controller manager is expected."
+                              enum:
+                                - ""
+                                - External
+                                - None
+                              type: string
+                              x-kubernetes-validations:
+                                - message: state is immutable once set
+                                  rule: self == oldSelf
+                          type: object
+                          x-kubernetes-validations:
+                            - message: state may not be added or removed once set
+                              rule: (has(self.state) == has(oldSelf.state)) || (!has(oldSelf.state) && self.state != "External")
+                      type: object
+                      x-kubernetes-validations:
+                        - message: cloudControllerManager may not be added or removed once set
+                          rule: has(self.cloudControllerManager) == has(oldSelf.cloudControllerManager)
+                    gcp:
+                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
+                      properties:
+                        clusterHostedDNS:
+                          default: Disabled
+                          description: clusterHostedDNS indicates the type of DNS solution in use within the cluster. Its default value of "Disabled" indicates that the cluster's DNS is the default provided by the cloud platform. It can be "Enabled" during install to bypass the configuration of the cloud default DNS. When "Enabled", the cluster needs to provide a self-hosted DNS solution for the cluster's installation to succeed. The cluster's use of the cloud's Load Balancers is unaffected by this setting. The value is immutable after it has been set at install time. Currently, there is no way for the customer to add additional DNS entries into the cluster hosted DNS. Enabling this functionality allows the user to start their own DNS solution outside the cluster after installation is complete. The customer would be responsible for configuring this custom DNS solution, and it can be run in addition to the in-cluster DNS solution.
+                          enum:
+                            - Enabled
+                            - Disabled
+                          type: string
+                          x-kubernetes-validations:
+                            - message: clusterHostedDNS is immutable and may only be configured during installation
+                              rule: self == oldSelf
+                        projectID:
+                          description: resourceGroupName is the Project ID for new GCP resources created for the cluster.
+                          type: string
+                        region:
+                          description: region holds the region for new GCP resources created for the cluster.
+                          type: string
+                        resourceLabels:
+                          description: resourceLabels is a list of additional labels to apply to GCP resources created for the cluster. See https://cloud.google.com/compute/docs/labeling-resources for information on labeling GCP resources. GCP supports a maximum of 64 labels per resource. OpenShift reserves 32 labels for internal use, allowing 32 labels for user configuration.
+                          items:
+                            description: GCPResourceLabel is a label to apply to GCP resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key part of the label. A label key can have a maximum of 63 characters and cannot be empty. Label key must begin with a lowercase letter, and must contain only lowercase letters, numeric characters, and the following special characters `_-`. Label key must not have the reserved prefixes `kubernetes-io` and `openshift-io`.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-z][0-9a-z_-]{0,62}$
+                                type: string
+                                x-kubernetes-validations:
+                                  - message: label keys must not start with either `openshift-io` or `kubernetes-io`
+                                    rule: '!self.startsWith(''openshift-io'') && !self.startsWith(''kubernetes-io'')'
+                              value:
+                                description: value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty. Value must contain only lowercase letters, numeric characters, and the following special characters `_-`.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[0-9a-z_-]{1,63}$
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                          x-kubernetes-validations:
+                            - message: resourceLabels are immutable and may only be configured during installation
+                              rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to GCP resources created for the cluster. See https://cloud.google.com/resource-manager/docs/tags/tags-overview for information on tagging GCP resources. GCP supports a maximum of 50 tags per resource.
+                          items:
+                            description: GCPResourceTag is a tag to apply to GCP resources created for the cluster.
+                            properties:
+                              key:
+                                description: key is the key part of the tag. A tag key can have a maximum of 63 characters and cannot be empty. Tag key must begin and end with an alphanumeric character, and must contain only uppercase, lowercase alphanumeric characters, and the following special characters `._-`.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.-]{0,61}[a-zA-Z0-9])?$
+                                type: string
+                              parentID:
+                                description: 'parentID is the ID of the hierarchical resource where the tags are defined, e.g. at the Organization or the Project level. To find the Organization or Project ID refer to the following pages: https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id, https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects. An OrganizationID must consist of decimal numbers, and cannot have leading zeroes. A ProjectID must be 6 to 30 characters in length, can only contain lowercase letters, numbers, and hyphens, and must start with a letter, and cannot end with a hyphen.'
+                                maxLength: 32
+                                minLength: 1
+                                pattern: (^[1-9][0-9]{0,31}$)|(^[a-z][a-z0-9-]{4,28}[a-z0-9]$)
+                                type: string
+                              value:
+                                description: value is the value part of the tag. A tag value can have a maximum of 63 characters and cannot be empty. Tag value must begin and end with an alphanumeric character, and must contain only uppercase, lowercase alphanumeric characters, and the following special characters `_-.@%=+:,*#&(){}[]` and spaces.
+                                maxLength: 63
+                                minLength: 1
+                                pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.@%=+:,*#&()\[\]{}\-\s]{0,61}[a-zA-Z0-9])?$
+                                type: string
+                            required:
+                              - key
+                              - parentID
+                              - value
+                            type: object
+                          maxItems: 50
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                          x-kubernetes-validations:
+                            - message: resourceTags are immutable and may only be configured during installation
+                              rule: self.all(x, x in oldSelf) && oldSelf.all(x, x in self)
+                      type: object
+                      x-kubernetes-validations:
+                        - message: resourceLabels may only be configured during installation
+                          rule: '!has(oldSelf.resourceLabels) && !has(self.resourceLabels) || has(oldSelf.resourceLabels) && has(self.resourceLabels)'
+                        - message: resourceTags may only be configured during installation
+                          rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags) || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                    ibmcloud:
+                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
+                      properties:
+                        cisInstanceCRN:
+                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        dnsInstanceCRN:
+                          description: DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        location:
+                          description: Location is where the cluster has been deployed
+                          type: string
+                        providerType:
+                          description: ProviderType indicates the type of cluster that was created
+                          type: string
+                        resourceGroupName:
+                          description: ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.
+                          type: string
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of an IBM Cloud service. These endpoints are consumed by components within the cluster to reach the respective IBM Cloud Services.
+                          items:
+                            description: IBMCloudServiceEndpoint stores the configuration of a custom url to override existing defaults of IBM Cloud Services.
+                            properties:
+                              name:
+                                description: 'name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`'
+                                enum:
+                                  - CIS
+                                  - COS
+                                  - DNSServices
+                                  - GlobalSearch
+                                  - GlobalTagging
+                                  - HyperProtect
+                                  - IAM
+                                  - KeyProtect
+                                  - ResourceController
+                                  - ResourceManager
+                                  - VPC
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                type: string
+                                x-kubernetes-validations:
+                                  - message: url must be a valid absolute URL
+                                    rule: isURL(self)
+                            required:
+                              - name
+                              - url
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                      type: object
+                    kubevirt:
+                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                      type: object
+                    nutanix:
+                      description: Nutanix contains settings specific to the Nutanix infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on Nutanix platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                      type: object
+                    openstack:
+                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        cloudName:
+                          description: cloudName is the name of the desired OpenStack cloud in the client configuration file (`clouds.yaml`).
+                          type: string
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on OpenStack platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for OpenStack deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                      type: object
+                    ovirt:
+                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on Ovirt platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                        nodeDNSIP:
+                          description: 'deprecated: as of 4.6, this field is no longer set or honored.  It will be removed in a future release.'
+                          type: string
+                      type: object
+                    powervs:
+                      description: PowerVS contains settings specific to the Power Systems Virtual Servers infrastructure provider.
+                      properties:
+                        cisInstanceCRN:
+                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        dnsInstanceCRN:
+                          description: DNSInstanceCRN is the CRN of the DNS Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        region:
+                          description: region holds the default Power VS region for new Power VS resources created by the cluster.
+                          type: string
+                        resourceGroup:
+                          description: 'resourceGroup is the resource group name for new IBMCloud resources created for a cluster. The resource group specified here will be used by cluster-image-registry-operator to set up a COS Instance in IBMCloud for the cluster registry. More about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs. When omitted, the image registry operator won''t be able to configure storage, which results in the image registry cluster operator not being in an available state.'
+                          maxLength: 40
+                          pattern: ^[a-zA-Z0-9-_ ]+$
+                          type: string
+                          x-kubernetes-validations:
+                            - message: resourceGroup is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
+                          items:
+                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
+                            properties:
+                              name:
+                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                pattern: ^[a-z0-9-]+$
+                                type: string
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                format: uri
+                                pattern: ^https://
+                                type: string
+                            required:
+                              - name
+                              - url
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        zone:
+                          description: 'zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported'
+                          type: string
+                      type: object
+                      x-kubernetes-validations:
+                        - message: cannot unset resourceGroup once set
+                          rule: '!has(oldSelf.resourceGroup) || has(self.resourceGroup)'
+                    type:
+                      description: "type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform. \n This value will be synced with to the `status.platform` and `status.platformStatus.type`. Currently this value cannot be changed once set."
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                      type: string
+                    vsphere:
+                      description: VSphere contains settings specific to the VSphere infrastructure provider.
+                      properties:
+                        apiServerInternalIP:
+                          description: "apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers. \n Deprecated: Use APIServerInternalIPs instead."
+                          type: string
+                        apiServerInternalIPs:
+                          description: apiServerInternalIPs are the IP addresses to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. These are the IPs for a self-hosted load balancer in front of the API servers. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        ingressIP:
+                          description: "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names. \n Deprecated: Use IngressIPs instead."
+                          type: string
+                        ingressIPs:
+                          description: ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IPs otherwise only one.
+                          format: ip
+                          items:
+                            type: string
+                          maxItems: 2
+                          type: array
+                          x-kubernetes-list-type: set
+                        loadBalancer:
+                          default:
+                            type: OpenShiftManagedDefault
+                          description: loadBalancer defines how the load balancer used by the cluster is configured.
+                          properties:
+                            type:
+                              default: OpenShiftManagedDefault
+                              description: type defines the type of load balancer used by the cluster on VSphere platform which can be a user-managed or openshift-managed load balancer that is to be used for the OpenShift API and Ingress endpoints. When set to OpenShiftManagedDefault the static pods in charge of API and Ingress traffic load-balancing defined in the machine config operator will be deployed. When set to UserManaged these static pods will not be deployed and it is expected that the load balancer is configured out of band by the deployer. When omitted, this means no opinion and the platform is left to choose a reasonable default. The default value is OpenShiftManagedDefault.
+                              enum:
+                                - OpenShiftManagedDefault
+                                - UserManaged
+                              type: string
+                              x-kubernetes-validations:
+                                - message: type is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                          type: object
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for vSphere deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                      type: object
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_ingress.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_ingress.crd.yaml
@@ -1,0 +1,334 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: ingresses.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Ingress
+    listKind: IngressList
+    plural: ingresses
+    singular: ingress
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Ingress holds cluster-wide information about ingress, including the default ingress domain used for routes. The canonical name is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                appsDomain:
+                  description: appsDomain is an optional domain to use instead of the one specified in the domain field when a Route is created without specifying an explicit host. If appsDomain is nonempty, this value is used to generate default host values for Route. Unlike domain, appsDomain may be modified after installation. This assumes a new ingresscontroller has been setup with a wildcard certificate.
+                  type: string
+                componentRoutes:
+                  description: "componentRoutes is an optional list of routes that are managed by OpenShift components that a cluster-admin is able to configure the hostname and serving certificate for. The namespace and name of each route in this list should match an existing entry in the status.componentRoutes list. \n To determine the set of configurable Routes, look at namespace and name of entries in the .status.componentRoutes list, where participating operators write the status of configurable routes."
+                  type: array
+                  items:
+                    description: ComponentRouteSpec allows for configuration of a route's hostname and serving certificate.
+                    type: object
+                    required:
+                      - hostname
+                      - name
+                      - namespace
+                    properties:
+                      hostname:
+                        description: hostname is the hostname that should be used by the route.
+                        type: string
+                        pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                      name:
+                        description: "name is the logical name of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized."
+                        type: string
+                        maxLength: 256
+                        minLength: 1
+                      namespace:
+                        description: "namespace is the namespace of the route to customize. \n The namespace and name of this componentRoute must match a corresponding entry in the list of status.componentRoutes if the route is to be customized."
+                        type: string
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      servingCertKeyPairSecret:
+                        description: servingCertKeyPairSecret is a reference to a secret of type `kubernetes.io/tls` in the openshift-config namespace. The serving cert/key pair must match and will be used by the operator to fulfill the intent of serving with this name. If the custom hostname uses the default routing suffix of the cluster, the Secret specification for a serving certificate will not be needed.
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced secret
+                            type: string
+                  x-kubernetes-list-map-keys:
+                    - namespace
+                    - name
+                  x-kubernetes-list-type: map
+                domain:
+                  description: "domain is used to generate a default host name for a route when the route's host name is empty. The generated host name will follow this pattern: \"<route-name>.<route-namespace>.<domain>\". \n It is also used as the default wildcard domain suffix for ingress. The default ingresscontroller domain will follow this pattern: \"*.<domain>\". \n Once set, changing domain is not currently supported."
+                  type: string
+                loadBalancer:
+                  description: loadBalancer contains the load balancer details in general which are not only specific to the underlying infrastructure provider of the current cluster and are required for Ingress Controller to work on OpenShift.
+                  type: object
+                  properties:
+                    platform:
+                      description: platform holds configuration specific to the underlying infrastructure provider for the ingress load balancers. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time.
+                      type: object
+                      properties:
+                        aws:
+                          description: aws contains settings specific to the Amazon Web Services infrastructure provider.
+                          type: object
+                          required:
+                            - type
+                          properties:
+                            type:
+                              description: "type allows user to set a load balancer type. When this field is set the default ingresscontroller will get created using the specified LBType. If this field is not set then the default ingress controller of LBType Classic will be created. Valid values are: \n * \"Classic\": A Classic Load Balancer that makes routing decisions at either the transport layer (TCP/SSL) or the application layer (HTTP/HTTPS). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#clb \n * \"NLB\": A Network Load Balancer that makes routing decisions at the transport layer (TCP/SSL). See the following for additional details: \n https://docs.aws.amazon.com/AmazonECS/latest/developerguide/load-balancer-types.html#nlb"
+                              type: string
+                              enum:
+                                - NLB
+                                - Classic
+                        type:
+                          description: type is the underlying infrastructure provider for the cluster. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud", "Nutanix" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.
+                          type: string
+                          enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                requiredHSTSPolicies:
+                  description: "requiredHSTSPolicies specifies HSTS policies that are required to be set on newly created  or updated routes matching the domainPattern/s and namespaceSelector/s that are specified in the policy. Each requiredHSTSPolicy must have at least a domainPattern and a maxAge to validate a route HSTS Policy route annotation, and affect route admission. \n A candidate route is checked for HSTS Policies if it has the HSTS Policy route annotation: \"haproxy.router.openshift.io/hsts_header\" E.g. haproxy.router.openshift.io/hsts_header: max-age=31536000;preload;includeSubDomains \n - For each candidate route, if it matches a requiredHSTSPolicy domainPattern and optional namespaceSelector, then the maxAge, preloadPolicy, and includeSubdomainsPolicy must be valid to be admitted.  Otherwise, the route is rejected. - The first match, by domainPattern and optional namespaceSelector, in the ordering of the RequiredHSTSPolicies determines the route's admission status. - If the candidate route doesn't match any requiredHSTSPolicy domainPattern and optional namespaceSelector, then it may use any HSTS Policy annotation. \n The HSTS policy configuration may be changed after routes have already been created. An update to a previously admitted route may then fail if the updated route does not conform to the updated HSTS policy configuration. However, changing the HSTS policy configuration will not cause a route that is already admitted to stop working. \n Note that if there are no RequiredHSTSPolicies, any HSTS Policy annotation on the route is valid."
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - domainPatterns
+                    properties:
+                      domainPatterns:
+                        description: "domainPatterns is a list of domains for which the desired HSTS annotations are required. If domainPatterns is specified and a route is created with a spec.host matching one of the domains, the route must specify the HSTS Policy components described in the matching RequiredHSTSPolicy. \n The use of wildcards is allowed like this: *.foo.com matches everything under foo.com. foo.com only matches foo.com, so to cover foo.com and everything under it, you must specify *both*."
+                        type: array
+                        minItems: 1
+                        items:
+                          type: string
+                      includeSubDomainsPolicy:
+                        description: 'includeSubDomainsPolicy means the HSTS Policy should apply to any subdomains of the host''s domain name.  Thus, for the host bar.foo.com, if includeSubDomainsPolicy was set to RequireIncludeSubDomains: - the host app.bar.foo.com would inherit the HSTS Policy of bar.foo.com - the host bar.foo.com would inherit the HSTS Policy of bar.foo.com - the host foo.com would NOT inherit the HSTS Policy of bar.foo.com - the host def.foo.com would NOT inherit the HSTS Policy of bar.foo.com'
+                        type: string
+                        enum:
+                          - RequireIncludeSubDomains
+                          - RequireNoIncludeSubDomains
+                          - NoOpinion
+                      maxAge:
+                        description: maxAge is the delta time range in seconds during which hosts are regarded as HSTS hosts. If set to 0, it negates the effect, and hosts are removed as HSTS hosts. If set to 0 and includeSubdomains is specified, all subdomains of the host are also removed as HSTS hosts. maxAge is a time-to-live value, and if this policy is not refreshed on a client, the HSTS policy will eventually expire on that client.
+                        type: object
+                        properties:
+                          largestMaxAge:
+                            description: The largest allowed value (in seconds) of the RequiredHSTSPolicy max-age This value can be left unspecified, in which case no upper limit is enforced.
+                            type: integer
+                            format: int32
+                            maximum: 2147483647
+                            minimum: 0
+                          smallestMaxAge:
+                            description: The smallest allowed value (in seconds) of the RequiredHSTSPolicy max-age Setting max-age=0 allows the deletion of an existing HSTS header from a host.  This is a necessary tool for administrators to quickly correct mistakes. This value can be left unspecified, in which case no lower limit is enforced.
+                            type: integer
+                            format: int32
+                            maximum: 2147483647
+                            minimum: 0
+                      namespaceSelector:
+                        description: namespaceSelector specifies a label selector such that the policy applies only to those routes that are in namespaces with labels that match the selector, and are in one of the DomainPatterns. Defaults to the empty LabelSelector, which matches everything.
+                        type: object
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            type: array
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              type: object
+                              required:
+                                - key
+                                - operator
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  type: array
+                                  items:
+                                    type: string
+                          matchLabels:
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                            additionalProperties:
+                              type: string
+                        x-kubernetes-map-type: atomic
+                      preloadPolicy:
+                        description: preloadPolicy directs the client to include hosts in its host preload list so that it never needs to do an initial load to get the HSTS header (note that this is not defined in RFC 6797 and is therefore client implementation-dependent).
+                        type: string
+                        enum:
+                          - RequirePreload
+                          - RequireNoPreload
+                          - NoOpinion
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                componentRoutes:
+                  description: componentRoutes is where participating operators place the current route status for routes whose hostnames and serving certificates can be customized by the cluster-admin.
+                  type: array
+                  items:
+                    description: ComponentRouteStatus contains information allowing configuration of a route's hostname and serving certificate.
+                    type: object
+                    required:
+                      - defaultHostname
+                      - name
+                      - namespace
+                      - relatedObjects
+                    properties:
+                      conditions:
+                        description: "conditions are used to communicate the state of the componentRoutes entry. \n Supported conditions include Available, Degraded and Progressing. \n If available is true, the content served by the route can be accessed by users. This includes cases where a default may continue to serve content while the customized route specified by the cluster-admin is being configured. \n If Degraded is true, that means something has gone wrong trying to handle the componentRoutes entry. The currentHostnames field may or may not be in effect. \n If Progressing is true, that means the component is taking some action related to the componentRoutes entry."
+                        type: array
+                        items:
+                          description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                          type: object
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          properties:
+                            lastTransitionTime:
+                              description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              type: string
+                              format: date-time
+                            message:
+                              description: message is a human readable message indicating details about the transition. This may be an empty string.
+                              type: string
+                              maxLength: 32768
+                            observedGeneration:
+                              description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                              type: integer
+                              format: int64
+                              minimum: 0
+                            reason:
+                              description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                              type: string
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              type: string
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                              type: string
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      consumingUsers:
+                        description: consumingUsers is a slice of ServiceAccounts that need to have read permission on the servingCertKeyPairSecret secret.
+                        type: array
+                        maxItems: 5
+                        items:
+                          description: ConsumingUser is an alias for string which we add validation to. Currently only service accounts are supported.
+                          type: string
+                          maxLength: 512
+                          minLength: 1
+                          pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      currentHostnames:
+                        description: currentHostnames is the list of current names used by the route. Typically, this list should consist of a single hostname, but if multiple hostnames are supported by the route the operator may write multiple entries to this list.
+                        type: array
+                        minItems: 1
+                        items:
+                          description: "Hostname is an alias for hostname string validation. \n The left operand of the | is the original kubebuilder hostname validation format, which is incorrect because it allows upper case letters, disallows hyphen or number in the TLD, and allows labels to start/end in non-alphanumeric characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256. ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$ \n The right operand of the | is a new pattern that mimics the current API route admission validation on hostname, except that it allows hostnames longer than the maximum length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$ \n Both operand patterns are made available so that modifications on ingress spec can still happen after an invalid hostname was saved via validation by the incorrect left operand of the | operator."
+                          type: string
+                          pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                      defaultHostname:
+                        description: defaultHostname is the hostname of this route prior to customization.
+                        type: string
+                        pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+                      name:
+                        description: "name is the logical name of the route to customize. It does not have to be the actual name of a route resource but it cannot be renamed. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized."
+                        type: string
+                        maxLength: 256
+                        minLength: 1
+                      namespace:
+                        description: "namespace is the namespace of the route to customize. It must be a real namespace. Using an actual namespace ensures that no two components will conflict and the same component can be installed multiple times. \n The namespace and name of this componentRoute must match a corresponding entry in the list of spec.componentRoutes if the route is to be customized."
+                        type: string
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      relatedObjects:
+                        description: relatedObjects is a list of resources which are useful when debugging or inspecting how spec.componentRoutes is applied.
+                        type: array
+                        minItems: 1
+                        items:
+                          description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                          type: object
+                          required:
+                            - group
+                            - name
+                            - resource
+                          properties:
+                            group:
+                              description: group of the referent.
+                              type: string
+                            name:
+                              description: name of the referent.
+                              type: string
+                            namespace:
+                              description: namespace of the referent.
+                              type: string
+                            resource:
+                              description: resource of the referent.
+                              type: string
+                  x-kubernetes-list-map-keys:
+                    - namespace
+                    - name
+                  x-kubernetes-list-type: map
+                defaultPlacement:
+                  description: "defaultPlacement is set at installation time to control which nodes will host the ingress router pods by default. The options are control-plane nodes or worker nodes. \n This field works by dictating how the Cluster Ingress Operator will consider unset replicas and nodePlacement fields in IngressController resources when creating the corresponding Deployments. \n See the documentation for the IngressController replicas and nodePlacement fields for more information. \n When omitted, the default value is Workers"
+                  type: string
+                  enum:
+                    - ControlPlane
+                    - Workers
+                    - ""
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_network-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_network-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,211 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: networks.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc. Please view network.spec for an explanation on what applies when configuring this resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs. This field is immutable after installation.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                externalIP:
+                  description: externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.
+                  type: object
+                  properties:
+                    autoAssignCIDRs:
+                      description: autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called "IngressIPs". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.
+                      type: array
+                      items:
+                        type: string
+                    policy:
+                      description: policy is a set of restrictions applied to the ExternalIP field. If nil or empty, then ExternalIP is not allowed to be set.
+                      type: object
+                      properties:
+                        allowedCIDRs:
+                          description: allowedCIDRs is the list of allowed CIDRs.
+                          type: array
+                          items:
+                            type: string
+                        rejectedCIDRs:
+                          description: rejectedCIDRs is the list of disallowed CIDRs. These take precedence over allowedCIDRs.
+                          type: array
+                          items:
+                            type: string
+                networkType:
+                  description: 'NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.'
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.
+                  type: array
+                  items:
+                    type: string
+                serviceNodePortRange:
+                  description: The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.
+                  type: string
+                  pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                clusterNetworkMTU:
+                  description: ClusterNetworkMTU is the MTU for inter-pod networking.
+                  type: integer
+                conditions:
+                  description: 'conditions represents the observations of a network.config current state. Known .status.conditions.type are: "NetworkTypeMigrationInProgress", "NetworkTypeMigrationMTUReady", "NetworkTypeMigrationTargetCNIAvailable", "NetworkTypeMigrationTargetCNIInUse" and "NetworkTypeMigrationOriginalCNIPurged"'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                migration:
+                  description: Migration contains the cluster network migration configuration.
+                  type: object
+                  properties:
+                    mtu:
+                      description: MTU contains the MTU migration configuration.
+                      type: object
+                      properties:
+                        machine:
+                          description: Machine contains MTU migration configuration for the machine's uplink.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                        network:
+                          description: Network contains MTU migration configuration for the default network.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                    networkType:
+                      description: 'NetworkType is the target plugin that is to be deployed. Currently supported values are: OpenShiftSDN, OVNKubernetes'
+                      type: string
+                      enum:
+                        - OpenShiftSDN
+                        - OVNKubernetes
+                networkType:
+                  description: NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here.
+                  type: array
+                  items:
+                    type: string
+      served: true
+      storage: true

--- a/payload-manifests/crds/0000_10_config-operator_01_network-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_network-Default.crd.yaml
@@ -1,0 +1,164 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: Default
+  name: networks.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc. Please view network.spec for an explanation on what applies when configuring this resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs. This field is immutable after installation.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                externalIP:
+                  description: externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.
+                  type: object
+                  properties:
+                    autoAssignCIDRs:
+                      description: autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called "IngressIPs". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.
+                      type: array
+                      items:
+                        type: string
+                    policy:
+                      description: policy is a set of restrictions applied to the ExternalIP field. If nil or empty, then ExternalIP is not allowed to be set.
+                      type: object
+                      properties:
+                        allowedCIDRs:
+                          description: allowedCIDRs is the list of allowed CIDRs.
+                          type: array
+                          items:
+                            type: string
+                        rejectedCIDRs:
+                          description: rejectedCIDRs is the list of disallowed CIDRs. These take precedence over allowedCIDRs.
+                          type: array
+                          items:
+                            type: string
+                networkType:
+                  description: 'NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.'
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.
+                  type: array
+                  items:
+                    type: string
+                serviceNodePortRange:
+                  description: The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.
+                  type: string
+                  pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                clusterNetworkMTU:
+                  description: ClusterNetworkMTU is the MTU for inter-pod networking.
+                  type: integer
+                migration:
+                  description: Migration contains the cluster network migration configuration.
+                  type: object
+                  properties:
+                    mtu:
+                      description: MTU contains the MTU migration configuration.
+                      type: object
+                      properties:
+                        machine:
+                          description: Machine contains MTU migration configuration for the machine's uplink.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                        network:
+                          description: Network contains MTU migration configuration for the default network.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                    networkType:
+                      description: 'NetworkType is the target plugin that is to be deployed. Currently supported values are: OpenShiftSDN, OVNKubernetes'
+                      type: string
+                      enum:
+                        - OpenShiftSDN
+                        - OVNKubernetes
+                networkType:
+                  description: NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here.
+                  type: array
+                  items:
+                    type: string
+      served: true
+      storage: true

--- a/payload-manifests/crds/0000_10_config-operator_01_network-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_network-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,211 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: networks.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Network holds cluster-wide information about Network. The canonical name is `cluster`. It is used to configure the desired network configuration, such as: IP address pools for services/pod IPs, network plugin, etc. Please view network.spec for an explanation on what applies when configuring this resource. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration. As a general rule, this SHOULD NOT be read directly. Instead, you should consume the NetworkStatus, as it indicates the currently deployed configuration. Currently, most spec fields are immutable after installation. Please view the individual ones for further details on each.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs. This field is immutable after installation.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                externalIP:
+                  description: externalIP defines configuration for controllers that affect Service.ExternalIP. If nil, then ExternalIP is not allowed to be set.
+                  type: object
+                  properties:
+                    autoAssignCIDRs:
+                      description: autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called "IngressIPs". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.
+                      type: array
+                      items:
+                        type: string
+                    policy:
+                      description: policy is a set of restrictions applied to the ExternalIP field. If nil or empty, then ExternalIP is not allowed to be set.
+                      type: object
+                      properties:
+                        allowedCIDRs:
+                          description: allowedCIDRs is the list of allowed CIDRs.
+                          type: array
+                          items:
+                            type: string
+                        rejectedCIDRs:
+                          description: rejectedCIDRs is the list of disallowed CIDRs. These take precedence over allowedCIDRs.
+                          type: array
+                          items:
+                            type: string
+                networkType:
+                  description: 'NetworkType is the plugin that is to be deployed (e.g. OpenShiftSDN). This should match a value that the cluster-network-operator understands, or else no networking will be installed. Currently supported values are: - OpenShiftSDN This field is immutable after installation.'
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here. This field is immutable after installation.
+                  type: array
+                  items:
+                    type: string
+                serviceNodePortRange:
+                  description: The port range allowed for Services of type NodePort. If not specified, the default of 30000-32767 will be used. Such Services without a NodePort specified will have one automatically allocated from this range. This parameter can be updated after the cluster is installed.
+                  type: string
+                  pattern: ^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])-([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                clusterNetwork:
+                  description: IP address pool to use for pod IPs.
+                  type: array
+                  items:
+                    description: ClusterNetworkEntry is a contiguous block of IP addresses from which pod IPs are allocated.
+                    type: object
+                    properties:
+                      cidr:
+                        description: The complete block for pod IPs.
+                        type: string
+                      hostPrefix:
+                        description: The size (prefix) of block to allocate to each node. If this field is not used by the plugin, it can be left unset.
+                        type: integer
+                        format: int32
+                        minimum: 0
+                clusterNetworkMTU:
+                  description: ClusterNetworkMTU is the MTU for inter-pod networking.
+                  type: integer
+                conditions:
+                  description: 'conditions represents the observations of a network.config current state. Known .status.conditions.type are: "NetworkTypeMigrationInProgress", "NetworkTypeMigrationMTUReady", "NetworkTypeMigrationTargetCNIAvailable", "NetworkTypeMigrationTargetCNIInUse" and "NetworkTypeMigrationOriginalCNIPurged"'
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                migration:
+                  description: Migration contains the cluster network migration configuration.
+                  type: object
+                  properties:
+                    mtu:
+                      description: MTU contains the MTU migration configuration.
+                      type: object
+                      properties:
+                        machine:
+                          description: Machine contains MTU migration configuration for the machine's uplink.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                        network:
+                          description: Network contains MTU migration configuration for the default network.
+                          type: object
+                          properties:
+                            from:
+                              description: From is the MTU to migrate from.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                            to:
+                              description: To is the MTU to migrate to.
+                              type: integer
+                              format: int32
+                              minimum: 0
+                    networkType:
+                      description: 'NetworkType is the target plugin that is to be deployed. Currently supported values are: OpenShiftSDN, OVNKubernetes'
+                      type: string
+                      enum:
+                        - OpenShiftSDN
+                        - OVNKubernetes
+                networkType:
+                  description: NetworkType is the plugin that is deployed (e.g. OpenShiftSDN).
+                  type: string
+                serviceNetwork:
+                  description: IP address pool for services. Currently, we only support a single entry here.
+                  type: array
+                  items:
+                    type: string
+      served: true
+      storage: true

--- a/payload-manifests/crds/0000_10_config-operator_01_node.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_node.crd.yaml
@@ -1,0 +1,59 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1107
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: nodes.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Node
+    listKind: NodeList
+    plural: nodes
+    singular: node
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Node holds cluster-wide information about node specific features. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                cgroupMode:
+                  description: CgroupMode determines the cgroups version on the node
+                  type: string
+                  enum:
+                    - v1
+                    - v2
+                    - ""
+                workerLatencyProfile:
+                  description: WorkerLatencyProfile determins the how fast the kubelet is updating the status and corresponding reaction of the cluster
+                  type: string
+                  enum:
+                    - Default
+                    - MediumUpdateAverageReaction
+                    - LowUpdateSlowReaction
+            status:
+              description: status holds observed values.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_oauth.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_oauth.crd.yaml
@@ -1,0 +1,444 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: oauths.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: OAuth
+    listKind: OAuthList
+    plural: oauths
+    singular: oauth
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "OAuth holds cluster-wide information about OAuth.  The canonical name is `cluster`. It is used to configure the integrated OAuth server. This configuration is only honored when the top level Authentication config has type set to IntegratedOAuth. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                identityProviders:
+                  description: identityProviders is an ordered list of ways for a user to identify themselves. When this list is empty, no identities are provisioned for users.
+                  type: array
+                  items:
+                    description: IdentityProvider provides identities for users authenticating using credentials
+                    type: object
+                    properties:
+                      basicAuth:
+                        description: basicAuth contains configuration options for the BasicAuth IdP
+                        type: object
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced config map
+                                type: string
+                          tlsClientCert:
+                            description: tlsClientCert is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate to present when connecting to the server. The key "tls.crt" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                          tlsClientKey:
+                            description: tlsClientKey is an optional reference to a secret by name that contains the PEM-encoded TLS private key for the client certificate referenced in tlsClientCert. The key "tls.key" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                          url:
+                            description: url is the remote URL to connect to
+                            type: string
+                      github:
+                        description: github enables user authentication using GitHub credentials
+                        type: object
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. This can only be configured when hostname is set to a non-empty value. The namespace for this config map is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced config map
+                                type: string
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the secret by name containing the oauth client secret. The key "clientSecret" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                          hostname:
+                            description: hostname is the optional domain (e.g. "mycompany.com") for use with a hosted instance of GitHub Enterprise. It must match the GitHub Enterprise settings value configured at /setup/settings#hostname.
+                            type: string
+                          organizations:
+                            description: organizations optionally restricts which organizations are allowed to log in
+                            type: array
+                            items:
+                              type: string
+                          teams:
+                            description: teams optionally restricts which teams are allowed to log in. Format is <org>/<team>.
+                            type: array
+                            items:
+                              type: string
+                      gitlab:
+                        description: gitlab enables user authentication using GitLab credentials
+                        type: object
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced config map
+                                type: string
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the secret by name containing the oauth client secret. The key "clientSecret" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                          url:
+                            description: url is the oauth server base URL
+                            type: string
+                      google:
+                        description: google enables user authentication using Google credentials
+                        type: object
+                        properties:
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the secret by name containing the oauth client secret. The key "clientSecret" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                          hostedDomain:
+                            description: hostedDomain is the optional Google App domain (e.g. "mycompany.com") to restrict logins to
+                            type: string
+                      htpasswd:
+                        description: htpasswd enables user authentication using an HTPasswd file to validate credentials
+                        type: object
+                        properties:
+                          fileData:
+                            description: fileData is a required reference to a secret by name containing the data to use as the htpasswd file. The key "htpasswd" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. If the specified htpasswd data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                      keystone:
+                        description: keystone enables user authentication using keystone password credentials
+                        type: object
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced config map
+                                type: string
+                          domainName:
+                            description: domainName is required for keystone v3
+                            type: string
+                          tlsClientCert:
+                            description: tlsClientCert is an optional reference to a secret by name that contains the PEM-encoded TLS client certificate to present when connecting to the server. The key "tls.crt" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                          tlsClientKey:
+                            description: tlsClientKey is an optional reference to a secret by name that contains the PEM-encoded TLS private key for the client certificate referenced in tlsClientCert. The key "tls.key" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. If the specified certificate data is not valid, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                          url:
+                            description: url is the remote URL to connect to
+                            type: string
+                      ldap:
+                        description: ldap enables user authentication using LDAP credentials
+                        type: object
+                        properties:
+                          attributes:
+                            description: attributes maps LDAP attributes to identities
+                            type: object
+                            properties:
+                              email:
+                                description: email is the list of attributes whose values should be used as the email address. Optional. If unspecified, no email is set for the identity
+                                type: array
+                                items:
+                                  type: string
+                              id:
+                                description: id is the list of attributes whose values should be used as the user ID. Required. First non-empty attribute is used. At least one attribute is required. If none of the listed attribute have a value, authentication fails. LDAP standard identity attribute is "dn"
+                                type: array
+                                items:
+                                  type: string
+                              name:
+                                description: name is the list of attributes whose values should be used as the display name. Optional. If unspecified, no display name is set for the identity LDAP standard display name attribute is "cn"
+                                type: array
+                                items:
+                                  type: string
+                              preferredUsername:
+                                description: preferredUsername is the list of attributes whose values should be used as the preferred username. LDAP standard login attribute is "uid"
+                                type: array
+                                items:
+                                  type: string
+                          bindDN:
+                            description: bindDN is an optional DN to bind with during the search phase.
+                            type: string
+                          bindPassword:
+                            description: bindPassword is an optional reference to a secret by name containing a password to bind with during the search phase. The key "bindPassword" is used to locate the data. If specified and the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                          ca:
+                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced config map
+                                type: string
+                          insecure:
+                            description: 'insecure, if true, indicates the connection should not use TLS WARNING: Should not be set to `true` with the URL scheme "ldaps://" as "ldaps://" URLs always attempt to connect using TLS, even when `insecure` is set to `true` When `true`, "ldap://" URLS connect insecurely. When `false`, "ldap://" URLs are upgraded to a TLS connection using StartTLS as specified in https://tools.ietf.org/html/rfc2830.'
+                            type: boolean
+                          url:
+                            description: 'url is an RFC 2255 URL which specifies the LDAP search parameters to use. The syntax of the URL is: ldap://host:port/basedn?attribute?scope?filter'
+                            type: string
+                      mappingMethod:
+                        description: mappingMethod determines how identities from this provider are mapped to users Defaults to "claim"
+                        type: string
+                      name:
+                        description: 'name is used to qualify the identities returned by this provider. - It MUST be unique and not shared by any other identity provider used - It MUST be a valid path segment: name cannot equal "." or ".." or contain "/" or "%" or ":" Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName'
+                        type: string
+                      openID:
+                        description: openID enables user authentication using OpenID credentials
+                        type: object
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. The key "ca.crt" is used to locate the data. If specified and the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. If empty, the default system roots are used. The namespace for this config map is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced config map
+                                type: string
+                          claims:
+                            description: claims mappings
+                            type: object
+                            properties:
+                              email:
+                                description: email is the list of claims whose values should be used as the email address. Optional. If unspecified, no email is set for the identity
+                                type: array
+                                items:
+                                  type: string
+                                x-kubernetes-list-type: atomic
+                              groups:
+                                description: groups is the list of claims value of which should be used to synchronize groups from the OIDC provider to OpenShift for the user. If multiple claims are specified, the first one with a non-empty value is used.
+                                type: array
+                                items:
+                                  description: OpenIDClaim represents a claim retrieved from an OpenID provider's tokens or userInfo responses
+                                  type: string
+                                  minLength: 1
+                                x-kubernetes-list-type: atomic
+                              name:
+                                description: name is the list of claims whose values should be used as the display name. Optional. If unspecified, no display name is set for the identity
+                                type: array
+                                items:
+                                  type: string
+                                x-kubernetes-list-type: atomic
+                              preferredUsername:
+                                description: preferredUsername is the list of claims whose values should be used as the preferred username. If unspecified, the preferred username is determined from the value of the sub claim
+                                type: array
+                                items:
+                                  type: string
+                                x-kubernetes-list-type: atomic
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the secret by name containing the oauth client secret. The key "clientSecret" is used to locate the data. If the secret or expected key is not found, the identity provider is not honored. The namespace for this secret is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced secret
+                                type: string
+                          extraAuthorizeParameters:
+                            description: extraAuthorizeParameters are any custom parameters to add to the authorize request.
+                            type: object
+                            additionalProperties:
+                              type: string
+                          extraScopes:
+                            description: extraScopes are any scopes to request in addition to the standard "openid" scope.
+                            type: array
+                            items:
+                              type: string
+                          issuer:
+                            description: issuer is the URL that the OpenID Provider asserts as its Issuer Identifier. It must use the https scheme with no query or fragment component.
+                            type: string
+                      requestHeader:
+                        description: requestHeader enables user authentication using request header credentials
+                        type: object
+                        properties:
+                          ca:
+                            description: ca is a required reference to a config map by name containing the PEM-encoded CA bundle. It is used as a trust anchor to validate the TLS certificate presented by the remote server. Specifically, it allows verification of incoming requests to prevent header spoofing. The key "ca.crt" is used to locate the data. If the config map or expected key is not found, the identity provider is not honored. If the specified ca data is not valid, the identity provider is not honored. The namespace for this config map is openshift-config.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced config map
+                                type: string
+                          challengeURL:
+                            description: challengeURL is a URL to redirect unauthenticated /authorize requests to Unauthenticated requests from OAuth clients which expect WWW-Authenticate challenges will be redirected here. ${url} is replaced with the current URL, escaped to be safe in a query parameter https://www.example.com/sso-login?then=${url} ${query} is replaced with the current query string https://www.example.com/auth-proxy/oauth/authorize?${query} Required when challenge is set to true.
+                            type: string
+                          clientCommonNames:
+                            description: clientCommonNames is an optional list of common names to require a match from. If empty, any client certificate validated against the clientCA bundle is considered authoritative.
+                            type: array
+                            items:
+                              type: string
+                          emailHeaders:
+                            description: emailHeaders is the set of headers to check for the email address
+                            type: array
+                            items:
+                              type: string
+                          headers:
+                            description: headers is the set of headers to check for identity information
+                            type: array
+                            items:
+                              type: string
+                          loginURL:
+                            description: loginURL is a URL to redirect unauthenticated /authorize requests to Unauthenticated requests from OAuth clients which expect interactive logins will be redirected here ${url} is replaced with the current URL, escaped to be safe in a query parameter https://www.example.com/sso-login?then=${url} ${query} is replaced with the current query string https://www.example.com/auth-proxy/oauth/authorize?${query} Required when login is set to true.
+                            type: string
+                          nameHeaders:
+                            description: nameHeaders is the set of headers to check for the display name
+                            type: array
+                            items:
+                              type: string
+                          preferredUsernameHeaders:
+                            description: preferredUsernameHeaders is the set of headers to check for the preferred username
+                            type: array
+                            items:
+                              type: string
+                      type:
+                        description: type identifies the identity provider type for this entry.
+                        type: string
+                  x-kubernetes-list-type: atomic
+                templates:
+                  description: templates allow you to customize pages like the login page.
+                  type: object
+                  properties:
+                    error:
+                      description: error is the name of a secret that specifies a go template to use to render error pages during the authentication or grant flow. The key "errors.html" is used to locate the template data. If specified and the secret or expected key is not found, the default error page is used. If the specified template is not valid, the default error page is used. If unspecified, the default error page is used. The namespace for this secret is openshift-config.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced secret
+                          type: string
+                    login:
+                      description: login is the name of a secret that specifies a go template to use to render the login page. The key "login.html" is used to locate the template data. If specified and the secret or expected key is not found, the default login page is used. If the specified template is not valid, the default login page is used. If unspecified, the default login page is used. The namespace for this secret is openshift-config.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced secret
+                          type: string
+                    providerSelection:
+                      description: providerSelection is the name of a secret that specifies a go template to use to render the provider selection page. The key "providers.html" is used to locate the template data. If specified and the secret or expected key is not found, the default provider selection page is used. If the specified template is not valid, the default provider selection page is used. If unspecified, the default provider selection page is used. The namespace for this secret is openshift-config.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced secret
+                          type: string
+                tokenConfig:
+                  description: tokenConfig contains options for authorization and access tokens
+                  type: object
+                  properties:
+                    accessTokenInactivityTimeout:
+                      description: "accessTokenInactivityTimeout defines the token inactivity timeout for tokens granted by any client. The value represents the maximum amount of time that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. The user will need to acquire a new token to regain access once a token times out. Takes valid time duration string such as \"5m\", \"1.5h\" or \"2h45m\". The minimum allowed value for duration is 300s (5 minutes). If the timeout is configured per client, then that value takes precedence. If the timeout value is not specified and the client does not override the value, then tokens are valid until their lifetime. \n WARNING: existing tokens' timeout will not be affected (lowered) by changing this value"
+                      type: string
+                    accessTokenInactivityTimeoutSeconds:
+                      description: 'accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.'
+                      type: integer
+                      format: int32
+                    accessTokenMaxAgeSeconds:
+                      description: accessTokenMaxAgeSeconds defines the maximum age of access tokens
+                      type: integer
+                      format: int32
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_project.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_project.crd.yaml
@@ -1,0 +1,55 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: projects.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Project
+    listKind: ProjectList
+    plural: projects
+    singular: project
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Project holds cluster-wide information about Project.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                projectRequestMessage:
+                  description: projectRequestMessage is the string presented to a user if they are unable to request a project via the projectrequest api endpoint
+                  type: string
+                projectRequestTemplate:
+                  description: projectRequestTemplate is the template to use for creating projects in response to projectrequest. This must point to a template in 'openshift-config' namespace. It is optional. If it is not specified, a default template is used.
+                  type: object
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced project request template
+                      type: string
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_scheduler.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_scheduler.crd.yaml
@@ -1,0 +1,68 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: schedulers.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Scheduler
+    listKind: SchedulerList
+    plural: schedulers
+    singular: scheduler
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Scheduler holds cluster-wide config information to run the Kubernetes Scheduler and influence its placement decisions. The canonical name for this config is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                defaultNodeSelector:
+                  description: 'defaultNodeSelector helps set the cluster-wide default node selector to restrict pod placement to specific nodes. This is applied to the pods created in all namespaces and creates an intersection with any existing nodeSelectors already set on a pod, additionally constraining that pod''s selector. For example, defaultNodeSelector: "type=user-node,region=east" would set nodeSelector field in pod spec to "type=user-node,region=east" to all pods created in all namespaces. Namespaces having project-wide node selectors won''t be impacted even if this field is set. This adds an annotation section to the namespace. For example, if a new namespace is created with node-selector=''type=user-node,region=east'', the annotation openshift.io/node-selector: type=user-node,region=east gets added to the project. When the openshift.io/node-selector annotation is set on the project the value is used in preference to the value we are setting for defaultNodeSelector field. For instance, openshift.io/node-selector: "type=user-node,region=west" means that the default of "type=user-node,region=east" set in defaultNodeSelector would not be applied.'
+                  type: string
+                mastersSchedulable:
+                  description: 'MastersSchedulable allows masters nodes to be schedulable. When this flag is turned on, all the master nodes in the cluster will be made schedulable, so that workload pods can run on them. The default value for this field is false, meaning none of the master nodes are schedulable. Important Note: Once the workload pods start running on the master nodes, extreme care must be taken to ensure that cluster-critical control plane components are not impacted. Please turn on this field after doing due diligence.'
+                  type: boolean
+                policy:
+                  description: 'DEPRECATED: the scheduler Policy API has been deprecated and will be removed in a future release. policy is a reference to a ConfigMap containing scheduler policy which has user specified predicates and priorities. If this ConfigMap is not available scheduler will default to use DefaultAlgorithmProvider. The namespace for this configmap is openshift-config.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                profile:
+                  description: "profile sets which scheduling profile should be set in order to configure scheduling decisions for new pods. \n Valid values are \"LowNodeUtilization\", \"HighNodeUtilization\", \"NoScoring\" Defaults to \"LowNodeUtilization\""
+                  type: string
+                  enum:
+                    - ""
+                    - LowNodeUtilization
+                    - HighNodeUtilization
+                    - NoScoring
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
This sets up a single directory to store all crds/manifests destined for the payload.

We want a single directory so that we can easily skip E2E tests when changed do not contribute to the payload directly from the API image.

The dockerfile now sources all CRDs from a single location, and we have scripts to check that the CRDs are up to date, and that no extra files are present in the CRD source folder.

IIUC we can't add the manifests directly to the payload at the moment because of the render unwinding from CCO, in the future I think we can simplify this and copy directly into the manifests folder, at which point we can update these scripts