### PR TITLE
stream of consciousness for adding clusterprofiles to the featureset tag

### DIFF
--- a/config/.codegen.yaml
+++ b/config/.codegen.yaml
@@ -1,8 +1,12 @@
 schemapatch:
   requiredFeatureSets:
-  - ""
-  - "Default"
-  - "TechPreviewNoUpgrade"
-  - "CustomNoUpgrade"
+    - ""
+    - "Default"
+    - "TechPreviewNoUpgrade"
+    - "CustomNoUpgrade"
+  mustHaveOneOfClusterProfile:
+    - "ibm-cloud-managed"
+    - "self-managed-high-availability"
+    - "single-node-developer"
 swaggerdocs:
   commentPolicy: Warn

--- a/config/v1/0000_10_config-operator_01_authentication.crd-Default-HostedControlPlane.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-Default-HostedControlPlane.yaml
@@ -1,0 +1,105 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/feature-set: Default
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Authentication specifies cluster-wide settings for authentication (like OAuth and webhook token authenticators). The canonical name of an instance is `cluster`. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                oauthMetadata:
+                  description: 'oauthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for an external OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 If oauthMetadata.name is non-empty, this value has precedence over any metadata reference stored in status. The key "oauthMetadata" is used to locate the data. If specified and the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+                serviceAccountIssuer:
+                  description: 'serviceAccountIssuer is the identifier of the bound service account token issuer. The default is https://kubernetes.default.svc WARNING: Updating this field will not result in immediate invalidation of all bound tokens with the previous issuer value. Instead, the tokens issued by previous service account issuer will continue to be trusted for a time period chosen by the platform (currently set to 24h). This time period is subject to change over time. This allows internal components to transition to use new service account issuer without service distruption.'
+                  type: string
+                type:
+                  description: type identifies the cluster managed, user facing authentication mode in use. Specifically, it manages the component that responds to login attempts. The default is IntegratedOAuth.
+                  type: string
+                  enum:
+                    - ""
+                    - None
+                    - IntegratedOAuth
+                webhookTokenAuthenticator:
+                  description: "webhookTokenAuthenticator configures a remote token reviewer. These remote authentication webhooks can be used to verify bearer tokens via the tokenreviews.authentication.k8s.io REST API. This is required to honor bearer tokens that are provisioned by an external authentication service. \n Can only be set if \"Type\" is set to \"None\"."
+                  type: object
+                  required:
+                    - kubeConfig
+                  properties:
+                    kubeConfig:
+                      description: "kubeConfig references a secret that contains kube config file data which describes how to access the remote webhook service. The namespace for the referenced secret is openshift-config. \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication \n The key \"kubeConfig\" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored."
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced secret
+                          type: string
+                webhookTokenAuthenticators:
+                  description: webhookTokenAuthenticators is DEPRECATED, setting it has no effect.
+                  type: array
+                  items:
+                    description: deprecatedWebhookTokenAuthenticator holds the necessary configuration options for a remote token authenticator. It's the same as WebhookTokenAuthenticator but it's missing the 'required' validation on KubeConfig field.
+                    type: object
+                    properties:
+                      kubeConfig:
+                        description: 'kubeConfig contains kube config file data which describes how to access the remote webhook service. For further details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication The key "kubeConfig" is used to locate the data. If the secret or expected key is not found, the webhook is not honored. If the specified kube config data is not valid, the webhook is not honored. The namespace for this secret is determined by the point of use.'
+                        type: object
+                        required:
+                          - name
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced secret
+                            type: string
+                  x-kubernetes-list-type: atomic
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                integratedOAuthMetadata:
+                  description: 'integratedOAuthMetadata contains the discovery endpoint data for OAuth 2.0 Authorization Server Metadata for the in-cluster integrated OAuth server. This discovery document can be viewed from its served location: oc get --raw ''/.well-known/oauth-authorization-server'' For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2 This contains the observed value based on cluster state. An explicitly set value in spec.oauthMetadata has precedence over this field. This field has no meaning if authentication spec.type is not set to IntegratedOAuth. The key "oauthMetadata" is used to locate the data. If the config map or expected key is not found, no metadata is served. If the specified metadata is not valid, no metadata is served. The namespace for this config map is openshift-config-managed.'
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      description: name is the metadata.name of the referenced config map
+                      type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/config/v1/0000_10_config-operator_01_authentication.crd-Default.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-Default.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/feature-set: Default

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -86,6 +86,7 @@ type AuthenticationSpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=1
 	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
+	// +openshift:enable:FeatureSets=Default,ClusterProfile=HostedControlPlane
 	OIDCProviders []OIDCProvider `json:"oidcProviders,omitempty"`
 }
 

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -85,8 +85,8 @@ type AuthenticationSpec struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=1
-	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
-	// +openshift:enable:FeatureSets=Default,ClusterProfile=HostedControlPlane
+	// +openshift:enable:ClusterProfileAwareFeatureSets:featureSet=CustomNoUpgrade;TechPreviewNoUpgrade
+	// +openshift:enable:ClusterProfileAwareFeatureSets:featureSet=Default,clusterProfile=HostedControlPlane
 	OIDCProviders []OIDCProvider `json:"oidcProviders,omitempty"`
 }
 

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -86,7 +86,7 @@ type AuthenticationSpec struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MaxItems=1
 	// +openshift:enable:ClusterProfileAwareFeatureSets:featureSet=CustomNoUpgrade;TechPreviewNoUpgrade
-	// +openshift:enable:ClusterProfileAwareFeatureSets:featureSet=Default,clusterProfile=HostedControlPlane
+	// +openshift:enable:ClusterProfileAwareFeatureSets:featureSet=Default,clusterProfile=ibm-cloud-managed
 	OIDCProviders []OIDCProvider `json:"oidcProviders,omitempty"`
 }
 

--- a/payload-command/render/render.go
+++ b/payload-command/render/render.go
@@ -27,6 +27,7 @@ type RenderOpts struct {
 	RenderedManifestInputFilename string
 	PayloadVersion                string
 	AssetOutputDir                string
+	ClusterProfile                string
 }
 
 func (o *RenderOpts) AddFlags(fs *flag.FlagSet) {
@@ -34,10 +35,20 @@ func (o *RenderOpts) AddFlags(fs *flag.FlagSet) {
 		"files or directories containing yaml or json manifests that will be created via cluster-bootstrapping.")
 	fs.StringVar(&o.PayloadVersion, "payload-version", o.PayloadVersion, "Version that will eventually be placed into ClusterOperator.status.  This normally comes from the CVO set via env var: OPERATOR_IMAGE_VERSION.")
 	fs.StringVar(&o.AssetOutputDir, "asset-output-dir", o.AssetOutputDir, "Output path for rendered manifests.")
+	fs.StringVar(&o.ClusterProfile, "cluster-profile", o.ClusterProfile, "self-managed-high-availability, single-node-developer, ibm-cloud-managed")
 }
 
 // Validate verifies the inputs.
 func (o *RenderOpts) Validate() error {
+	switch o.ClusterProfile {
+	case "":
+		// to be disallowed soonish
+	case "self-managed-high-availability", "single-node-developer", "ibm-cloud-managed":
+		// ok
+	default:
+		return fmt.Errorf("--cluster-profile must be one of self-managed-high-availability, single-node-developer, ibm-cloud-managed")
+	}
+
 	return nil
 }
 
@@ -80,6 +91,7 @@ func (o *RenderOpts) Run() error {
 		bootstrapManifestLocation,
 		filepath.Join(o.AssetOutputDir, "manifests"),
 		featureSet,
+		o.ClusterProfile,
 		nil,
 	)
 	if err != nil {

--- a/payload-command/render/renderassets/write.go
+++ b/payload-command/render/renderassets/write.go
@@ -6,9 +6,12 @@ import (
 )
 
 // SubstituteAndCopyFiles read files from the input dir, selects some by predicate, transforms them, and writes the content to output dir.
-func SubstituteAndCopyFiles(assetInputDir, assetOutputDir, featureSet string, templateData interface{}, additionalPredicates ...FileInfoPredicate) error {
+func SubstituteAndCopyFiles(assetInputDir, assetOutputDir, featureSet, clusterProfile string, templateData interface{}, additionalPredicates ...FileInfoPredicate) error {
 	defaultPredicates := []FileInfoPredicate{OnlyYaml}
-	manifestPredicates := []FileContentsPredicate{InstallerFeatureSet(featureSet)}
+	manifestPredicates := []FileContentsPredicate{
+		InstallerFeatureSet(featureSet),
+		ClusterProfile(clusterProfile),
+	}
 
 	// write assets
 	manifests, err := New(

--- a/tools/codegen/cmd/schemapatch.go
+++ b/tools/codegen/cmd/schemapatch.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	controllerGen       string
-	requiredFeatureSets []string
+	controllerGen               string
+	requiredFeatureSets         []string
+	mustHaveOneOfClusterProfile []string
 )
 
 // schemapatchCmd represents the schemapatch command
@@ -45,6 +46,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&controllerGen, "controller-gen", "", "Path to the controller-gen tool to use. If omitted, will use the built in generator (Only applicable to the schemapatch generator)")
 	rootCmd.PersistentFlags().StringSliceVar(&requiredFeatureSets, "required-feature-sets", []string{}, "Specific feature sets to generate CRDs schemas for (Only applicable to the schemapatch generator)")
+	rootCmd.PersistentFlags().StringSliceVar(&mustHaveOneOfClusterProfile, "cluster-profiles", []string{}, "Specific cluster profiles to generate CRDs schemas for (Only applicable to the schemapatch generator)")
 }
 
 // newSchemaPatchGenerator builds a new schemapatch generator.
@@ -55,8 +57,9 @@ func newSchemaPatchGenerator() generation.Generator {
 	}
 
 	return schemapatch.NewGenerator(schemapatch.Options{
-		ControllerGen:       controllerGen,
-		RequiredFeatureSets: requiredFeatureSetsList,
-		Verify:              verify,
+		ControllerGen:               controllerGen,
+		RequiredFeatureSets:         requiredFeatureSetsList,
+		MustHaveOneOfClusterProfile: sets.NewString(mustHaveOneOfClusterProfile...),
+		Verify:                      verify,
 	})
 }

--- a/tools/codegen/pkg/generation/types.go
+++ b/tools/codegen/pkg/generation/types.go
@@ -91,6 +91,8 @@ type SchemaPatchConfig struct {
 	// When omitted, any manifest with a feature set annotation will be ignored.
 	// Example entries are `""` (empty string), `"TechPreviewNoUpgrade"` or `"TechPreviewNoUpgrade,CustomNoUpgrade"`.
 	RequiredFeatureSets []string `json:"requiredFeatureSets,omitempty"`
+
+	MustHaveOneOfClusterProfile []string `json:"mustHaveOneOfClusterProfile,omitempty"`
 }
 
 // SwaggerDocsConfig is the configuration for the swaggerdocs generator.

--- a/tools/codegen/pkg/schemapatch/featuresets.go
+++ b/tools/codegen/pkg/schemapatch/featuresets.go
@@ -16,7 +16,7 @@ import (
 
 // shouldProcessGroupVersion determines, based on the required feature sets, whether this group version should be
 // generated or not.
-func shouldProcessGroupVersion(version generation.APIVersionContext, requiredFeatureSets []sets.String) (bool, error) {
+func shouldProcessGroupVersion(version generation.APIVersionContext, requiredFeatureSets []sets.String, mustHaveOneOfClusterProfile sets.String) (bool, error) {
 	dirEntries, err := os.ReadDir(version.Path)
 	if err != nil {
 		return false, fmt.Errorf("could not read file info for directory %s: %v", version.Path, err)
@@ -34,7 +34,7 @@ func shouldProcessGroupVersion(version generation.APIVersionContext, requiredFea
 			return false, fmt.Errorf("could not read CRD file %s: %v", fileInfo.Name(), err)
 		}
 
-		if mayHandleFile(data, requiredFeatureSets) {
+		if mayHandleFile(data, requiredFeatureSets, mustHaveOneOfClusterProfile) {
 			// At least one file needs to be processed, process the whole group version.
 			return true, nil
 		}
@@ -45,18 +45,18 @@ func shouldProcessGroupVersion(version generation.APIVersionContext, requiredFea
 
 // mayHandleFile determines, from the feature sets, whether this patch should be handled.
 // Currently, the only check is the feature-set annotation.
-func mayHandleFile(rawContent []byte, requiredFeatureSets []sets.String) bool {
+func mayHandleFile(rawContent []byte, requiredFeatureSets []sets.String, mustHaveOneOfClusterProfile sets.String) bool {
 	manifest := &unstructured.Unstructured{}
 	if err := kyaml.Unmarshal(rawContent, &manifest); err != nil {
 		return true
 	}
 
 	if len(requiredFeatureSets) == 0 {
-		return mayHandleObject(manifest, sets.NewString())
+		return mayHandleObject(manifest, sets.NewString(), mustHaveOneOfClusterProfile)
 	}
 
 	for _, requiredFeatureSet := range requiredFeatureSets {
-		if mayHandleObject(manifest, requiredFeatureSet) {
+		if mayHandleObject(manifest, requiredFeatureSet, mustHaveOneOfClusterProfile) {
 			return true
 		}
 	}
@@ -66,10 +66,22 @@ func mayHandleFile(rawContent []byte, requiredFeatureSets []sets.String) bool {
 
 // mayHandleObject determines, from the feature sets, whether a kube like object should be handled.
 // Currently, the only check is the feature-set annotation.
-func mayHandleObject(manifest metav1.Object, requiredFeatureSets sets.String) bool {
+func mayHandleObject(manifest metav1.Object, requiredFeatureSets, mustHaveOneOfClusterProfile sets.String) bool {
 	manifestFeatureSets := getObjectFeatureSets(manifest)
+	if !manifestFeatureSets.Equal(requiredFeatureSets) {
+		return false
+	}
 
-	return manifestFeatureSets.Equal(requiredFeatureSets)
+	if len(mustHaveOneOfClusterProfile) == 0 {
+		return true
+	}
+
+	manifestClusterProfiles := getObjectClusterProfiles(manifest)
+	if len(mustHaveOneOfClusterProfile.Intersection(manifestClusterProfiles)) > 0 {
+		return true
+	}
+
+	return false
 }
 
 // getObjectFeatureSets returns the feature sets for a kube like object.
@@ -82,4 +94,19 @@ func getObjectFeatureSets(manifest metav1.Object) sets.String {
 	}
 
 	return manifestFeatureSets
+}
+
+func getObjectClusterProfiles(manifest metav1.Object) sets.String {
+	manifestClusterProfiles := sets.NewString()
+	for annotationName, annotationValue := range manifest.GetAnnotations() {
+		if !strings.HasPrefix(annotationName, "include.release.openshift.io/") {
+			continue
+		}
+		if annotationValue != "true" {
+			continue
+		}
+		manifestClusterProfiles.Insert(annotationName[len("include.release.openshift.io/"):])
+	}
+
+	return manifestClusterProfiles
 }

--- a/tools/codegen/pkg/schemapatch/generator.go
+++ b/tools/codegen/pkg/schemapatch/generator.go
@@ -251,11 +251,12 @@ func loadSchemaPatchGenerationContextsForVersion(version generation.APIVersionCo
 		}
 
 		generationContexts = append(generationContexts, schemaPatchGenerationContext{
-			manifestPath:        filepath.Join(version.Path, fileInfo.Name()),
-			manifestFileMode:    manifestInfo.Mode(),
-			manifestData:        data,
-			patchPath:           patchPath,
-			requiredFeatureSets: getObjectFeatureSets(partialObject),
+			manifestPath:                filepath.Join(version.Path, fileInfo.Name()),
+			manifestFileMode:            manifestInfo.Mode(),
+			manifestData:                data,
+			patchPath:                   patchPath,
+			requiredFeatureSets:         getObjectFeatureSets(partialObject),
+			mustHaveOneOfClusterProfile: getObjectClusterProfiles(partialObject),
 		})
 	}
 

--- a/tools/codegen/pkg/schemapatch/schemapatch.go
+++ b/tools/codegen/pkg/schemapatch/schemapatch.go
@@ -18,7 +18,10 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/schemapatcher"
 )
 
-const openshiftFeatureSetEnv = "OPENSHIFT_REQUIRED_FEATURESET"
+const (
+	openshiftFeatureSetEnv     = "OPENSHIFT_REQUIRED_FEATURESET"
+	openshiftClusterProfileEnv = "OPENSHIFT_REQUIRED_CLUSTERPROFILE"
+)
 
 // executeSchemaPatchForManifestWithBinary executes the controller-gen binary with the schemapatch:manifests arg.
 func executeSchemaPatchForManifestWithBinary(controllerGen string, dir string, versionPaths []string, buf *bytes.Buffer, requiredFeatureSets sets.String) error {
@@ -96,6 +99,11 @@ func executeSchemaPatchForManifest(gc schemaPatchGenerationContext, buf *bytes.B
 	markers.RequiredFeatureSets.Insert(gc.requiredFeatureSets.List()...)
 	defer func() {
 		markers.RequiredFeatureSets = sets.NewString()
+	}()
+
+	markers.RequiredClusterProfiles.Insert(gc.mustHaveOneOfClusterProfile.List()...)
+	defer func() {
+		markers.RequiredClusterProfiles = sets.NewString()
 	}()
 
 	gen := schemapatcher.Generator{

--- a/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
+++ b/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
@@ -24,6 +24,8 @@ func init() {
 }
 
 const OpenShiftFeatureSetMarkerName = "openshift:enable:FeatureSets"
+// TODO, owed to Joel in 4.16 to update all FeatureSets to be a FeatureSetClusterProfileTuple and collapse this back down
+const OpenShiftClusterProfileAwareFeatureSets = "openshift:enable:ClusterProfileAwareFeatureSets"
 const OpenShiftFeatureSetAwareEnumMarkerName = "openshift:validation:FeatureSetAwareEnum"
 const OpenShiftFeatureSetAwareXValidationMarkerName = "openshift:validation:FeatureSetAwareXValidation"
 
@@ -36,10 +38,20 @@ func init() {
 		must(markers.MakeDefinition(OpenShiftFeatureSetMarkerName, markers.DescribesField, []string{})).
 			WithHelp(markers.SimpleHelp("OpenShift", "specifies the FeatureSet that is required to generate this field.")),
 	)
+	FieldOnlyMarkers = append(FieldOnlyMarkers,
+		must(markers.MakeDefinition(OpenShiftClusterProfileAwareFeatureSets, markers.DescribesField, FeatureSetClusterProfileTuple{})).
+			WithHelp(markers.SimpleHelp("OpenShift", "specifies the FeatureSet that is required to generate this field.")),
+	)
 	ValidationMarkers = append(ValidationMarkers,
 		must(markers.MakeDefinition(OpenShiftFeatureSetAwareXValidationMarkerName, markers.DescribesType, FeatureSetXValidation{})).
 			WithHelp(markers.SimpleHelp("OpenShift", "specifies the FeatureSet that is required to generate this XValidation rule.")),
 	)
+}
+
+
+type FeatureSetClusterProfileTuple struct {
+	FeatureSetNames []string `marker:"featureSet"`
+	ClusterProfiles      []string `marker:"clusterProfile,optional"`
 }
 
 type FeatureSetEnum struct {

--- a/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
+++ b/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
@@ -10,16 +10,22 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/markers"
 )
 
-var RequiredFeatureSets = sets.NewString()
+var (
+	RequiredFeatureSets = sets.NewString()
+	RequiredClusterProfiles = sets.NewString()
+)
 
 func init() {
-	featureSet := os.Getenv("OPENSHIFT_REQUIRED_FEATURESET")
-	if len(featureSet) == 0 {
-		return
+	if featureSet := os.Getenv("OPENSHIFT_REQUIRED_FEATURESET"); len(featureSet) > 0 {
+		for _, curr := range strings.Split(featureSet, ",") {
+			RequiredFeatureSets.Insert(curr)
+		}
 	}
 
-	for _, curr := range strings.Split(featureSet, ",") {
-		RequiredFeatureSets.Insert(curr)
+	if clusterProfile := os.Getenv("OPENSHIFT_REQUIRED_CLUSTERPROFILE"); len(clusterProfile) > 0 {
+		for _, curr := range strings.Split(clusterProfile, ",") {
+			RequiredClusterProfiles.Insert(curr)
+		}
 	}
 }
 

--- a/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/patch_schema.go
+++ b/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/patch_schema.go
@@ -11,26 +11,46 @@ import (
 // Right now, the only skip is based on the featureset marker.
 func mayHandleField(field markers.FieldInfo) bool {
 	uncastFeatureSet := field.Markers.Get(crdmarkers.OpenShiftFeatureSetMarkerName)
-	if uncastFeatureSet == nil {
-		return true
-	}
-
-	featureSetsForField, ok := uncastFeatureSet.([]string)
-	if !ok {
-		clusterProfileAndFeatureSet, ok := uncastFeatureSet.(crdmarkers.FeatureSetClusterProfileTuple)
+	if uncastFeatureSet != nil {
+		featureSetsForField, ok := uncastFeatureSet.([]string)
 		if !ok {
-			panic(fmt.Sprintf("actually got %t", uncastFeatureSet))
+				panic(fmt.Sprintf("actually got %t", uncastFeatureSet))
 		}
-		if false{
-			fmt.Printf("#### got %v\n", clusterProfileAndFeatureSet)
+		//  if any of the field's declared featureSets match any of the manifest's declared featuresets, include the field.
+		for _, currFeatureSetForField := range featureSetsForField {
+			if crdmarkers.RequiredFeatureSets.Has(currFeatureSetForField) {
+				return true
+			}
 		}
 		return false
 	}
+
+	uncastFeatureSet = field.Markers.Get(crdmarkers.OpenShiftClusterProfileAwareFeatureSets)
+	clusterProfileAndFeatureSet, ok := uncastFeatureSet.(crdmarkers.FeatureSetClusterProfileTuple)
+	if !ok {
+		panic(fmt.Sprintf("actually got %t", uncastFeatureSet))
+	}
+	foundFeatureSet := false
 	//  if any of the field's declared featureSets match any of the manifest's declared featuresets, include the field.
-	for _, currFeatureSetForField := range featureSetsForField {
+	for _, currFeatureSetForField := range clusterProfileAndFeatureSet.FeatureSetNames {
 		if crdmarkers.RequiredFeatureSets.Has(currFeatureSetForField) {
-			return true
+			foundFeatureSet = true
+			break
 		}
 	}
+	if !foundFeatureSet{
+		return false
+	}
+	if len(clusterProfileAndFeatureSet.ClusterProfiles) == 0{
+		return true
+	}
+
+	for _, currClusterProfileForFeature := range clusterProfileAndFeatureSet.ClusterProfiles{
+		if crdmarkers.RequiredClusterProfiles.Has(currClusterProfileForFeature) {
+			foundFeatureSet = true
+			break
+		}
+	}
+
 	return false
 }

--- a/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/patch_schema.go
+++ b/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/patch_schema.go
@@ -26,6 +26,9 @@ func mayHandleField(field markers.FieldInfo) bool {
 	}
 
 	uncastFeatureSet = field.Markers.Get(crdmarkers.OpenShiftClusterProfileAwareFeatureSets)
+	if uncastFeatureSet == nil{
+		return true
+	}
 	clusterProfileAndFeatureSet, ok := uncastFeatureSet.(crdmarkers.FeatureSetClusterProfileTuple)
 	if !ok {
 		panic(fmt.Sprintf("actually got %t", uncastFeatureSet))
@@ -47,8 +50,7 @@ func mayHandleField(field markers.FieldInfo) bool {
 
 	for _, currClusterProfileForFeature := range clusterProfileAndFeatureSet.ClusterProfiles{
 		if crdmarkers.RequiredClusterProfiles.Has(currClusterProfileForFeature) {
-			foundFeatureSet = true
-			break
+			return true
 		}
 	}
 

--- a/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/patch_schema.go
+++ b/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/patch_schema.go
@@ -17,7 +17,14 @@ func mayHandleField(field markers.FieldInfo) bool {
 
 	featureSetsForField, ok := uncastFeatureSet.([]string)
 	if !ok {
-		panic(fmt.Sprintf("actually got %t", uncastFeatureSet))
+		clusterProfileAndFeatureSet, ok := uncastFeatureSet.(crdmarkers.FeatureSetClusterProfileTuple)
+		if !ok {
+			panic(fmt.Sprintf("actually got %t", uncastFeatureSet))
+		}
+		if false{
+			fmt.Printf("#### got %v\n", clusterProfileAndFeatureSet)
+		}
+		return false
 	}
 	//  if any of the field's declared featureSets match any of the manifest's declared featuresets, include the field.
 	for _, currFeatureSetForField := range featureSetsForField {


### PR DESCRIPTION
The commits don't make much sense, I'll label key points in the diff.

Some observations:
1. @stlaz was naughty and didn't create a featuregate to use to disable control loops in controllers
2. I think the minimal thing we could do in 4.15 is
    1. fix render to honor cluster profile
    2. create a different Default CRD yaml for authentication for hypershift
    3. update the 4.15 installer to pass the --cluster-profile flag to rendering
    4. update hypershift to pass the render command the cluster-profile flag
    5. require the cluster-profile flag in 4.15 openshift/api
    6. create a yaml patch to add the fields we need to authentication

This leaves us in a pretty nasty spot for 4.15, but it would do the thing we need it to do without solving
1. the fact that we want different gates in hypershift and self-managed
2. how we enable different schemas for these different tuples

Logically we need a manifest for each (featureset,clusterprofile) tuple.  Where that manifest is produced has some options.  If we can think of a way to generate partial schemas for each feature gate, we could do something like

1. for each featuregate
    1. run a generator for every CRD we want to produce a partial schema of "everything ungated plus your gate"
    2. this would leave us with dozens of files for every CRD, though I suppose we only need to store the ones that had content for that gate.
1. for each featureset,clusterprofile tuple
    1. produce a list of enabled featuregates (this require us to refactor how to we register the gates)
    2. produce a complete, properly annotated, CRD manifest that somehow combined all the partial schemas.

I think server-side-apply (the structured merge diff library: https://github.com/kubernetes-sigs/structured-merge-diff) represents a potential way to combine these since nothing should be removed.

Our tests would need to either
1. update to use featuregates and hope we don't need combinations of enabled
2. update to reference crdName,featureset,clusterprofile tuples and we look them up in a well-known location

This may be generally valuable since the yaml patches will likely need some kind of similar targeting.

cc @JoelSpeed 