### PR TITLE
config/v1/types_cluster_version: Drop never-implemented 'Evaluating' conditionalUpdates condition type

### DIFF
--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion-CustomNoUpgrade.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion-CustomNoUpgrade.crd.yaml
@@ -391,10 +391,8 @@ spec:
                   properties:
                     conditions:
                       description: 'conditions represents the observations of the
-                        conditional update''s current status. Known types are: * Evaluating,
-                        for whether the cluster-version operator will attempt to evaluate
-                        any risks[].matchingRules. * Recommended, for whether the
-                        update is recommended for the current cluster.'
+                        conditional update''s current status. Known types are: * Recommended,
+                        for whether the update is recommended for the current cluster.'
                       items:
                         description: "Condition contains details for one aspect of
                           the current state of this API Resource. --- This struct

--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion-Default.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion-Default.crd.yaml
@@ -338,10 +338,8 @@ spec:
                   properties:
                     conditions:
                       description: 'conditions represents the observations of the
-                        conditional update''s current status. Known types are: * Evaluating,
-                        for whether the cluster-version operator will attempt to evaluate
-                        any risks[].matchingRules. * Recommended, for whether the
-                        update is recommended for the current cluster.'
+                        conditional update''s current status. Known types are: * Recommended,
+                        for whether the update is recommended for the current cluster.'
                       items:
                         description: "Condition contains details for one aspect of
                           the current state of this API Resource. --- This struct

--- a/config/v1/0000_00_cluster-version-operator_01_clusterversion-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/0000_00_cluster-version-operator_01_clusterversion-TechPreviewNoUpgrade.crd.yaml
@@ -391,10 +391,8 @@ spec:
                   properties:
                     conditions:
                       description: 'conditions represents the observations of the
-                        conditional update''s current status. Known types are: * Evaluating,
-                        for whether the cluster-version operator will attempt to evaluate
-                        any risks[].matchingRules. * Recommended, for whether the
-                        update is recommended for the current cluster.'
+                        conditional update''s current status. Known types are: * Recommended,
+                        for whether the update is recommended for the current cluster.'
                       items:
                         description: "Condition contains details for one aspect of
                           the current state of this API Resource. --- This struct

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -691,7 +691,6 @@ type ConditionalUpdate struct {
 
 	// conditions represents the observations of the conditional update's
 	// current status. Known types are:
-	// * Evaluating, for whether the cluster-version operator will attempt to evaluate any risks[].matchingRules.
 	// * Recommended, for whether the update is recommended for the current cluster.
 	// +patchMergeKey=type
 	// +patchStrategy=merge

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -743,7 +743,7 @@ var map_ConditionalUpdate = map[string]string{
 	"":           "ConditionalUpdate represents an update which is recommended to some clusters on the version the current cluster is reconciling, but which may not be recommended for the current cluster.",
 	"release":    "release is the target of the update.",
 	"risks":      "risks represents the range of issues associated with updating to the target release. The cluster-version operator will evaluate all entries, and only recommend the update if there is at least one entry and all entries recommend the update.",
-	"conditions": "conditions represents the observations of the conditional update's current status. Known types are: * Evaluating, for whether the cluster-version operator will attempt to evaluate any risks[].matchingRules. * Recommended, for whether the update is recommended for the current cluster.",
+	"conditions": "conditions represents the observations of the conditional update's current status. Known types are: * Recommended, for whether the update is recommended for the current cluster.",
 }
 
 func (ConditionalUpdate) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -10959,7 +10959,7 @@ func schema_openshift_api_config_v1_ConditionalUpdate(ref common.ReferenceCallba
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "conditions represents the observations of the conditional update's current status. Known types are: * Evaluating, for whether the cluster-version operator will attempt to evaluate any risks[].matchingRules. * Recommended, for whether the update is recommended for the current cluster.",
+							Description: "conditions represents the observations of the conditional update's current status. Known types are: * Recommended, for whether the update is recommended for the current cluster.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -5593,7 +5593,7 @@
       ],
       "properties": {
         "conditions": {
-          "description": "conditions represents the observations of the conditional update's current status. Known types are: * Evaluating, for whether the cluster-version operator will attempt to evaluate any risks[].matchingRules. * Recommended, for whether the update is recommended for the current cluster.",
+          "description": "conditions represents the observations of the conditional update's current status. Known types are: * Recommended, for whether the update is recommended for the current cluster.",
           "type": "array",
           "items": {
             "default": {},


### PR DESCRIPTION
Catching up with openshift/enhancements@c446cd7846 (openshift/enhancements#1420), which points out that this type was never implemented, because `Recommended=Unknown` is sufficient to say "we're trying (and failing) to figure out if some of the target's risks apply to the cluster".