### PR TITLE
WIP 4.16 add Bound service account token type

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -50217,7 +50217,7 @@ func schema_openshift_api_operator_v1_OpenShiftControllerManagerSpec(ref common.
 					},
 					"imageRegistryAuthTokenType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "imageRegistryAuthTokenType specifies the kind of service account token when used when generating image pull secrets for the integrated image registry.",
+							Description: "imageRegistryAuthTokenType directs the openshift-controller-manager to use either a legacy,(unbound, long-lived) service acccount tokens or a bound service account token when generating image pull secrets for the integrated image registry.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -50215,6 +50215,13 @@ func schema_openshift_api_operator_v1_OpenShiftControllerManagerSpec(ref common.
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
+					"imageRegistryAuthTokenType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "imageRegistryAuthTokenType specifies the kind of service account token when used when generating image pull secrets for the integrated image registry.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"managementState"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -29376,7 +29376,7 @@
       ],
       "properties": {
         "imageRegistryAuthTokenType": {
-          "description": "imageRegistryAuthTokenType specifies the kind of service account token when used when generating image pull secrets for the integrated image registry.",
+          "description": "imageRegistryAuthTokenType directs the openshift-controller-manager to use either a legacy,(unbound, long-lived) service acccount tokens or a bound service account token when generating image pull secrets for the integrated image registry.",
           "type": "string"
         },
         "logLevel": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -29375,6 +29375,10 @@
         "managementState"
       ],
       "properties": {
+        "imageRegistryAuthTokenType": {
+          "description": "imageRegistryAuthTokenType specifies the kind of service account token when used when generating image pull secrets for the integrated image registry.",
+          "type": "string"
+        },
         "logLevel": {
           "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands.\n\nValid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
           "type": "string"

--- a/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
@@ -40,11 +40,14 @@ spec:
           spec:
             properties:
               imageRegistryAuthTokenType:
-                description: imageRegistryAuthTokenType specifies the kind of service
-                  account token when used when generating image pull secrets for the
-                  integrated image registry.
+                default: Bound
+                description: imageRegistryAuthTokenType directs the openshift-controller-manager
+                  to use either a legacy,(unbound, long-lived) service acccount tokens
+                  or a bound service account token when generating image pull secrets
+                  for the integrated image registry.
                 enum:
                 - Legacy
+                - Bound
                 type: string
               logLevel:
                 default: Normal

--- a/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
+++ b/operator/v1/0000_50_cluster-openshift-controller-manager-operator_02_config.crd.yaml
@@ -39,6 +39,13 @@ spec:
             type: object
           spec:
             properties:
+              imageRegistryAuthTokenType:
+                description: imageRegistryAuthTokenType specifies the kind of service
+                  account token when used when generating image pull secrets for the
+                  integrated image registry.
+                enum:
+                - Legacy
+                type: string
               logLevel:
                 default: Normal
                 description: "logLevel is an intent based logging for an overall component.

--- a/operator/v1/stable.openshiftcontrollermanager.testsuite.yaml
+++ b/operator/v1/stable.openshiftcontrollermanager.testsuite.yaml
@@ -12,5 +12,6 @@ tests:
       apiVersion: operator.openshift.io/v1
       kind: OpenShiftControllerManager
       spec:
+        imageRegistryAuthTokenType: Legacy
         logLevel: Normal
         operatorLogLevel: Normal

--- a/operator/v1/stable.openshiftcontrollermanager.testsuite.yaml
+++ b/operator/v1/stable.openshiftcontrollermanager.testsuite.yaml
@@ -12,6 +12,6 @@ tests:
       apiVersion: operator.openshift.io/v1
       kind: OpenShiftControllerManager
       spec:
-        imageRegistryAuthTokenType: Legacy
+        imageRegistryAuthTokenType: Bound
         logLevel: Normal
         operatorLogLevel: Normal

--- a/operator/v1/types_openshiftcontrollermanager.go
+++ b/operator/v1/types_openshiftcontrollermanager.go
@@ -28,7 +28,19 @@ type OpenShiftControllerManager struct {
 
 type OpenShiftControllerManagerSpec struct {
 	OperatorSpec `json:",inline"`
+
+	// imageRegistryAuthTokenType specifies the kind of service account token when used
+	// when generating image pull secrets for the integrated image registry.
+	// +kubebuilder:validation:Enum=Legacy
+	// +optional
+	ImageRegistryAuthTokenType ServiceAccountTokenType `json:"imageRegistryAuthTokenType,omitempty"`
 }
+
+type ServiceAccountTokenType string
+
+const (
+	ServiceAccountLegacyTokenType ServiceAccountTokenType = "Legacy"
+)
 
 type OpenShiftControllerManagerStatus struct {
 	OperatorStatus `json:",inline"`

--- a/operator/v1/types_openshiftcontrollermanager.go
+++ b/operator/v1/types_openshiftcontrollermanager.go
@@ -29,9 +29,11 @@ type OpenShiftControllerManager struct {
 type OpenShiftControllerManagerSpec struct {
 	OperatorSpec `json:",inline"`
 
-	// imageRegistryAuthTokenType specifies the kind of service account token when used
-	// when generating image pull secrets for the integrated image registry.
-	// +kubebuilder:validation:Enum=Legacy
+	// imageRegistryAuthTokenType directs the openshift-controller-manager to use either a
+	// legacy,(unbound, long-lived) service acccount tokens or a bound service account
+	// token when generating image pull secrets for the integrated image registry.
+	// +kubebuilder:default=Bound
+	// +kubebuilder:validation:Enum=Legacy;Bound
 	// +optional
 	ImageRegistryAuthTokenType ServiceAccountTokenType `json:"imageRegistryAuthTokenType,omitempty"`
 }
@@ -40,6 +42,7 @@ type ServiceAccountTokenType string
 
 const (
 	ServiceAccountLegacyTokenType ServiceAccountTokenType = "Legacy"
+	ServiceAccountBoundTokenType  ServiceAccountTokenType = "Bound"
 )
 
 type OpenShiftControllerManagerStatus struct {

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1648,6 +1648,14 @@ func (OpenShiftControllerManagerList) SwaggerDoc() map[string]string {
 	return map_OpenShiftControllerManagerList
 }
 
+var map_OpenShiftControllerManagerSpec = map[string]string{
+	"imageRegistryAuthTokenType": "imageRegistryAuthTokenType specifies the kind of service account token when used when generating image pull secrets for the integrated image registry.",
+}
+
+func (OpenShiftControllerManagerSpec) SwaggerDoc() map[string]string {
+	return map_OpenShiftControllerManagerSpec
+}
+
 var map_KubeScheduler = map[string]string{
 	"":         "KubeScheduler provides information to configure an operator to manage scheduler.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
 	"metadata": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1649,7 +1649,7 @@ func (OpenShiftControllerManagerList) SwaggerDoc() map[string]string {
 }
 
 var map_OpenShiftControllerManagerSpec = map[string]string{
-	"imageRegistryAuthTokenType": "imageRegistryAuthTokenType specifies the kind of service account token when used when generating image pull secrets for the integrated image registry.",
+	"imageRegistryAuthTokenType": "imageRegistryAuthTokenType directs the openshift-controller-manager to use either a legacy,(unbound, long-lived) service acccount tokens or a bound service account token when generating image pull secrets for the integrated image registry.",
 }
 
 func (OpenShiftControllerManagerSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Introduce a configuration option to allow users to specify the type of service account token to use for the integrated image registry image pull secret auth.

```
apiVersion: operator.openshift.io/v1
kind: OpenShiftControllerManager
spec:
  imageRegistryAuthTokenType: Legacy
```

In version v4.15:
 - The default, and only value, will be `Legacy`. 
 - The value will explicitly be added to the OCM-O config.

In version 4.16:
 - The default value will be `Bound`.
 - The value will not be explicitly set.
 - Users who upgrade from v4.15 will still be configured to use the `Legacy` service account tokens until they update the OCM-O config to switch to `Bound`.
