### PR TITLE
OCPBUGS-29774: Add hypershift cluster profile

### DIFF
--- a/authorization/v1/zz_generated.crd-manifests/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
+++ b/authorization/v1/zz_generated.crd-manifests/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: rolebindingrestrictions.authorization.openshift.io

--- a/cloudnetwork/v1/zz_generated.crd-manifests/001_cloudprivateipconfigs.crd.yaml
+++ b/cloudnetwork/v1/zz_generated.crd-manifests/001_cloudprivateipconfigs.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/859
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: cloudprivateipconfigs.cloud.network.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_03_config-operator_01_proxies.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_03_config-operator_01_proxies.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: proxies.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_03_marketplace_01_operatorhubs.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_03_marketplace_01_operatorhubs.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     capability.openshift.io/name: marketplace
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: operatorhubs.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: apiservers.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-HypershiftIndependent-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-HypershiftIndependent-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,553 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Authentication specifies cluster-wide settings for authentication
+          (like OAuth and webhook token authenticators). The canonical name of an
+          instance is `cluster`. \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              oauthMetadata:
+                description: 'oauthMetadata contains the discovery endpoint data for
+                  OAuth 2.0 Authorization Server Metadata for an external OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw ''/.well-known/oauth-authorization-server'' For further
+                  details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  If oauthMetadata.name is non-empty, this value has precedence over
+                  any metadata reference stored in status. The key "oauthMetadata"
+                  is used to locate the data. If specified and the config map or expected
+                  key is not found, no metadata is served. If the specified metadata
+                  is not valid, no metadata is served. The namespace for this config
+                  map is openshift-config.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcProviders:
+                description: "OIDCProviders are OIDC identity providers that can issue
+                  tokens for this cluster Can only be set if \"Type\" is set to \"OIDC\".
+                  \n At most one provider can be configured."
+                items:
+                  properties:
+                    claimMappings:
+                      description: ClaimMappings describes rules on how to transform
+                        information from an ID token into a cluster identity
+                      properties:
+                        groups:
+                          description: Groups is a name of the claim that should be
+                            used to construct groups for the cluster identity. The
+                            referenced claim must use array of strings values.
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              description: "Prefix is a string to prefix the value
+                                from the token in the result of the claim mapping.
+                                \n By default, no prefixing occurs. \n Example: if
+                                `prefix` is set to \"myoidc:\"\" and the `claim` in
+                                JWT contains an array of strings \"a\", \"b\" and
+                                \ \"c\", the mapping will result in an array of string
+                                \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                        username:
+                          description: "Username is a name of the claim that should
+                            be used to construct usernames for the cluster identity.
+                            \n Default value: \"sub\""
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              properties:
+                                prefixString:
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - prefixString
+                              type: object
+                            prefixPolicy:
+                              description: "PrefixPolicy specifies how a prefix should
+                                apply. \n By default, claims other than `email` will
+                                be prefixed with the issuer URL to prevent naming
+                                clashes with other plugins. \n Set to \"NoPrefix\"
+                                to disable prefixing. \n Example: (1) `prefix` is
+                                set to \"myoidc:\" and `claim` is set to \"username\".
+                                If the JWT claim `username` contains value `userA`,
+                                the resulting mapped value will be \"myoidc:userA\".
+                                (2) `prefix` is set to \"myoidc:\" and `claim` is
+                                set to \"email\". If the JWT `email` claim contains
+                                value \"userA@myoidc.tld\", the resulting mapped value
+                                will be \"myoidc:userA@myoidc.tld\". (3) `prefix`
+                                is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                the JWT claims include \"username\":\"userA\" and
+                                \"email\":\"userA@myoidc.tld\", and `claim` is set
+                                to: (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\"
+                                (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                              enum:
+                              - ""
+                              - NoPrefix
+                              - Prefix
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                          x-kubernetes-validations:
+                          - message: prefix must be set if prefixPolicy is 'Prefix',
+                              but must remain unset otherwise
+                            rule: 'has(self.prefixPolicy) && self.prefixPolicy ==
+                              ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString)
+                              > 0) : !has(self.prefix)'
+                      type: object
+                    claimValidationRules:
+                      description: ClaimValidationRules are rules that are applied
+                        to validate token claims to authenticate users.
+                      items:
+                        properties:
+                          requiredClaim:
+                            description: RequiredClaim allows configuring a required
+                              claim name and its expected value
+                            properties:
+                              claim:
+                                description: Claim is a name of a required claim.
+                                  Only claims with string values are supported.
+                                minLength: 1
+                                type: string
+                              requiredValue:
+                                description: RequiredValue is the required value for
+                                  the claim.
+                                minLength: 1
+                                type: string
+                            required:
+                            - claim
+                            - requiredValue
+                            type: object
+                          type:
+                            default: RequiredClaim
+                            description: Type sets the type of the validation rule
+                            enum:
+                            - RequiredClaim
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    issuer:
+                      description: Issuer describes atributes of the OIDC token issuer
+                      properties:
+                        audiences:
+                          description: Audiences is an array of audiences that the
+                            token was issued for. Valid tokens must include at least
+                            one of these values in their "aud" claim. Must be set
+                            to exactly one value.
+                          items:
+                            minLength: 1
+                            type: string
+                          maxItems: 10
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-type: set
+                        issuerCertificateAuthority:
+                          description: CertificateAuthority is a reference to a config
+                            map in the configuration namespace. The .data of the configMap
+                            must contain the "ca-bundle.crt" key. If unset, system
+                            trust is used instead.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        issuerURL:
+                          description: URL is the serving URL of the token issuer.
+                            Must use the https:// scheme.
+                          pattern: ^https:\/\/[^\s]
+                          type: string
+                      required:
+                      - audiences
+                      - issuerURL
+                      type: object
+                    name:
+                      description: Name of the OIDC provider
+                      minLength: 1
+                      type: string
+                    oidcClients:
+                      description: OIDCClients contains configuration for the platform's
+                        clients that need to request tokens from the issuer
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          clientSecret:
+                            description: ClientSecret refers to a secret in the `openshift-config`
+                              namespace that contains the client secret in the `clientSecret`
+                              key of the `.data` field
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          componentName:
+                            description: ComponentName is the name of the component
+                              that is supposed to consume this client configuration
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          componentNamespace:
+                            description: ComponentNamespace is the namespace of the
+                              component that is supposed to consume this client configuration
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                          extraScopes:
+                            description: ExtraScopes is an optional set of scopes
+                              to request tokens with.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - clientID
+                        - componentName
+                        - componentNamespace
+                        type: object
+                      maxItems: 20
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - componentNamespace
+                      - componentName
+                      x-kubernetes-list-type: map
+                  required:
+                  - issuer
+                  - name
+                  type: object
+                maxItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              serviceAccountIssuer:
+                description: 'serviceAccountIssuer is the identifier of the bound
+                  service account token issuer. The default is https://kubernetes.default.svc
+                  WARNING: Updating this field will not result in immediate invalidation
+                  of all bound tokens with the previous issuer value. Instead, the
+                  tokens issued by previous service account issuer will continue to
+                  be trusted for a time period chosen by the platform (currently set
+                  to 24h). This time period is subject to change over time. This allows
+                  internal components to transition to use new service account issuer
+                  without service distruption.'
+                type: string
+              type:
+                description: type identifies the cluster managed, user facing authentication
+                  mode in use. Specifically, it manages the component that responds
+                  to login attempts. The default is IntegratedOAuth.
+                enum:
+                - ""
+                - None
+                - IntegratedOAuth
+                - OIDC
+                type: string
+              webhookTokenAuthenticator:
+                description: "webhookTokenAuthenticator configures a remote token
+                  reviewer. These remote authentication webhooks can be used to verify
+                  bearer tokens via the tokenreviews.authentication.k8s.io REST API.
+                  This is required to honor bearer tokens that are provisioned by
+                  an external authentication service. \n Can only be set if \"Type\"
+                  is set to \"None\"."
+                properties:
+                  kubeConfig:
+                    description: "kubeConfig references a secret that contains kube
+                      config file data which describes how to access the remote webhook
+                      service. The namespace for the referenced secret is openshift-config.
+                      \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                      \n The key \"kubeConfig\" is used to locate the data. If the
+                      secret or expected key is not found, the webhook is not honored.
+                      If the specified kube config data is not valid, the webhook
+                      is not honored."
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - kubeConfig
+                type: object
+              webhookTokenAuthenticators:
+                description: webhookTokenAuthenticators is DEPRECATED, setting it
+                  has no effect.
+                items:
+                  description: deprecatedWebhookTokenAuthenticator holds the necessary
+                    configuration options for a remote token authenticator. It's the
+                    same as WebhookTokenAuthenticator but it's missing the 'required'
+                    validation on KubeConfig field.
+                  properties:
+                    kubeConfig:
+                      description: 'kubeConfig contains kube config file data which
+                        describes how to access the remote webhook service. For further
+                        details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                        The key "kubeConfig" is used to locate the data. If the secret
+                        or expected key is not found, the webhook is not honored.
+                        If the specified kube config data is not valid, the webhook
+                        is not honored. The namespace for this secret is determined
+                        by the point of use.'
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced
+                            secret
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              integratedOAuthMetadata:
+                description: 'integratedOAuthMetadata contains the discovery endpoint
+                  data for OAuth 2.0 Authorization Server Metadata for the in-cluster
+                  integrated OAuth server. This discovery document can be viewed from
+                  its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                  For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  This contains the observed value based on cluster state. An explicitly
+                  set value in spec.oauthMetadata has precedence over this field.
+                  This field has no meaning if authentication spec.type is not set
+                  to IntegratedOAuth. The key "oauthMetadata" is used to locate the
+                  data. If the config map or expected key is not found, no metadata
+                  is served. If the specified metadata is not valid, no metadata is
+                  served. The namespace for this config map is openshift-config-managed.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcClients:
+                description: OIDCClients is where participating operators place the
+                  current OIDC client status for OIDC clients that can be customized
+                  by the cluster-admin.
+                items:
+                  properties:
+                    componentName:
+                      description: ComponentName is the name of the component that
+                        will consume a client configuration.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    componentNamespace:
+                      description: ComponentNamespace is the namespace of the component
+                        that will consume a client configuration.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    conditions:
+                      description: "Conditions are used to communicate the state of
+                        the `oidcClients` entry. \n Supported conditions include Available,
+                        Degraded and Progressing. \n If Available is true, the component
+                        is successfully using the configured client. If Degraded is
+                        true, that means something has gone wrong trying to handle
+                        the client configuration. If Progressing is true, that means
+                        the component is taking some action related to the `oidcClients`
+                        entry."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    consumingUsers:
+                      description: ConsumingUsers is a slice of ServiceAccounts that
+                        need to have read permission on the `clientSecret` secret.
+                      items:
+                        description: ConsumingUser is an alias for string which we
+                          add validation to. Currently only service accounts are supported.
+                        maxLength: 512
+                        minLength: 1
+                        pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      maxItems: 5
+                      type: array
+                      x-kubernetes-list-type: set
+                    currentOIDCClients:
+                      description: CurrentOIDCClients is a list of clients that the
+                        component is currently using.
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          issuerURL:
+                            description: URL is the serving URL of the token issuer.
+                              Must use the https:// scheme.
+                            pattern: ^https:\/\/[^\s]
+                            type: string
+                          oidcProviderName:
+                            description: OIDCName refers to the `name` of the provider
+                              from `oidcProviders`
+                            minLength: 1
+                            type: string
+                        required:
+                        - clientID
+                        - issuerURL
+                        - oidcProviderName
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - issuerURL
+                      - clientID
+                      x-kubernetes-list-type: map
+                  required:
+                  - componentName
+                  - componentNamespace
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - componentNamespace
+                - componentName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: all oidcClients in the oidcProviders must match their componentName
+            and componentNamespace to either a previously configured oidcClient or
+            they must exist in the status.oidcClients
+          rule: '!has(self.spec.oidcProviders) || self.spec.oidcProviders.all(p, !has(p.oidcClients)
+            || p.oidcClients.all(specC, self.status.oidcClients.exists(statusC, statusC.componentNamespace
+            == specC.componentNamespace && statusC.componentName == specC.componentName)
+            || (has(oldSelf.spec.oidcProviders) && oldSelf.spec.oidcProviders.exists(oldP,
+            oldP.name == p.name && has(oldP.oidcClients) && oldP.oidcClients.exists(oldC,
+            oldC.componentNamespace == specC.componentNamespace && oldC.componentName
+            == specC.componentName)))))'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-HypershiftIndependent-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-HypershiftIndependent-Default.crd.yaml
@@ -1,0 +1,171 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
+    release.openshift.io/feature-set: Default
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Authentication specifies cluster-wide settings for authentication
+          (like OAuth and webhook token authenticators). The canonical name of an
+          instance is `cluster`. \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              oauthMetadata:
+                description: 'oauthMetadata contains the discovery endpoint data for
+                  OAuth 2.0 Authorization Server Metadata for an external OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw ''/.well-known/oauth-authorization-server'' For further
+                  details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  If oauthMetadata.name is non-empty, this value has precedence over
+                  any metadata reference stored in status. The key "oauthMetadata"
+                  is used to locate the data. If specified and the config map or expected
+                  key is not found, no metadata is served. If the specified metadata
+                  is not valid, no metadata is served. The namespace for this config
+                  map is openshift-config.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountIssuer:
+                description: 'serviceAccountIssuer is the identifier of the bound
+                  service account token issuer. The default is https://kubernetes.default.svc
+                  WARNING: Updating this field will not result in immediate invalidation
+                  of all bound tokens with the previous issuer value. Instead, the
+                  tokens issued by previous service account issuer will continue to
+                  be trusted for a time period chosen by the platform (currently set
+                  to 24h). This time period is subject to change over time. This allows
+                  internal components to transition to use new service account issuer
+                  without service distruption.'
+                type: string
+              type:
+                description: type identifies the cluster managed, user facing authentication
+                  mode in use. Specifically, it manages the component that responds
+                  to login attempts. The default is IntegratedOAuth.
+                enum:
+                - ""
+                - None
+                - IntegratedOAuth
+                type: string
+              webhookTokenAuthenticator:
+                description: "webhookTokenAuthenticator configures a remote token
+                  reviewer. These remote authentication webhooks can be used to verify
+                  bearer tokens via the tokenreviews.authentication.k8s.io REST API.
+                  This is required to honor bearer tokens that are provisioned by
+                  an external authentication service. \n Can only be set if \"Type\"
+                  is set to \"None\"."
+                properties:
+                  kubeConfig:
+                    description: "kubeConfig references a secret that contains kube
+                      config file data which describes how to access the remote webhook
+                      service. The namespace for the referenced secret is openshift-config.
+                      \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                      \n The key \"kubeConfig\" is used to locate the data. If the
+                      secret or expected key is not found, the webhook is not honored.
+                      If the specified kube config data is not valid, the webhook
+                      is not honored."
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - kubeConfig
+                type: object
+              webhookTokenAuthenticators:
+                description: webhookTokenAuthenticators is DEPRECATED, setting it
+                  has no effect.
+                items:
+                  description: deprecatedWebhookTokenAuthenticator holds the necessary
+                    configuration options for a remote token authenticator. It's the
+                    same as WebhookTokenAuthenticator but it's missing the 'required'
+                    validation on KubeConfig field.
+                  properties:
+                    kubeConfig:
+                      description: 'kubeConfig contains kube config file data which
+                        describes how to access the remote webhook service. For further
+                        details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                        The key "kubeConfig" is used to locate the data. If the secret
+                        or expected key is not found, the webhook is not honored.
+                        If the specified kube config data is not valid, the webhook
+                        is not honored. The namespace for this secret is determined
+                        by the point of use.'
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced
+                            secret
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              integratedOAuthMetadata:
+                description: 'integratedOAuthMetadata contains the discovery endpoint
+                  data for OAuth 2.0 Authorization Server Metadata for the in-cluster
+                  integrated OAuth server. This discovery document can be viewed from
+                  its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                  For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  This contains the observed value based on cluster state. An explicitly
+                  set value in spec.oauthMetadata has precedence over this field.
+                  This field has no meaning if authentication spec.type is not set
+                  to IntegratedOAuth. The key "oauthMetadata" is used to locate the
+                  data. If the config map or expected key is not found, no metadata
+                  is served. If the specified metadata is not valid, no metadata is
+                  served. The namespace for this config map is openshift-config-managed.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-HypershiftIndependent-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-HypershiftIndependent-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,553 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Authentication specifies cluster-wide settings for authentication
+          (like OAuth and webhook token authenticators). The canonical name of an
+          instance is `cluster`. \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              oauthMetadata:
+                description: 'oauthMetadata contains the discovery endpoint data for
+                  OAuth 2.0 Authorization Server Metadata for an external OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw ''/.well-known/oauth-authorization-server'' For further
+                  details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  If oauthMetadata.name is non-empty, this value has precedence over
+                  any metadata reference stored in status. The key "oauthMetadata"
+                  is used to locate the data. If specified and the config map or expected
+                  key is not found, no metadata is served. If the specified metadata
+                  is not valid, no metadata is served. The namespace for this config
+                  map is openshift-config.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcProviders:
+                description: "OIDCProviders are OIDC identity providers that can issue
+                  tokens for this cluster Can only be set if \"Type\" is set to \"OIDC\".
+                  \n At most one provider can be configured."
+                items:
+                  properties:
+                    claimMappings:
+                      description: ClaimMappings describes rules on how to transform
+                        information from an ID token into a cluster identity
+                      properties:
+                        groups:
+                          description: Groups is a name of the claim that should be
+                            used to construct groups for the cluster identity. The
+                            referenced claim must use array of strings values.
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              description: "Prefix is a string to prefix the value
+                                from the token in the result of the claim mapping.
+                                \n By default, no prefixing occurs. \n Example: if
+                                `prefix` is set to \"myoidc:\"\" and the `claim` in
+                                JWT contains an array of strings \"a\", \"b\" and
+                                \ \"c\", the mapping will result in an array of string
+                                \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                        username:
+                          description: "Username is a name of the claim that should
+                            be used to construct usernames for the cluster identity.
+                            \n Default value: \"sub\""
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              properties:
+                                prefixString:
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - prefixString
+                              type: object
+                            prefixPolicy:
+                              description: "PrefixPolicy specifies how a prefix should
+                                apply. \n By default, claims other than `email` will
+                                be prefixed with the issuer URL to prevent naming
+                                clashes with other plugins. \n Set to \"NoPrefix\"
+                                to disable prefixing. \n Example: (1) `prefix` is
+                                set to \"myoidc:\" and `claim` is set to \"username\".
+                                If the JWT claim `username` contains value `userA`,
+                                the resulting mapped value will be \"myoidc:userA\".
+                                (2) `prefix` is set to \"myoidc:\" and `claim` is
+                                set to \"email\". If the JWT `email` claim contains
+                                value \"userA@myoidc.tld\", the resulting mapped value
+                                will be \"myoidc:userA@myoidc.tld\". (3) `prefix`
+                                is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                the JWT claims include \"username\":\"userA\" and
+                                \"email\":\"userA@myoidc.tld\", and `claim` is set
+                                to: (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\"
+                                (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                              enum:
+                              - ""
+                              - NoPrefix
+                              - Prefix
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                          x-kubernetes-validations:
+                          - message: prefix must be set if prefixPolicy is 'Prefix',
+                              but must remain unset otherwise
+                            rule: 'has(self.prefixPolicy) && self.prefixPolicy ==
+                              ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString)
+                              > 0) : !has(self.prefix)'
+                      type: object
+                    claimValidationRules:
+                      description: ClaimValidationRules are rules that are applied
+                        to validate token claims to authenticate users.
+                      items:
+                        properties:
+                          requiredClaim:
+                            description: RequiredClaim allows configuring a required
+                              claim name and its expected value
+                            properties:
+                              claim:
+                                description: Claim is a name of a required claim.
+                                  Only claims with string values are supported.
+                                minLength: 1
+                                type: string
+                              requiredValue:
+                                description: RequiredValue is the required value for
+                                  the claim.
+                                minLength: 1
+                                type: string
+                            required:
+                            - claim
+                            - requiredValue
+                            type: object
+                          type:
+                            default: RequiredClaim
+                            description: Type sets the type of the validation rule
+                            enum:
+                            - RequiredClaim
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    issuer:
+                      description: Issuer describes atributes of the OIDC token issuer
+                      properties:
+                        audiences:
+                          description: Audiences is an array of audiences that the
+                            token was issued for. Valid tokens must include at least
+                            one of these values in their "aud" claim. Must be set
+                            to exactly one value.
+                          items:
+                            minLength: 1
+                            type: string
+                          maxItems: 10
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-type: set
+                        issuerCertificateAuthority:
+                          description: CertificateAuthority is a reference to a config
+                            map in the configuration namespace. The .data of the configMap
+                            must contain the "ca-bundle.crt" key. If unset, system
+                            trust is used instead.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        issuerURL:
+                          description: URL is the serving URL of the token issuer.
+                            Must use the https:// scheme.
+                          pattern: ^https:\/\/[^\s]
+                          type: string
+                      required:
+                      - audiences
+                      - issuerURL
+                      type: object
+                    name:
+                      description: Name of the OIDC provider
+                      minLength: 1
+                      type: string
+                    oidcClients:
+                      description: OIDCClients contains configuration for the platform's
+                        clients that need to request tokens from the issuer
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          clientSecret:
+                            description: ClientSecret refers to a secret in the `openshift-config`
+                              namespace that contains the client secret in the `clientSecret`
+                              key of the `.data` field
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          componentName:
+                            description: ComponentName is the name of the component
+                              that is supposed to consume this client configuration
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          componentNamespace:
+                            description: ComponentNamespace is the namespace of the
+                              component that is supposed to consume this client configuration
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                          extraScopes:
+                            description: ExtraScopes is an optional set of scopes
+                              to request tokens with.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - clientID
+                        - componentName
+                        - componentNamespace
+                        type: object
+                      maxItems: 20
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - componentNamespace
+                      - componentName
+                      x-kubernetes-list-type: map
+                  required:
+                  - issuer
+                  - name
+                  type: object
+                maxItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              serviceAccountIssuer:
+                description: 'serviceAccountIssuer is the identifier of the bound
+                  service account token issuer. The default is https://kubernetes.default.svc
+                  WARNING: Updating this field will not result in immediate invalidation
+                  of all bound tokens with the previous issuer value. Instead, the
+                  tokens issued by previous service account issuer will continue to
+                  be trusted for a time period chosen by the platform (currently set
+                  to 24h). This time period is subject to change over time. This allows
+                  internal components to transition to use new service account issuer
+                  without service distruption.'
+                type: string
+              type:
+                description: type identifies the cluster managed, user facing authentication
+                  mode in use. Specifically, it manages the component that responds
+                  to login attempts. The default is IntegratedOAuth.
+                enum:
+                - ""
+                - None
+                - IntegratedOAuth
+                - OIDC
+                type: string
+              webhookTokenAuthenticator:
+                description: "webhookTokenAuthenticator configures a remote token
+                  reviewer. These remote authentication webhooks can be used to verify
+                  bearer tokens via the tokenreviews.authentication.k8s.io REST API.
+                  This is required to honor bearer tokens that are provisioned by
+                  an external authentication service. \n Can only be set if \"Type\"
+                  is set to \"None\"."
+                properties:
+                  kubeConfig:
+                    description: "kubeConfig references a secret that contains kube
+                      config file data which describes how to access the remote webhook
+                      service. The namespace for the referenced secret is openshift-config.
+                      \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                      \n The key \"kubeConfig\" is used to locate the data. If the
+                      secret or expected key is not found, the webhook is not honored.
+                      If the specified kube config data is not valid, the webhook
+                      is not honored."
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - kubeConfig
+                type: object
+              webhookTokenAuthenticators:
+                description: webhookTokenAuthenticators is DEPRECATED, setting it
+                  has no effect.
+                items:
+                  description: deprecatedWebhookTokenAuthenticator holds the necessary
+                    configuration options for a remote token authenticator. It's the
+                    same as WebhookTokenAuthenticator but it's missing the 'required'
+                    validation on KubeConfig field.
+                  properties:
+                    kubeConfig:
+                      description: 'kubeConfig contains kube config file data which
+                        describes how to access the remote webhook service. For further
+                        details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                        The key "kubeConfig" is used to locate the data. If the secret
+                        or expected key is not found, the webhook is not honored.
+                        If the specified kube config data is not valid, the webhook
+                        is not honored. The namespace for this secret is determined
+                        by the point of use.'
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced
+                            secret
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              integratedOAuthMetadata:
+                description: 'integratedOAuthMetadata contains the discovery endpoint
+                  data for OAuth 2.0 Authorization Server Metadata for the in-cluster
+                  integrated OAuth server. This discovery document can be viewed from
+                  its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                  For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  This contains the observed value based on cluster state. An explicitly
+                  set value in spec.oauthMetadata has precedence over this field.
+                  This field has no meaning if authentication spec.type is not set
+                  to IntegratedOAuth. The key "oauthMetadata" is used to locate the
+                  data. If the config map or expected key is not found, no metadata
+                  is served. If the specified metadata is not valid, no metadata is
+                  served. The namespace for this config map is openshift-config-managed.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcClients:
+                description: OIDCClients is where participating operators place the
+                  current OIDC client status for OIDC clients that can be customized
+                  by the cluster-admin.
+                items:
+                  properties:
+                    componentName:
+                      description: ComponentName is the name of the component that
+                        will consume a client configuration.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    componentNamespace:
+                      description: ComponentNamespace is the namespace of the component
+                        that will consume a client configuration.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    conditions:
+                      description: "Conditions are used to communicate the state of
+                        the `oidcClients` entry. \n Supported conditions include Available,
+                        Degraded and Progressing. \n If Available is true, the component
+                        is successfully using the configured client. If Degraded is
+                        true, that means something has gone wrong trying to handle
+                        the client configuration. If Progressing is true, that means
+                        the component is taking some action related to the `oidcClients`
+                        entry."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    consumingUsers:
+                      description: ConsumingUsers is a slice of ServiceAccounts that
+                        need to have read permission on the `clientSecret` secret.
+                      items:
+                        description: ConsumingUser is an alias for string which we
+                          add validation to. Currently only service accounts are supported.
+                        maxLength: 512
+                        minLength: 1
+                        pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      maxItems: 5
+                      type: array
+                      x-kubernetes-list-type: set
+                    currentOIDCClients:
+                      description: CurrentOIDCClients is a list of clients that the
+                        component is currently using.
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          issuerURL:
+                            description: URL is the serving URL of the token issuer.
+                              Must use the https:// scheme.
+                            pattern: ^https:\/\/[^\s]
+                            type: string
+                          oidcProviderName:
+                            description: OIDCName refers to the `name` of the provider
+                              from `oidcProviders`
+                            minLength: 1
+                            type: string
+                        required:
+                        - clientID
+                        - issuerURL
+                        - oidcProviderName
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - issuerURL
+                      - clientID
+                      x-kubernetes-list-type: map
+                  required:
+                  - componentName
+                  - componentNamespace
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - componentNamespace
+                - componentName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: all oidcClients in the oidcProviders must match their componentName
+            and componentNamespace to either a previously configured oidcClient or
+            they must exist in the status.oidcClients
+          rule: '!has(self.spec.oidcProviders) || self.spec.oidcProviders.all(p, !has(p.oidcClients)
+            || p.oidcClients.all(specC, self.status.oidcClients.exists(statusC, statusC.componentNamespace
+            == specC.componentNamespace && statusC.componentName == specC.componentName)
+            || (has(oldSelf.spec.oidcProviders) && oldSelf.spec.oidcProviders.exists(oldP,
+            oldP.name == p.name && has(oldP.oidcClients) && oldP.oidcClients.exists(oldC,
+            oldC.componentNamespace == specC.componentNamespace && oldC.componentName
+            == specC.componentName)))))'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_consoles.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_consoles.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consoles.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: dnses.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: featuregates.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagecontentpolicies.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagecontentpolicies.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/874
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: imagecontentpolicies.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1126
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: imagedigestmirrorsets.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_images.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_images.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: images.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagetagmirrorsets.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagetagmirrorsets.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1126
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: imagetagmirrorsets.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: ingresses.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1107
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: nodes.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_oauths.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_oauths.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: oauths.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_projects.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_projects.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: projects.config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/config/v1/zz_generated.crd-manifests/0000_10_openshift-controller-manager_01_builds.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_openshift-controller-manager_01_builds.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     capability.openshift.io/name: Build
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: builds.config.openshift.io

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_backups-CustomNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_backups-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1482
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_backups-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_backups-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1482
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1457
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1457
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagepolicies-CustomNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagepolicies-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1457
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagepolicies-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagepolicies-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1457
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_insightsdatagathers-CustomNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_insightsdatagathers-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1245
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_insightsdatagathers-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_insightsdatagathers-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1245
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/console/v1/zz_generated.crd-manifests/00_consoleclidownloads.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consoleclidownloads.crd.yaml
@@ -8,6 +8,7 @@ metadata:
     description: Extension for configuring openshift web console command line interface
       (CLI) downloads.
     displayName: ConsoleCLIDownload
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consoleclidownloads.console.openshift.io

--- a/console/v1/zz_generated.crd-manifests/00_consoleexternalloglinks.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consoleexternalloglinks.crd.yaml
@@ -8,6 +8,7 @@ metadata:
     description: ConsoleExternalLogLink is an extension for customizing OpenShift
       web console log links.
     displayName: ConsoleExternalLogLinks
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consoleexternalloglinks.console.openshift.io

--- a/console/v1/zz_generated.crd-manifests/00_consolelinks.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consolelinks.crd.yaml
@@ -7,6 +7,7 @@ metadata:
     capability.openshift.io/name: Console
     description: Extension for customizing OpenShift web console links
     displayName: ConsoleLinks
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consolelinks.console.openshift.io

--- a/console/v1/zz_generated.crd-manifests/00_consolenotifications.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consolenotifications.crd.yaml
@@ -7,6 +7,7 @@ metadata:
     capability.openshift.io/name: Console
     description: Extension for configuring openshift web console notifications.
     displayName: ConsoleNotification
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consolenotifications.console.openshift.io

--- a/console/v1/zz_generated.crd-manifests/00_consolequickstarts.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consolequickstarts.crd.yaml
@@ -8,6 +8,7 @@ metadata:
     description: Extension for guiding user through various workflows in the OpenShift
       web console.
     displayName: ConsoleQuickStart
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consolequickstarts.console.openshift.io

--- a/console/v1/zz_generated.crd-manifests/00_consolesamples.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consolesamples.crd.yaml
@@ -8,6 +8,7 @@ metadata:
     description: ConsoleSample is an extension to customizing OpenShift web console
       by adding samples.
     displayName: ConsoleSample
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consolesamples.console.openshift.io

--- a/console/v1/zz_generated.crd-manifests/00_consoleyamlsamples.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consoleyamlsamples.crd.yaml
@@ -7,6 +7,7 @@ metadata:
     capability.openshift.io/name: Console
     description: Extension for configuring openshift web console YAML samples.
     displayName: ConsoleYAMLSample
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consoleyamlsamples.console.openshift.io

--- a/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
@@ -7,6 +7,7 @@ metadata:
     capability.openshift.io/name: Console
     description: Extension for configuring openshift web console plugins.
     displayName: ConsolePlugin
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.beta.openshift.io/inject-cabundle: "true"

--- a/console/v1alpha1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
+++ b/console/v1alpha1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
@@ -7,6 +7,7 @@ metadata:
     capability.openshift.io/name: Console
     description: Extension for configuring openshift web console plugins.
     displayName: ConsolePlugin
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.beta.openshift.io/inject-cabundle: "true"

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-CustomNoUpgrade.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/xxx
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-Default.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/xxx
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-TechPreviewNoUpgrade.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/xxx
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/example/v1alpha1/zz_generated.crd-manifests/0000_50_my-operator_01_notstableconfigtypes-CustomNoUpgrade.crd.yaml
+++ b/example/v1alpha1/zz_generated.crd-manifests/0000_50_my-operator_01_notstableconfigtypes-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/xxx
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/example/v1alpha1/zz_generated.crd-manifests/0000_50_my-operator_01_notstableconfigtypes-TechPreviewNoUpgrade.crd.yaml
+++ b/example/v1alpha1/zz_generated.crd-manifests/0000_50_my-operator_01_notstableconfigtypes-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/xxx
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/helm/v1beta1/zz_generated.crd-manifests/00_helmchartrepositories.crd.yaml
+++ b/helm/v1beta1/zz_generated.crd-manifests/00_helmchartrepositories.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/598
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: helmchartrepositories.helm.openshift.io

--- a/helm/v1beta1/zz_generated.crd-manifests/00_projecthelmchartrepositories.crd.yaml
+++ b/helm/v1beta1/zz_generated.crd-manifests/00_projecthelmchartrepositories.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1084
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: projecthelmchartrepositories.helm.openshift.io

--- a/imageregistry/v1/zz_generated.crd-manifests/00_configs-Default.crd.yaml
+++ b/imageregistry/v1/zz_generated.crd-manifests/00_configs-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/519
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/imageregistry/v1/zz_generated.crd-manifests/01_imagepruners.crd.yaml
+++ b/imageregistry/v1/zz_generated.crd-manifests/01_imagepruners.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/555
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: imagepruners.imageregistry.operator.openshift.io

--- a/insights/v1alpha1/zz_generated.crd-manifests/0000_10_insights_01_datagathers-CustomNoUpgrade.crd.yaml
+++ b/insights/v1alpha1/zz_generated.crd-manifests/0000_10_insights_01_datagathers-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1365
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/insights/v1alpha1/zz_generated.crd-manifests/0000_10_insights_01_datagathers-TechPreviewNoUpgrade.crd.yaml
+++ b/insights/v1alpha1/zz_generated.crd-manifests/0000_10_insights_01_datagathers-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1365
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_containerruntimeconfigs.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_containerruntimeconfigs.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   labels:

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_kubeletconfigs.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_kubeletconfigs.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   labels:

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigpools-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigpools-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigpools-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigpools-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigs.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigs.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   labels:

--- a/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1596
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1596
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1773
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1773
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1773
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1773
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_pinnedimagesets-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_pinnedimagesets-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1713
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_pinnedimagesets-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_pinnedimagesets-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1713
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/monitoring/v1/zz_generated.crd-manifests/0000_50_monitoring_01_alertingrules.crd.yaml
+++ b/monitoring/v1/zz_generated.crd-manifests/0000_50_monitoring_01_alertingrules.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1406
     api.openshift.io/merged-by-featuregates: "true"
     description: OpenShift Monitoring alerting rules
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: alertingrules.monitoring.openshift.io

--- a/monitoring/v1/zz_generated.crd-manifests/0000_50_monitoring_02_alertrelabelconfigs.crd.yaml
+++ b/monitoring/v1/zz_generated.crd-manifests/0000_50_monitoring_02_alertrelabelconfigs.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1406
     api.openshift.io/merged-by-featuregates: "true"
     description: OpenShift Monitoring alert relabel configurations
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: alertrelabelconfigs.monitoring.openshift.io

--- a/network/v1/zz_generated.crd-manifests/001_clusternetworks.crd.yaml
+++ b/network/v1/zz_generated.crd-manifests/001_clusternetworks.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/527
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: clusternetworks.network.openshift.io

--- a/network/v1/zz_generated.crd-manifests/002_hostsubnets.crd.yaml
+++ b/network/v1/zz_generated.crd-manifests/002_hostsubnets.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/527
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: hostsubnets.network.openshift.io

--- a/network/v1/zz_generated.crd-manifests/003_netnamespaces.crd.yaml
+++ b/network/v1/zz_generated.crd-manifests/003_netnamespaces.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/527
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: netnamespaces.network.openshift.io

--- a/network/v1/zz_generated.crd-manifests/004_egressnetworkpolicies.crd.yaml
+++ b/network/v1/zz_generated.crd-manifests/004_egressnetworkpolicies.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/527
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: egressnetworkpolicies.network.openshift.io

--- a/network/v1alpha1/zz_generated.crd-manifests/0000_70_dns_00_dnsnameresolvers-CustomNoUpgrade.crd.yaml
+++ b/network/v1alpha1/zz_generated.crd-manifests/0000_70_dns_00_dnsnameresolvers-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1524
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/network/v1alpha1/zz_generated.crd-manifests/0000_70_dns_00_dnsnameresolvers-TechPreviewNoUpgrade.crd.yaml
+++ b/network/v1alpha1/zz_generated.crd-manifests/0000_70_dns_00_dnsnameresolvers-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1524
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/networkoperator/v1/generated.proto
+++ b/networkoperator/v1/generated.proto
@@ -35,6 +35,7 @@ option go_package = "github.com/openshift/api/networkoperator/v1";
 // +openshift:file-pattern=operatorOrdering=001
 // +kubebuilder:metadata:annotations=include.release.openshift.io/self-managed-high-availability=true
 // +kubebuilder:metadata:annotations=include.release.openshift.io/ibm-cloud-managed=true
+// +kubebuilder:metadata:annotations=include.release.openshift.io/hypershift=true
 // +kubebuilder:printcolumn:name="Condition",type=string,JSONPath=".status.conditions[*].type"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=".status.conditions[*].status"
 message EgressRouter {

--- a/networkoperator/v1/types_egressrouter.go
+++ b/networkoperator/v1/types_egressrouter.go
@@ -28,6 +28,7 @@ import (
 // +openshift:file-pattern=operatorOrdering=001
 // +kubebuilder:metadata:annotations=include.release.openshift.io/self-managed-high-availability=true
 // +kubebuilder:metadata:annotations=include.release.openshift.io/ibm-cloud-managed=true
+// +kubebuilder:metadata:annotations=include.release.openshift.io/hypershift=true
 // +kubebuilder:printcolumn:name="Condition",type=string,JSONPath=".status.conditions[*].type"
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=".status.conditions[*].status"
 type EgressRouter struct {

--- a/operator/v1/zz_generated.crd-manifests/0000_10_config-operator_01_configs.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_10_config-operator_01_configs.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/612
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: configs.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/752
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/752
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/752
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: kubeapiservers.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: kubecontrollermanagers.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: kubeschedulers.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: openshiftapiservers.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_40_cloud-credential_00_cloudcredentials.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_40_cloud-credential_00_cloudcredentials.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/692
     api.openshift.io/merged-by-featuregates: "true"
     capability.openshift.io/name: CloudCredential
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: cloudcredentials.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_40_kube-storage-version-migrator_00_kubestorageversionmigrators.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_40_kube-storage-version-migrator_00_kubestorageversionmigrators.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/503
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: kubestorageversionmigrators.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_50_console_01_consoles.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_console_01_consoles.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/486
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consoles.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/616
     api.openshift.io/merged-by-featuregates: "true"
     capability.openshift.io/name: Ingress
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: ingresscontrollers.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_50_insights_00_insightsoperators.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_insights_00_insightsoperators.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1237
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: insightsoperators.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: openshiftcontrollermanagers.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_50_service-ca_02_servicecas.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_service-ca_02_servicecas.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: servicecas.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_50_storage_01_storages.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_storage_01_storages.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/670
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: storages.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_70_dns_00_dnses.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_dns_00_dnses.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: dnses.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_80_csi-snapshot-controller_01_csisnapshotcontrollers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_csi-snapshot-controller_01_csisnapshotcontrollers.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/562
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: csisnapshotcontrollers.operator.openshift.io

--- a/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1453
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/701
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/701
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/701
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagecontentsourcepolicies.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagecontentsourcepolicies.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: imagecontentsourcepolicies.operator.openshift.io

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_etcd_01_etcdbackups-CustomNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_etcd_01_etcdbackups-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1482
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_etcd_01_etcdbackups-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_etcd_01_etcdbackups-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1482
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-CustomNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1504
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1504
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/operatoringress/v1/zz_generated.crd-manifests/0000_50_dns_01_dnsrecords.crd.yaml
+++ b/operatoringress/v1/zz_generated.crd-manifests/0000_50_dns_01_dnsrecords.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/584
     api.openshift.io/merged-by-featuregates: "true"
     capability.openshift.io/name: Ingress
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: dnsrecords.ingress.operator.openshift.io

--- a/payload-manifests/crds/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: clusterresourcequotas.quota.openshift.io

--- a/payload-manifests/crds/0000_03_config-operator_01_proxies.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_proxies.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: proxies.config.openshift.io

--- a/payload-manifests/crds/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: rolebindingrestrictions.authorization.openshift.io

--- a/payload-manifests/crds/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: securitycontextconstraints.security.openshift.io

--- a/payload-manifests/crds/0000_03_config-operator_02_rangeallocations.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_02_rangeallocations.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/751
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: rangeallocations.security.internal.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_apiservers.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiservers.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: apiservers.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-HypershiftIndependent-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-HypershiftIndependent-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,553 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Authentication specifies cluster-wide settings for authentication
+          (like OAuth and webhook token authenticators). The canonical name of an
+          instance is `cluster`. \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              oauthMetadata:
+                description: 'oauthMetadata contains the discovery endpoint data for
+                  OAuth 2.0 Authorization Server Metadata for an external OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw ''/.well-known/oauth-authorization-server'' For further
+                  details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  If oauthMetadata.name is non-empty, this value has precedence over
+                  any metadata reference stored in status. The key "oauthMetadata"
+                  is used to locate the data. If specified and the config map or expected
+                  key is not found, no metadata is served. If the specified metadata
+                  is not valid, no metadata is served. The namespace for this config
+                  map is openshift-config.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcProviders:
+                description: "OIDCProviders are OIDC identity providers that can issue
+                  tokens for this cluster Can only be set if \"Type\" is set to \"OIDC\".
+                  \n At most one provider can be configured."
+                items:
+                  properties:
+                    claimMappings:
+                      description: ClaimMappings describes rules on how to transform
+                        information from an ID token into a cluster identity
+                      properties:
+                        groups:
+                          description: Groups is a name of the claim that should be
+                            used to construct groups for the cluster identity. The
+                            referenced claim must use array of strings values.
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              description: "Prefix is a string to prefix the value
+                                from the token in the result of the claim mapping.
+                                \n By default, no prefixing occurs. \n Example: if
+                                `prefix` is set to \"myoidc:\"\" and the `claim` in
+                                JWT contains an array of strings \"a\", \"b\" and
+                                \ \"c\", the mapping will result in an array of string
+                                \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                        username:
+                          description: "Username is a name of the claim that should
+                            be used to construct usernames for the cluster identity.
+                            \n Default value: \"sub\""
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              properties:
+                                prefixString:
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - prefixString
+                              type: object
+                            prefixPolicy:
+                              description: "PrefixPolicy specifies how a prefix should
+                                apply. \n By default, claims other than `email` will
+                                be prefixed with the issuer URL to prevent naming
+                                clashes with other plugins. \n Set to \"NoPrefix\"
+                                to disable prefixing. \n Example: (1) `prefix` is
+                                set to \"myoidc:\" and `claim` is set to \"username\".
+                                If the JWT claim `username` contains value `userA`,
+                                the resulting mapped value will be \"myoidc:userA\".
+                                (2) `prefix` is set to \"myoidc:\" and `claim` is
+                                set to \"email\". If the JWT `email` claim contains
+                                value \"userA@myoidc.tld\", the resulting mapped value
+                                will be \"myoidc:userA@myoidc.tld\". (3) `prefix`
+                                is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                the JWT claims include \"username\":\"userA\" and
+                                \"email\":\"userA@myoidc.tld\", and `claim` is set
+                                to: (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\"
+                                (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                              enum:
+                              - ""
+                              - NoPrefix
+                              - Prefix
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                          x-kubernetes-validations:
+                          - message: prefix must be set if prefixPolicy is 'Prefix',
+                              but must remain unset otherwise
+                            rule: 'has(self.prefixPolicy) && self.prefixPolicy ==
+                              ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString)
+                              > 0) : !has(self.prefix)'
+                      type: object
+                    claimValidationRules:
+                      description: ClaimValidationRules are rules that are applied
+                        to validate token claims to authenticate users.
+                      items:
+                        properties:
+                          requiredClaim:
+                            description: RequiredClaim allows configuring a required
+                              claim name and its expected value
+                            properties:
+                              claim:
+                                description: Claim is a name of a required claim.
+                                  Only claims with string values are supported.
+                                minLength: 1
+                                type: string
+                              requiredValue:
+                                description: RequiredValue is the required value for
+                                  the claim.
+                                minLength: 1
+                                type: string
+                            required:
+                            - claim
+                            - requiredValue
+                            type: object
+                          type:
+                            default: RequiredClaim
+                            description: Type sets the type of the validation rule
+                            enum:
+                            - RequiredClaim
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    issuer:
+                      description: Issuer describes atributes of the OIDC token issuer
+                      properties:
+                        audiences:
+                          description: Audiences is an array of audiences that the
+                            token was issued for. Valid tokens must include at least
+                            one of these values in their "aud" claim. Must be set
+                            to exactly one value.
+                          items:
+                            minLength: 1
+                            type: string
+                          maxItems: 10
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-type: set
+                        issuerCertificateAuthority:
+                          description: CertificateAuthority is a reference to a config
+                            map in the configuration namespace. The .data of the configMap
+                            must contain the "ca-bundle.crt" key. If unset, system
+                            trust is used instead.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        issuerURL:
+                          description: URL is the serving URL of the token issuer.
+                            Must use the https:// scheme.
+                          pattern: ^https:\/\/[^\s]
+                          type: string
+                      required:
+                      - audiences
+                      - issuerURL
+                      type: object
+                    name:
+                      description: Name of the OIDC provider
+                      minLength: 1
+                      type: string
+                    oidcClients:
+                      description: OIDCClients contains configuration for the platform's
+                        clients that need to request tokens from the issuer
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          clientSecret:
+                            description: ClientSecret refers to a secret in the `openshift-config`
+                              namespace that contains the client secret in the `clientSecret`
+                              key of the `.data` field
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          componentName:
+                            description: ComponentName is the name of the component
+                              that is supposed to consume this client configuration
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          componentNamespace:
+                            description: ComponentNamespace is the namespace of the
+                              component that is supposed to consume this client configuration
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                          extraScopes:
+                            description: ExtraScopes is an optional set of scopes
+                              to request tokens with.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - clientID
+                        - componentName
+                        - componentNamespace
+                        type: object
+                      maxItems: 20
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - componentNamespace
+                      - componentName
+                      x-kubernetes-list-type: map
+                  required:
+                  - issuer
+                  - name
+                  type: object
+                maxItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              serviceAccountIssuer:
+                description: 'serviceAccountIssuer is the identifier of the bound
+                  service account token issuer. The default is https://kubernetes.default.svc
+                  WARNING: Updating this field will not result in immediate invalidation
+                  of all bound tokens with the previous issuer value. Instead, the
+                  tokens issued by previous service account issuer will continue to
+                  be trusted for a time period chosen by the platform (currently set
+                  to 24h). This time period is subject to change over time. This allows
+                  internal components to transition to use new service account issuer
+                  without service distruption.'
+                type: string
+              type:
+                description: type identifies the cluster managed, user facing authentication
+                  mode in use. Specifically, it manages the component that responds
+                  to login attempts. The default is IntegratedOAuth.
+                enum:
+                - ""
+                - None
+                - IntegratedOAuth
+                - OIDC
+                type: string
+              webhookTokenAuthenticator:
+                description: "webhookTokenAuthenticator configures a remote token
+                  reviewer. These remote authentication webhooks can be used to verify
+                  bearer tokens via the tokenreviews.authentication.k8s.io REST API.
+                  This is required to honor bearer tokens that are provisioned by
+                  an external authentication service. \n Can only be set if \"Type\"
+                  is set to \"None\"."
+                properties:
+                  kubeConfig:
+                    description: "kubeConfig references a secret that contains kube
+                      config file data which describes how to access the remote webhook
+                      service. The namespace for the referenced secret is openshift-config.
+                      \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                      \n The key \"kubeConfig\" is used to locate the data. If the
+                      secret or expected key is not found, the webhook is not honored.
+                      If the specified kube config data is not valid, the webhook
+                      is not honored."
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - kubeConfig
+                type: object
+              webhookTokenAuthenticators:
+                description: webhookTokenAuthenticators is DEPRECATED, setting it
+                  has no effect.
+                items:
+                  description: deprecatedWebhookTokenAuthenticator holds the necessary
+                    configuration options for a remote token authenticator. It's the
+                    same as WebhookTokenAuthenticator but it's missing the 'required'
+                    validation on KubeConfig field.
+                  properties:
+                    kubeConfig:
+                      description: 'kubeConfig contains kube config file data which
+                        describes how to access the remote webhook service. For further
+                        details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                        The key "kubeConfig" is used to locate the data. If the secret
+                        or expected key is not found, the webhook is not honored.
+                        If the specified kube config data is not valid, the webhook
+                        is not honored. The namespace for this secret is determined
+                        by the point of use.'
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced
+                            secret
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              integratedOAuthMetadata:
+                description: 'integratedOAuthMetadata contains the discovery endpoint
+                  data for OAuth 2.0 Authorization Server Metadata for the in-cluster
+                  integrated OAuth server. This discovery document can be viewed from
+                  its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                  For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  This contains the observed value based on cluster state. An explicitly
+                  set value in spec.oauthMetadata has precedence over this field.
+                  This field has no meaning if authentication spec.type is not set
+                  to IntegratedOAuth. The key "oauthMetadata" is used to locate the
+                  data. If the config map or expected key is not found, no metadata
+                  is served. If the specified metadata is not valid, no metadata is
+                  served. The namespace for this config map is openshift-config-managed.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcClients:
+                description: OIDCClients is where participating operators place the
+                  current OIDC client status for OIDC clients that can be customized
+                  by the cluster-admin.
+                items:
+                  properties:
+                    componentName:
+                      description: ComponentName is the name of the component that
+                        will consume a client configuration.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    componentNamespace:
+                      description: ComponentNamespace is the namespace of the component
+                        that will consume a client configuration.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    conditions:
+                      description: "Conditions are used to communicate the state of
+                        the `oidcClients` entry. \n Supported conditions include Available,
+                        Degraded and Progressing. \n If Available is true, the component
+                        is successfully using the configured client. If Degraded is
+                        true, that means something has gone wrong trying to handle
+                        the client configuration. If Progressing is true, that means
+                        the component is taking some action related to the `oidcClients`
+                        entry."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    consumingUsers:
+                      description: ConsumingUsers is a slice of ServiceAccounts that
+                        need to have read permission on the `clientSecret` secret.
+                      items:
+                        description: ConsumingUser is an alias for string which we
+                          add validation to. Currently only service accounts are supported.
+                        maxLength: 512
+                        minLength: 1
+                        pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      maxItems: 5
+                      type: array
+                      x-kubernetes-list-type: set
+                    currentOIDCClients:
+                      description: CurrentOIDCClients is a list of clients that the
+                        component is currently using.
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          issuerURL:
+                            description: URL is the serving URL of the token issuer.
+                              Must use the https:// scheme.
+                            pattern: ^https:\/\/[^\s]
+                            type: string
+                          oidcProviderName:
+                            description: OIDCName refers to the `name` of the provider
+                              from `oidcProviders`
+                            minLength: 1
+                            type: string
+                        required:
+                        - clientID
+                        - issuerURL
+                        - oidcProviderName
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - issuerURL
+                      - clientID
+                      x-kubernetes-list-type: map
+                  required:
+                  - componentName
+                  - componentNamespace
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - componentNamespace
+                - componentName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: all oidcClients in the oidcProviders must match their componentName
+            and componentNamespace to either a previously configured oidcClient or
+            they must exist in the status.oidcClients
+          rule: '!has(self.spec.oidcProviders) || self.spec.oidcProviders.all(p, !has(p.oidcClients)
+            || p.oidcClients.all(specC, self.status.oidcClients.exists(statusC, statusC.componentNamespace
+            == specC.componentNamespace && statusC.componentName == specC.componentName)
+            || (has(oldSelf.spec.oidcProviders) && oldSelf.spec.oidcProviders.exists(oldP,
+            oldP.name == p.name && has(oldP.oidcClients) && oldP.oidcClients.exists(oldC,
+            oldC.componentNamespace == specC.componentNamespace && oldC.componentName
+            == specC.componentName)))))'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-HypershiftIndependent-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-HypershiftIndependent-Default.crd.yaml
@@ -1,0 +1,171 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
+    release.openshift.io/feature-set: Default
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Authentication specifies cluster-wide settings for authentication
+          (like OAuth and webhook token authenticators). The canonical name of an
+          instance is `cluster`. \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              oauthMetadata:
+                description: 'oauthMetadata contains the discovery endpoint data for
+                  OAuth 2.0 Authorization Server Metadata for an external OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw ''/.well-known/oauth-authorization-server'' For further
+                  details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  If oauthMetadata.name is non-empty, this value has precedence over
+                  any metadata reference stored in status. The key "oauthMetadata"
+                  is used to locate the data. If specified and the config map or expected
+                  key is not found, no metadata is served. If the specified metadata
+                  is not valid, no metadata is served. The namespace for this config
+                  map is openshift-config.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              serviceAccountIssuer:
+                description: 'serviceAccountIssuer is the identifier of the bound
+                  service account token issuer. The default is https://kubernetes.default.svc
+                  WARNING: Updating this field will not result in immediate invalidation
+                  of all bound tokens with the previous issuer value. Instead, the
+                  tokens issued by previous service account issuer will continue to
+                  be trusted for a time period chosen by the platform (currently set
+                  to 24h). This time period is subject to change over time. This allows
+                  internal components to transition to use new service account issuer
+                  without service distruption.'
+                type: string
+              type:
+                description: type identifies the cluster managed, user facing authentication
+                  mode in use. Specifically, it manages the component that responds
+                  to login attempts. The default is IntegratedOAuth.
+                enum:
+                - ""
+                - None
+                - IntegratedOAuth
+                type: string
+              webhookTokenAuthenticator:
+                description: "webhookTokenAuthenticator configures a remote token
+                  reviewer. These remote authentication webhooks can be used to verify
+                  bearer tokens via the tokenreviews.authentication.k8s.io REST API.
+                  This is required to honor bearer tokens that are provisioned by
+                  an external authentication service. \n Can only be set if \"Type\"
+                  is set to \"None\"."
+                properties:
+                  kubeConfig:
+                    description: "kubeConfig references a secret that contains kube
+                      config file data which describes how to access the remote webhook
+                      service. The namespace for the referenced secret is openshift-config.
+                      \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                      \n The key \"kubeConfig\" is used to locate the data. If the
+                      secret or expected key is not found, the webhook is not honored.
+                      If the specified kube config data is not valid, the webhook
+                      is not honored."
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - kubeConfig
+                type: object
+              webhookTokenAuthenticators:
+                description: webhookTokenAuthenticators is DEPRECATED, setting it
+                  has no effect.
+                items:
+                  description: deprecatedWebhookTokenAuthenticator holds the necessary
+                    configuration options for a remote token authenticator. It's the
+                    same as WebhookTokenAuthenticator but it's missing the 'required'
+                    validation on KubeConfig field.
+                  properties:
+                    kubeConfig:
+                      description: 'kubeConfig contains kube config file data which
+                        describes how to access the remote webhook service. For further
+                        details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                        The key "kubeConfig" is used to locate the data. If the secret
+                        or expected key is not found, the webhook is not honored.
+                        If the specified kube config data is not valid, the webhook
+                        is not honored. The namespace for this secret is determined
+                        by the point of use.'
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced
+                            secret
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              integratedOAuthMetadata:
+                description: 'integratedOAuthMetadata contains the discovery endpoint
+                  data for OAuth 2.0 Authorization Server Metadata for the in-cluster
+                  integrated OAuth server. This discovery document can be viewed from
+                  its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                  For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  This contains the observed value based on cluster state. An explicitly
+                  set value in spec.oauthMetadata has precedence over this field.
+                  This field has no meaning if authentication spec.type is not set
+                  to IntegratedOAuth. The key "oauthMetadata" is used to locate the
+                  data. If the config map or expected key is not found, no metadata
+                  is served. If the specified metadata is not valid, no metadata is
+                  served. The namespace for this config map is openshift-config-managed.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-HypershiftIndependent-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-HypershiftIndependent-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,553 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Authentication specifies cluster-wide settings for authentication
+          (like OAuth and webhook token authenticators). The canonical name of an
+          instance is `cluster`. \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              oauthMetadata:
+                description: 'oauthMetadata contains the discovery endpoint data for
+                  OAuth 2.0 Authorization Server Metadata for an external OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw ''/.well-known/oauth-authorization-server'' For further
+                  details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  If oauthMetadata.name is non-empty, this value has precedence over
+                  any metadata reference stored in status. The key "oauthMetadata"
+                  is used to locate the data. If specified and the config map or expected
+                  key is not found, no metadata is served. If the specified metadata
+                  is not valid, no metadata is served. The namespace for this config
+                  map is openshift-config.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcProviders:
+                description: "OIDCProviders are OIDC identity providers that can issue
+                  tokens for this cluster Can only be set if \"Type\" is set to \"OIDC\".
+                  \n At most one provider can be configured."
+                items:
+                  properties:
+                    claimMappings:
+                      description: ClaimMappings describes rules on how to transform
+                        information from an ID token into a cluster identity
+                      properties:
+                        groups:
+                          description: Groups is a name of the claim that should be
+                            used to construct groups for the cluster identity. The
+                            referenced claim must use array of strings values.
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              description: "Prefix is a string to prefix the value
+                                from the token in the result of the claim mapping.
+                                \n By default, no prefixing occurs. \n Example: if
+                                `prefix` is set to \"myoidc:\"\" and the `claim` in
+                                JWT contains an array of strings \"a\", \"b\" and
+                                \ \"c\", the mapping will result in an array of string
+                                \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                        username:
+                          description: "Username is a name of the claim that should
+                            be used to construct usernames for the cluster identity.
+                            \n Default value: \"sub\""
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              properties:
+                                prefixString:
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - prefixString
+                              type: object
+                            prefixPolicy:
+                              description: "PrefixPolicy specifies how a prefix should
+                                apply. \n By default, claims other than `email` will
+                                be prefixed with the issuer URL to prevent naming
+                                clashes with other plugins. \n Set to \"NoPrefix\"
+                                to disable prefixing. \n Example: (1) `prefix` is
+                                set to \"myoidc:\" and `claim` is set to \"username\".
+                                If the JWT claim `username` contains value `userA`,
+                                the resulting mapped value will be \"myoidc:userA\".
+                                (2) `prefix` is set to \"myoidc:\" and `claim` is
+                                set to \"email\". If the JWT `email` claim contains
+                                value \"userA@myoidc.tld\", the resulting mapped value
+                                will be \"myoidc:userA@myoidc.tld\". (3) `prefix`
+                                is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                the JWT claims include \"username\":\"userA\" and
+                                \"email\":\"userA@myoidc.tld\", and `claim` is set
+                                to: (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\"
+                                (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                              enum:
+                              - ""
+                              - NoPrefix
+                              - Prefix
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                          x-kubernetes-validations:
+                          - message: prefix must be set if prefixPolicy is 'Prefix',
+                              but must remain unset otherwise
+                            rule: 'has(self.prefixPolicy) && self.prefixPolicy ==
+                              ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString)
+                              > 0) : !has(self.prefix)'
+                      type: object
+                    claimValidationRules:
+                      description: ClaimValidationRules are rules that are applied
+                        to validate token claims to authenticate users.
+                      items:
+                        properties:
+                          requiredClaim:
+                            description: RequiredClaim allows configuring a required
+                              claim name and its expected value
+                            properties:
+                              claim:
+                                description: Claim is a name of a required claim.
+                                  Only claims with string values are supported.
+                                minLength: 1
+                                type: string
+                              requiredValue:
+                                description: RequiredValue is the required value for
+                                  the claim.
+                                minLength: 1
+                                type: string
+                            required:
+                            - claim
+                            - requiredValue
+                            type: object
+                          type:
+                            default: RequiredClaim
+                            description: Type sets the type of the validation rule
+                            enum:
+                            - RequiredClaim
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    issuer:
+                      description: Issuer describes atributes of the OIDC token issuer
+                      properties:
+                        audiences:
+                          description: Audiences is an array of audiences that the
+                            token was issued for. Valid tokens must include at least
+                            one of these values in their "aud" claim. Must be set
+                            to exactly one value.
+                          items:
+                            minLength: 1
+                            type: string
+                          maxItems: 10
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-type: set
+                        issuerCertificateAuthority:
+                          description: CertificateAuthority is a reference to a config
+                            map in the configuration namespace. The .data of the configMap
+                            must contain the "ca-bundle.crt" key. If unset, system
+                            trust is used instead.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        issuerURL:
+                          description: URL is the serving URL of the token issuer.
+                            Must use the https:// scheme.
+                          pattern: ^https:\/\/[^\s]
+                          type: string
+                      required:
+                      - audiences
+                      - issuerURL
+                      type: object
+                    name:
+                      description: Name of the OIDC provider
+                      minLength: 1
+                      type: string
+                    oidcClients:
+                      description: OIDCClients contains configuration for the platform's
+                        clients that need to request tokens from the issuer
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          clientSecret:
+                            description: ClientSecret refers to a secret in the `openshift-config`
+                              namespace that contains the client secret in the `clientSecret`
+                              key of the `.data` field
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          componentName:
+                            description: ComponentName is the name of the component
+                              that is supposed to consume this client configuration
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          componentNamespace:
+                            description: ComponentNamespace is the namespace of the
+                              component that is supposed to consume this client configuration
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                          extraScopes:
+                            description: ExtraScopes is an optional set of scopes
+                              to request tokens with.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - clientID
+                        - componentName
+                        - componentNamespace
+                        type: object
+                      maxItems: 20
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - componentNamespace
+                      - componentName
+                      x-kubernetes-list-type: map
+                  required:
+                  - issuer
+                  - name
+                  type: object
+                maxItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              serviceAccountIssuer:
+                description: 'serviceAccountIssuer is the identifier of the bound
+                  service account token issuer. The default is https://kubernetes.default.svc
+                  WARNING: Updating this field will not result in immediate invalidation
+                  of all bound tokens with the previous issuer value. Instead, the
+                  tokens issued by previous service account issuer will continue to
+                  be trusted for a time period chosen by the platform (currently set
+                  to 24h). This time period is subject to change over time. This allows
+                  internal components to transition to use new service account issuer
+                  without service distruption.'
+                type: string
+              type:
+                description: type identifies the cluster managed, user facing authentication
+                  mode in use. Specifically, it manages the component that responds
+                  to login attempts. The default is IntegratedOAuth.
+                enum:
+                - ""
+                - None
+                - IntegratedOAuth
+                - OIDC
+                type: string
+              webhookTokenAuthenticator:
+                description: "webhookTokenAuthenticator configures a remote token
+                  reviewer. These remote authentication webhooks can be used to verify
+                  bearer tokens via the tokenreviews.authentication.k8s.io REST API.
+                  This is required to honor bearer tokens that are provisioned by
+                  an external authentication service. \n Can only be set if \"Type\"
+                  is set to \"None\"."
+                properties:
+                  kubeConfig:
+                    description: "kubeConfig references a secret that contains kube
+                      config file data which describes how to access the remote webhook
+                      service. The namespace for the referenced secret is openshift-config.
+                      \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                      \n The key \"kubeConfig\" is used to locate the data. If the
+                      secret or expected key is not found, the webhook is not honored.
+                      If the specified kube config data is not valid, the webhook
+                      is not honored."
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - kubeConfig
+                type: object
+              webhookTokenAuthenticators:
+                description: webhookTokenAuthenticators is DEPRECATED, setting it
+                  has no effect.
+                items:
+                  description: deprecatedWebhookTokenAuthenticator holds the necessary
+                    configuration options for a remote token authenticator. It's the
+                    same as WebhookTokenAuthenticator but it's missing the 'required'
+                    validation on KubeConfig field.
+                  properties:
+                    kubeConfig:
+                      description: 'kubeConfig contains kube config file data which
+                        describes how to access the remote webhook service. For further
+                        details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                        The key "kubeConfig" is used to locate the data. If the secret
+                        or expected key is not found, the webhook is not honored.
+                        If the specified kube config data is not valid, the webhook
+                        is not honored. The namespace for this secret is determined
+                        by the point of use.'
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced
+                            secret
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              integratedOAuthMetadata:
+                description: 'integratedOAuthMetadata contains the discovery endpoint
+                  data for OAuth 2.0 Authorization Server Metadata for the in-cluster
+                  integrated OAuth server. This discovery document can be viewed from
+                  its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                  For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  This contains the observed value based on cluster state. An explicitly
+                  set value in spec.oauthMetadata has precedence over this field.
+                  This field has no meaning if authentication spec.type is not set
+                  to IntegratedOAuth. The key "oauthMetadata" is used to locate the
+                  data. If the config map or expected key is not found, no metadata
+                  is served. If the specified metadata is not valid, no metadata is
+                  served. The namespace for this config map is openshift-config-managed.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcClients:
+                description: OIDCClients is where participating operators place the
+                  current OIDC client status for OIDC clients that can be customized
+                  by the cluster-admin.
+                items:
+                  properties:
+                    componentName:
+                      description: ComponentName is the name of the component that
+                        will consume a client configuration.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    componentNamespace:
+                      description: ComponentNamespace is the namespace of the component
+                        that will consume a client configuration.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    conditions:
+                      description: "Conditions are used to communicate the state of
+                        the `oidcClients` entry. \n Supported conditions include Available,
+                        Degraded and Progressing. \n If Available is true, the component
+                        is successfully using the configured client. If Degraded is
+                        true, that means something has gone wrong trying to handle
+                        the client configuration. If Progressing is true, that means
+                        the component is taking some action related to the `oidcClients`
+                        entry."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    consumingUsers:
+                      description: ConsumingUsers is a slice of ServiceAccounts that
+                        need to have read permission on the `clientSecret` secret.
+                      items:
+                        description: ConsumingUser is an alias for string which we
+                          add validation to. Currently only service accounts are supported.
+                        maxLength: 512
+                        minLength: 1
+                        pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      maxItems: 5
+                      type: array
+                      x-kubernetes-list-type: set
+                    currentOIDCClients:
+                      description: CurrentOIDCClients is a list of clients that the
+                        component is currently using.
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          issuerURL:
+                            description: URL is the serving URL of the token issuer.
+                              Must use the https:// scheme.
+                            pattern: ^https:\/\/[^\s]
+                            type: string
+                          oidcProviderName:
+                            description: OIDCName refers to the `name` of the provider
+                              from `oidcProviders`
+                            minLength: 1
+                            type: string
+                        required:
+                        - clientID
+                        - issuerURL
+                        - oidcProviderName
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - issuerURL
+                      - clientID
+                      x-kubernetes-list-type: map
+                  required:
+                  - componentName
+                  - componentNamespace
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - componentNamespace
+                - componentName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: all oidcClients in the oidcProviders must match their componentName
+            and componentNamespace to either a previously configured oidcClient or
+            they must exist in the status.oidcClients
+          rule: '!has(self.spec.oidcProviders) || self.spec.oidcProviders.all(p, !has(p.oidcClients)
+            || p.oidcClients.all(specC, self.status.oidcClients.exists(statusC, statusC.componentNamespace
+            == specC.componentNamespace && statusC.componentName == specC.componentName)
+            || (has(oldSelf.spec.oidcProviders) && oldSelf.spec.oidcProviders.exists(oldP,
+            oldP.name == p.name && has(oldP.oidcClients) && oldP.oidcClients.exists(oldC,
+            oldC.componentNamespace == specC.componentNamespace && oldC.componentName
+            == specC.componentName)))))'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-HypershiftIndependent.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-HypershiftIndependent.crd.yaml
@@ -1,0 +1,552 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
+  name: authentications.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "Authentication specifies cluster-wide settings for authentication
+          (like OAuth and webhook token authenticators). The canonical name of an
+          instance is `cluster`. \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              oauthMetadata:
+                description: 'oauthMetadata contains the discovery endpoint data for
+                  OAuth 2.0 Authorization Server Metadata for an external OAuth server.
+                  This discovery document can be viewed from its served location:
+                  oc get --raw ''/.well-known/oauth-authorization-server'' For further
+                  details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  If oauthMetadata.name is non-empty, this value has precedence over
+                  any metadata reference stored in status. The key "oauthMetadata"
+                  is used to locate the data. If specified and the config map or expected
+                  key is not found, no metadata is served. If the specified metadata
+                  is not valid, no metadata is served. The namespace for this config
+                  map is openshift-config.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcProviders:
+                description: "OIDCProviders are OIDC identity providers that can issue
+                  tokens for this cluster Can only be set if \"Type\" is set to \"OIDC\".
+                  \n At most one provider can be configured."
+                items:
+                  properties:
+                    claimMappings:
+                      description: ClaimMappings describes rules on how to transform
+                        information from an ID token into a cluster identity
+                      properties:
+                        groups:
+                          description: Groups is a name of the claim that should be
+                            used to construct groups for the cluster identity. The
+                            referenced claim must use array of strings values.
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              description: "Prefix is a string to prefix the value
+                                from the token in the result of the claim mapping.
+                                \n By default, no prefixing occurs. \n Example: if
+                                `prefix` is set to \"myoidc:\"\" and the `claim` in
+                                JWT contains an array of strings \"a\", \"b\" and
+                                \ \"c\", the mapping will result in an array of string
+                                \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\"."
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                        username:
+                          description: "Username is a name of the claim that should
+                            be used to construct usernames for the cluster identity.
+                            \n Default value: \"sub\""
+                          properties:
+                            claim:
+                              description: Claim is a JWT token claim to be used in
+                                the mapping
+                              type: string
+                            prefix:
+                              properties:
+                                prefixString:
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - prefixString
+                              type: object
+                            prefixPolicy:
+                              description: "PrefixPolicy specifies how a prefix should
+                                apply. \n By default, claims other than `email` will
+                                be prefixed with the issuer URL to prevent naming
+                                clashes with other plugins. \n Set to \"NoPrefix\"
+                                to disable prefixing. \n Example: (1) `prefix` is
+                                set to \"myoidc:\" and `claim` is set to \"username\".
+                                If the JWT claim `username` contains value `userA`,
+                                the resulting mapped value will be \"myoidc:userA\".
+                                (2) `prefix` is set to \"myoidc:\" and `claim` is
+                                set to \"email\". If the JWT `email` claim contains
+                                value \"userA@myoidc.tld\", the resulting mapped value
+                                will be \"myoidc:userA@myoidc.tld\". (3) `prefix`
+                                is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                the JWT claims include \"username\":\"userA\" and
+                                \"email\":\"userA@myoidc.tld\", and `claim` is set
+                                to: (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\"
+                                (b) \"email\": the mapped value will be \"userA@myoidc.tld\""
+                              enum:
+                              - ""
+                              - NoPrefix
+                              - Prefix
+                              type: string
+                          required:
+                          - claim
+                          type: object
+                          x-kubernetes-validations:
+                          - message: prefix must be set if prefixPolicy is 'Prefix',
+                              but must remain unset otherwise
+                            rule: 'has(self.prefixPolicy) && self.prefixPolicy ==
+                              ''Prefix'' ? (has(self.prefix) && size(self.prefix.prefixString)
+                              > 0) : !has(self.prefix)'
+                      type: object
+                    claimValidationRules:
+                      description: ClaimValidationRules are rules that are applied
+                        to validate token claims to authenticate users.
+                      items:
+                        properties:
+                          requiredClaim:
+                            description: RequiredClaim allows configuring a required
+                              claim name and its expected value
+                            properties:
+                              claim:
+                                description: Claim is a name of a required claim.
+                                  Only claims with string values are supported.
+                                minLength: 1
+                                type: string
+                              requiredValue:
+                                description: RequiredValue is the required value for
+                                  the claim.
+                                minLength: 1
+                                type: string
+                            required:
+                            - claim
+                            - requiredValue
+                            type: object
+                          type:
+                            default: RequiredClaim
+                            description: Type sets the type of the validation rule
+                            enum:
+                            - RequiredClaim
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    issuer:
+                      description: Issuer describes atributes of the OIDC token issuer
+                      properties:
+                        audiences:
+                          description: Audiences is an array of audiences that the
+                            token was issued for. Valid tokens must include at least
+                            one of these values in their "aud" claim. Must be set
+                            to exactly one value.
+                          items:
+                            minLength: 1
+                            type: string
+                          maxItems: 10
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-type: set
+                        issuerCertificateAuthority:
+                          description: CertificateAuthority is a reference to a config
+                            map in the configuration namespace. The .data of the configMap
+                            must contain the "ca-bundle.crt" key. If unset, system
+                            trust is used instead.
+                          properties:
+                            name:
+                              description: name is the metadata.name of the referenced
+                                config map
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        issuerURL:
+                          description: URL is the serving URL of the token issuer.
+                            Must use the https:// scheme.
+                          pattern: ^https:\/\/[^\s]
+                          type: string
+                      required:
+                      - audiences
+                      - issuerURL
+                      type: object
+                    name:
+                      description: Name of the OIDC provider
+                      minLength: 1
+                      type: string
+                    oidcClients:
+                      description: OIDCClients contains configuration for the platform's
+                        clients that need to request tokens from the issuer
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          clientSecret:
+                            description: ClientSecret refers to a secret in the `openshift-config`
+                              namespace that contains the client secret in the `clientSecret`
+                              key of the `.data` field
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          componentName:
+                            description: ComponentName is the name of the component
+                              that is supposed to consume this client configuration
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          componentNamespace:
+                            description: ComponentNamespace is the namespace of the
+                              component that is supposed to consume this client configuration
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                          extraScopes:
+                            description: ExtraScopes is an optional set of scopes
+                              to request tokens with.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                        required:
+                        - clientID
+                        - componentName
+                        - componentNamespace
+                        type: object
+                      maxItems: 20
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - componentNamespace
+                      - componentName
+                      x-kubernetes-list-type: map
+                  required:
+                  - issuer
+                  - name
+                  type: object
+                maxItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              serviceAccountIssuer:
+                description: 'serviceAccountIssuer is the identifier of the bound
+                  service account token issuer. The default is https://kubernetes.default.svc
+                  WARNING: Updating this field will not result in immediate invalidation
+                  of all bound tokens with the previous issuer value. Instead, the
+                  tokens issued by previous service account issuer will continue to
+                  be trusted for a time period chosen by the platform (currently set
+                  to 24h). This time period is subject to change over time. This allows
+                  internal components to transition to use new service account issuer
+                  without service distruption.'
+                type: string
+              type:
+                description: type identifies the cluster managed, user facing authentication
+                  mode in use. Specifically, it manages the component that responds
+                  to login attempts. The default is IntegratedOAuth.
+                enum:
+                - ""
+                - None
+                - IntegratedOAuth
+                - OIDC
+                type: string
+              webhookTokenAuthenticator:
+                description: "webhookTokenAuthenticator configures a remote token
+                  reviewer. These remote authentication webhooks can be used to verify
+                  bearer tokens via the tokenreviews.authentication.k8s.io REST API.
+                  This is required to honor bearer tokens that are provisioned by
+                  an external authentication service. \n Can only be set if \"Type\"
+                  is set to \"None\"."
+                properties:
+                  kubeConfig:
+                    description: "kubeConfig references a secret that contains kube
+                      config file data which describes how to access the remote webhook
+                      service. The namespace for the referenced secret is openshift-config.
+                      \n For further details, see: \n https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                      \n The key \"kubeConfig\" is used to locate the data. If the
+                      secret or expected key is not found, the webhook is not honored.
+                      If the specified kube config data is not valid, the webhook
+                      is not honored."
+                    properties:
+                      name:
+                        description: name is the metadata.name of the referenced secret
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - kubeConfig
+                type: object
+              webhookTokenAuthenticators:
+                description: webhookTokenAuthenticators is DEPRECATED, setting it
+                  has no effect.
+                items:
+                  description: deprecatedWebhookTokenAuthenticator holds the necessary
+                    configuration options for a remote token authenticator. It's the
+                    same as WebhookTokenAuthenticator but it's missing the 'required'
+                    validation on KubeConfig field.
+                  properties:
+                    kubeConfig:
+                      description: 'kubeConfig contains kube config file data which
+                        describes how to access the remote webhook service. For further
+                        details, see: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#webhook-token-authentication
+                        The key "kubeConfig" is used to locate the data. If the secret
+                        or expected key is not found, the webhook is not honored.
+                        If the specified kube config data is not valid, the webhook
+                        is not honored. The namespace for this secret is determined
+                        by the point of use.'
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced
+                            secret
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              integratedOAuthMetadata:
+                description: 'integratedOAuthMetadata contains the discovery endpoint
+                  data for OAuth 2.0 Authorization Server Metadata for the in-cluster
+                  integrated OAuth server. This discovery document can be viewed from
+                  its served location: oc get --raw ''/.well-known/oauth-authorization-server''
+                  For further details, see the IETF Draft: https://tools.ietf.org/html/draft-ietf-oauth-discovery-04#section-2
+                  This contains the observed value based on cluster state. An explicitly
+                  set value in spec.oauthMetadata has precedence over this field.
+                  This field has no meaning if authentication spec.type is not set
+                  to IntegratedOAuth. The key "oauthMetadata" is used to locate the
+                  data. If the config map or expected key is not found, no metadata
+                  is served. If the specified metadata is not valid, no metadata is
+                  served. The namespace for this config map is openshift-config-managed.'
+                properties:
+                  name:
+                    description: name is the metadata.name of the referenced config
+                      map
+                    type: string
+                required:
+                - name
+                type: object
+              oidcClients:
+                description: OIDCClients is where participating operators place the
+                  current OIDC client status for OIDC clients that can be customized
+                  by the cluster-admin.
+                items:
+                  properties:
+                    componentName:
+                      description: ComponentName is the name of the component that
+                        will consume a client configuration.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    componentNamespace:
+                      description: ComponentNamespace is the namespace of the component
+                        that will consume a client configuration.
+                      maxLength: 63
+                      minLength: 1
+                      type: string
+                    conditions:
+                      description: "Conditions are used to communicate the state of
+                        the `oidcClients` entry. \n Supported conditions include Available,
+                        Degraded and Progressing. \n If Available is true, the component
+                        is successfully using the configured client. If Degraded is
+                        true, that means something has gone wrong trying to handle
+                        the client configuration. If Progressing is true, that means
+                        the component is taking some action related to the `oidcClients`
+                        entry."
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource. --- This struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example, \n type FooStatus struct{
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another. This should
+                              be when the underlying condition changed.  If that is
+                              not known, then using the time when the API field changed
+                              is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human readable message indicating
+                              details about the transition. This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: observedGeneration represents the .metadata.generation
+                              that the condition was set based upon. For instance,
+                              if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                              is 9, the condition is out of date with respect to the
+                              current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: reason contains a programmatic identifier
+                              indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected
+                              values and meanings for this field, and whether the
+                              values are considered a guaranteed API. The value should
+                              be a CamelCase string. This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              --- Many .condition.type values are consistent across
+                              resources like Available, but because arbitrary conditions
+                              can be useful (see .node.status.conditions), the ability
+                              to deconflict is important. The regex it matches is
+                              (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    consumingUsers:
+                      description: ConsumingUsers is a slice of ServiceAccounts that
+                        need to have read permission on the `clientSecret` secret.
+                      items:
+                        description: ConsumingUser is an alias for string which we
+                          add validation to. Currently only service accounts are supported.
+                        maxLength: 512
+                        minLength: 1
+                        pattern: ^system:serviceaccount:[a-z0-9]([-a-z0-9]*[a-z0-9])?:[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      maxItems: 5
+                      type: array
+                      x-kubernetes-list-type: set
+                    currentOIDCClients:
+                      description: CurrentOIDCClients is a list of clients that the
+                        component is currently using.
+                      items:
+                        properties:
+                          clientID:
+                            description: ClientID is the identifier of the OIDC client
+                              from the OIDC provider
+                            minLength: 1
+                            type: string
+                          issuerURL:
+                            description: URL is the serving URL of the token issuer.
+                              Must use the https:// scheme.
+                            pattern: ^https:\/\/[^\s]
+                            type: string
+                          oidcProviderName:
+                            description: OIDCName refers to the `name` of the provider
+                              from `oidcProviders`
+                            minLength: 1
+                            type: string
+                        required:
+                        - clientID
+                        - issuerURL
+                        - oidcProviderName
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - issuerURL
+                      - clientID
+                      x-kubernetes-list-type: map
+                  required:
+                  - componentName
+                  - componentNamespace
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - componentNamespace
+                - componentName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: all oidcClients in the oidcProviders must match their componentName
+            and componentNamespace to either a previously configured oidcClient or
+            they must exist in the status.oidcClients
+          rule: '!has(self.spec.oidcProviders) || self.spec.oidcProviders.all(p, !has(p.oidcClients)
+            || p.oidcClients.all(specC, self.status.oidcClients.exists(statusC, statusC.componentNamespace
+            == specC.componentNamespace && statusC.componentName == specC.componentName)
+            || (has(oldSelf.spec.oidcProviders) && oldSelf.spec.oidcProviders.exists(oldP,
+            oldP.name == p.name && has(oldP.oidcClients) && oldP.oidcClients.exists(oldC,
+            oldC.componentNamespace == specC.componentNamespace && oldC.componentName
+            == specC.componentName)))))'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_configs.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_configs.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/612
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: configs.operator.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_consoles.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_consoles.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: consoles.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_dnses.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_dnses.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: dnses.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_featuregates.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_featuregates.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: featuregates.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_imagecontentpolicies.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagecontentpolicies.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/874
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: imagecontentpolicies.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_imagecontentsourcepolicies.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagecontentsourcepolicies.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: imagecontentsourcepolicies.operator.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1126
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: imagedigestmirrorsets.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_images.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_images.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: images.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_imagetagmirrorsets.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagetagmirrorsets.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1126
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: imagetagmirrorsets.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/payload-manifests/crds/0000_10_config-operator_01_ingresses.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_ingresses.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: ingresses.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_networks-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_networks-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/payload-manifests/crds/0000_10_config-operator_01_networks-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_networks-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/payload-manifests/crds/0000_10_config-operator_01_networks-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_networks-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/payload-manifests/crds/0000_10_config-operator_01_nodes.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_nodes.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1107
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: nodes.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_oauths.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_oauths.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: oauths.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_projects.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_projects.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: projects.config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_schedulers-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_schedulers-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/payload-manifests/crds/0000_10_config-operator_01_schedulers-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_schedulers-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/payload-manifests/crds/0000_10_config-operator_01_schedulers-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_schedulers-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/payload-manifests/featuregates/featureGate-HypershiftIndependent-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-HypershiftIndependent-Default.yaml
@@ -1,0 +1,206 @@
+{
+    "apiVersion": "config.openshift.io/v1",
+    "kind": "FeatureGate",
+    "metadata": {
+        "annotations": {
+            "include.release.openshift.io/hypershift": "false-except-for-the-config-operator"
+        },
+        "creationTimestamp": null,
+        "name": "cluster"
+    },
+    "spec": {},
+    "status": {
+        "featureGates": [
+            {
+                "disabled": [
+                    {
+                        "name": "AutomatedEtcdBackup"
+                    },
+                    {
+                        "name": "CSIDriverSharedResource"
+                    },
+                    {
+                        "name": "ClusterAPIInstall"
+                    },
+                    {
+                        "name": "DNSNameResolver"
+                    },
+                    {
+                        "name": "DynamicResourceAllocation"
+                    },
+                    {
+                        "name": "EventedPLEG"
+                    },
+                    {
+                        "name": "Example"
+                    },
+                    {
+                        "name": "ExternalOIDC"
+                    },
+                    {
+                        "name": "ExternalRouteCertificate"
+                    },
+                    {
+                        "name": "GCPClusterHostedDNS"
+                    },
+                    {
+                        "name": "GCPLabelsTags"
+                    },
+                    {
+                        "name": "GatewayAPI"
+                    },
+                    {
+                        "name": "HardwareSpeed"
+                    },
+                    {
+                        "name": "ImagePolicy"
+                    },
+                    {
+                        "name": "InsightsConfig"
+                    },
+                    {
+                        "name": "InsightsConfigAPI"
+                    },
+                    {
+                        "name": "InsightsOnDemandDataGather"
+                    },
+                    {
+                        "name": "InstallAlternateInfrastructureAWS"
+                    },
+                    {
+                        "name": "MachineAPIOperatorDisableMachineHealthCheckController"
+                    },
+                    {
+                        "name": "MachineAPIProviderOpenStack"
+                    },
+                    {
+                        "name": "MachineConfigNodes"
+                    },
+                    {
+                        "name": "ManagedBootImages"
+                    },
+                    {
+                        "name": "MaxUnavailableStatefulSet"
+                    },
+                    {
+                        "name": "MetricsCollectionProfiles"
+                    },
+                    {
+                        "name": "MetricsServer"
+                    },
+                    {
+                        "name": "MixedCPUsAllocation"
+                    },
+                    {
+                        "name": "NetworkDiagnosticsConfig"
+                    },
+                    {
+                        "name": "NewOLM"
+                    },
+                    {
+                        "name": "NodeDisruptionPolicy"
+                    },
+                    {
+                        "name": "NodeSwap"
+                    },
+                    {
+                        "name": "OnClusterBuild"
+                    },
+                    {
+                        "name": "PinnedImages"
+                    },
+                    {
+                        "name": "PlatformOperators"
+                    },
+                    {
+                        "name": "RouteExternalCertificate"
+                    },
+                    {
+                        "name": "ServiceAccountTokenNodeBinding"
+                    },
+                    {
+                        "name": "ServiceAccountTokenNodeBindingValidation"
+                    },
+                    {
+                        "name": "ServiceAccountTokenPodNodeInfo"
+                    },
+                    {
+                        "name": "SignatureStores"
+                    },
+                    {
+                        "name": "SigstoreImageVerification"
+                    },
+                    {
+                        "name": "TranslateStreamCloseWebsocketRequests"
+                    },
+                    {
+                        "name": "UpgradeStatus"
+                    },
+                    {
+                        "name": "VSphereDriverConfiguration"
+                    },
+                    {
+                        "name": "ValidatingAdmissionPolicy"
+                    },
+                    {
+                        "name": "VolumeGroupSnapshot"
+                    }
+                ],
+                "enabled": [
+                    {
+                        "name": "AdminNetworkPolicy"
+                    },
+                    {
+                        "name": "AlibabaPlatform"
+                    },
+                    {
+                        "name": "AzureWorkloadIdentity"
+                    },
+                    {
+                        "name": "BareMetalLoadBalancer"
+                    },
+                    {
+                        "name": "BuildCSIVolumes"
+                    },
+                    {
+                        "name": "CloudDualStackNodeIPs"
+                    },
+                    {
+                        "name": "DisableKubeletCloudCredentialProviders"
+                    },
+                    {
+                        "name": "ExternalCloudProvider"
+                    },
+                    {
+                        "name": "ExternalCloudProviderAzure"
+                    },
+                    {
+                        "name": "ExternalCloudProviderExternal"
+                    },
+                    {
+                        "name": "ExternalCloudProviderGCP"
+                    },
+                    {
+                        "name": "KMSv1"
+                    },
+                    {
+                        "name": "NetworkLiveMigration"
+                    },
+                    {
+                        "name": "OpenShiftPodSecurityAdmission"
+                    },
+                    {
+                        "name": "PrivateHostedZoneAWS"
+                    },
+                    {
+                        "name": "VSphereControlPlaneMachineSet"
+                    },
+                    {
+                        "name": "VSphereStaticIPs"
+                    }
+                ],
+                "version": ""
+            }
+        ]
+    }
+}

--- a/payload-manifests/featuregates/featureGate-HypershiftIndependent-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-HypershiftIndependent-TechPreviewNoUpgrade.yaml
@@ -1,0 +1,208 @@
+{
+    "apiVersion": "config.openshift.io/v1",
+    "kind": "FeatureGate",
+    "metadata": {
+        "annotations": {
+            "include.release.openshift.io/hypershift": "false-except-for-the-config-operator"
+        },
+        "creationTimestamp": null,
+        "name": "cluster"
+    },
+    "spec": {
+        "featureSet": "TechPreviewNoUpgrade"
+    },
+    "status": {
+        "featureGates": [
+            {
+                "disabled": [
+                    {
+                        "name": "ClusterAPIInstall"
+                    },
+                    {
+                        "name": "EventedPLEG"
+                    },
+                    {
+                        "name": "MachineAPIOperatorDisableMachineHealthCheckController"
+                    }
+                ],
+                "enabled": [
+                    {
+                        "name": "AdminNetworkPolicy"
+                    },
+                    {
+                        "name": "AlibabaPlatform"
+                    },
+                    {
+                        "name": "AutomatedEtcdBackup"
+                    },
+                    {
+                        "name": "AzureWorkloadIdentity"
+                    },
+                    {
+                        "name": "BareMetalLoadBalancer"
+                    },
+                    {
+                        "name": "BuildCSIVolumes"
+                    },
+                    {
+                        "name": "CSIDriverSharedResource"
+                    },
+                    {
+                        "name": "CloudDualStackNodeIPs"
+                    },
+                    {
+                        "name": "DNSNameResolver"
+                    },
+                    {
+                        "name": "DisableKubeletCloudCredentialProviders"
+                    },
+                    {
+                        "name": "DynamicResourceAllocation"
+                    },
+                    {
+                        "name": "Example"
+                    },
+                    {
+                        "name": "ExternalCloudProvider"
+                    },
+                    {
+                        "name": "ExternalCloudProviderAzure"
+                    },
+                    {
+                        "name": "ExternalCloudProviderExternal"
+                    },
+                    {
+                        "name": "ExternalCloudProviderGCP"
+                    },
+                    {
+                        "name": "ExternalOIDC"
+                    },
+                    {
+                        "name": "ExternalRouteCertificate"
+                    },
+                    {
+                        "name": "GCPClusterHostedDNS"
+                    },
+                    {
+                        "name": "GCPLabelsTags"
+                    },
+                    {
+                        "name": "GatewayAPI"
+                    },
+                    {
+                        "name": "HardwareSpeed"
+                    },
+                    {
+                        "name": "ImagePolicy"
+                    },
+                    {
+                        "name": "InsightsConfig"
+                    },
+                    {
+                        "name": "InsightsConfigAPI"
+                    },
+                    {
+                        "name": "InsightsOnDemandDataGather"
+                    },
+                    {
+                        "name": "InstallAlternateInfrastructureAWS"
+                    },
+                    {
+                        "name": "KMSv1"
+                    },
+                    {
+                        "name": "MachineAPIProviderOpenStack"
+                    },
+                    {
+                        "name": "MachineConfigNodes"
+                    },
+                    {
+                        "name": "ManagedBootImages"
+                    },
+                    {
+                        "name": "MaxUnavailableStatefulSet"
+                    },
+                    {
+                        "name": "MetricsCollectionProfiles"
+                    },
+                    {
+                        "name": "MetricsServer"
+                    },
+                    {
+                        "name": "MixedCPUsAllocation"
+                    },
+                    {
+                        "name": "NetworkDiagnosticsConfig"
+                    },
+                    {
+                        "name": "NetworkLiveMigration"
+                    },
+                    {
+                        "name": "NewOLM"
+                    },
+                    {
+                        "name": "NodeDisruptionPolicy"
+                    },
+                    {
+                        "name": "NodeSwap"
+                    },
+                    {
+                        "name": "OnClusterBuild"
+                    },
+                    {
+                        "name": "OpenShiftPodSecurityAdmission"
+                    },
+                    {
+                        "name": "PinnedImages"
+                    },
+                    {
+                        "name": "PlatformOperators"
+                    },
+                    {
+                        "name": "PrivateHostedZoneAWS"
+                    },
+                    {
+                        "name": "RouteExternalCertificate"
+                    },
+                    {
+                        "name": "ServiceAccountTokenNodeBinding"
+                    },
+                    {
+                        "name": "ServiceAccountTokenNodeBindingValidation"
+                    },
+                    {
+                        "name": "ServiceAccountTokenPodNodeInfo"
+                    },
+                    {
+                        "name": "SignatureStores"
+                    },
+                    {
+                        "name": "SigstoreImageVerification"
+                    },
+                    {
+                        "name": "TranslateStreamCloseWebsocketRequests"
+                    },
+                    {
+                        "name": "UpgradeStatus"
+                    },
+                    {
+                        "name": "VSphereControlPlaneMachineSet"
+                    },
+                    {
+                        "name": "VSphereDriverConfiguration"
+                    },
+                    {
+                        "name": "VSphereStaticIPs"
+                    },
+                    {
+                        "name": "ValidatingAdmissionPolicy"
+                    },
+                    {
+                        "name": "VolumeGroupSnapshot"
+                    }
+                ],
+                "version": ""
+            }
+        ]
+    }
+}

--- a/quota/v1/zz_generated.crd-manifests/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
+++ b/quota/v1/zz_generated.crd-manifests/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: clusterresourcequotas.quota.openshift.io

--- a/route/v1/zz_generated.crd-manifests/routes-CustomNoUpgrade.crd.yaml
+++ b/route/v1/zz_generated.crd-manifests/routes-CustomNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1228
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade

--- a/route/v1/zz_generated.crd-manifests/routes-Default.crd.yaml
+++ b/route/v1/zz_generated.crd-manifests/routes-Default.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1228
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: Default

--- a/route/v1/zz_generated.crd-manifests/routes-TechPreviewNoUpgrade.crd.yaml
+++ b/route/v1/zz_generated.crd-manifests/routes-TechPreviewNoUpgrade.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1228
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade

--- a/samples/v1/zz_generated.crd-manifests/00_configs.crd.yaml
+++ b/samples/v1/zz_generated.crd-manifests/00_configs.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     description: Extension for configuring openshift samples operator.
     displayName: ConfigsSamples
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: configs.samples.operator.openshift.io

--- a/security/v1/zz_generated.crd-manifests/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
+++ b/security/v1/zz_generated.crd-manifests/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: securitycontextconstraints.security.openshift.io

--- a/securityinternal/v1/zz_generated.crd-manifests/0000_03_config-operator_02_rangeallocations.crd.yaml
+++ b/securityinternal/v1/zz_generated.crd-manifests/0000_03_config-operator_02_rangeallocations.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/751
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: rangeallocations.security.internal.openshift.io

--- a/sharedresource/v1alpha1/zz_generated.crd-manifests/sharedconfigmaps.crd.yaml
+++ b/sharedresource/v1alpha1/zz_generated.crd-manifests/sharedconfigmaps.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     description: Extension for sharing ConfigMaps across Namespaces
     displayName: SharedConfigMap
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: sharedconfigmaps.sharedresource.openshift.io

--- a/sharedresource/v1alpha1/zz_generated.crd-manifests/sharedsecrets.crd.yaml
+++ b/sharedresource/v1alpha1/zz_generated.crd-manifests/sharedsecrets.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     description: Extension for sharing Secrets across Namespaces
     displayName: SharedSecret
+    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: sharedsecrets.sharedresource.openshift.io

--- a/tests/crd_filter.go
+++ b/tests/crd_filter.go
@@ -14,6 +14,7 @@ import (
 var (
 	clusterProfileToShortName = map[string]string{
 		"include.release.openshift.io/ibm-cloud-managed":              "Hypershift",
+		"include.release.openshift.io/hypershift":                     "HypershiftIndependent",
 		"include.release.openshift.io/self-managed-high-availability": "SelfManagedHA",
 		"include.release.openshift.io/single-node-developer":          "SingleNode",
 	}

--- a/tools/codegen/cmd/featuregate-test-analyzer.go
+++ b/tools/codegen/cmd/featuregate-test-analyzer.go
@@ -438,6 +438,9 @@ func listTestResultFor(featureGate string, clusterProfiles sets.Set[string]) (ma
 	if clusterProfiles.Has("Hypershift") {
 		jobVariantsToCheck = append(jobVariantsToCheck, requiredHypershiftJobVariants...)
 	}
+	if clusterProfiles.Has("HypershiftIndependent") {
+		jobVariantsToCheck = append(jobVariantsToCheck, requiredHypershiftJobVariants...)
+	}
 	if clusterProfiles.Has("SelfManagedHA") {
 		jobVariantsToCheck = append(jobVariantsToCheck, requiredSelfManagedJobVariants...)
 	}

--- a/tools/codegen/pkg/manifestmerge/generator.go
+++ b/tools/codegen/pkg/manifestmerge/generator.go
@@ -34,6 +34,7 @@ var (
 
 	allClusterProfiles = []string{
 		"include.release.openshift.io/ibm-cloud-managed",
+		"include.release.openshift.io/hypershift",
 		"include.release.openshift.io/self-managed-high-availability",
 	}
 )

--- a/tools/codegen/pkg/utils/featureset.go
+++ b/tools/codegen/pkg/utils/featureset.go
@@ -8,6 +8,7 @@ import (
 var (
 	clusterProfileToShortName = map[string]string{
 		"include.release.openshift.io/ibm-cloud-managed":              "Hypershift",
+		"include.release.openshift.io/hypershift":                     "HypershiftIndependent",
 		"include.release.openshift.io/self-managed-high-availability": "SelfManagedHA",
 	}
 )


### PR DESCRIPTION
Since HyperShift / Hosted Control Plane have adopted `include.release.openshift.io/ibm-cloud-managed`, to tailor the resources of clusters running in the ROKS IBM environment, the `include.release.openshift.io/hypershift` addition will allow Hypershift to express different profile choices than ROKS