### PR TITLE
OCPBUGS-29196: Update AWSCSIDriverConfigSpec fields validation to accept all current AWS partitions

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -74,7 +74,7 @@ spec:
                           to encrypt volumes with a user-defined KMS key, rather than
                           the default KMS key used by AWS. The value may be either
                           the ARN or Alias ARN of a KMS key.
-                        pattern: ^arn:(aws|aws-cn|aws-us-gov):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$
+                        pattern: ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$
                         type: string
                     type: object
                   azure:

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -160,7 +160,7 @@ type AWSCSIDriverConfigSpec struct {
 	// kmsKeyARN sets the cluster default storage class to encrypt volumes with a user-defined KMS key,
 	// rather than the default KMS key used by AWS.
 	// The value may be either the ARN or Alias ARN of a KMS key.
-	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$`
+	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$`
 	// +optional
 	KMSKeyARN string `json:"kmsKeyARN,omitempty"`
 }


### PR DESCRIPTION
When trying to set up KMS encryption in us-isob-east-1 region validation fails on the custom resource.