### PR TITLE
OCPBUGS-19358: Allow GIT_LFS_SKIP_SMUDGE environment variable

### DIFF
--- a/build/v1/consts.go
+++ b/build/v1/consts.go
@@ -164,9 +164,10 @@ const (
 	StatusReasonBuildPodEvicted StatusReason = "BuildPodEvicted"
 )
 
-// env vars
-// WhitelistEnvVarNames is a list of special env vars allows s2i containers
-var WhitelistEnvVarNames = []string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY", "HTTP_PROXY", "HTTPS_PROXY", "LANG", "NO_PROXY"}
+// WhitelistEnvVarNames is a list of environment variable names that are allowed to be specified
+// in a buildconfig and merged into the created build pods, the code for this is located in
+// openshift/openshift-controller-manager
+var WhitelistEnvVarNames = []string{"BUILD_LOGLEVEL", "GIT_SSL_NO_VERIFY", "GIT_LFS_SKIP_SMUDGE", "HTTP_PROXY", "HTTPS_PROXY", "LANG", "NO_PROXY"}
 
 // env vars
 const (


### PR DESCRIPTION
Since introducing the 'git-lfs' package into the build container, we have had customers that have an issue with the git-lfs automatically being run and would like the option to disable this functionality via the 'GIT_LFS_SKIP_SMUDGE' environment variable.