### PR TITLE
[release-4.15] OCPBUGS-29213: Remove SigstoreImageVerification feature gate

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -193,16 +193,6 @@ var (
 		OwningProduct:       ocpSpecific,
 	}
 
-	FeatureGateSigstoreImageVerification = FeatureGateName("SigstoreImageVerification")
-	sigstoreImageVerification            = FeatureGateDescription{
-		FeatureGateAttributes: FeatureGateAttributes{
-			Name: FeatureGateSigstoreImageVerification,
-		},
-		OwningJiraComponent: "node",
-		ResponsiblePerson:   "sgrunert",
-		OwningProduct:       ocpSpecific,
-	}
-
 	FeatureGateGCPLabelsTags = FeatureGateName("GCPLabelsTags")
 	gcpLabelsTags            = FeatureGateDescription{
 		FeatureGateAttributes: FeatureGateAttributes{
@@ -391,7 +381,6 @@ var (
 		ResponsiblePerson:   "jspeed",
 		OwningProduct:       kubernetes,
 	}
-
 
 	FeatureGateOnClusterBuild = FeatureGateName("OnClusterBuild")
 	onClusterBuild            = FeatureGateDescription{

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -174,7 +174,6 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(gateGatewayAPI).
 		with(maxUnavailableStatefulSet).
 		without(eventedPleg).
-		with(sigstoreImageVerification).
 		with(gcpLabelsTags).
 		with(gcpClusterHostedDNS).
 		with(vSphereStaticIPs).

--- a/payload-manifests/featuregates/featureGate-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Default.yaml
@@ -86,9 +86,6 @@
                         "name": "SignatureStores"
                     },
                     {
-                        "name": "SigstoreImageVerification"
-                    },
-                    {
                         "name": "VSphereControlPlaneMachineSet"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
+++ b/payload-manifests/featuregates/featureGate-LatencySensitive.yaml
@@ -88,9 +88,6 @@
                         "name": "SignatureStores"
                     },
                     {
-                        "name": "SigstoreImageVerification"
-                    },
-                    {
                         "name": "VSphereControlPlaneMachineSet"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
@@ -120,9 +120,6 @@
                         "name": "SignatureStores"
                     },
                     {
-                        "name": "SigstoreImageVerification"
-                    },
-                    {
                         "name": "VSphereControlPlaneMachineSet"
                     },
                     {


### PR DESCRIPTION
The CRD ClusterImagePolicy for image verification feature hasn't been implemented OCP 4.15. We plan this feature for 4.16