### PR TITLE
OCPBUGS-23788: Only allow valid values for gatewayConfig.ipForwarding

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-CustomNoUpgrade.crd.yaml
@@ -817,6 +817,17 @@ spec:
                   is ignored.
                 type: boolean
             type: object
+            x-kubernetes-validations:
+            - message: invalid value for IPForwarding, valid values are 'Restricted'
+                or 'Global'
+              rule: '!has(self.defaultNetwork) || !has(self.defaultNetwork.ovnKubernetesConfig)
+                || !has(self.defaultNetwork.ovnKubernetesConfig.gatewayConfig) ||
+                !has(self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding)
+                || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                == oldSelf.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                == ''Restricted'' || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                == ''Global'''
           status:
             description: NetworkStatus is detailed operator status, which is distilled
               up to the Network clusteroperator object.

--- a/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
@@ -812,6 +812,17 @@ spec:
                   is ignored.
                 type: boolean
             type: object
+            x-kubernetes-validations:
+            - message: invalid value for IPForwarding, valid values are 'Restricted'
+                or 'Global'
+              rule: '!has(self.defaultNetwork) || !has(self.defaultNetwork.ovnKubernetesConfig)
+                || !has(self.defaultNetwork.ovnKubernetesConfig.gatewayConfig) ||
+                !has(self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding)
+                || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                == oldSelf.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                == ''Restricted'' || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                == ''Global'''
           status:
             description: NetworkStatus is detailed operator status, which is distilled
               up to the Network clusteroperator object.

--- a/operator/v1/0000_70_cluster-network-operator_01-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-TechPreviewNoUpgrade.crd.yaml
@@ -817,6 +817,17 @@ spec:
                   is ignored.
                 type: boolean
             type: object
+            x-kubernetes-validations:
+            - message: invalid value for IPForwarding, valid values are 'Restricted'
+                or 'Global'
+              rule: '!has(self.defaultNetwork) || !has(self.defaultNetwork.ovnKubernetesConfig)
+                || !has(self.defaultNetwork.ovnKubernetesConfig.gatewayConfig) ||
+                !has(self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding)
+                || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                == oldSelf.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                == ''Restricted'' || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding
+                == ''Global'''
           status:
             description: NetworkStatus is detailed operator status, which is distilled
               up to the Network clusteroperator object.

--- a/operator/v1/stable.network.testsuite.yaml
+++ b/operator/v1/stable.network.testsuite.yaml
@@ -16,7 +16,7 @@ tests:
         logLevel: Normal
         operatorLogLevel: Normal
   - name: Should be able to pass a valid IPV4 CIDR to IPV4 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -25,7 +25,7 @@ tests:
             gatewayConfig:
               ipv4:
                 internalMasqueradeSubnet: "169.254.168.0/29"
-    expected: | 
+    expected: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -41,7 +41,7 @@ tests:
         logLevel: Normal
         operatorLogLevel: Normal
   - name: Should not be able to pass CIDR with a subnet larger than /29 to IPV4 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -52,7 +52,7 @@ tests:
                 internalMasqueradeSubnet: 10.10.10.10/32
     expectedError: "Invalid value: \"string\": subnet must be in the range /0 to /29 inclusive"
   - name: Should not be able to pass CIDR with a subnet smaller than /0 to IPV4 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -63,7 +63,7 @@ tests:
                 internalMasqueradeSubnet: 10.10.10.10/-1
     expectedError: "Invalid value: \"string\": subnet must be in the range /0 to /29 inclusive"
   - name: Should not be able to add an IP address with the incorrect number of octets to IPV4 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -74,7 +74,7 @@ tests:
                 internalMasqueradeSubnet: 10.10.10/24
     expectedError: "Invalid value: \"string\": a valid IPv4 address must contain 4 octets"
   - name: Should not be able to add an IP address with leading zeros in an octet to IPV4 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -85,7 +85,7 @@ tests:
                 internalMasqueradeSubnet: 10.10.010.10/24
     expectedError: "Invalid value: \"string\": IP address octets must not contain leading zeros, and must be less or equal to 255"
   - name: Should not be able to add an IP address with with zero for the first octet to internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -96,7 +96,7 @@ tests:
                 internalMasqueradeSubnet: 0.10.10.10/24
     expectedError: "Invalid value: \"string\": first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255"
   - name: Should not be able to add an IP address with an octet greater than 255 to IPV4 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -107,7 +107,7 @@ tests:
                 internalMasqueradeSubnet: 10.10.10.256/24
     expectedError: "Invalid value: \"string\": IP address octets must not contain leading zeros, and must be less or equal to 255"
   - name: Should be able to pass a valid IPV6 CIDR to IPV6 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -116,7 +116,7 @@ tests:
             gatewayConfig:
               ipv6:
                 internalMasqueradeSubnet: "abcd:ef01:2345:6789:abcd:ef01:2345:6789/125"
-    expected: | 
+    expected: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -132,7 +132,7 @@ tests:
         logLevel: Normal
         operatorLogLevel: Normal
   - name: Should be able to pass a valid shorthand IPV6 CIDR to IPV6 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -141,7 +141,7 @@ tests:
             gatewayConfig:
               ipv6:
                 internalMasqueradeSubnet: "abcd:ef01:2345:6789::2345:6789/20"
-    expected: | 
+    expected: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -157,7 +157,7 @@ tests:
         logLevel: Normal
         operatorLogLevel: Normal
   - name: Should not be able to pass invalid IPV6 CIDR to IPV6 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -168,7 +168,7 @@ tests:
                 internalMasqueradeSubnet: "foo"
     expectedError:  "Invalid value: \"string\": subnet must be in the range /0 to /125 inclusive"
   - name: Should not be able to add an IP address with the more than 8 octets to IPV6 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -179,7 +179,7 @@ tests:
                 internalMasqueradeSubnet: abcd:ef01:2345:6789:abcd:ef01:2345:6789:abcd/125
     expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
   - name: Should not be able to add a dual IP address to IPV6 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -190,7 +190,7 @@ tests:
                 internalMasqueradeSubnet: abcd:ef01:2345:6789:abcd:ef01:2345:1.2.3.4/125
     expectedError: "Invalid value: \"string\": IPv6 dual addresses are not permitted, value should not contain `.` characters"
   - name: Should be able to pass a double elided IPV6 CIDR to IPV6 internalMasqueradeSubnet
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -201,7 +201,7 @@ tests:
                 internalMasqueradeSubnet: "abcd::ef01::2345:6789/20"
     expectedError: "Invalid value: \"string\": IPv6 addresses must contain at most one '::' and may only be shortened once"
   - name: "Should not be able to pass a complete IPV6 CIDR with a :: expander to v6InternalMasqueradeSubnet"
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -212,7 +212,7 @@ tests:
                 internalMasqueradeSubnet: "abcd:ef01:2345:6789::abcd:ef01:2345:6789/125"
     expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
   - name: Should not be able to pass a IPV6 CIDR without enough segments to v6InternalMasqueradeSubnet"
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -223,7 +223,7 @@ tests:
                 internalMasqueradeSubnet: "abcd:ef01:2345:6789:abcd:ef01:2345/125"
     expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
   - name: "Should not be able to pass an elided IPV6 CIDR with only a single empty segment to IPV6 internalMasqueradeSubnet"
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -234,7 +234,7 @@ tests:
                 internalMasqueradeSubnet: "abcd:ef01:2345:6789:abcd:ef01:2345::/125"
     expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
   - name: "Should not be able to pass an invalid IPV6 CIDR with a segment that contains invalid values"
-    initial: | 
+    initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
       spec:
@@ -275,14 +275,14 @@ tests:
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         defaultNetwork:
           ovnKubernetesConfig:
             ipsecConfig: {}
     expected: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         defaultNetwork:
           ovnKubernetesConfig:
             ipsecConfig: {}
@@ -293,7 +293,7 @@ tests:
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         defaultNetwork:
           ovnKubernetesConfig:
             ipsecConfig:
@@ -301,7 +301,7 @@ tests:
     expected: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         defaultNetwork:
           ovnKubernetesConfig:
             ipsecConfig:
@@ -313,13 +313,13 @@ tests:
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         defaultNetwork:
           ovnKubernetesConfig:
     expected: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         defaultNetwork: {}
         disableNetworkDiagnostics: false
         logLevel: Normal
@@ -328,12 +328,64 @@ tests:
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         defaultNetwork:
           ovnKubernetesConfig:
-            ipsecConfig: 
+            ipsecConfig:
               mode: ""
     expectedError: "Unsupported value: \"\": supported values: \"Disabled\", \"External\", \"Full\""
+  # Due to a limitation with current K8s capabilities, we have to implement custom ratcheting validation with
+  # XValidation rules. However, when oldSelf is not present, our rule will not be evaluated. Given that our
+  # rule is applied to the spec:, if the resource is not present, the rule will not be evaluated at all due to the
+  # absence of oldSelf.
+  # Therefore, it *is* possible to create a Network CR with an invalid configuration, albeit in practice, the
+  # Network CR would already exist unless admins explicitly delete and recreate it.
+  - name: "Should be able to pass an invalid ipForwarding value on create due to limitations with xValidation (FIXME)"
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "invalid"
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "invalid"
+              routingViaHost: false
+            ipsecConfig:
+              mode: Disabled
+       disableNetworkDiagnostics: false
+       logLevel: "Normal"
+       operatorLogLevel: "Normal"
+  - name: "Should be able to pass a valid ipForwarding value on create"
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "Global"
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "Global"
+              routingViaHost: false
+            ipsecConfig:
+              mode: Disabled
+       disableNetworkDiagnostics: false
+       logLevel: "Normal"
+       operatorLogLevel: "Normal"
   onUpdate:
   - name: "IPsec - Removing ipsecConfig.mode is not allowed"
     initial: |
@@ -384,7 +436,7 @@ tests:
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         defaultNetwork:
           ovnKubernetesConfig:
             ipsecConfig: {}
@@ -399,7 +451,7 @@ tests:
     expected: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         defaultNetwork:
           ovnKubernetesConfig:
             ipsecConfig: {}
@@ -407,3 +459,145 @@ tests:
         disableNetworkDiagnostics: false
         logLevel: Normal
         operatorLogLevel: Normal
+  - name: "Should not allow an empty spec Network operator to update ipForwarding to an invalid value"
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec: {}
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "invalid"
+    expectedError:  "invalid value for IPForwarding, valid values are 'Restricted' or 'Global'"
+  - name: "Should not allow network operator to update ipForwarding from a valid to an invalid value"
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "Global"
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "invalid"
+    expectedError:  "invalid value for IPForwarding, valid values are 'Restricted' or 'Global'"
+  - name: "Should not allow network operator to update ipForwarding from a valid to an empty (invalid) value"
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "Global"
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: ""
+    expectedError:  "invalid value for IPForwarding, valid values are 'Restricted' or 'Global'"
+  - name: "Should allow network operator to update ipForwarding to a valid value"
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "Global"
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "Restricted"
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "Restricted"
+              routingViaHost: false
+            ipsecConfig:
+              mode: Disabled
+       disableNetworkDiagnostics: false
+       logLevel: "Normal"
+       operatorLogLevel: "Normal"
+  - name: "Should allow network operator to keep an old invalid ipForwarding value"
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "invalid"
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "invalid"
+       disableNetworkDiagnostics: true
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "invalid"
+              routingViaHost: false
+            ipsecConfig:
+              mode: Disabled
+       disableNetworkDiagnostics: true
+       logLevel: "Normal"
+       operatorLogLevel: "Normal"
+  - name: "Should allow network operator to remove ipForwarding value"
+    initial: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              ipForwarding: "Global"
+    updated: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig: {}
+    expected: |
+      apiVersion: operator.openshift.io/v1
+      kind: Network
+      spec:
+       defaultNetwork:
+          ovnKubernetesConfig:
+            gatewayConfig:
+              routingViaHost: false
+            ipsecConfig:
+              mode: Disabled
+       disableNetworkDiagnostics: false
+       logLevel: "Normal"
+       operatorLogLevel: "Normal"

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -48,6 +48,7 @@ type NetworkList struct {
 }
 
 // NetworkSpec is the top-level network configuration object.
+// +kubebuilder:validation:XValidation:rule="!has(self.defaultNetwork) || !has(self.defaultNetwork.ovnKubernetesConfig) || !has(self.defaultNetwork.ovnKubernetesConfig.gatewayConfig) || !has(self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding) || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding == oldSelf.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding == 'Restricted' || self.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipForwarding == 'Global'",message="invalid value for IPForwarding, valid values are 'Restricted' or 'Global'"
 type NetworkSpec struct {
 	OperatorSpec `json:",inline"`
 


### PR DESCRIPTION
gatewayConfig.ipForwarding shall only allow "", "Global" and "Restricted".

Reported-at: https://issues.redhat.com/browse/OCPBUGS-23788

Launch clusterbot test cluster with: `launch 4.16,openshift/api#1691,openshift/cluster-network-operator#2172 aws`

(or try with gcp as well if aws fails)