### PR TITLE
SDN-4596: Promote `AdminNetworkPolicy` to GA

### DIFF
--- a/config/v1/feature_gates.go
+++ b/config/v1/feature_gates.go
@@ -356,7 +356,7 @@ var (
 					reportProblemsToJiraComponent("Networking/ovn-kubernetes").
 					contactPerson("tssurya").
 					productScope(ocpSpecific).
-					enableIn(TechPreviewNoUpgrade).
+					enableIn(Default, TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateNetworkLiveMigration = newFeatureGate("NetworkLiveMigration").

--- a/features.md
+++ b/features.md
@@ -1,6 +1,5 @@
 | FeatureGate | Default on Hypershift | Default on SelfManagedHA | TechPreviewNoUpgrade on Hypershift | TechPreviewNoUpgrade on SelfManagedHA  |
 | ------ | --- | --- | --- | ---  |
-| AdminNetworkPolicy| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | AlertingRules| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | AutomatedEtcdBackup| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | CSIDriverSharedResource| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
@@ -41,6 +40,7 @@
 | ValidatingAdmissionPolicy| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | VolumeGroupSnapshot| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ExternalOIDC| <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| AdminNetworkPolicy| <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | AlibabaPlatform| <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | AzureWorkloadIdentity| <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | BareMetalLoadBalancer| <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -14,9 +14,6 @@
             {
                 "disabled": [
                     {
-                        "name": "AdminNetworkPolicy"
-                    },
-                    {
                         "name": "AlertingRules"
                     },
                     {
@@ -144,6 +141,9 @@
                     }
                 ],
                 "enabled": [
+                    {
+                        "name": "AdminNetworkPolicy"
+                    },
                     {
                         "name": "AlibabaPlatform"
                     },

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -14,9 +14,6 @@
             {
                 "disabled": [
                     {
-                        "name": "AdminNetworkPolicy"
-                    },
-                    {
                         "name": "AlertingRules"
                     },
                     {
@@ -147,6 +144,9 @@
                     }
                 ],
                 "enabled": [
+                    {
+                        "name": "AdminNetworkPolicy"
+                    },
                     {
                         "name": "AlibabaPlatform"
                     },


### PR DESCRIPTION
This PR:

1. Moves ANP featuregate to also be part of the default set so that the feature is enabled by default (gate was being used from CNO)
2. Work related to https://issues.redhat.com/browse/SDN-4157 4.16 epic ANP
3. Aim is to have this feature ON by default on all OCP/HCP clusters

Unsure if I need to do PRs in other repos like CCC? I tried to look through https://docs.google.com/document/d/1zOL38_KDKwAvsx-LMHfyDdX4-jq3HQU1YWBjfuHaM0Q/edit but not sure what the new process is since the API code around FG has changed quiet a bit. After this PR I wonder if I need to do something else, pointers in right direction will be much appreciated!

E2E Test Info: This feature's tests live in: https://github.com/kubernetes-sigs/network-policy-api/tree/main/conformance and they are run as presubmits in: https://github.com/ovn-org/ovn-kubernetes/blob/master/test/conformance/network_policy_v2_test.go#L58 repo

Feature has been TechPreview for 2 releases, time to GA this.