### PR TITLE
OCPBUGS-29435: allow multiple audiences to be configured for kube-apiserver

### DIFF
--- a/config/v1/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
@@ -141,7 +141,8 @@ spec:
                           audiences:
                             description: Audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their "aud" claim. Must be set to exactly one value.
                             type: array
-                            maxItems: 1
+                            maxItems: 10
+                            minItems: 1
                             items:
                               type: string
                               minLength: 1

--- a/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
@@ -123,7 +123,8 @@ spec:
                             items:
                               minLength: 1
                               type: string
-                            maxItems: 1
+                            maxItems: 10
+                            minItems: 1
                             type: array
                             x-kubernetes-list-type: set
                           issuerCertificateAuthority:

--- a/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml-patch
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml-patch
@@ -91,7 +91,8 @@
             audiences:
               description: Audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their "aud" claim. Must be set to exactly one value.
               type: array
-              maxItems: 1
+              maxItems: 10
+              minItems: 1
               items:
                 type: string
                 minLength: 1

--- a/config/v1/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
+++ b/config/v1/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
@@ -126,7 +126,8 @@ spec:
                             items:
                               minLength: 1
                               type: string
-                            maxItems: 1
+                            maxItems: 10
+                            minItems: 1
                             type: array
                             x-kubernetes-list-type: set
                           issuerCertificateAuthority:

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -240,7 +240,8 @@ type TokenIssuer struct {
 	//
 	// +listType=set
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxItems=1
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=10
 	// +required
 	Audiences []TokenAudience `json:"audiences"`
 

--- a/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-CustomNoUpgrade.yaml
@@ -141,7 +141,8 @@ spec:
                           audiences:
                             description: Audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their "aud" claim. Must be set to exactly one value.
                             type: array
-                            maxItems: 1
+                            maxItems: 10
+                            minItems: 1
                             items:
                               type: string
                               minLength: 1

--- a/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-Default-Hypershift.yaml
@@ -123,7 +123,8 @@ spec:
                             items:
                               minLength: 1
                               type: string
-                            maxItems: 1
+                            maxItems: 10
+                            minItems: 1
                             type: array
                             x-kubernetes-list-type: set
                           issuerCertificateAuthority:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentication.crd-TechPreviewNoUpgrade.yaml
@@ -126,7 +126,8 @@ spec:
                             items:
                               minLength: 1
                               type: string
-                            maxItems: 1
+                            maxItems: 10
+                            minItems: 1
                             type: array
                             x-kubernetes-list-type: set
                           issuerCertificateAuthority:


### PR DESCRIPTION
Manual backport of https://github.com/openshift/api/pull/1771

/assign @deads2k 