### PR TITLE
Add a mention of 'make generate-with-container' to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Since Kubernetes 1.16, every CRD created in `apiextensions.k8s.io/v1` is require
 
 These schemas are often very long and complex, and should not be written by hand. For OpenShift, we provide Makefile targets in [build-machinery-go](https://github.com/openshift/build-machinery-go/) which generate the schema, built on upstream's [controller-gen](https://github.com/kubernetes-sigs/controller-tools) tool.
 
-If you make a change to a CRD type in this repo, simply calling `make update-codegen-crds` should regenerate all CRDs and update the manifests. If yours is not updated, ensure that the path to its API is included in our [calls to the Makefile targets](https://github.com/openshift/api/blob/release-4.5/Makefile#L17-L29).
+If you make a change to a CRD type in this repo, simply calling `make update-codegen-crds` should regenerate all CRDs and update the manifests. If yours is not updated, ensure that the path to its API is included in our [calls to the Makefile targets](https://github.com/openshift/api/blob/release-4.5/Makefile#L17-L29), if this doesn't help try calling `make generate-with-container` for executing the generators in a controlled environment.
 
 To add this generator to another repo:
 1. Vendor `github.com/openshift/build-machinery-go`


### PR DESCRIPTION
Just a minor doc change - mentioning the "make generate-with-container" option when file generation fails. 