### PR TITLE
OTA-1169: Add feature gate for upgrade status

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -407,7 +407,7 @@ var (
 		FeatureGateAttributes: FeatureGateAttributes{
 			Name: FeatureGateSignatureStores,
 		},
-		OwningJiraComponent: "over-the-air-updates",
+		OwningJiraComponent: "Cluster Version Operator",
 		ResponsiblePerson:   "lmohanty",
 		OwningProduct:       ocpSpecific,
 	}

--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -431,4 +431,14 @@ var (
 		ResponsiblePerson:   "jhernand",
 		OwningProduct:       ocpSpecific,
 	}
+
+	FeatureGateUpgradeStatus = FeatureGateName("UpgradeStatus")
+	upgradeStatus            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateUpgradeStatus,
+		},
+		OwningJiraComponent: "Cluster Version Operator",
+		ResponsiblePerson:   "pmuller",
+		OwningProduct:       ocpSpecific,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -195,6 +195,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(onClusterBuild).
 		with(signatureStores).
 		with(pinnedImages).
+		with(upgradeStatus).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),

--- a/payload-manifests/featuregates/featureGate-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Default.yaml
@@ -92,6 +92,9 @@
                         "name": "SigstoreImageVerification"
                     },
                     {
+                        "name": "UpgradeStatus"
+                    },
+                    {
                         "name": "VSphereControlPlaneMachineSet"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
+++ b/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
@@ -94,6 +94,9 @@
                         "name": "SigstoreImageVerification"
                     },
                     {
+                        "name": "UpgradeStatus"
+                    },
+                    {
                         "name": "VSphereControlPlaneMachineSet"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
@@ -129,6 +129,9 @@
                         "name": "SigstoreImageVerification"
                     },
                     {
+                        "name": "UpgradeStatus"
+                    },
+                    {
                         "name": "VSphereControlPlaneMachineSet"
                     },
                     {


### PR DESCRIPTION
Add a new `UpgradeStatus` feature gate for the work towards improved upgrade status & health insights information provided via a future `oc adm upgrade status` command.

The code for this feature does not exist yet except for experimental client-side logic implemented in `oc`.

Related: https://issues.redhat.com/browse/OTA-1114
Related: https://github.com/jupierce/oc-update-design-ideas/blob/main/status.md
