### PR TITLE
OCPBUGS-18991: Add BuildInterrupted type

### DIFF
--- a/machineconfiguration/v1/types.go
+++ b/machineconfiguration/v1/types.go
@@ -517,6 +517,8 @@ const (
 	MachineConfigPoolBuildSuccess MachineConfigPoolConditionType = "BuildSuccess"
 
 	MachineConfigPoolBuildFailed MachineConfigPoolConditionType = "BuildFailed"
+
+	MachineConfigPoolBuildInterrupted MachineConfigPoolConditionType = "BuildInterrupted"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
BuildInterrupted indicates that the build has been stopped by some sort of user action or outside force. It is not necessarily a failure but causes the build to be thrown away.