### PR TITLE
OCPBUGS-31058: config/ingress: Make Hostname godoc user-friendly

### DIFF
--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -169,20 +169,20 @@ const (
 // +kubebuilder:validation:MaxLength=512
 type ConsumingUser string
 
-// Hostname is an alias for hostname string validation.
-//
-// The left operand of the | is the original kubebuilder hostname validation format, which is incorrect because it
-// allows upper case letters, disallows hyphen or number in the TLD, and allows labels to start/end in non-alphanumeric
-// characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256.
-// ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$
-//
-// The right operand of the | is a new pattern that mimics the current API route admission validation on hostname,
-// except that it allows hostnames longer than the maximum length:
-// ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
-//
-// Both operand patterns are made available so that modifications on ingress spec can still happen after an invalid hostname
-// was saved via validation by the incorrect left operand of the | operator.
-//
+// Hostname is a host name as defined by RFC-1123.
+// + ---
+// + The left operand of the | is the original kubebuilder hostname validation format, which is incorrect because it
+// + allows upper case letters, disallows hyphen or number in the TLD, and allows labels to start/end in non-alphanumeric
+// + characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256.
+// + ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$
+// +
+// + The right operand of the | is a new pattern that mimics the current API route admission validation on hostname,
+// + except that it allows hostnames longer than the maximum length:
+// + ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
+// +
+// + Both operand patterns are made available so that modifications on ingress spec can still happen after an invalid hostname
+// + was saved via validation by the incorrect left operand of the | operator.
+// +
 // +kubebuilder:validation:Pattern=`^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$`
 type Hostname string
 

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses.crd.yaml
@@ -448,21 +448,7 @@ spec:
                         hostname, but if multiple hostnames are supported by the route
                         the operator may write multiple entries to this list.
                       items:
-                        description: "Hostname is an alias for hostname string validation.
-                          \n The left operand of the | is the original kubebuilder
-                          hostname validation format, which is incorrect because it
-                          allows upper case letters, disallows hyphen or number in
-                          the TLD, and allows labels to start/end in non-alphanumeric
-                          characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256.
-                          ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$
-                          \n The right operand of the | is a new pattern that mimics
-                          the current API route admission validation on hostname,
-                          except that it allows hostnames longer than the maximum
-                          length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
-                          \n Both operand patterns are made available so that modifications
-                          on ingress spec can still happen after an invalid hostname
-                          was saved via validation by the incorrect left operand of
-                          the | operator."
+                        description: Hostname is a host name as defined by RFC-1123.
                         pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
                         type: string
                       minItems: 1

--- a/config/v1/zz_generated.featuregated-crd-manifests/ingresses.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/ingresses.config.openshift.io/AAA_ungated.yaml
@@ -448,21 +448,7 @@ spec:
                         hostname, but if multiple hostnames are supported by the route
                         the operator may write multiple entries to this list.
                       items:
-                        description: "Hostname is an alias for hostname string validation.
-                          \n The left operand of the | is the original kubebuilder
-                          hostname validation format, which is incorrect because it
-                          allows upper case letters, disallows hyphen or number in
-                          the TLD, and allows labels to start/end in non-alphanumeric
-                          characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256.
-                          ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$
-                          \n The right operand of the | is a new pattern that mimics
-                          the current API route admission validation on hostname,
-                          except that it allows hostnames longer than the maximum
-                          length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
-                          \n Both operand patterns are made available so that modifications
-                          on ingress spec can still happen after an invalid hostname
-                          was saved via validation by the incorrect left operand of
-                          the | operator."
+                        description: Hostname is a host name as defined by RFC-1123.
                         pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
                         type: string
                       minItems: 1

--- a/payload-manifests/crds/0000_10_config-operator_01_ingresses.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_ingresses.crd.yaml
@@ -448,21 +448,7 @@ spec:
                         hostname, but if multiple hostnames are supported by the route
                         the operator may write multiple entries to this list.
                       items:
-                        description: "Hostname is an alias for hostname string validation.
-                          \n The left operand of the | is the original kubebuilder
-                          hostname validation format, which is incorrect because it
-                          allows upper case letters, disallows hyphen or number in
-                          the TLD, and allows labels to start/end in non-alphanumeric
-                          characters.  See https://bugzilla.redhat.com/show_bug.cgi?id=2039256.
-                          ^([a-zA-Z0-9\\p{S}\\p{L}]((-?[a-zA-Z0-9\\p{S}\\p{L}]{0,62})?)|([a-zA-Z0-9\\p{S}\\p{L}](([a-zA-Z0-9-\\p{S}\\p{L}]{0,61}[a-zA-Z0-9\\p{S}\\p{L}])?)(\\.)){1,}([a-zA-Z\\p{L}]){2,63})$
-                          \n The right operand of the | is a new pattern that mimics
-                          the current API route admission validation on hostname,
-                          except that it allows hostnames longer than the maximum
-                          length: ^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
-                          \n Both operand patterns are made available so that modifications
-                          on ingress spec can still happen after an invalid hostname
-                          was saved via validation by the incorrect left operand of
-                          the | operator."
+                        description: Hostname is a host name as defined by RFC-1123.
                         pattern: ^([a-zA-Z0-9\p{S}\p{L}]((-?[a-zA-Z0-9\p{S}\p{L}]{0,62})?)|([a-zA-Z0-9\p{S}\p{L}](([a-zA-Z0-9-\p{S}\p{L}]{0,61}[a-zA-Z0-9\p{S}\p{L}])?)(\.)){1,}([a-zA-Z\p{L}]){2,63})$|^(([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})[\.]){0,}([a-z0-9][-a-z0-9]{0,61}[a-z0-9]|[a-z0-9]{1,63})$
                         type: string
                       minItems: 1


### PR DESCRIPTION
Add the necessary kubebuilder syntax to the godoc for the ingress config API's Hostname type in order to hide developer notes from the generated CRD's description for the `status.componentRoutes.currentHostnames` field.  Also, add a user-oriented description of the field with a reference to the relevant RFC.

Before this change, the `oc explain` output for the API field described it in terms of its Go type, kubebuilder syntax, and regular-expression syntax for validation.  After this change, the `oc explain` output for the API field describes it in terms that are relevant to the end-user.

The commit that added the validation did not mention *which* RFC it was enforcing.  The closest RFC seems to be [RFC-1123](https://www.rfc-editor.org/rfc/rfc1123) in that the validation allows the host name to start with a decimal digit, although the validation seems a little looser than RFC-1123 in that allows arbitrary Unicode letters and symbols with `\p{L}` and `\p{S}`.  The intent seems to be that the end-user should use RFC-1123 compliant host names, and validation is looser only as necessary for backwards-compatibility.

Follow-up to #1120.