### PR TITLE
OPNET-466: PlatformLoadBalancer becomes GA for On-Prem

### DIFF
--- a/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
+++ b/config/v1/0000_10_config-operator_01_infrastructure-Default.crd.yaml
@@ -1197,6 +1197,34 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                      loadBalancer:
+                        default:
+                          type: OpenShiftManagedDefault
+                        description: loadBalancer defines how the load balancer used
+                          by the cluster is configured.
+                        properties:
+                          type:
+                            default: OpenShiftManagedDefault
+                            description: type defines the type of load balancer used
+                              by the cluster on BareMetal platform which can be a
+                              user-managed or openshift-managed load balancer that
+                              is to be used for the OpenShift API and Ingress endpoints.
+                              When set to OpenShiftManagedDefault the static pods
+                              in charge of API and Ingress traffic load-balancing
+                              defined in the machine config operator will be deployed.
+                              When set to UserManaged these static pods will not be
+                              deployed and it is expected that the load balancer is
+                              configured out of band by the deployer. When omitted,
+                              this means no opinion and the platform is left to choose
+                              a reasonable default. The default value is OpenShiftManagedDefault.
+                            enum:
+                            - OpenShiftManagedDefault
+                            - UserManaged
+                            type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1431,6 +1459,34 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                      loadBalancer:
+                        default:
+                          type: OpenShiftManagedDefault
+                        description: loadBalancer defines how the load balancer used
+                          by the cluster is configured.
+                        properties:
+                          type:
+                            default: OpenShiftManagedDefault
+                            description: type defines the type of load balancer used
+                              by the cluster on Nutanix platform which can be a user-managed
+                              or openshift-managed load balancer that is to be used
+                              for the OpenShift API and Ingress endpoints. When set
+                              to OpenShiftManagedDefault the static pods in charge
+                              of API and Ingress traffic load-balancing defined in
+                              the machine config operator will be deployed. When set
+                              to UserManaged these static pods will not be deployed
+                              and it is expected that the load balancer is configured
+                              out of band by the deployer. When omitted, this means
+                              no opinion and the platform is left to choose a reasonable
+                              default. The default value is OpenShiftManagedDefault.
+                            enum:
+                            - OpenShiftManagedDefault
+                            - UserManaged
+                            type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
                     type: object
                   openstack:
                     description: OpenStack contains settings specific to the OpenStack
@@ -1575,6 +1631,34 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                      loadBalancer:
+                        default:
+                          type: OpenShiftManagedDefault
+                        description: loadBalancer defines how the load balancer used
+                          by the cluster is configured.
+                        properties:
+                          type:
+                            default: OpenShiftManagedDefault
+                            description: type defines the type of load balancer used
+                              by the cluster on Ovirt platform which can be a user-managed
+                              or openshift-managed load balancer that is to be used
+                              for the OpenShift API and Ingress endpoints. When set
+                              to OpenShiftManagedDefault the static pods in charge
+                              of API and Ingress traffic load-balancing defined in
+                              the machine config operator will be deployed. When set
+                              to UserManaged these static pods will not be deployed
+                              and it is expected that the load balancer is configured
+                              out of band by the deployer. When omitted, this means
+                              no opinion and the platform is left to choose a reasonable
+                              default. The default value is OpenShiftManagedDefault.
+                            enum:
+                            - OpenShiftManagedDefault
+                            - UserManaged
+                            type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
                       nodeDNSIP:
                         description: 'deprecated: as of 4.6, this field is no longer
                           set or honored.  It will be removed in a future release.'
@@ -1730,6 +1814,34 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                      loadBalancer:
+                        default:
+                          type: OpenShiftManagedDefault
+                        description: loadBalancer defines how the load balancer used
+                          by the cluster is configured.
+                        properties:
+                          type:
+                            default: OpenShiftManagedDefault
+                            description: type defines the type of load balancer used
+                              by the cluster on VSphere platform which can be a user-managed
+                              or openshift-managed load balancer that is to be used
+                              for the OpenShift API and Ingress endpoints. When set
+                              to OpenShiftManagedDefault the static pods in charge
+                              of API and Ingress traffic load-balancing defined in
+                              the machine config operator will be deployed. When set
+                              to UserManaged these static pods will not be deployed
+                              and it is expected that the load balancer is configured
+                              out of band by the deployer. When omitted, this means
+                              no opinion and the platform is left to choose a reasonable
+                              default. The default value is OpenShiftManagedDefault.
+                            enum:
+                            - OpenShiftManagedDefault
+                            - UserManaged
+                            type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.

--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -530,6 +530,6 @@ var (
 						reportProblemsToJiraComponent("metal").
 						contactPerson("EmilienM").
 						productScope(ocpSpecific).
-						enableIn(TechPreviewNoUpgrade).
+						enableIn(Default, TechPreviewNoUpgrade).
 						mustRegister()
 )

--- a/config/v1/stable.infrastructure.testsuite.yaml
+++ b/config/v1/stable.infrastructure.testsuite.yaml
@@ -519,7 +519,46 @@ tests:
               loadBalancer:
                 type: OpenShiftManagedDefault
             type: OpenStack
-    - name: Should be able to override the default load balancer with a valid value
+    - name: Should be able to override the default BareMetal load balancer with a valid value
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            baremetal: {}
+            type: BareMetal
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            baremetal: {}
+            type: BareMetal
+        status:
+          platform: BareMetal
+          platformStatus:
+            baremetal:
+              loadBalancer:
+                type: UserManaged
+            type: BareMetal
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            baremetal: {}
+            type: BareMetal
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: BareMetal
+          platformStatus:
+            baremetal:
+              loadBalancer:
+                type: UserManaged
+            type: BareMetal
+    - name: Should be able to override the default OpenStack load balancer with a valid value
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -558,7 +597,41 @@ tests:
               loadBalancer:
                 type: UserManaged
             type: OpenStack
-    - name: Should not allow changing the immutable load balancer type field
+    - name: Should not allow changing the immutable BareMetal load balancer type field
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            baremetal: {}
+            type: BareMetal
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: BareMetal
+          platformStatus:
+            baremetal:
+              loadBalancer:
+                type: OpenShiftManagedDefault
+            type: BareMetal
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: BareMetal
+            baremetal: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: BareMetal
+          platformStatus:
+            baremetal:
+              loadBalancer:
+                type: UserManaged
+            type: BareMetal
+      expectedStatusError: "status.platformStatus.baremetal.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
+    - name: Should not allow changing the immutable OpenStack load balancer type field
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -592,7 +665,7 @@ tests:
                 type: UserManaged
             type: OpenStack
       expectedStatusError: "status.platformStatus.openstack.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
-    - name: Should not allow removing the immutable load balancer type field that was initially set
+    - name: Should not allow removing the immutable OpenStack load balancer type field that was initially set
       initial: |
         apiVersion: config.openshift.io/v1
         kind: Infrastructure
@@ -624,6 +697,38 @@ tests:
             openstack: {}
             type: OpenStack
       expectedStatusError: "status.platformStatus.openstack.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
+    - name: Should not allow removing the immutable BareMetal load balancer type field that was initially set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            baremetal: {}
+            type: BareMetal
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: BareMetal
+          platformStatus:
+            baremetal:
+              loadBalancer:
+                type: UserManaged
+            type: BareMetal
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: BareMetal
+            baremetal: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailable
+          platform: BareMetal
+          platformStatus:
+            baremetal: {}
+            type: BareMetal
+      expectedStatusError: "status.platformStatus.baremetal.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
     - name: Should not allow setting the load balancer type to a wrong value
       initial: |
         apiVersion: config.openshift.io/v1

--- a/config/v1/techpreview.infrastructure.testsuite.yaml
+++ b/config/v1/techpreview.infrastructure.testsuite.yaml
@@ -83,111 +83,6 @@ tests:
             loadBalancer:
               type: OpenShiftManagedDefault
           type: BareMetal
-  - name: Should be able to override the default load balancer with a valid value
-    initial: |
-      apiVersion: config.openshift.io/v1
-      kind: Infrastructure
-      spec:
-        platformSpec:
-          baremetal: {}
-          type: BareMetal
-    updated: |
-      apiVersion: config.openshift.io/v1
-      kind: Infrastructure
-      spec:
-        platformSpec:
-          baremetal: {}
-          type: BareMetal
-      status:
-        platform: BareMetal
-        platformStatus:
-          baremetal:
-            loadBalancer:
-              type: UserManaged
-          type: BareMetal
-    expected: |
-      apiVersion: config.openshift.io/v1
-      kind: Infrastructure
-      spec:
-        platformSpec:
-          baremetal: {}
-          type: BareMetal
-      status:
-        controlPlaneTopology: HighlyAvailable
-        cpuPartitioning: None
-        infrastructureTopology: HighlyAvailable
-        platform: BareMetal
-        platformStatus:
-          baremetal:
-            loadBalancer:
-              type: UserManaged
-          type: BareMetal
-  - name: Should not allow changing the immutable load balancer type field
-    initial: |
-      apiVersion: config.openshift.io/v1
-      kind: Infrastructure
-      spec:
-        platformSpec:
-          baremetal: {}
-          type: BareMetal
-      status:
-        controlPlaneTopology: HighlyAvailable
-        infrastructureTopology: HighlyAvailable
-        platform: BareMetal
-        platformStatus:
-          baremetal:
-            loadBalancer:
-              type: OpenShiftManagedDefault
-          type: BareMetal
-    updated: |
-      apiVersion: config.openshift.io/v1
-      kind: Infrastructure
-      spec:
-        platformSpec:
-          type: BareMetal
-          baremetal: {}
-      status:
-        controlPlaneTopology: HighlyAvailable
-        infrastructureTopology: HighlyAvailable
-        platform: BareMetal
-        platformStatus:
-          baremetal:
-            loadBalancer:
-              type: UserManaged
-          type: BareMetal
-    expectedStatusError: "status.platformStatus.baremetal.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
-  - name: Should not allow removing the immutable load balancer type field that was initially set
-    initial: |
-      apiVersion: config.openshift.io/v1
-      kind: Infrastructure
-      spec:
-        platformSpec:
-          baremetal: {}
-          type: BareMetal
-      status:
-        controlPlaneTopology: HighlyAvailable
-        infrastructureTopology: HighlyAvailable
-        platform: BareMetal
-        platformStatus:
-          baremetal:
-            loadBalancer:
-              type: UserManaged
-          type: BareMetal
-    updated: |
-      apiVersion: config.openshift.io/v1
-      kind: Infrastructure
-      spec:
-        platformSpec:
-          type: BareMetal
-          baremetal: {}
-      status:
-        controlPlaneTopology: HighlyAvailable
-        infrastructureTopology: HighlyAvailable
-        platform: BareMetal
-        platformStatus:
-          baremetal: {}
-          type: BareMetal
-    expectedStatusError: "status.platformStatus.baremetal.loadBalancer.type: Invalid value: \"string\": type is immutable once set"
   - name: Should not allow setting the load balancer type to a wrong value
     initial: |
       apiVersion: config.openshift.io/v1
@@ -654,7 +549,7 @@ tests:
         infrastructureTopology: HighlyAvailable
         platform: GCP
         platformStatus:
-          gcp: 
+          gcp:
             cloudLoadBalancerConfig:
               dnsType: ClusterHosted
               clusterHosted:

--- a/machineconfiguration/v1/0000_80_controllerconfig-Default.crd.yaml
+++ b/machineconfiguration/v1/0000_80_controllerconfig-Default.crd.yaml
@@ -1510,6 +1510,36 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on BareMetal platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.
@@ -1756,6 +1786,36 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Nutanix platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
                             type: object
                           openstack:
                             description: OpenStack contains settings specific to the
@@ -1912,6 +1972,36 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Ovirt platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
                               nodeDNSIP:
                                 description: 'deprecated: as of 4.6, this field is
                                   no longer set or honored.  It will be removed in
@@ -2077,6 +2167,36 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on VSphere platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.

--- a/machineconfiguration/v1/stable.controllerconfig.testsuite.yaml
+++ b/machineconfiguration/v1/stable.controllerconfig.testsuite.yaml
@@ -100,3 +100,120 @@ tests:
           namespace: openshift-config
         releaseImage: ""
         rootCAData: Y2VydGlmaWNhdGUK
+  - name: Should be able to create a ControllerConfig for vSphere with external load balancer
+    initial: |
+      apiVersion: machineconfiguration.openshift.io/v1
+      kind: ControllerConfig
+      spec:
+        additionalTrustBundle: Y2VydGlmaWNhdGUK
+        baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+        baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+        cloudProviderCAData: null
+        cloudProviderConfig: ""
+        clusterDNSIP: fd02::a
+        dns:
+          apiVersion: config.openshift.io/v1
+          kind: DNS
+          spec:
+            baseDomain: fake.redhat.com
+        images:
+          machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+        infra:
+          apiVersion: config.openshift.io/v1
+          kind: Infrastructure
+          spec:
+            cloudConfig:
+              name: ""
+            platformSpec:
+              type: VSphere
+              vsphere: {}
+          status:
+            apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+            apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+            cpuPartitioning: "None"
+            controlPlaneTopology: SingleReplica
+            etcdDiscoveryDomain: ""
+            infrastructureName: cnfde4-sxhr7
+            infrastructureTopology: SingleReplica
+            platform: VSphere
+            platformStatus:
+              type: VSphere
+              vsphere:
+                apiServerInternalIP: 10.38.153.2
+                apiServerInternalIPs:
+                - 10.38.153.2
+                ingressIP: 10.38.153.3
+                ingressIPs:
+                - 10.38.153.3
+                loadBalancer:
+                  type: UserManaged
+        ipFamilies: IPv6
+        kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+        network: null
+        networkType: OVNKubernetes
+        osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+        platform: none
+        proxy: null
+        pullSecret:
+          name: pull-secret
+          namespace: openshift-config
+        releaseImage: ""
+        rootCAData: Y2VydGlmaWNhdGUK
+    expected: |
+      apiVersion: machineconfiguration.openshift.io/v1
+      kind: ControllerConfig
+      spec:
+        additionalTrustBundle: Y2VydGlmaWNhdGUK
+        baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+        baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+        cloudProviderCAData: null
+        cloudProviderConfig: ""
+        clusterDNSIP: fd02::a
+        dns:
+          apiVersion: config.openshift.io/v1
+          kind: DNS
+          spec:
+            baseDomain: fake.redhat.com
+        images:
+          machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+        infra:
+          apiVersion: config.openshift.io/v1
+          kind: Infrastructure
+          spec:
+            cloudConfig:
+              name: ""
+            platformSpec:
+              type: VSphere
+              vsphere: {}
+          status:
+            apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+            apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+            cpuPartitioning: "None"
+            controlPlaneTopology: SingleReplica
+            etcdDiscoveryDomain: ""
+            infrastructureName: cnfde4-sxhr7
+            infrastructureTopology: SingleReplica
+            platform: VSphere
+            platformStatus:
+              type: VSphere
+              vsphere:
+                apiServerInternalIP: 10.38.153.2
+                apiServerInternalIPs:
+                - 10.38.153.2
+                ingressIP: 10.38.153.3
+                ingressIPs:
+                - 10.38.153.3
+                loadBalancer:
+                  type: UserManaged
+        ipFamilies: IPv6
+        kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+        network: null
+        networkType: OVNKubernetes
+        osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+        platform: none
+        proxy: null
+        pullSecret:
+          name: pull-secret
+          namespace: openshift-config
+        releaseImage: ""
+        rootCAData: Y2VydGlmaWNhdGUK

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructure-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructure-Default.crd.yaml
@@ -1197,6 +1197,34 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                      loadBalancer:
+                        default:
+                          type: OpenShiftManagedDefault
+                        description: loadBalancer defines how the load balancer used
+                          by the cluster is configured.
+                        properties:
+                          type:
+                            default: OpenShiftManagedDefault
+                            description: type defines the type of load balancer used
+                              by the cluster on BareMetal platform which can be a
+                              user-managed or openshift-managed load balancer that
+                              is to be used for the OpenShift API and Ingress endpoints.
+                              When set to OpenShiftManagedDefault the static pods
+                              in charge of API and Ingress traffic load-balancing
+                              defined in the machine config operator will be deployed.
+                              When set to UserManaged these static pods will not be
+                              deployed and it is expected that the load balancer is
+                              configured out of band by the deployer. When omitted,
+                              this means no opinion and the platform is left to choose
+                              a reasonable default. The default value is OpenShiftManagedDefault.
+                            enum:
+                            - OpenShiftManagedDefault
+                            - UserManaged
+                            type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1431,6 +1459,34 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                      loadBalancer:
+                        default:
+                          type: OpenShiftManagedDefault
+                        description: loadBalancer defines how the load balancer used
+                          by the cluster is configured.
+                        properties:
+                          type:
+                            default: OpenShiftManagedDefault
+                            description: type defines the type of load balancer used
+                              by the cluster on Nutanix platform which can be a user-managed
+                              or openshift-managed load balancer that is to be used
+                              for the OpenShift API and Ingress endpoints. When set
+                              to OpenShiftManagedDefault the static pods in charge
+                              of API and Ingress traffic load-balancing defined in
+                              the machine config operator will be deployed. When set
+                              to UserManaged these static pods will not be deployed
+                              and it is expected that the load balancer is configured
+                              out of band by the deployer. When omitted, this means
+                              no opinion and the platform is left to choose a reasonable
+                              default. The default value is OpenShiftManagedDefault.
+                            enum:
+                            - OpenShiftManagedDefault
+                            - UserManaged
+                            type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
                     type: object
                   openstack:
                     description: OpenStack contains settings specific to the OpenStack
@@ -1575,6 +1631,34 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                      loadBalancer:
+                        default:
+                          type: OpenShiftManagedDefault
+                        description: loadBalancer defines how the load balancer used
+                          by the cluster is configured.
+                        properties:
+                          type:
+                            default: OpenShiftManagedDefault
+                            description: type defines the type of load balancer used
+                              by the cluster on Ovirt platform which can be a user-managed
+                              or openshift-managed load balancer that is to be used
+                              for the OpenShift API and Ingress endpoints. When set
+                              to OpenShiftManagedDefault the static pods in charge
+                              of API and Ingress traffic load-balancing defined in
+                              the machine config operator will be deployed. When set
+                              to UserManaged these static pods will not be deployed
+                              and it is expected that the load balancer is configured
+                              out of band by the deployer. When omitted, this means
+                              no opinion and the platform is left to choose a reasonable
+                              default. The default value is OpenShiftManagedDefault.
+                            enum:
+                            - OpenShiftManagedDefault
+                            - UserManaged
+                            type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
                       nodeDNSIP:
                         description: 'deprecated: as of 4.6, this field is no longer
                           set or honored.  It will be removed in a future release.'
@@ -1730,6 +1814,34 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                      loadBalancer:
+                        default:
+                          type: OpenShiftManagedDefault
+                        description: loadBalancer defines how the load balancer used
+                          by the cluster is configured.
+                        properties:
+                          type:
+                            default: OpenShiftManagedDefault
+                            description: type defines the type of load balancer used
+                              by the cluster on VSphere platform which can be a user-managed
+                              or openshift-managed load balancer that is to be used
+                              for the OpenShift API and Ingress endpoints. When set
+                              to OpenShiftManagedDefault the static pods in charge
+                              of API and Ingress traffic load-balancing defined in
+                              the machine config operator will be deployed. When set
+                              to UserManaged these static pods will not be deployed
+                              and it is expected that the load balancer is configured
+                              out of band by the deployer. When omitted, this means
+                              no opinion and the platform is left to choose a reasonable
+                              default. The default value is OpenShiftManagedDefault.
+                            enum:
+                            - OpenShiftManagedDefault
+                            - UserManaged
+                            type: string
+                            x-kubernetes-validations:
+                            - message: type is immutable once set
+                              rule: oldSelf == '' || self == oldSelf
+                        type: object
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.

--- a/payload-manifests/featuregates/featureGate-Default-Hypershift.yaml
+++ b/payload-manifests/featuregates/featureGate-Default-Hypershift.yaml
@@ -23,9 +23,6 @@
                         "name": "AutomatedEtcdBackup"
                     },
                     {
-                        "name": "BareMetalLoadBalancer"
-                    },
-                    {
                         "name": "CSIDriverSharedResource"
                     },
                     {
@@ -134,6 +131,9 @@
                     },
                     {
                         "name": "AzureWorkloadIdentity"
+                    },
+                    {
+                        "name": "BareMetalLoadBalancer"
                     },
                     {
                         "name": "BuildCSIVolumes"

--- a/payload-manifests/featuregates/featureGate-Default-SelfManagedHA.yaml
+++ b/payload-manifests/featuregates/featureGate-Default-SelfManagedHA.yaml
@@ -23,9 +23,6 @@
                         "name": "AutomatedEtcdBackup"
                     },
                     {
-                        "name": "BareMetalLoadBalancer"
-                    },
-                    {
                         "name": "CSIDriverSharedResource"
                     },
                     {
@@ -137,6 +134,9 @@
                     },
                     {
                         "name": "AzureWorkloadIdentity"
+                    },
+                    {
+                        "name": "BareMetalLoadBalancer"
                     },
                     {
                         "name": "BuildCSIVolumes"

--- a/payload-manifests/featuregates/featureGate-Default-SingleNode.yaml
+++ b/payload-manifests/featuregates/featureGate-Default-SingleNode.yaml
@@ -23,9 +23,6 @@
                         "name": "AutomatedEtcdBackup"
                     },
                     {
-                        "name": "BareMetalLoadBalancer"
-                    },
-                    {
                         "name": "CSIDriverSharedResource"
                     },
                     {
@@ -137,6 +134,9 @@
                     },
                     {
                         "name": "AzureWorkloadIdentity"
+                    },
+                    {
+                        "name": "BareMetalLoadBalancer"
                     },
                     {
                         "name": "BuildCSIVolumes"

--- a/payload-manifests/featuregates/featureGate-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Default.yaml
@@ -20,9 +20,6 @@
                         "name": "AutomatedEtcdBackup"
                     },
                     {
-                        "name": "BareMetalLoadBalancer"
-                    },
-                    {
                         "name": "CSIDriverSharedResource"
                     },
                     {
@@ -134,6 +131,9 @@
                     },
                     {
                         "name": "AzureWorkloadIdentity"
+                    },
+                    {
+                        "name": "BareMetalLoadBalancer"
                     },
                     {
                         "name": "BuildCSIVolumes"


### PR DESCRIPTION
This PR promotes the PlatformLoadBalancer to GA for bare-metal and vSphere platforms. The feature has been in TP for long enough so that we are ready to promote it.