### PR TITLE
OCPBUGS-27222: Allow modified IPv6 address as CPIC name

### DIFF
--- a/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
+++ b/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
@@ -44,7 +44,7 @@ spec:
               name:
                 anyOf:
                 - format: ipv4
-                - format: ipv6
+                - pattern: ^[0-9a-f]{4}(\.[0-9a-f]{4}){7}$
                 type: string
             type: object
           spec:

--- a/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml-patch
+++ b/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml-patch
@@ -7,4 +7,4 @@
         type: string
         anyOf:
         - format: ipv4
-        - format: ipv6
+        - pattern: '^[0-9a-f]{4}(\.[0-9a-f]{4}){7}$'


### PR DESCRIPTION
CloudPrivateIPConfig's name is supposed to be an IPv4 or IPv6 address. However, the K8s constraints do not allow colons in the names of the resources, so for IPv6 addresses the names are the addresses fully expanded with colons replaced with dots. E.g. `fc00:f853:ccd:e793::54` becomes `fc00.f853.0ccd.e793.0000.0000.0000.0054`. This means that standard K8s validation of `format: ipv6` will not work as it'll try parsing the address using golang's `net` library and that will fail due to `s/\:/\./`.

This commit replaces `format: ipv6` with a pattern that matches fully expanded IPv6 addresses to fix the problem.