### PR TITLE
CORS-2979: Include AWS Alt Infra in Tech Preview

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -183,7 +183,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(dnsNameResolver).
 		with(machineConfigNodes).
 		with(metricsServer).
-		without(installAlternateInfrastructureAWS).
+		with(installAlternateInfrastructureAWS).
 		without(clusterAPIInstall).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().


### PR DESCRIPTION
Enables AWS SDK alternate infrastructure in tech preview feature set.