### PR TITLE
SPLAT-1385: introduce TagIDs field to vSphere providerSpec

### DIFF
--- a/machine/v1beta1/types_vsphereprovider.go
+++ b/machine/v1beta1/types_vsphereprovider.go
@@ -51,6 +51,12 @@ type VSphereMachineProviderSpec struct {
 	// This parameter will be ignored if 'LinkedClone' CloneMode is set.
 	// +optional
 	DiskGiB int32 `json:"diskGiB,omitempty"`
+	// tagIDs is an optional set of tags to add to an instance. Specified tagIDs
+	// must use URN-notation instead of display names. A maximum of 10 tag IDs may be specified.
+	// +kubebuilder:validation:Pattern:="^(urn):(vmomi):(InventoryServiceTag):([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}):([^:]+)$"
+	// +kubebuilder:example=urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9578:GLOBAL
+	// +optional
+	TagIDs []string `json:"tagIDs,omitempty"`
 	// Snapshot is the name of the snapshot from which the VM was cloned
 	// +optional
 	Snapshot string `json:"snapshot"`

--- a/machine/v1beta1/zz_generated.deepcopy.go
+++ b/machine/v1beta1/zz_generated.deepcopy.go
@@ -1784,6 +1784,11 @@ func (in *VSphereMachineProviderSpec) DeepCopyInto(out *VSphereMachineProviderSp
 		**out = **in
 	}
 	in.Network.DeepCopyInto(&out.Network)
+	if in.TagIDs != nil {
+		in, out := &in.TagIDs, &out.TagIDs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/machine/v1beta1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1beta1/zz_generated.swagger_doc_generated.go
@@ -772,6 +772,7 @@ var map_VSphereMachineProviderSpec = map[string]string{
 	"numCoresPerSocket": "NumCPUs is the number of cores among which to distribute CPUs in this virtual machine. Defaults to the analogue property value in the template from which this machine is cloned.",
 	"memoryMiB":         "MemoryMiB is the size of a virtual machine's memory, in MiB. Defaults to the analogue property value in the template from which this machine is cloned.",
 	"diskGiB":           "DiskGiB is the size of a virtual machine's disk, in GiB. Defaults to the analogue property value in the template from which this machine is cloned. This parameter will be ignored if 'LinkedClone' CloneMode is set.",
+	"tagIDs":            "tagIDs is an optional set of tags to add to an instance. Specified tagIDs must use URN-notation instead of display names. A maximum of 10 tag IDs may be specified.",
 	"snapshot":          "Snapshot is the name of the snapshot from which the VM was cloned",
 	"cloneMode":         "CloneMode specifies the type of clone operation. The LinkedClone mode is only support for templates that have at least one snapshot. If the template has no snapshots, then CloneMode defaults to FullClone. When LinkedClone mode is enabled the DiskGiB field is ignored as it is not possible to expand disks of linked clones. Defaults to FullClone. When using LinkedClone, if no snapshots exist for the source template, falls back to FullClone.",
 }

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -37045,6 +37045,21 @@ func schema_openshift_api_machine_v1beta1_VSphereMachineProviderSpec(ref common.
 							Format:      "int32",
 						},
 					},
+					"tagIDs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "tagIDs is an optional set of tags to add to an instance. Specified tagIDs must use URN-notation instead of display names. A maximum of 10 tag IDs may be specified.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 					"snapshot": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Snapshot is the name of the snapshot from which the VM was cloned",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -21533,6 +21533,14 @@
           "type": "string",
           "default": ""
         },
+        "tagIDs": {
+          "description": "tagIDs is an optional set of tags to add to an instance. Specified tagIDs must use URN-notation instead of display names. A maximum of 10 tag IDs may be specified.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "default": ""
+          }
+        },
         "template": {
           "description": "Template is the name, inventory path, or instance UUID of the template used to clone new machines.",
           "type": "string",


### PR DESCRIPTION
This PR intends to address RFE https://issues.redhat.com/browse/RFE-1799. Additional tags are provided by the declaring a slice of tags referenced by their URN ID. This is consistent with how [CAPV ingests additional tags](https://github.com/openshift/cluster-api-provider-vsphere/blob/b21c0ba942580e08352ad6b3170ee17a010a2a00/apis/v1beta1/types.go#L190-L193) for a VM.