### PR TITLE
OPNET-477: PlatformLoadBalancer becomes GA for Nutanix

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -1829,7 +1829,6 @@ type NutanixPlatformStatus struct {
 	// loadBalancer defines how the load balancer used by the cluster is configured.
 	// +default={"type": "OpenShiftManagedDefault"}
 	// +kubebuilder:default={"type": "OpenShiftManagedDefault"}
-	// +openshift:enable:FeatureSets=CustomNoUpgrade;TechPreviewNoUpgrade
 	// +optional
 	LoadBalancer *NutanixPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 }


### PR DESCRIPTION
This PR promotes the PlatformLoadBalancer to GA for Nutanix.

The feature has been in TP for long enough so that we are ready to promote it.