### PR TITLE
clean up NodeDisruptionPolicySpecAction godoc

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -50959,7 +50959,7 @@ func schema_openshift_api_operator_v1_NodeDisruptionPolicySpecAction(ref common.
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed Valid value are Reboot, Drain, Reload, Restart, DaemonReload, None and Special reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
+							Description: "type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed Valid values are Reboot, Drain, Reload, Restart, DaemonReload and None. reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -51149,7 +51149,7 @@ func schema_openshift_api_operator_v1_NodeDisruptionPolicyStatusAction(ref commo
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed Valid value are Reboot, Drain, Reload, Restart, DaemonReload, None and Special reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
+							Description: "type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed Valid values are Reboot, Drain, Reload, Restart, DaemonReload, None and Special. reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -29770,7 +29770,7 @@
           "$ref": "#/definitions/com.github.openshift.api.operator.v1.RestartService"
         },
         "type": {
-          "description": "type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed Valid value are Reboot, Drain, Reload, Restart, DaemonReload, None and Special reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
+          "description": "type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed Valid values are Reboot, Drain, Reload, Restart, DaemonReload and None. reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
           "type": "string",
           "default": ""
         }
@@ -29876,7 +29876,7 @@
           "$ref": "#/definitions/com.github.openshift.api.operator.v1.RestartService"
         },
         "type": {
-          "description": "type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed Valid value are Reboot, Drain, Reload, Restart, DaemonReload, None and Special reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
+          "description": "type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed Valid values are Reboot, Drain, Reload, Restart, DaemonReload, None and Special. reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
           "type": "string",
           "default": ""
         }

--- a/operator/v1/types_machineconfiguration.go
+++ b/operator/v1/types_machineconfiguration.go
@@ -351,7 +351,7 @@ type NodeDisruptionPolicyStatusSSHKey struct {
 // +union
 type NodeDisruptionPolicySpecAction struct {
 	// type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed
-	// Valid value are Reboot, Drain, Reload, Restart, DaemonReload, None and Special
+	// Valid values are Reboot, Drain, Reload, Restart, DaemonReload and None.
 	// reload/restart requires a corresponding service target specified in the reload/restart field.
 	// Other values require no further configuration
 	// +unionDiscriminator
@@ -370,7 +370,7 @@ type NodeDisruptionPolicySpecAction struct {
 // +union
 type NodeDisruptionPolicyStatusAction struct {
 	// type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed
-	// Valid value are Reboot, Drain, Reload, Restart, DaemonReload, None and Special
+	// Valid values are Reboot, Drain, Reload, Restart, DaemonReload, None and Special.
 	// reload/restart requires a corresponding service target specified in the reload/restart field.
 	// Other values require no further configuration
 	// +unionDiscriminator

--- a/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-CustomNoUpgrade.crd.yaml
@@ -308,11 +308,11 @@ spec:
                               type:
                                 description: type represents the commands that will
                                   be carried out if this NodeDisruptionPolicySpecActionType
-                                  is executed Valid value are Reboot, Drain, Reload,
-                                  Restart, DaemonReload, None and Special reload/restart
-                                  requires a corresponding service target specified
-                                  in the reload/restart field. Other values require
-                                  no further configuration
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
                                 enum:
                                 - Reboot
                                 - Drain
@@ -448,11 +448,10 @@ spec:
                             type:
                               description: type represents the commands that will
                                 be carried out if this NodeDisruptionPolicySpecActionType
-                                is executed Valid value are Reboot, Drain, Reload,
-                                Restart, DaemonReload, None and Special reload/restart
-                                requires a corresponding service target specified
-                                in the reload/restart field. Other values require
-                                no further configuration
+                                is executed Valid values are Reboot, Drain, Reload,
+                                Restart, DaemonReload and None. reload/restart requires
+                                a corresponding service target specified in the reload/restart
+                                field. Other values require no further configuration
                               enum:
                               - Reboot
                               - Drain
@@ -581,11 +580,11 @@ spec:
                               type:
                                 description: type represents the commands that will
                                   be carried out if this NodeDisruptionPolicySpecActionType
-                                  is executed Valid value are Reboot, Drain, Reload,
-                                  Restart, DaemonReload, None and Special reload/restart
-                                  requires a corresponding service target specified
-                                  in the reload/restart field. Other values require
-                                  no further configuration
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
                                 enum:
                                 - Reboot
                                 - Drain
@@ -865,11 +864,11 @@ spec:
                                   type:
                                     description: type represents the commands that
                                       will be carried out if this NodeDisruptionPolicyStatusActionType
-                                      is executed Valid value are Reboot, Drain, Reload,
-                                      Restart, DaemonReload, None and Special reload/restart
-                                      requires a corresponding service target specified
-                                      in the reload/restart field. Other values require
-                                      no further configuration
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
                                     enum:
                                     - Reboot
                                     - Drain
@@ -1004,8 +1003,8 @@ spec:
                                 type:
                                   description: type represents the commands that will
                                     be carried out if this NodeDisruptionPolicyStatusActionType
-                                    is executed Valid value are Reboot, Drain, Reload,
-                                    Restart, DaemonReload, None and Special reload/restart
+                                    is executed Valid values are Reboot, Drain, Reload,
+                                    Restart, DaemonReload, None and Special. reload/restart
                                     requires a corresponding service target specified
                                     in the reload/restart field. Other values require
                                     no further configuration
@@ -1140,11 +1139,11 @@ spec:
                                   type:
                                     description: type represents the commands that
                                       will be carried out if this NodeDisruptionPolicyStatusActionType
-                                      is executed Valid value are Reboot, Drain, Reload,
-                                      Restart, DaemonReload, None and Special reload/restart
-                                      requires a corresponding service target specified
-                                      in the reload/restart field. Other values require
-                                      no further configuration
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
                                     enum:
                                     - Reboot
                                     - Drain

--- a/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-DevPreviewNoUpgrade.crd.yaml
@@ -308,11 +308,11 @@ spec:
                               type:
                                 description: type represents the commands that will
                                   be carried out if this NodeDisruptionPolicySpecActionType
-                                  is executed Valid value are Reboot, Drain, Reload,
-                                  Restart, DaemonReload, None and Special reload/restart
-                                  requires a corresponding service target specified
-                                  in the reload/restart field. Other values require
-                                  no further configuration
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
                                 enum:
                                 - Reboot
                                 - Drain
@@ -448,11 +448,10 @@ spec:
                             type:
                               description: type represents the commands that will
                                 be carried out if this NodeDisruptionPolicySpecActionType
-                                is executed Valid value are Reboot, Drain, Reload,
-                                Restart, DaemonReload, None and Special reload/restart
-                                requires a corresponding service target specified
-                                in the reload/restart field. Other values require
-                                no further configuration
+                                is executed Valid values are Reboot, Drain, Reload,
+                                Restart, DaemonReload and None. reload/restart requires
+                                a corresponding service target specified in the reload/restart
+                                field. Other values require no further configuration
                               enum:
                               - Reboot
                               - Drain
@@ -581,11 +580,11 @@ spec:
                               type:
                                 description: type represents the commands that will
                                   be carried out if this NodeDisruptionPolicySpecActionType
-                                  is executed Valid value are Reboot, Drain, Reload,
-                                  Restart, DaemonReload, None and Special reload/restart
-                                  requires a corresponding service target specified
-                                  in the reload/restart field. Other values require
-                                  no further configuration
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
                                 enum:
                                 - Reboot
                                 - Drain
@@ -865,11 +864,11 @@ spec:
                                   type:
                                     description: type represents the commands that
                                       will be carried out if this NodeDisruptionPolicyStatusActionType
-                                      is executed Valid value are Reboot, Drain, Reload,
-                                      Restart, DaemonReload, None and Special reload/restart
-                                      requires a corresponding service target specified
-                                      in the reload/restart field. Other values require
-                                      no further configuration
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
                                     enum:
                                     - Reboot
                                     - Drain
@@ -1004,8 +1003,8 @@ spec:
                                 type:
                                   description: type represents the commands that will
                                     be carried out if this NodeDisruptionPolicyStatusActionType
-                                    is executed Valid value are Reboot, Drain, Reload,
-                                    Restart, DaemonReload, None and Special reload/restart
+                                    is executed Valid values are Reboot, Drain, Reload,
+                                    Restart, DaemonReload, None and Special. reload/restart
                                     requires a corresponding service target specified
                                     in the reload/restart field. Other values require
                                     no further configuration
@@ -1140,11 +1139,11 @@ spec:
                                   type:
                                     description: type represents the commands that
                                       will be carried out if this NodeDisruptionPolicyStatusActionType
-                                      is executed Valid value are Reboot, Drain, Reload,
-                                      Restart, DaemonReload, None and Special reload/restart
-                                      requires a corresponding service target specified
-                                      in the reload/restart field. Other values require
-                                      no further configuration
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
                                     enum:
                                     - Reboot
                                     - Drain

--- a/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml
@@ -308,11 +308,11 @@ spec:
                               type:
                                 description: type represents the commands that will
                                   be carried out if this NodeDisruptionPolicySpecActionType
-                                  is executed Valid value are Reboot, Drain, Reload,
-                                  Restart, DaemonReload, None and Special reload/restart
-                                  requires a corresponding service target specified
-                                  in the reload/restart field. Other values require
-                                  no further configuration
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
                                 enum:
                                 - Reboot
                                 - Drain
@@ -448,11 +448,10 @@ spec:
                             type:
                               description: type represents the commands that will
                                 be carried out if this NodeDisruptionPolicySpecActionType
-                                is executed Valid value are Reboot, Drain, Reload,
-                                Restart, DaemonReload, None and Special reload/restart
-                                requires a corresponding service target specified
-                                in the reload/restart field. Other values require
-                                no further configuration
+                                is executed Valid values are Reboot, Drain, Reload,
+                                Restart, DaemonReload and None. reload/restart requires
+                                a corresponding service target specified in the reload/restart
+                                field. Other values require no further configuration
                               enum:
                               - Reboot
                               - Drain
@@ -581,11 +580,11 @@ spec:
                               type:
                                 description: type represents the commands that will
                                   be carried out if this NodeDisruptionPolicySpecActionType
-                                  is executed Valid value are Reboot, Drain, Reload,
-                                  Restart, DaemonReload, None and Special reload/restart
-                                  requires a corresponding service target specified
-                                  in the reload/restart field. Other values require
-                                  no further configuration
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
                                 enum:
                                 - Reboot
                                 - Drain
@@ -865,11 +864,11 @@ spec:
                                   type:
                                     description: type represents the commands that
                                       will be carried out if this NodeDisruptionPolicyStatusActionType
-                                      is executed Valid value are Reboot, Drain, Reload,
-                                      Restart, DaemonReload, None and Special reload/restart
-                                      requires a corresponding service target specified
-                                      in the reload/restart field. Other values require
-                                      no further configuration
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
                                     enum:
                                     - Reboot
                                     - Drain
@@ -1004,8 +1003,8 @@ spec:
                                 type:
                                   description: type represents the commands that will
                                     be carried out if this NodeDisruptionPolicyStatusActionType
-                                    is executed Valid value are Reboot, Drain, Reload,
-                                    Restart, DaemonReload, None and Special reload/restart
+                                    is executed Valid values are Reboot, Drain, Reload,
+                                    Restart, DaemonReload, None and Special. reload/restart
                                     requires a corresponding service target specified
                                     in the reload/restart field. Other values require
                                     no further configuration
@@ -1140,11 +1139,11 @@ spec:
                                   type:
                                     description: type represents the commands that
                                       will be carried out if this NodeDisruptionPolicyStatusActionType
-                                      is executed Valid value are Reboot, Drain, Reload,
-                                      Restart, DaemonReload, None and Special reload/restart
-                                      requires a corresponding service target specified
-                                      in the reload/restart field. Other values require
-                                      no further configuration
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
                                     enum:
                                     - Reboot
                                     - Drain

--- a/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/NodeDisruptionPolicy.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/NodeDisruptionPolicy.yaml
@@ -174,11 +174,11 @@ spec:
                               type:
                                 description: type represents the commands that will
                                   be carried out if this NodeDisruptionPolicySpecActionType
-                                  is executed Valid value are Reboot, Drain, Reload,
-                                  Restart, DaemonReload, None and Special reload/restart
-                                  requires a corresponding service target specified
-                                  in the reload/restart field. Other values require
-                                  no further configuration
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
                                 enum:
                                 - Reboot
                                 - Drain
@@ -314,11 +314,10 @@ spec:
                             type:
                               description: type represents the commands that will
                                 be carried out if this NodeDisruptionPolicySpecActionType
-                                is executed Valid value are Reboot, Drain, Reload,
-                                Restart, DaemonReload, None and Special reload/restart
-                                requires a corresponding service target specified
-                                in the reload/restart field. Other values require
-                                no further configuration
+                                is executed Valid values are Reboot, Drain, Reload,
+                                Restart, DaemonReload and None. reload/restart requires
+                                a corresponding service target specified in the reload/restart
+                                field. Other values require no further configuration
                               enum:
                               - Reboot
                               - Drain
@@ -447,11 +446,11 @@ spec:
                               type:
                                 description: type represents the commands that will
                                   be carried out if this NodeDisruptionPolicySpecActionType
-                                  is executed Valid value are Reboot, Drain, Reload,
-                                  Restart, DaemonReload, None and Special reload/restart
-                                  requires a corresponding service target specified
-                                  in the reload/restart field. Other values require
-                                  no further configuration
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
                                 enum:
                                 - Reboot
                                 - Drain
@@ -731,11 +730,11 @@ spec:
                                   type:
                                     description: type represents the commands that
                                       will be carried out if this NodeDisruptionPolicyStatusActionType
-                                      is executed Valid value are Reboot, Drain, Reload,
-                                      Restart, DaemonReload, None and Special reload/restart
-                                      requires a corresponding service target specified
-                                      in the reload/restart field. Other values require
-                                      no further configuration
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
                                     enum:
                                     - Reboot
                                     - Drain
@@ -870,8 +869,8 @@ spec:
                                 type:
                                   description: type represents the commands that will
                                     be carried out if this NodeDisruptionPolicyStatusActionType
-                                    is executed Valid value are Reboot, Drain, Reload,
-                                    Restart, DaemonReload, None and Special reload/restart
+                                    is executed Valid values are Reboot, Drain, Reload,
+                                    Restart, DaemonReload, None and Special. reload/restart
                                     requires a corresponding service target specified
                                     in the reload/restart field. Other values require
                                     no further configuration
@@ -1006,11 +1005,11 @@ spec:
                                   type:
                                     description: type represents the commands that
                                       will be carried out if this NodeDisruptionPolicyStatusActionType
-                                      is executed Valid value are Reboot, Drain, Reload,
-                                      Restart, DaemonReload, None and Special reload/restart
-                                      requires a corresponding service target specified
-                                      in the reload/restart field. Other values require
-                                      no further configuration
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
                                     enum:
                                     - Reboot
                                     - Drain

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1346,7 +1346,7 @@ func (NodeDisruptionPolicyConfig) SwaggerDoc() map[string]string {
 }
 
 var map_NodeDisruptionPolicySpecAction = map[string]string{
-	"type":    "type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed Valid value are Reboot, Drain, Reload, Restart, DaemonReload, None and Special reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
+	"type":    "type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed Valid values are Reboot, Drain, Reload, Restart, DaemonReload and None. reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
 	"reload":  "reload specifies the service to reload, only valid if type is reload",
 	"restart": "restart specifies the service to restart, only valid if type is restart",
 }
@@ -1393,7 +1393,7 @@ func (NodeDisruptionPolicyStatus) SwaggerDoc() map[string]string {
 }
 
 var map_NodeDisruptionPolicyStatusAction = map[string]string{
-	"type":    "type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed Valid value are Reboot, Drain, Reload, Restart, DaemonReload, None and Special reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
+	"type":    "type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed Valid values are Reboot, Drain, Reload, Restart, DaemonReload, None and Special. reload/restart requires a corresponding service target specified in the reload/restart field. Other values require no further configuration",
 	"reload":  "reload specifies the service to reload, only valid if type is reload",
 	"restart": "restart specifies the service to restart, only valid if type is restart",
 }


### PR DESCRIPTION
This fixes the godoc on `NodeDisruptionPolicySpecAction`. It incorrectly specified Special as a possible value for the enum, when it wasn't. `Special` is only a possible value for `NodeDisruptionPolicyStatusActionType`, which is not settable by the user.