### PR TITLE
OCPBUGS-26441: disable psa

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -194,6 +194,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		without(disableKubeletCloudCredentialProviders).
 		with(onClusterBuild).
 		with(signatureStores).
+		with(openShiftPodSecurityAdmission).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),
@@ -201,7 +202,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 
 var defaultFeatures = &FeatureGateEnabledDisabled{
 	Enabled: []FeatureGateDescription{
-		openShiftPodSecurityAdmission,
 		alibabaPlatform, // This is a bug, it should be TechPreviewNoUpgrade. This must be downgraded before 4.14 is shipped.
 		azureWorkloadIdentity,
 		cloudDualStackNodeIPs,


### PR DESCRIPTION
Cherry-Pick of https://github.com/openshift/api/pull/1575

# What

Move PSA enforcement from default feature-set to technical preview.

# Why

Still to many PS violations to enforce it for 4.15.

# Note

After:
```
$ kubectl create namespace psa-check
namespace/psa-check created

$ kubectl get ns psa-check -oyaml 
apiVersion: v1
kind: Namespace
metadata:
  labels:
    kubernetes.io/metadata.name: psa-check
    pod-security.kubernetes.io/audit: restricted
    pod-security.kubernetes.io/audit-version: v1.24
    pod-security.kubernetes.io/warn: restricted
    pod-security.kubernetes.io/warn-version: v1.24
  name: psa-check
  resourceVersion: "65330"
  uid: d275932b-a57e-4405-ab56-956f511c0ca3
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```

Before:
```
$ kubectl create namespace psa-check
namespace/psa-check created

$ kubectl get ns psa-check -oyaml 
apiVersion: v1
kind: Namespace
metadata:
  labels:
    kubernetes.io/metadata.name: psa-check
    pod-security.kubernetes.io/audit: restricted
    pod-security.kubernetes.io/audit-version: v1.24
    pod-security.kubernetes.io/enforce: restricted
    pod-security.kubernetes.io/enforce-version: v1.24
    pod-security.kubernetes.io/warn: restricted
    pod-security.kubernetes.io/warn-version: v1.24
  name: psa-check
  resourceVersion: "46617"
  uid: 7c062a36-448a-4daf-bccc-b8d2a33c28f9
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```