### PR TITLE
MCO-838: Add feature gate for pinned images

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -421,4 +421,14 @@ var (
 		ResponsiblePerson:   "dgrisonnet",
 		OwningProduct:       kubernetes,
 	}
+
+	FeatureGatePinnedImages = FeatureGateName("PinnedImages")
+	pinnedImages            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGatePinnedImages,
+		},
+		OwningJiraComponent: "MachineConfigOperator",
+		ResponsiblePerson:   "jhernand",
+		OwningProduct:       ocpSpecific,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -194,6 +194,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		without(disableKubeletCloudCredentialProviders).
 		with(onClusterBuild).
 		with(signatureStores).
+		with(pinnedImages).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),


### PR DESCRIPTION
This patch adds a new `PinnedImages` feature gate for the pin and pre-load images feature described [here](https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/pin-and-pre-load-images.md).

Related: https://issues.redhat.com/browse/MCO-838
Related: https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/pin-and-pre-load-images.md