### PR TITLE
[release-4.15] OCPBUGS-28928: Add UnservableInFutureVersions route status condition type

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -55746,7 +55746,7 @@ func schema_openshift_api_route_v1_RouteIngressCondition(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type is the type of the condition. Currently only Admitted.",
+							Description: "Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -32842,7 +32842,7 @@
           "default": ""
         },
         "type": {
-          "description": "Type is the type of the condition. Currently only Admitted.",
+          "description": "Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.",
           "type": "string",
           "default": ""
         }

--- a/route/v1/generated.proto
+++ b/route/v1/generated.proto
@@ -213,7 +213,7 @@ message RouteIngress {
 // router.
 message RouteIngressCondition {
   // Type is the type of the condition.
-  // Currently only Admitted.
+  // Currently only Admitted or UnservableInFutureVersions.
   optional string type = 1;
 
   // Status is the status of the condition.

--- a/route/v1/route-CustomNoUpgrade.crd.yaml
+++ b/route/v1/route-CustomNoUpgrade.crd.yaml
@@ -344,7 +344,7 @@ spec:
                               description: Status is the status of the condition. Can be True, False, Unknown.
                               type: string
                             type:
-                              description: Type is the type of the condition. Currently only Admitted.
+                              description: Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.
                               type: string
                       host:
                         description: Host is the host string under which the route is exposed; this value is required

--- a/route/v1/route-TechPreviewNoUpgrade.crd.yaml
+++ b/route/v1/route-TechPreviewNoUpgrade.crd.yaml
@@ -344,7 +344,7 @@ spec:
                               description: Status is the status of the condition. Can be True, False, Unknown.
                               type: string
                             type:
-                              description: Type is the type of the condition. Currently only Admitted.
+                              description: Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.
                               type: string
                       host:
                         description: Host is the host string under which the route is exposed; this value is required

--- a/route/v1/route.crd.yaml
+++ b/route/v1/route.crd.yaml
@@ -376,7 +376,7 @@ spec:
                               description: Status is the status of the condition. Can be True, False, Unknown.
                               type: string
                             type:
-                              description: Type is the type of the condition. Currently only Admitted.
+                              description: Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.
                               type: string
                           required:
                             - status

--- a/route/v1/types.go
+++ b/route/v1/types.go
@@ -369,14 +369,16 @@ type RouteIngressConditionType string
 const (
 	// RouteAdmitted means the route is able to service requests for the provided Host
 	RouteAdmitted RouteIngressConditionType = "Admitted"
-	// TODO: add other route condition types
+	// RouteUnservableInFutureVersions indicates that the route is using an unsupported
+	// configuration that may be incompatible with a future version of OpenShift.
+	RouteUnservableInFutureVersions RouteIngressConditionType = "UnservableInFutureVersions"
 )
 
 // RouteIngressCondition contains details for the current condition of this route on a particular
 // router.
 type RouteIngressCondition struct {
 	// Type is the type of the condition.
-	// Currently only Admitted.
+	// Currently only Admitted or UnservableInFutureVersions.
 	Type RouteIngressConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=RouteIngressConditionType"`
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.

--- a/route/v1/zz_generated.swagger_doc_generated.go
+++ b/route/v1/zz_generated.swagger_doc_generated.go
@@ -85,7 +85,7 @@ func (RouteIngress) SwaggerDoc() map[string]string {
 
 var map_RouteIngressCondition = map[string]string{
 	"":                   "RouteIngressCondition contains details for the current condition of this route on a particular router.",
-	"type":               "Type is the type of the condition. Currently only Admitted.",
+	"type":               "Type is the type of the condition. Currently only Admitted or UnservableInFutureVersions.",
 	"status":             "Status is the status of the condition. Can be True, False, Unknown.",
 	"reason":             "(brief) reason for the condition's last transition, and is usually a machine and human readable constant",
 	"message":            "Human readable message indicating details about last transition.",


### PR DESCRIPTION
Cherry-Pick of https://github.com/openshift/api/pull/1722

Add UnservableInFutureVersions as a route status condition type. This change allows the router to indicate that a route is using an unsupported configuration and will be unservable in the future. The ingress operator may use this condition to block upgrades.