### PR TITLE
SPLAT-1240: annotate default CRD with default feature-set annotation

### DIFF
--- a/machine/v1/0000_10_controlplanemachineset-Default.crd.yaml
+++ b/machine/v1/0000_10_controlplanemachineset-Default.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1112
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: Default
   creationTimestamp: null
   name: controlplanemachinesets.machine.openshift.io
 spec:


### PR DESCRIPTION
Confirmed that with this change, the Default feature set CRD is not applied when TechPreviewNoUpgrade feature set is enabled in https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/228 .

```
I1115 16:34:23.292105       1 payload.go:210] excluding Filename: "0000_30_control-plane-machine-set-operator_00_controlplanemachineset-customnoupgrade.crd.yaml" Group: "apiextensions.k8s.io" Kind: "CustomResourceDefinition" Name: "controlplanemachinesets.machine.openshift.io": "TechPreviewNoUpgrade" is required, and release.openshift.io/feature-set=CustomNoUpgrade
I1115 16:34:23.326421       1 payload.go:210] excluding Filename: "0000_30_control-plane-machine-set-operator_00_controlplanemachineset-default.crd.yaml" Group: "apiextensions.k8s.io" Kind: "CustomResourceDefinition" Name: "controlplanemachinesets.machine.openshift.io": "TechPreviewNoUpgrade" is required, and release.openshift.io/feature-set=Default
```
