### PR TITLE
Add omitempty to NetworkMigration.Mode

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -48146,7 +48146,6 @@ func schema_openshift_api_operator_v1_NetworkMigration(ref common.ReferenceCallb
 					"mode": {
 						SchemaProps: spec.SchemaProps{
 							Description: "mode indicates the mode of network migration. The supported values are \"Live\", \"Offline\" and omitted. A \"Live\" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An \"Offline\" migration operation will cause service interruption. During an \"Offline\" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is \"Offline\".",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -28208,8 +28208,7 @@
         },
         "mode": {
           "description": "mode indicates the mode of network migration. The supported values are \"Live\", \"Offline\" and omitted. A \"Live\" migration operation will not cause service interruption by migrating the CNI of each node one by one. The cluster network will work as normal during the network migration. An \"Offline\" migration operation will cause service interruption. During an \"Offline\" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration. When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time. The current default value is \"Offline\".",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "mtu": {
           "description": "mtu contains the MTU migration configuration. Set this to allow changing the MTU values for the default network. If unset, the operation of changing the MTU for the default network will be rejected.",

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -159,7 +159,7 @@ type NetworkMigration struct {
 	// The current default value is "Offline".
 	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	// +optional
-	Mode NetworkMigrationMode `json:"mode"`
+	Mode NetworkMigrationMode `json:"mode,omitempty"`
 }
 
 type FeaturesMigration struct {


### PR DESCRIPTION
Cluster network operator encodes the `NetworkSpec` from `operator/v1/types_network.go`.
Without the `omitempty` it would always try to apply the `Mode` even if it is not specified in the CRD:
```
DEBUG: Applying: {
  "apiVersion": "operator.openshift.io/v1",
  "kind": "Network",
  "spec": {
    ...
    "migration": {
      "mode": "",
      "networkType": "OVNKubernetes"
    },
    ...
  },
  ...
}
I1129 11:20:19.640079       1 log.go:194] Failed to update the operator configuration: could not apply (operator.openshift.io/v1, Kind=Network) /cluster, err: failed to apply / update (operator.openshift.io/v1, Kind=Network) /cluster: failed to create typed patch object (/cluster; operator.openshift.io/v1, Kind=Network): .spec.migration.mode: field not declared in schema
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-network-operator/2134/pull-ci-openshift-cluster-network-operator-master-e2e-aws-ovn-network-migration/1729805963273179136/artifacts/e2e-aws-ovn-network-migration/gather-extra/artifacts/pods/openshift-network-operator_network-operator-77b7dd4878-9d9m9_network-operator.log


The `omitempty` can be removed when `NetworkMigration.Mode` goes GA.  