### PR TITLE
SPLAT-1293: Moved vSphereStaticIPs into Default from TechPreview

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -322,7 +322,7 @@ var (
 					reportProblemsToJiraComponent("splat").
 					contactPerson("rvanderp3").
 					productScope(ocpSpecific).
-					enableIn(TechPreviewNoUpgrade).
+					enableIn(Default, TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateRouteExternalCertificate = newFeatureGate("RouteExternalCertificate").

--- a/payload-manifests/featuregates/featureGate-Default-Hypershift.yaml
+++ b/payload-manifests/featuregates/featureGate-Default-Hypershift.yaml
@@ -119,9 +119,6 @@
                         "name": "UpgradeStatus"
                     },
                     {
-                        "name": "VSphereStaticIPs"
-                    },
-                    {
                         "name": "ValidatingAdmissionPolicy"
                     },
                     {
@@ -170,6 +167,9 @@
                     },
                     {
                         "name": "VSphereControlPlaneMachineSet"
+                    },
+                    {
+                        "name": "VSphereStaticIPs"
                     }
                 ],
                 "version": ""

--- a/payload-manifests/featuregates/featureGate-Default-SelfManagedHA.yaml
+++ b/payload-manifests/featuregates/featureGate-Default-SelfManagedHA.yaml
@@ -122,9 +122,6 @@
                         "name": "UpgradeStatus"
                     },
                     {
-                        "name": "VSphereStaticIPs"
-                    },
-                    {
                         "name": "ValidatingAdmissionPolicy"
                     },
                     {
@@ -170,6 +167,9 @@
                     },
                     {
                         "name": "VSphereControlPlaneMachineSet"
+                    },
+                    {
+                        "name": "VSphereStaticIPs"
                     }
                 ],
                 "version": ""

--- a/payload-manifests/featuregates/featureGate-Default-SingleNode.yaml
+++ b/payload-manifests/featuregates/featureGate-Default-SingleNode.yaml
@@ -122,9 +122,6 @@
                         "name": "UpgradeStatus"
                     },
                     {
-                        "name": "VSphereStaticIPs"
-                    },
-                    {
                         "name": "ValidatingAdmissionPolicy"
                     },
                     {
@@ -170,6 +167,9 @@
                     },
                     {
                         "name": "VSphereControlPlaneMachineSet"
+                    },
+                    {
+                        "name": "VSphereStaticIPs"
                     }
                 ],
                 "version": ""

--- a/payload-manifests/featuregates/featureGate-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Default.yaml
@@ -119,9 +119,6 @@
                         "name": "UpgradeStatus"
                     },
                     {
-                        "name": "VSphereStaticIPs"
-                    },
-                    {
                         "name": "ValidatingAdmissionPolicy"
                     },
                     {
@@ -167,6 +164,9 @@
                     },
                     {
                         "name": "VSphereControlPlaneMachineSet"
+                    },
+                    {
+                        "name": "VSphereStaticIPs"
                     }
                 ],
                 "version": ""


### PR DESCRIPTION
[SPLAT-1293](https://issues.redhat.com/browse/SPLAT-1293)

## Changes
- Changed vSphereStaticIPs to now be on by default for GA support removing the need to set TechPreviewNoUpgrade.

## Blocking
- https://github.com/openshift/installer/pull/7943