### PR TITLE
NP-874: Promote SDN Live Migration to GA

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -187,7 +187,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(metricsServer).
 		with(installAlternateInfrastructureAWS).
 		without(clusterAPIInstall).
-		with(sdnLiveMigration).
 		with(mixedCPUsAllocation).
 		with(managedBootImages).
 		without(disableKubeletCloudCredentialProviders).
@@ -215,6 +214,7 @@ var defaultFeatures = &FeatureGateEnabledDisabled{
 		buildCSIVolumes,
 		kmsv1,
 		vSphereControlPlaneMachineset,
+		sdnLiveMigration,
 	},
 	Disabled: []FeatureGateDescription{
 		disableKubeletCloudCredentialProviders, // We do not currently ship the correct config to use the external credentials provider.

--- a/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
+++ b/operator/v1/0000_70_cluster-network-operator_01-Default.crd.yaml
@@ -695,6 +695,23 @@ spec:
                           defaults to 'true' and multicast configure is migrated.
                         type: boolean
                     type: object
+                  mode:
+                    description: mode indicates the mode of network migration. The
+                      supported values are "Live", "Offline" and omitted. A "Live"
+                      migration operation will not cause service interruption by migrating
+                      the CNI of each node one by one. The cluster network will work
+                      as normal during the network migration. An "Offline" migration
+                      operation will cause service interruption. During an "Offline"
+                      migration, two rounds of node reboots are required. The cluster
+                      network will be malfunctioning during the network migration.
+                      When omitted, this means no opinion and the platform is left
+                      to choose a reasonable default which is subject to change over
+                      time. The current default value is "Offline".
+                    enum:
+                    - Live
+                    - Offline
+                    - ""
+                    type: string
                   mtu:
                     description: mtu contains the MTU migration configuration. Set
                       this to allow changing the MTU values for the default network.

--- a/operator/v1/stable.network.testsuite.yaml
+++ b/operator/v1/stable.network.testsuite.yaml
@@ -255,11 +255,11 @@ tests:
               ipv6:
                 internalMasqueradeSubnet: "abcd:eff01:2345:6789::2345:6789/20"
     expectedError: "Invalid value: \"string\": each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 2"
-  - name: Should not be able to create migration mode
+  - name: Should be able to create migration mode
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
-      spec: 
+      spec:
         migration:
           mode: Live
     expected: |
@@ -269,7 +269,8 @@ tests:
         disableNetworkDiagnostics: false
         logLevel: Normal
         operatorLogLevel: Normal
-        migration: {}
+        migration:
+          mode: Live
   - name: "IPsec - Empty ipsecConfig is allowed in initial state"
     initial: |
       apiVersion: operator.openshift.io/v1

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -157,7 +157,6 @@ type NetworkMigration struct {
 	// An "Offline" migration operation will cause service interruption. During an "Offline" migration, two rounds of node reboots are required. The cluster network will be malfunctioning during the network migration.
 	// When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time.
 	// The current default value is "Offline".
-	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	// +optional
 	Mode NetworkMigrationMode `json:"mode"`
 }

--- a/payload-manifests/featuregates/featureGate-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Default.yaml
@@ -71,9 +71,6 @@
                         "name": "MixedCPUsAllocation"
                     },
                     {
-                        "name": "NetworkLiveMigration"
-                    },
-                    {
                         "name": "NodeSwap"
                     },
                     {
@@ -131,6 +128,9 @@
                     },
                     {
                         "name": "KMSv1"
+                    },
+                    {
+                        "name": "NetworkLiveMigration"
                     },
                     {
                         "name": "OpenShiftPodSecurityAdmission"

--- a/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
+++ b/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
@@ -73,9 +73,6 @@
                         "name": "MixedCPUsAllocation"
                     },
                     {
-                        "name": "NetworkLiveMigration"
-                    },
-                    {
                         "name": "NodeSwap"
                     },
                     {
@@ -133,6 +130,9 @@
                     },
                     {
                         "name": "KMSv1"
+                    },
+                    {
+                        "name": "NetworkLiveMigration"
                     },
                     {
                         "name": "OpenShiftPodSecurityAdmission"


### PR DESCRIPTION
CI history for this feature:

master
[pull-ci-openshift-cluster-network-operator-master-e2e-aws-live-migration-sdn-ovn](https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-cluster-network-operator-master-e2e-aws-live-migration-sdn-ovn)
[pull-ci-openshift-cluster-network-operator-master-e2e-aws-live-migration-sdn-ovn-rollback](https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-cluster-network-operator-master-e2e-aws-live-migration-sdn-ovn-rollback)
4.15
[pull-ci-openshift-cluster-network-operator-master-e2e-aws-live-migration-sdn-ovn](https://prow.ci.openshift.org/?job=pull-ci-openshift-cluster-network-operator-release-4.15-e2e-aws-live-migration-sdn-ovn)
[pull-ci-openshift-cluster-network-operator-master-e2e-aws-live-migration-sdn-ovn-rollback](https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/pull-ci-openshift-cluster-network-operator-release-4.15-e2e-aws-live-migration-sdn-ovn-rollback)

/hold


