### PR TITLE
machineconfiguration/v1: update MCP v1alpha1 field to omitempty

### DIFF
--- a/machineconfiguration/v1/types.go
+++ b/machineconfiguration/v1/types.go
@@ -509,7 +509,7 @@ type MachineConfigPoolStatus struct {
 	// +listType=map
 	// +listMapKey=poolSynchronizerType
 	// +optional
-	PoolSynchronizersStatus []PoolSynchronizerStatus `json:"poolSynchronizersStatus"`
+	PoolSynchronizersStatus []PoolSynchronizerStatus `json:"poolSynchronizersStatus,omitempty"`
 }
 
 // +kubebuilder:validation:XValidation:rule="self.machineCount >= self.updatedMachineCount", message="machineCount must be greater than or equal to updatedMachineCount"


### PR DESCRIPTION
As per api docs around adding unstable fields to stable API versions. I made a mistake and did not set this field as omitempty. The result is client-go on StatusUpdate will always send the field to the API server. The result a warning passed via response heafer bubbled up as.

```
W0419 20:26:02.583321       1 warnings.go:70] unknown field "status.poolSynchronizersStatus"
```

```
ensure the field is optional
- add the omitempty struct tag
- add the // +optional comment tag
- ensure the field is entirely absent from API responses when empty (optional fields should be pointers, anyway)
```

This change will generate the type as a reference in client-go so a value will not be sent if it is disabled.

ref :https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md#adding-unstable-features-to-stable-versions