### PR TITLE
NE-1303: cluster version: add v4.16 set and ingress capability

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion-CustomNoUpgrade.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion-CustomNoUpgrade.crd.yaml
@@ -82,6 +82,7 @@ spec:
                       - ImageRegistry
                       - OperatorLifecycleManager
                       - CloudCredential
+                      - Ingress
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -97,6 +98,7 @@ spec:
                     - v4.13
                     - v4.14
                     - v4.15
+                    - v4.16
                     - vCurrent
                     type: string
                 type: object
@@ -348,6 +350,7 @@ spec:
                       - ImageRegistry
                       - OperatorLifecycleManager
                       - CloudCredential
+                      - Ingress
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -372,6 +375,7 @@ spec:
                       - ImageRegistry
                       - OperatorLifecycleManager
                       - CloudCredential
+                      - Ingress
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic

--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion-Default.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion-Default.crd.yaml
@@ -82,6 +82,7 @@ spec:
                       - ImageRegistry
                       - OperatorLifecycleManager
                       - CloudCredential
+                      - Ingress
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -97,6 +98,7 @@ spec:
                     - v4.13
                     - v4.14
                     - v4.15
+                    - v4.16
                     - vCurrent
                     type: string
                 type: object
@@ -295,6 +297,7 @@ spec:
                       - ImageRegistry
                       - OperatorLifecycleManager
                       - CloudCredential
+                      - Ingress
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -319,6 +322,7 @@ spec:
                       - ImageRegistry
                       - OperatorLifecycleManager
                       - CloudCredential
+                      - Ingress
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic

--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion-TechPreviewNoUpgrade.crd.yaml
@@ -82,6 +82,7 @@ spec:
                       - ImageRegistry
                       - OperatorLifecycleManager
                       - CloudCredential
+                      - Ingress
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -97,6 +98,7 @@ spec:
                     - v4.13
                     - v4.14
                     - v4.15
+                    - v4.16
                     - vCurrent
                     type: string
                 type: object
@@ -348,6 +350,7 @@ spec:
                       - ImageRegistry
                       - OperatorLifecycleManager
                       - CloudCredential
+                      - Ingress
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -372,6 +375,7 @@ spec:
                       - ImageRegistry
                       - OperatorLifecycleManager
                       - CloudCredential
+                      - Ingress
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -278,7 +278,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry;OperatorLifecycleManager;CloudCredential
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry;OperatorLifecycleManager;CloudCredential;Ingress
 type ClusterVersionCapability string
 
 const (
@@ -376,6 +376,20 @@ const (
 	// ClusterVersionCapabilityCloudCredential manages credentials for cloud providers
 	// in openshift cluster
 	ClusterVersionCapabilityCloudCredential ClusterVersionCapability = "CloudCredential"
+
+	// ClusterVersionCapabilityIngress manages the cluster ingress operator
+	// which is responsible for running the ingress controllers (including OpenShift router).
+	//
+	// The following CRDs are part of the capability as well:
+	// IngressController
+	// DNSRecord
+	// GatewayClass
+	// Gateway
+	// HTTPRoute
+	// ReferenceGrant
+	//
+	// WARNING: This capability cannot be disabled on the standalone OpenShift.
+	ClusterVersionCapabilityIngress ClusterVersionCapability = "Ingress"
 )
 
 // KnownClusterVersionCapabilities includes all known optional, core cluster components.
@@ -394,10 +408,11 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityImageRegistry,
 	ClusterVersionCapabilityOperatorLifecycleManager,
 	ClusterVersionCapabilityCloudCredential,
+	ClusterVersionCapabilityIngress,
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
-// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;v4.14;v4.15;vCurrent
+// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;v4.14;v4.15;v4.16;vCurrent
 type ClusterVersionCapabilitySet string
 
 const (
@@ -434,6 +449,12 @@ const (
 	// OpenShift.  This list will remain the same no matter which
 	// version of OpenShift is installed.
 	ClusterVersionCapabilitySet4_15 ClusterVersionCapabilitySet = "v4.15"
+
+	// ClusterVersionCapabilitySet4_16 is the recommended set of
+	// optional capabilities to enable for the 4.16 version of
+	// OpenShift.  This list will remain the same no matter which
+	// version of OpenShift is installed.
+	ClusterVersionCapabilitySet4_16 ClusterVersionCapabilitySet = "v4.16"
 
 	// ClusterVersionCapabilitySetCurrent is the recommended set
 	// of optional capabilities to enable for the cluster's
@@ -501,6 +522,23 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityOperatorLifecycleManager,
 		ClusterVersionCapabilityCloudCredential,
 	},
+	ClusterVersionCapabilitySet4_16: {
+		ClusterVersionCapabilityBaremetal,
+		ClusterVersionCapabilityConsole,
+		ClusterVersionCapabilityInsights,
+		ClusterVersionCapabilityMarketplace,
+		ClusterVersionCapabilityStorage,
+		ClusterVersionCapabilityOpenShiftSamples,
+		ClusterVersionCapabilityCSISnapshot,
+		ClusterVersionCapabilityNodeTuning,
+		ClusterVersionCapabilityMachineAPI,
+		ClusterVersionCapabilityBuild,
+		ClusterVersionCapabilityDeploymentConfig,
+		ClusterVersionCapabilityImageRegistry,
+		ClusterVersionCapabilityOperatorLifecycleManager,
+		ClusterVersionCapabilityCloudCredential,
+		ClusterVersionCapabilityIngress,
+	},
 	ClusterVersionCapabilitySetCurrent: {
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityConsole,
@@ -516,6 +554,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityImageRegistry,
 		ClusterVersionCapabilityOperatorLifecycleManager,
 		ClusterVersionCapabilityCloudCredential,
+		ClusterVersionCapabilityIngress,
 	},
 }
 

--- a/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
+++ b/operator/v1/0000_50_ingress-operator_00-ingresscontroller.crd.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/616
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/operatoringress/v1/0000_50_dns-record.yaml
+++ b/operatoringress/v1/0000_50_dns-record.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/584
+    capability.openshift.io/name: Ingress
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
Retake of https://github.com/openshift/api/pull/1516.

Enhancement Proposal: https://github.com/openshift/enhancements/pull/1415.

This PR introduces a new `Ingress` cluster capability which allows to enable or disable the default ingress of the OpenShift cluster: the cluster ingress operator and its custom resources. The `Ingress` capability is added to a new 4.16 capabilityset as it's the first capability added for 4.16. The two CRDs managed by the cluster ingress operator are annotated with `Ingress` capability: `IngressController`, `DNSRecord`.