### PR TITLE
have the CVO manage CRDs from the api image

### DIFF
--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -21,14 +21,13 @@ COPY operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.y
 
 # these are applied by the CVO
 COPY manifests /manifests
-# TODO copy these back when we're ready to make the switch from cluster-config-operator to here
-#COPY config/v1/*_config-operator_*.yaml /manifests
-#COPY quota/v1/*.crd.yaml /manifests
-#COPY security/v1/*.crd.yaml /manifests
-#COPY securityinternal/v1/*.crd.yaml /manifests
-#COPY authorization/v1/*.crd.yaml /manifests
-#COPY operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml /manifests
-#COPY operator/v1/0000_10_config-operator_*.yaml /manifests
-#COPY payload-command/empty-resources /manifests
+COPY config/v1/*_config-operator_*.yaml /manifests
+COPY quota/v1/*.crd.yaml /manifests
+COPY security/v1/*.crd.yaml /manifests
+COPY securityinternal/v1/*.crd.yaml /manifests
+COPY authorization/v1/*.crd.yaml /manifests
+COPY operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml /manifests
+COPY operator/v1/0000_10_config-operator_*.yaml /manifests
+COPY payload-command/empty-resources /manifests
 
 LABEL io.openshift.release.operator true


### PR DESCRIPTION
Full chain is 
1. https://github.com/openshift/api/pull/1666
2. https://github.com/openshift/cluster-config-operator/pull/379
3. https://github.com/openshift/installer/pull/7666
4. https://github.com/openshift/cluster-config-operator/pull/349
5. https://github.com/openshift/cluster-config-operator/pull/382
6. https://github.com/openshift/cluster-config-operator/pull/380
7. https://github.com/openshift/cluster-config-operator/pull/381
8. https://github.com/openshift/api/pull/1669
9. https://github.com/openshift/cluster-config-operator/pull/380
10. https://github.com/openshift/api/pull/1665
11. https://github.com/openshift/api/pull/1662
12. https://github.com/openshift/api/pull/1642
13. https://github.com/openshift/release/pull/43522
14. https://github.com/openshift/api/pull/1635
15. https://github.com/openshift-eng/ocp-build-data/pull/3778
16. https://github.com/openshift/api/pull/1567
17. 

/hold

must merge together with https://github.com/openshift/cluster-config-operator/pull/379

While the vendored level in cluster-config-operator matches, these can show green simultaneously.  When that happens, we need to manually merge both to avoid future conflicts.