### PR TITLE
SPLAT-1097: IBMCloud: Add IBM Cloud Service names

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
@@ -750,9 +750,19 @@ spec:
                             description: IBMCloudServiceEndpoint stores the configuration of a custom url to override existing defaults of IBM Cloud Services.
                             properties:
                               name:
-                                description: name is the name of the IBM Cloud service. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
-                                maxLength: 32
-                                pattern: ^[a-zA-Z0-9-]+$
+                                description: 'name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`'
+                                enum:
+                                  - CIS
+                                  - COS
+                                  - DNSServices
+                                  - GlobalSearch
+                                  - GlobalTagging
+                                  - HyperProtect
+                                  - IAM
+                                  - KeyProtect
+                                  - ResourceController
+                                  - ResourceManager
+                                  - VPC
                                 type: string
                               url:
                                 description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.

--- a/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
@@ -655,9 +655,19 @@ spec:
                             description: IBMCloudServiceEndpoint stores the configuration of a custom url to override existing defaults of IBM Cloud Services.
                             properties:
                               name:
-                                description: name is the name of the IBM Cloud service. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
-                                maxLength: 32
-                                pattern: ^[a-zA-Z0-9-]+$
+                                description: 'name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`'
+                                enum:
+                                  - CIS
+                                  - COS
+                                  - DNSServices
+                                  - GlobalSearch
+                                  - GlobalTagging
+                                  - HyperProtect
+                                  - IAM
+                                  - KeyProtect
+                                  - ResourceController
+                                  - ResourceManager
+                                  - VPC
                                 type: string
                               url:
                                 description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.

--- a/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
@@ -750,9 +750,19 @@ spec:
                             description: IBMCloudServiceEndpoint stores the configuration of a custom url to override existing defaults of IBM Cloud Services.
                             properties:
                               name:
-                                description: name is the name of the IBM Cloud service. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
-                                maxLength: 32
-                                pattern: ^[a-zA-Z0-9-]+$
+                                description: 'name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`'
+                                enum:
+                                  - CIS
+                                  - COS
+                                  - DNSServices
+                                  - GlobalSearch
+                                  - GlobalTagging
+                                  - HyperProtect
+                                  - IAM
+                                  - KeyProtect
+                                  - ResourceController
+                                  - ResourceManager
+                                  - VPC
                                 type: string
                               url:
                                 description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.

--- a/config/v1/stable.infrastructure.testsuite.yaml
+++ b/config/v1/stable.infrastructure.testsuite.yaml
@@ -993,9 +993,9 @@ tests:
             type: IBMCloud
             ibmcloud:
               serviceEndpoints:
-              - name: DummyVPC
+              - name: VPC
                 url: https://dummy.vpc.com
-              - name: DummyCOS
+              - name: COS
                 url: https://dummy.cos.com
       expected: |
         apiVersion: config.openshift.io/v1
@@ -1010,9 +1010,9 @@ tests:
             type: IBMCloud
             ibmcloud:
               serviceEndpoints:
-              - name: DummyVPC
+              - name: VPC
                 url: https://dummy.vpc.com
-              - name: DummyCOS
+              - name: COS
                 url: https://dummy.cos.com
     - name: Should not be able to add empty (URL) ServiceEndpoints to IBMCloud PlatformStatus
       initial: |
@@ -1035,7 +1035,7 @@ tests:
             type: IBMCloud
             ibmcloud:
               serviceEndpoints:
-              - name: EmptyCOS
+              - name: COS
                 url: " "
       expectedStatusError: " status.platformStatus.ibmcloud.serviceEndpoints[0].url: Invalid value: \"string\": url must be a valid absolute URL"
     - name: Should not be able to add invalid (URL) ServiceEndpoints to IBMCloud PlatformStatus
@@ -1059,8 +1059,34 @@ tests:
             type: IBMCloud
             ibmcloud:
               serviceEndpoints:
-              - name: DummyVPC
+              - name: VPC
                 url: https://dummy.vpc.com
-              - name: BadCOS
+              - name: COS
                 url: dummy-cos-com
       expectedStatusError: " status.platformStatus.ibmcloud.serviceEndpoints[1].url: Invalid value: \"string\": url must be a valid absolute URL"
+    - name: Should not be able to add invalid (Name) ServiceEndpoints to IBMCloud PlatformStatus
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platform: IBMCloud
+          platformStatus:
+            type: IBMCloud
+            ibmcloud:
+              serviceEndpoints: []
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platform: IBMCloud
+          platformStatus:
+            type: IBMCloud
+            ibmcloud:
+              serviceEndpoints:
+              - name: VPC
+                url: https://dummy.vpc.com
+              - name: BadService
+                url: https://bad-service.com
+      expectedStatusError: " status.platformStatus.ibmcloud.serviceEndpoints[1].name: Unsupported value: \"BadService\": supported values: \"CIS\", \"COS\", \"DNSServices\", \"GlobalSearch\", \"GlobalTagging\", \"HyperProtect\", \"IAM\", \"KeyProtect\", \"ResourceController\", \"ResourceManager\", \"VPC\""

--- a/config/v1/types.go
+++ b/config/v1/types.go
@@ -398,3 +398,33 @@ const (
 	// NoOpinionIncludeSubDomains means HSTS "includeSubDomains" doesn't matter to the RequiredHSTSPolicy
 	NoOpinionIncludeSubDomains IncludeSubDomainsPolicy = "NoOpinion"
 )
+
+// IBMCloudServiceName contains a value specifying the name of an IBM Cloud Service,
+// which are used by MAPI, CIRO, CIO, Installer, etc.
+// +kubebuilder:validation:Enum=CIS;COS;DNSServices;GlobalSearch;GlobalTagging;HyperProtect;IAM;KeyProtect;ResourceController;ResourceManager;VPC
+type IBMCloudServiceName string
+
+const (
+	// IBMCloudServiceCIS is the name for IBM Cloud CIS.
+	IBMCloudServiceCIS IBMCloudServiceName = "CIS"
+	// IBMCloudServiceCOS is the name for IBM Cloud COS.
+	IBMCloudServiceCOS IBMCloudServiceName = "COS"
+	// IBMCloudServiceDNSServices is the name for IBM Cloud DNS Services.
+	IBMCloudServiceDNSServices IBMCloudServiceName = "DNSServices"
+	// IBMCloudServiceGlobalSearch is the name for IBM Cloud Global Search.
+	IBMCloudServiceGlobalSearch IBMCloudServiceName = "GlobalSearch"
+	// IBMCloudServiceGlobalTagging is the name for IBM Cloud Global Tagging.
+	IBMCloudServiceGlobalTagging IBMCloudServiceName = "GlobalTagging"
+	// IBMCloudServiceHyperProtect is the name for IBM Cloud Hyper Protect.
+	IBMCloudServiceHyperProtect IBMCloudServiceName = "HyperProtect"
+	// IBMCloudServiceIAM is the name for IBM Cloud IAM.
+	IBMCloudServiceIAM IBMCloudServiceName = "IAM"
+	// IBMCloudServiceKeyProtect is the name for IBM Cloud Key Protect.
+	IBMCloudServiceKeyProtect IBMCloudServiceName = "KeyProtect"
+	// IBMCloudServiceResourceController is the name for IBM Cloud Resource Controller.
+	IBMCloudServiceResourceController IBMCloudServiceName = "ResourceController"
+	// IBMCloudServiceResourceManager is the name for IBM Cloud Resource Manager.
+	IBMCloudServiceResourceManager IBMCloudServiceName = "ResourceManager"
+	// IBMCloudServiceVPC is the name for IBM Cloud VPC.
+	IBMCloudServiceVPC IBMCloudServiceName = "VPC"
+)

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -1182,15 +1182,14 @@ type VSpherePlatformStatus struct {
 // override existing defaults of IBM Cloud Services.
 type IBMCloudServiceEndpoint struct {
 	// name is the name of the IBM Cloud service.
+	// Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC.
 	// For example, the IBM Cloud Private IAM service could be configured with the
 	// service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
 	// Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured
 	// with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9-]+$`
-	// +kubebuilder:validation:MaxLength=32
-	Name string `json:"name"`
+	Name IBMCloudServiceName `json:"name"`
 
 	// url is fully qualified URI with scheme https, that overrides the default generated
 	// endpoint for a client.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1366,7 +1366,7 @@ func (IBMCloudPlatformStatus) SwaggerDoc() map[string]string {
 
 var map_IBMCloudServiceEndpoint = map[string]string{
 	"":     "IBMCloudServiceEndpoint stores the configuration of a custom url to override existing defaults of IBM Cloud Services.",
-	"name": "name is the name of the IBM Cloud service. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
+	"name": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
 	"url":  "url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.",
 }
 

--- a/machineconfiguration/v1/0000_80_controllerconfig.crd.yaml
+++ b/machineconfiguration/v1/0000_80_controllerconfig.crd.yaml
@@ -859,10 +859,20 @@ spec:
                                       - url
                                     properties:
                                       name:
-                                        description: name is the name of the IBM Cloud service. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`
+                                        description: 'name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`'
                                         type: string
-                                        maxLength: 32
-                                        pattern: ^[a-zA-Z0-9-]+$
+                                        enum:
+                                          - CIS
+                                          - COS
+                                          - DNSServices
+                                          - GlobalSearch
+                                          - GlobalTagging
+                                          - HyperProtect
+                                          - IAM
+                                          - KeyProtect
+                                          - ResourceController
+                                          - ResourceManager
+                                          - VPC
                                       url:
                                         description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
                                         type: string

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -12669,7 +12669,7 @@ func schema_openshift_api_config_v1_IBMCloudServiceEndpoint(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "name is the name of the IBM Cloud service. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
+							Description: "name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -6691,7 +6691,7 @@
       ],
       "properties": {
         "name": {
-          "description": "name is the name of the IBM Cloud service. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
+          "description": "name is the name of the IBM Cloud service. Possible values are: CIS, COS, DNSServices, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, ResourceController, ResourceManager, or VPC. For example, the IBM Cloud Private IAM service could be configured with the service `name` of `IAM` and `url` of `https://private.iam.cloud.ibm.com` Whereas the IBM Cloud Private VPC service for US South (Dallas) could be configured with the service `name` of `VPC` and `url` of `https://us.south.private.iaas.cloud.ibm.com`",
           "type": "string",
           "default": ""
         },


### PR DESCRIPTION
Add a new enum and values for IBM Cloud Service names.

Related: https://issues.redhat.com/browse/SPLAT-1097