### PR TITLE
WIP: Enable UnauthenticatedHTTP2DOSMitigation by default

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -451,4 +451,14 @@ var (
 		ResponsiblePerson:   "akashem",
 		OwningProduct:       kubernetes,
 	}
+
+	FeatureGateUnauthenticatedHTTP2DOSMitigation = FeatureGateName("UnauthenticatedHTTP2DOSMitigation")
+	unauthenticatedHTTP2DOSMitigation            = FeatureGateDescription{
+		FeatureGateAttributes: FeatureGateAttributes{
+			Name: FeatureGateUnauthenticatedHTTP2DOSMitigation,
+		},
+		OwningJiraComponent: "kube-apiserver",
+		ResponsiblePerson:   "dgrisonnet",
+		OwningProduct:       kubernetes,
+	}
 )

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -215,6 +215,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		privateHostedZoneAWS,
 		buildCSIVolumes,
 		kmsv1,
+		unauthenticatedHTTP2DOSMitigation,
 	},
 	Disabled: []FeatureGateDescription{
 		disableKubeletCloudCredentialProviders, // We do not currently ship the correct config to use the external credentials provider.

--- a/payload-command/render/renderassets/rendered_manifests_test.go
+++ b/payload-command/render/renderassets/rendered_manifests_test.go
@@ -124,4 +124,5 @@ status:
     - name: KMSv1
     - name: OpenShiftPodSecurityAdmission
     - name: PrivateHostedZoneAWS
+    - name: UnauthenticatedHTTP2DOSMitigation
     version: 4.15.0-0.ci.test-2023-11-14-160047-ci-op-tfcc12t7-latest`

--- a/payload-manifests/featuregates/featureGate-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Default.yaml
@@ -140,6 +140,9 @@
                     },
                     {
                         "name": "PrivateHostedZoneAWS"
+                    },
+                    {
+                        "name": "UnauthenticatedHTTP2DOSMitigation"
                     }
                 ],
                 "version": ""

--- a/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
+++ b/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
@@ -142,6 +142,9 @@
                     },
                     {
                         "name": "PrivateHostedZoneAWS"
+                    },
+                    {
+                        "name": "UnauthenticatedHTTP2DOSMitigation"
                     }
                 ],
                 "version": ""

--- a/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
@@ -132,6 +132,9 @@
                         "name": "TranslateStreamCloseWebsocketRequests"
                     },
                     {
+                        "name": "UnauthenticatedHTTP2DOSMitigation"
+                    },
+                    {
                         "name": "UpgradeStatus"
                     },
                     {


### PR DESCRIPTION
This should help getting rid of the carry patch that we previously added to enforce the `UnauthenticatedHTTP2DOSMitigation` feature-gate