### PR TITLE
API-1710: Add configuration option to specify the type of service account token to use

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -50244,6 +50244,13 @@ func schema_openshift_api_operator_v1_OpenShiftControllerManagerSpec(ref common.
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
+					"imageRegistryAuthTokenType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "imageRegistryAuthTokenType specifies the kind of service account token when used when generating image pull secrets for the integrated image registry.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"managementState"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -29391,6 +29391,10 @@
         "managementState"
       ],
       "properties": {
+        "imageRegistryAuthTokenType": {
+          "description": "imageRegistryAuthTokenType specifies the kind of service account token when used when generating image pull secrets for the integrated image registry.",
+          "type": "string"
+        },
         "logLevel": {
           "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands.\n\nValid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
           "type": "string"

--- a/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
@@ -39,6 +39,13 @@ spec:
             type: object
           spec:
             properties:
+              imageRegistryAuthTokenType:
+                description: imageRegistryAuthTokenType specifies the kind of service
+                  account token when used when generating image pull secrets for the
+                  integrated image registry.
+                enum:
+                - Legacy
+                type: string
               logLevel:
                 default: Normal
                 description: "logLevel is an intent based logging for an overall component.

--- a/operator/v1/types_openshiftcontrollermanager.go
+++ b/operator/v1/types_openshiftcontrollermanager.go
@@ -28,7 +28,19 @@ type OpenShiftControllerManager struct {
 
 type OpenShiftControllerManagerSpec struct {
 	OperatorSpec `json:",inline"`
+
+	// imageRegistryAuthTokenType specifies the kind of service account token when used
+	// when generating image pull secrets for the integrated image registry.
+	// +kubebuilder:validation:Enum=Legacy
+	// +optional
+	ImageRegistryAuthTokenType ServiceAccountTokenType `json:"imageRegistryAuthTokenType,omitempty"`
 }
+
+type ServiceAccountTokenType string
+
+const (
+	ServiceAccountLegacyTokenType ServiceAccountTokenType = "Legacy"
+)
 
 type OpenShiftControllerManagerStatus struct {
 	OperatorStatus `json:",inline"`

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1648,6 +1648,14 @@ func (OpenShiftControllerManagerList) SwaggerDoc() map[string]string {
 	return map_OpenShiftControllerManagerList
 }
 
+var map_OpenShiftControllerManagerSpec = map[string]string{
+	"imageRegistryAuthTokenType": "imageRegistryAuthTokenType specifies the kind of service account token when used when generating image pull secrets for the integrated image registry.",
+}
+
+func (OpenShiftControllerManagerSpec) SwaggerDoc() map[string]string {
+	return map_OpenShiftControllerManagerSpec
+}
+
 var map_KubeScheduler = map[string]string{
 	"":         "KubeScheduler provides information to configure an operator to manage scheduler.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
 	"metadata": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",


### PR DESCRIPTION
Introduce a configuration option to allow users to specify the type of service account token to use for the integrated image registry image pull secret auth.

```
apiVersion: operator.openshift.io/v1
kind: OpenShiftControllerManager
spec:
  imageRegistryAuthTokenType: Legacy
```

In version v4.15:
 - The default, and only value, will be `Legacy`. 
 - The value will explicitly be added to the OCM-O config.

In version 4.16:
 - The default value will be `Bound`.
 - The value will not be explicitly set.
 - Users who upgrade from v4.15 will still be configured to use the `Legacy` service account tokens until they update the OCM-O config to switch to `Bound`.

---

- Proof PR 1: https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/331
  - build artifacts show value written in both fresh install and upgrade jobs.
- Follow up PR: Only for v4.16. https://github.com/openshift/api/pull/1761 
- Proof PR 2 for 4.16: https://github.com/openshift/cluster-openshift-controller-manager-operator/pull/332
- Job showing value preserved on upgrade in a from Proof PR 1 to Proof PR 2:
  - <a href="https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1755829021754527744">`workflow-upgrade openshift-upgrade-aws openshift/cluster-openshift-controller-manager-operator#331 openshift/cluster-openshift-controller-manager-operator#332`</a>
- ocm-o log showing `Legacy` value observed on upgrade: [openshift-controller-manager-operator.log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1755829021754527744/artifacts/launch/gather-extra/artifacts/pods/openshift-controller-manager-operator_openshift-controller-manager-operator-d8564ff98-pw4rc_openshift-controller-manager-operator.log)