### PR TITLE
fix MCN CRD to use proper Drained and Cordoned condition types

### DIFF
--- a/machineconfiguration/v1alpha1/0000_80_machineconfignode-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/0000_80_machineconfignode-CustomNoUpgrade.crd.yaml
@@ -53,11 +53,11 @@ spec:
           name: UpdatedFilesAndOS
           priority: 1
           type: string
-        - jsonPath: .status.conditions[?(@.type=="CordonedNode")].status
+        - jsonPath: .status.conditions[?(@.type=="Cordoned")].status
           name: CordonedNode
           priority: 1
           type: string
-        - jsonPath: .status.conditions[?(@.type=="DrainedNode")].status
+        - jsonPath: .status.conditions[?(@.type=="Drained")].status
           name: DrainedNode
           priority: 1
           type: string

--- a/machineconfiguration/v1alpha1/0000_80_machineconfignode-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/0000_80_machineconfignode-TechPreviewNoUpgrade.crd.yaml
@@ -53,11 +53,11 @@ spec:
           name: UpdatedFilesAndOS
           priority: 1
           type: string
-        - jsonPath: .status.conditions[?(@.type=="CordonedNode")].status
+        - jsonPath: .status.conditions[?(@.type=="Cordoned")].status
           name: CordonedNode
           priority: 1
           type: string
-        - jsonPath: .status.conditions[?(@.type=="DrainedNode")].status
+        - jsonPath: .status.conditions[?(@.type=="Drained")].status
           name: DrainedNode
           priority: 1
           type: string


### PR DESCRIPTION
These CRD selectors do not match the constants in types_machineconfignode.go I'd prefer to change the CRD now before 4.15 is cut. But if not, I can change the types later.