### PR TITLE
[4.15] OCPBUGS-29370: Update AWSCSIDriverConfigSpec fields validation to accept all current AWS partitions

### DIFF
--- a/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
+++ b/operator/v1/0000_90_cluster_csi_driver_01_config.crd.yaml
@@ -59,7 +59,7 @@ spec:
                       properties:
                         kmsKeyARN:
                           description: kmsKeyARN sets the cluster default storage class to encrypt volumes with a user-defined KMS key, rather than the default KMS key used by AWS. The value may be either the ARN or Alias ARN of a KMS key.
-                          pattern: ^arn:(aws|aws-cn|aws-us-gov):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$
+                          pattern: ^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$
                           type: string
                       type: object
                     azure:

--- a/operator/v1/types_csi_cluster_driver.go
+++ b/operator/v1/types_csi_cluster_driver.go
@@ -159,7 +159,7 @@ type AWSCSIDriverConfigSpec struct {
 	// kmsKeyARN sets the cluster default storage class to encrypt volumes with a user-defined KMS key,
 	// rather than the default KMS key used by AWS.
 	// The value may be either the ARN or Alias ARN of a KMS key.
-	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$`
+	// +kubebuilder:validation:Pattern:=`^arn:(aws|aws-cn|aws-us-gov|aws-iso|aws-iso-b|aws-iso-e|aws-iso-f):kms:[a-z0-9-]+:[0-9]{12}:(key|alias)\/.*$`
 	// +optional
 	KMSKeyARN string `json:"kmsKeyARN,omitempty"`
 }


### PR DESCRIPTION
Cherry-pick https://github.com/openshift/api/commit/72a9eae21ecb292364d00707ca0cb062bead70b0 into release-4.15
/cc @openshift/storage
