### PR TITLE
Add IBM Cloud managed annotations to network.operator CRD

### DIFF
--- a/operator/v1/0000_70_cluster-network-operator_01-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-CustomNoUpgrade.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: Default

--- a/operator/v1/0000_70_cluster-network-operator_01-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-TechPreviewNoUpgrade.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade


### PR DESCRIPTION
Currently CNO applies the IBM Cloud managed annotation by patching the network.operator CRDs from the api: https://github.com/openshift/cluster-network-operator/blob/e23d612d00c74985ba1a4bfb84580dfbf19d77f0/hack/update-codegen.sh#L55-L66

Set the annotation directly in the API to avoid the extra step in CNO.