### PR TITLE
OCPBUGS-15934: use *resource.Quantity to not automatically set 0

### DIFF
--- a/machineconfiguration/v1/types.go
+++ b/machineconfiguration/v1/types.go
@@ -679,12 +679,12 @@ type ContainerRuntimeConfiguration struct {
 	// Negative numbers indicate that no size limit is imposed.
 	// If it is positive, it must be >= 8192 to match/exceed conmon's read buffer.
 	// +optional
-	LogSizeMax resource.Quantity `json:"logSizeMax,omitempty"`
+	LogSizeMax *resource.Quantity `json:"logSizeMax,omitempty"`
 
 	// overlaySize specifies the maximum size of a container image.
 	// This flag can be used to set quota on the size of container images. (default: 10GB)
 	// +optional
-	OverlaySize resource.Quantity `json:"overlaySize,omitempty"`
+	OverlaySize *resource.Quantity `json:"overlaySize,omitempty"`
 
 	// defaultRuntime is the name of the OCI runtime to be used as the default.
 	// +optional

--- a/machineconfiguration/v1/zz_generated.deepcopy.go
+++ b/machineconfiguration/v1/zz_generated.deepcopy.go
@@ -168,8 +168,16 @@ func (in *ContainerRuntimeConfiguration) DeepCopyInto(out *ContainerRuntimeConfi
 		*out = new(int64)
 		**out = **in
 	}
-	out.LogSizeMax = in.LogSizeMax.DeepCopy()
-	out.OverlaySize = in.OverlaySize.DeepCopy()
+	if in.LogSizeMax != nil {
+		in, out := &in.LogSizeMax, &out.LogSizeMax
+		x := (*in).DeepCopy()
+		*out = &x
+	}
+	if in.OverlaySize != nil {
+		in, out := &in.OverlaySize, &out.OverlaySize
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->
close: https://issues.redhat.com/browse/OCPBUGS-15934
**- What I did**
Change the type of `OverlaySize` and `LogSizeMax` resource.Quantity to pointer *resource.Quantity. 
the struct type will be set as 0 automatically when retrieving the ctrcfg object.

I am uncertain if we can make this update to current ContainerruntimeConfig API, I propose this change because the ContainerruntimeConfig API is currently MCO internal.
**- How to verify it**
```
# apply the containerruntimeconfig CR
apiVersion: machineconfiguration.openshift.io/v1
kind: ContainerRuntimeConfig
metadata:
 name: pidlimit
spec:
 machineConfigPoolSelector:
   matchLabels:
     pools.operator.machineconfiguration.openshift.io/worker: '' 
 containerRuntimeConfig:
   pidsLimit: 4096 
   logLevel: debug

# current result:
$ oc get containerruntimeconfig  pidlimit -o json | jq '.spec.containerRuntimeConfig'
{
  "logLevel": "debug",
  "logSizeMax": "0",
  "overlaySize": "0",
  "pidsLimit": 4096
}

# after this patch, it will be 
$ oc get containerruntimeconfig  pidlimit -o json | jq '.spec.containerRuntimeConfig'
{
  "logLevel": "debug",
  "pidsLimit": 4096
}
```
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
