### PR TITLE
OCPBUGS-29435: allow multiple audiences to be configured for kube-apiserver

### DIFF
--- a/config/v1/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
@@ -269,7 +269,7 @@ spec:
                   - issuer
                   - name
                   type: object
-                maxItems: 1
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
@@ -267,7 +267,7 @@ spec:
                   - issuer
                   - name
                   type: object
-                maxItems: 1
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml-patch
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml-patch
@@ -3,7 +3,7 @@
   value:
     description: "OIDCProviders are OIDC identity providers that can issue tokens for this cluster Can only be set if \"Type\" is set to \"OIDC\". \n At most one provider can be configured."
     type: array
-    maxItems: 1
+    maxItems: 10
     items:
       type: object
       required:

--- a/config/v1/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
@@ -270,7 +270,7 @@ spec:
                   - issuer
                   - name
                   type: object
-                maxItems: 1
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -84,7 +84,7 @@ type AuthenticationSpec struct {
 	//
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=1
+	// +kubebuilder:validation:MaxItems=10
 	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	OIDCProviders []OIDCProvider `json:"oidcProviders,omitempty"`
 }

--- a/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
@@ -269,7 +269,7 @@ spec:
                   - issuer
                   - name
                   type: object
-                maxItems: 1
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
@@ -267,7 +267,7 @@ spec:
                   - issuer
                   - name
                   type: object
-                maxItems: 1
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
@@ -270,7 +270,7 @@ spec:
                   - issuer
                   - name
                   type: object
-                maxItems: 1
+                maxItems: 10
                 type: array
                 x-kubernetes-list-map-keys:
                 - name


### PR DESCRIPTION
wait for lgtm and approval on https://github.com/openshift/kubernetes/pull/1881 prior to merge, but after that no coordination is required.

/assign @soltysh 
/cc @stlaz 