### PR TITLE
features: add alternative installers to TP

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -183,6 +183,8 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(dnsNameResolver).
 		with(machineConfigNodes).
 		with(metricsServer).
+		without(installAlternateInfrastructureAWS).
+		without(clusterAPIInstall).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),


### PR DESCRIPTION
Adds the AWS SDK and CAPI Install path to the tech preview feature set, but includes them as Disabled by default.