### PR TITLE
Add ImagePolicyList and ClusterImagePolicyList to scheme known types

### DIFF
--- a/config/v1alpha1/register.go
+++ b/config/v1alpha1/register.go
@@ -34,6 +34,10 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&InsightsDataGatherList{},
 		&Backup{},
 		&BackupList{},
+		&ImagePolicy{},
+		&ImagePolicyList{},
+		&ClusterImagePolicy{},
+		&ClusterImagePolicyList{},
 	)
 	metav1.AddToGroupVersion(scheme, GroupVersion)
 	return nil


### PR DESCRIPTION
https://github.com/openshift/api/pull/1457 did not add ImagePolicyList and ClusterImagePolicyList to scheme known types, led to error `no kind "ClusterImagePolicyList" is registered for version "config.openshift.io/v1alpha1" in scheme`.