### PR TITLE
STOR-1700: VolumeGroupSnapshot will not be TechPreview in 4.16

### DIFF
--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -195,7 +195,7 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 		with(pinnedImages).
 		with(upgradeStatus).
 		with(translateStreamCloseWebsocketRequests).
-		with(volumeGroupSnapshot).
+		without(volumeGroupSnapshot).
 		toFeatures(defaultFeatures),
 	LatencySensitive: newDefaultFeatures().
 		toFeatures(defaultFeatures),

--- a/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-TechPreviewNoUpgrade.yaml
@@ -23,6 +23,9 @@
                     },
                     {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
+                    },
+                    {
+                        "name": "VolumeGroupSnapshot"
                     }
                 ],
                 "enabled": [
@@ -142,9 +145,6 @@
                     },
                     {
                         "name": "ValidatingAdmissionPolicy"
-                    },
-                    {
-                        "name": "VolumeGroupSnapshot"
                     }
                 ],
                 "version": ""


### PR DESCRIPTION
Users will need to user the `CustomNoUpgrade` featureSet instead.

