### PR TITLE
backport the openshift owner anntotation

### DIFF
--- a/annotations/annotations.go
+++ b/annotations/annotations.go
@@ -25,4 +25,10 @@ const (
 
 	// OpenShiftLongDescriptionAnnotation is a resource's long description
 	OpenShiftLongDescriptionAnnotation = "openshift.io/long-description"
+
+	// OpenShiftComponent is a common, optional annotation that stores the owning component for a resource.
+	// The component is for whatever bug tracker we're using.  That used to be bugzilla, now it is
+	// a jira component and subcomponent in OCPBUGS.
+	// For example, "Etcd" or "Networking / ovn-kubernetes"
+	OpenShiftComponent = "openshift.io/owning-component"
 )


### PR DESCRIPTION
Some projects are still on kube 1.27.  Rather than bring them all up to master, backporting this unversioned annotation will broaden adoption.