### PR TITLE
Add InPlacePodVerticalScaling featuregate (TechPreviewNoUpgrade)

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -595,4 +595,11 @@ var (
 						productScope(ocpSpecific).
 						enableIn(TechPreviewNoUpgrade).
 						mustRegister()
+
+	FeatureGateInPlacePodVerticalScaling = newFeatureGate("InPlacePodVerticalScaling").
+						reportProblemsToJiraComponent("node").
+						contactPerson("joelsmith").
+						productScope(kubernetes).
+						enableIn(TechPreviewNoUpgrade).
+						mustRegister()
 )

--- a/features.md
+++ b/features.md
@@ -12,6 +12,7 @@
 | GatewayAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | HardwareSpeed| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ImagePolicy| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| InPlacePodVerticalScaling| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | InsightsConfig| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | InsightsConfigAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | InsightsOnDemandDataGather| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -56,6 +56,9 @@
                         "name": "ImagePolicy"
                     },
                     {
+                        "name": "InPlacePodVerticalScaling"
+                    },
+                    {
                         "name": "InsightsConfig"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -99,6 +99,9 @@
                         "name": "ImagePolicy"
                     },
                     {
+                        "name": "InPlacePodVerticalScaling"
+                    },
+                    {
                         "name": "InsightsConfig"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -59,6 +59,9 @@
                         "name": "ImagePolicy"
                     },
                     {
+                        "name": "InPlacePodVerticalScaling"
+                    },
+                    {
                         "name": "InsightsConfig"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -99,6 +99,9 @@
                         "name": "ImagePolicy"
                     },
                     {
+                        "name": "InPlacePodVerticalScaling"
+                    },
+                    {
                         "name": "InsightsConfig"
                     },
                     {


### PR DESCRIPTION
This feature allows a pod spec's resource requests and limits to be modified, and is an important upcoming feature for Vertical Pod Autoscaler to be able to modify pods without evicting and replacing them.