### PR TITLE
Set DisableKubeletCloudCredentialProviders upstream feature gate to False

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -381,4 +381,14 @@ var (
 		ResponsiblePerson:   "djoshy",
 		OwningProduct:       ocpSpecific,
 	}
+
+	FeatureGateDisableKubeletCloudCredentialProviders = FeatureGateName("DisableKubeletCloudCredentialProviders")
+	disableKubeletCloudCredentialProviders            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateDisableKubeletCloudCredentialProviders,
+		},
+		OwningJiraComponent: "cloud-provider",
+		ResponsiblePerson:   "jspeed",
+		OwningProduct:       kubernetes,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -159,8 +159,10 @@ type FeatureGateEnabledDisabled struct {
 var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 	Default: defaultFeatures,
 	CustomNoUpgrade: {
-		Enabled:  []FeatureGateDescription{},
-		Disabled: []FeatureGateDescription{},
+		Enabled: []FeatureGateDescription{},
+		Disabled: []FeatureGateDescription{
+			disableKubeletCloudCredentialProviders, // We do not currently ship the correct config to use the external credentials provider.
+		},
 	},
 	TechPreviewNoUpgrade: newDefaultFeatures().
 		with(validatingAdmissionPolicy).
@@ -189,6 +191,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(sdnLiveMigration).
 		with(mixedCPUsAllocation).
 		with(managedBootImages).
+		without(disableKubeletCloudCredentialProviders).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),
@@ -207,7 +210,9 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		privateHostedZoneAWS,
 		buildCSIVolumes,
 	},
-	Disabled: []FeatureGateDescription{},
+	Disabled: []FeatureGateDescription{
+		disableKubeletCloudCredentialProviders, // We do not currently ship the correct config to use the external credentials provider.
+	},
 }
 
 type featureSetBuilder struct {


### PR DESCRIPTION
Based on discussion in https://redhat-internal.slack.com/archives/C065R4NCLGM/p1701682788330769, we need to disable this feature gate until we have time to test and configure the credentials providers.

This will require us to make changes in the MCO to set up new configuration and run the credentials binaries on the host.

CC @elmiko @soltysh 