### PR TITLE
Simplify CEL validations in network operator

### DIFF
--- a/operator/v1/tests/networks.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/tests/networks.operator.openshift.io/AAA_ungated.yaml
@@ -72,7 +72,7 @@ tests:
             gatewayConfig:
               ipv4:
                 internalMasqueradeSubnet: 10.10.10/24
-    expectedError: "Invalid value: \"string\": a valid IPv4 address must contain 4 octets"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv4.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV4 CIDR format"
   - name: Should not be able to add an IP address with leading zeros in an octet to IPV4 internalMasqueradeSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -83,7 +83,7 @@ tests:
             gatewayConfig:
               ipv4:
                 internalMasqueradeSubnet: 10.10.010.10/24
-    expectedError: "Invalid value: \"string\": IP address octets must not contain leading zeros, and must be less or equal to 255"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv4.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV4 CIDR format"
   - name: Should not be able to add an IP address with with zero for the first octet to internalMasqueradeSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -94,7 +94,7 @@ tests:
             gatewayConfig:
               ipv4:
                 internalMasqueradeSubnet: 0.10.10.10/24
-    expectedError: "Invalid value: \"string\": first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv4.internalMasqueradeSubnet: Invalid value: \"string\": first IP address octet must not be 0"
   - name: Should not be able to add an IP address with an octet greater than 255 to IPV4 internalMasqueradeSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -105,7 +105,7 @@ tests:
             gatewayConfig:
               ipv4:
                 internalMasqueradeSubnet: 10.10.10.256/24
-    expectedError: "Invalid value: \"string\": IP address octets must not contain leading zeros, and must be less or equal to 255"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv4.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV4 CIDR format"
   - name: Should be able to pass a valid IPV6 CIDR to IPV6 internalMasqueradeSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -177,7 +177,7 @@ tests:
             gatewayConfig:
               ipv6:
                 internalMasqueradeSubnet: abcd:ef01:2345:6789:abcd:ef01:2345:6789:abcd/125
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv6.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
   - name: Should not be able to add a dual IP address to IPV6 internalMasqueradeSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -188,8 +188,8 @@ tests:
             gatewayConfig:
               ipv6:
                 internalMasqueradeSubnet: abcd:ef01:2345:6789:abcd:ef01:2345:1.2.3.4/125
-    expectedError: "Invalid value: \"string\": IPv6 dual addresses are not permitted, value should not contain `.` characters"
-  - name: Should be able to pass a double elided IPV6 CIDR to IPV6 internalMasqueradeSubnet
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv6.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
+  - name: Should not be able to pass a double elided IPV6 CIDR to IPV6 internalMasqueradeSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
       kind: Network
@@ -199,7 +199,7 @@ tests:
             gatewayConfig:
               ipv6:
                 internalMasqueradeSubnet: "abcd::ef01::2345:6789/20"
-    expectedError: "Invalid value: \"string\": IPv6 addresses must contain at most one '::' and may only be shortened once"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv6.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
   - name: "Should not be able to pass a complete IPV6 CIDR with a :: expander to v6InternalMasqueradeSubnet"
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -210,7 +210,7 @@ tests:
             gatewayConfig:
               ipv6:
                 internalMasqueradeSubnet: "abcd:ef01:2345:6789::abcd:ef01:2345:6789/125"
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv6.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
   - name: Should not be able to pass a IPV6 CIDR without enough segments to v6InternalMasqueradeSubnet"
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -221,18 +221,7 @@ tests:
             gatewayConfig:
               ipv6:
                 internalMasqueradeSubnet: "abcd:ef01:2345:6789:abcd:ef01:2345/125"
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
-  - name: "Should not be able to pass an elided IPV6 CIDR with only a single empty segment to IPV6 internalMasqueradeSubnet"
-    initial: |
-      apiVersion: operator.openshift.io/v1
-      kind: Network
-      spec:
-       defaultNetwork:
-          ovnKubernetesConfig:
-            gatewayConfig:
-              ipv6:
-                internalMasqueradeSubnet: "abcd:ef01:2345:6789:abcd:ef01:2345::/125"
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv6.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
   - name: "Should not be able to pass an invalid IPV6 CIDR with a segment that contains invalid values"
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -243,7 +232,7 @@ tests:
             gatewayConfig:
               ipv6:
                 internalMasqueradeSubnet: "xbcd:ef01:2345:6789::2345:6789/20"
-    expectedError: "Invalid value: \"string\": each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 1"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv6.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
   - name: "Should not be able to pass an invalid IPV6 CIDR with a segment that is 5 characters long"
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -254,7 +243,7 @@ tests:
             gatewayConfig:
               ipv6:
                 internalMasqueradeSubnet: "abcd:eff01:2345:6789::2345:6789/20"
-    expectedError: "Invalid value: \"string\": each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 2"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.gatewayConfig.ipv6.internalMasqueradeSubnet: Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
   - name: "IPsec - Empty ipsecConfig is allowed in initial state"
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -389,7 +378,7 @@ tests:
           ovnKubernetesConfig:
             ipv4:
               internalTransitSwitchSubnet: "0.10.10.10/24"
-    expectedError: "Invalid value: \"string\": first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.ipv4.internalTransitSwitchSubnet: Invalid value: \"string\": first IP address octet must not be 0"
   - name: Should not be able to add an IP address with an octet greater than 255 to IPV4 internalTransitSwitchSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -463,7 +452,7 @@ tests:
           ovnKubernetesConfig:
             ipv6:
               internalTransitSwitchSubnet: abcd:ef01:2345:6789:abcd:ef01:2345:6789:abcd/125
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.ipv6.internalTransitSwitchSubnet: Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
   - name: Should not be able to add a dual IP address to IPV6 internalTransitSwitchSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -493,27 +482,7 @@ tests:
           ovnKubernetesConfig:
             ipv6:
               internalTransitSwitchSubnet: "abcd:ef01:2345:6789::abcd:ef01:2345:6789/125"
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
-  - name: Should not be able to pass an elided IPV6 CIDR with only a single empty segment to IPV6 internalTransitSwitchSubnet
-    initial: |
-      apiVersion: operator.openshift.io/v1
-      kind: Network
-      spec:
-       defaultNetwork:
-          ovnKubernetesConfig:
-            ipv6:
-              internalTransitSwitchSubnet: "abcd:ef01:2345:6789:abcd:ef01:2345::/125"
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
-  - name: Should not be able to pass an elided IPV6 CIDR with only a single empty segment to IPV6 internalTransitSwitchSubnet
-    initial: |
-      apiVersion: operator.openshift.io/v1
-      kind: Network
-      spec:
-       defaultNetwork:
-          ovnKubernetesConfig:
-            ipv6:
-              internalTransitSwitchSubnet: "abcd:ef01:2345:6789:abcd:ef01:2345::/125"
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.ipv6.internalTransitSwitchSubnet: Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
   - name: Should not be able to pass an invalid IPV6 CIDR with a segment that contains invalid values to IPV6 internalTransitSwitchSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -605,7 +574,7 @@ tests:
           ovnKubernetesConfig:
             ipv4:
               internalJoinSubnet: "0.10.10.10/24"
-    expectedError: "Invalid value: \"string\": first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255"
+    expectedError: "spec.defaultNetwork.ovnKubernetesConfig.ipv4.internalJoinSubnet: Invalid value: \"string\": first IP address octet must not be 0"
   - name: Should not be able to add an IP address with an octet greater than 255 to IPV4 internalJoinSubnet
     initial: |
       apiVersion: operator.openshift.io/v1
@@ -710,26 +679,6 @@ tests:
             ipv6:
               internalJoinSubnet: "abcd:ef01:2345:6789::abcd:ef01:2345:6789/125"
     expectedError: "Invalid value: \"string\": Subnet must be in valid IPV6 CIDR format"
-  - name: Should not be able to pass an elided IPV6 CIDR with only a single empty segment to IPV6 internalJoinSubnet
-    initial: |
-      apiVersion: operator.openshift.io/v1
-      kind: Network
-      spec:
-       defaultNetwork:
-          ovnKubernetesConfig:
-            ipv6:
-              internalJoinSubnet: "abcd:ef01:2345:6789:abcd:ef01:2345::/125"
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
-  - name: Should not be able to pass an elided IPV6 CIDR with only a single empty segment to IPV6 internalJoinSubnet
-    initial: |
-      apiVersion: operator.openshift.io/v1
-      kind: Network
-      spec:
-       defaultNetwork:
-          ovnKubernetesConfig:
-            ipv6:
-              internalJoinSubnet: "abcd:ef01:2345:6789:abcd:ef01:2345::/125"
-    expectedError: "Invalid value: \"string\": a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
   - name: Should not be able to pass an invalid IPV6 CIDR with a segment that contains invalid values to IPV6 internalJoinSubnet
     initial: |
       apiVersion: operator.openshift.io/v1

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -135,7 +135,7 @@ const (
 )
 
 // NetworkMigration represents the cluster network configuration.
-// +openshift:validation:FeatureGateAwareXValidation:featureGate=NetworkLiveMigration,rule="!has(self.mtu) || !has(self.networkType) || self.networkType == '' || has(self.mode) && self.mode == 'Live'",message="networkType migration in mode other than 'Live' may not be configured at the same time as mtu migration"
+// +openshift:validation:FeatureGateAwareXValidation:featureGate=NetworkLiveMigration,rule="!has(self.mtu) || !has(self.networkType) || self.networkType == \"\" || has(self.mode) && self.mode == 'Live'",message="networkType migration in mode other than 'Live' may not be configured at the same time as mtu migration"
 type NetworkMigration struct {
 	// networkType is the target type of network migration. Set this to the
 	// target network type to allow changing the default network. If unset, the
@@ -450,8 +450,8 @@ type IPv4OVNKubernetesConfig struct {
 	// The value must be in proper IPV4 CIDR format
 	// +kubebuilder:validation:MaxLength=18
 	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).ip().family() == 4",message="Subnet must be in valid IPV4 CIDR format"
-	// +kubebuilder:validation:XValidation:rule="[self.findAll('[0-9]+')[0]].all(x, x != '0' && int(x) <= 255 && !x.startsWith('0'))",message="first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255"
-	// +kubebuilder:validation:XValidation:rule="[int(self.split('/')[1])].all(x, x <= 30 && x >= 0)",message="subnet must be in the range /0 to /30 inclusive"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).prefixLength() <= 30",message="subnet must be in the range /0 to /30 inclusive"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && int(self.split('.')[0]) > 0",message="first IP address octet must not be 0"
 	// +optional
 	InternalTransitSwitchSubnet string `json:"internalTransitSwitchSubnet,omitempty"`
 	// internalJoinSubnet is a v4 subnet used internally by ovn-kubernetes in case the
@@ -464,8 +464,8 @@ type IPv4OVNKubernetesConfig struct {
 	// The value must be in proper IPV4 CIDR format
 	// +kubebuilder:validation:MaxLength=18
 	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).ip().family() == 4",message="Subnet must be in valid IPV4 CIDR format"
-	// +kubebuilder:validation:XValidation:rule="[self.findAll('[0-9]+')[0]].all(x, x != '0' && int(x) <= 255 && !x.startsWith('0'))",message="first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255"
-	// +kubebuilder:validation:XValidation:rule="[int(self.split('/')[1])].all(x, x <= 30 && x >= 0)",message="subnet must be in the range /0 to /30 inclusive"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).prefixLength() <= 30",message="subnet must be in the range /0 to /30 inclusive"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && int(self.split('.')[0]) > 0",message="first IP address octet must not be 0"
 	// +optional
 	InternalJoinSubnet string `json:"internalJoinSubnet,omitempty"`
 }
@@ -484,10 +484,8 @@ type IPv6OVNKubernetesConfig struct {
 	// The value must be in proper IPV6 CIDR format
 	// Note that IPV6 dual addresses are not permitted
 	// +kubebuilder:validation:MaxLength=48
-    // +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).ip().family() == 6",message="Subnet must be in valid IPV6 CIDR format"
-	// +kubebuilder:validation:XValidation:rule="self.split('/').size() == 2 && [int(self.split('/')[1])].all(x, x <= 125 && x >= 0)",message="subnet must be in the range /0 to /125 inclusive"
-	// +kubebuilder:validation:XValidation:rule="self.contains('::') ? self.split('/')[0].split(':').size() <= 8 : self.split('/')[0].split(':').size() == 8",message="a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
-	// +kubebuilder:validation:XValidation:rule="!self.contains('.')",message="IPv6 dual addresses are not permitted, value should not contain `.` characters"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).ip().family() == 6",message="Subnet must be in valid IPV6 CIDR format"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).prefixLength() <= 125",message="subnet must be in the range /0 to /125 inclusive"
 	// +optional
 	InternalTransitSwitchSubnet string `json:"internalTransitSwitchSubnet,omitempty"`
 	// internalJoinSubnet is a v6 subnet used internally by ovn-kubernetes in case the
@@ -501,9 +499,7 @@ type IPv6OVNKubernetesConfig struct {
 	// Note that IPV6 dual addresses are not permitted
 	// +kubebuilder:validation:MaxLength=48
 	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).ip().family() == 6",message="Subnet must be in valid IPV6 CIDR format"
-	// +kubebuilder:validation:XValidation:rule="self.split('/').size() == 2 && [int(self.split('/')[1])].all(x, x <= 125 && x >= 0)",message="subnet must be in the range /0 to /125 inclusive"
-	// +kubebuilder:validation:XValidation:rule="self.contains('::') ? self.split('/')[0].split(':').size() <= 8 : self.split('/')[0].split(':').size() == 8",message="a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
-	// +kubebuilder:validation:XValidation:rule="!self.contains('.')",message="IPv6 dual addresses are not permitted, value should not contain `.` characters"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).prefixLength() <= 125",message="subnet must be in the range /0 to /125 inclusive"
 	// +optional
 	InternalJoinSubnet string `json:"internalJoinSubnet,omitempty"`
 }
@@ -581,11 +577,9 @@ type IPv4GatewayConfig struct {
 	// The current default subnet is 169.254.169.0/29
 	// The value must be in proper IPV4 CIDR format
 	// +kubebuilder:validation:MaxLength=18
-	// +kubebuilder:validation:XValidation:rule="self.indexOf('/') == self.lastIndexOf('/')",message="CIDR format must contain exactly one '/'"
-	// +kubebuilder:validation:XValidation:rule="[int(self.split('/')[1])].all(x, x <= 29 && x >= 0)",message="subnet must be in the range /0 to /29 inclusive"
-	// +kubebuilder:validation:XValidation:rule="self.split('/')[0].split('.').size() == 4",message="a valid IPv4 address must contain 4 octets"
-	// +kubebuilder:validation:XValidation:rule="[self.findAll('[0-9]+')[0]].all(x, x != '0' && int(x) <= 255 && !x.startsWith('0'))",message="first IP address octet must not contain leading zeros, must be greater than 0 and less or equal to 255"
-	// +kubebuilder:validation:XValidation:rule="[self.findAll('[0-9]+')[1], self.findAll('[0-9]+')[2], self.findAll('[0-9]+')[3]].all(x, int(x) <= 255 && (x == '0' || !x.startsWith('0')))",message="IP address octets must not contain leading zeros, and must be less or equal to 255"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).ip().family() == 4",message="Subnet must be in valid IPV4 CIDR format"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).prefixLength() <= 29",message="subnet must be in the range /0 to /29 inclusive"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && int(self.split('.')[0]) > 0",message="first IP address octet must not be 0"
 	// +optional
 	InternalMasqueradeSubnet string `json:"internalMasqueradeSubnet,omitempty"`
 }
@@ -601,19 +595,8 @@ type IPv6GatewayConfig struct {
 	// When omitted, this means no opinion and the platform is left to choose a reasonable default which is subject to change over time.
 	// The current default subnet is fd69::/125
 	// Note that IPV6 dual addresses are not permitted
-	// +kubebuilder:validation:XValidation:rule="self.indexOf('/') == self.lastIndexOf('/')",message="CIDR format must contain exactly one '/'"
-	// +kubebuilder:validation:XValidation:rule="self.split('/').size() == 2 && [int(self.split('/')[1])].all(x, x <= 125 && x >= 0)",message="subnet must be in the range /0 to /125 inclusive"
-	// +kubebuilder:validation:XValidation:rule="self.indexOf('::') == self.lastIndexOf('::')",message="IPv6 addresses must contain at most one '::' and may only be shortened once"
-	// +kubebuilder:validation:XValidation:rule="self.contains('::') ? self.split('/')[0].split(':').size() <= 8 : self.split('/')[0].split(':').size() == 8",message="a valid IPv6 address must contain 8 segments unless elided (::), in which case it must contain at most 6 non-empty segments"
-	// +kubebuilder:validation:XValidation:rule="self.split('/')[0].split(':').size() >=1 ? [self.split('/')[0].split(':', 8)[0]].all(x, x == '' || (x.matches('^[0-9A-Fa-f]{1,4}$')) && size(x)<5 ) : true",message="each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 1"
-	// +kubebuilder:validation:XValidation:rule="self.split('/')[0].split(':').size() >=2 ? [self.split('/')[0].split(':', 8)[1]].all(x, x == '' || (x.matches('^[0-9A-Fa-f]{1,4}$')) && size(x)<5 ) : true",message="each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 2"
-	// +kubebuilder:validation:XValidation:rule="self.split('/')[0].split(':').size() >=3 ? [self.split('/')[0].split(':', 8)[2]].all(x, x == '' || (x.matches('^[0-9A-Fa-f]{1,4}$')) && size(x)<5 ) : true",message="each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 3"
-	// +kubebuilder:validation:XValidation:rule="self.split('/')[0].split(':').size() >=4 ? [self.split('/')[0].split(':', 8)[3]].all(x, x == '' || (x.matches('^[0-9A-Fa-f]{1,4}$')) && size(x)<5 ) : true",message="each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 4"
-	// +kubebuilder:validation:XValidation:rule="self.split('/')[0].split(':').size() >=5 ? [self.split('/')[0].split(':', 8)[4]].all(x, x == '' || (x.matches('^[0-9A-Fa-f]{1,4}$')) && size(x)<5 ) : true",message="each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 5"
-	// +kubebuilder:validation:XValidation:rule="self.split('/')[0].split(':').size() >=6 ? [self.split('/')[0].split(':', 8)[5]].all(x, x == '' || (x.matches('^[0-9A-Fa-f]{1,4}$')) && size(x)<5 ) : true",message="each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 6"
-	// +kubebuilder:validation:XValidation:rule="self.split('/')[0].split(':').size() >=7 ? [self.split('/')[0].split(':', 8)[6]].all(x, x == '' || (x.matches('^[0-9A-Fa-f]{1,4}$')) && size(x)<5 ) : true",message="each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 7"
-	// +kubebuilder:validation:XValidation:rule="self.split('/')[0].split(':').size() >=8 ? [self.split('/')[0].split(':', 8)[7]].all(x, x == '' || (x.matches('^[0-9A-Fa-f]{1,4}$')) && size(x)<5 ) : true",message="each segment of an IPv6 address must be a hexadecimal number between 0 and FFFF, failed on segment 8"
-	// +kubebuilder:validation:XValidation:rule="!self.contains('.')",message="IPv6 dual addresses are not permitted, value should not contain `.` characters"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).ip().family() == 6",message="Subnet must be in valid IPV6 CIDR format"
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && cidr(self).prefixLength() <= 125",message="subnet must be in the range /0 to /125 inclusive"
 	// +optional
 	InternalMasqueradeSubnet string `json:"internalMasqueradeSubnet,omitempty"`
 }

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks.crd.yaml
@@ -278,23 +278,15 @@ spec:
                                 maxLength: 18
                                 type: string
                                 x-kubernetes-validations:
-                                - message: CIDR format must contain exactly one '/'
-                                  rule: self.indexOf('/') == self.lastIndexOf('/')
+                                - message: Subnet must be in valid IPV4 CIDR format
+                                  rule: isCIDR(self) && cidr(self).ip().family() ==
+                                    4
                                 - message: subnet must be in the range /0 to /29 inclusive
-                                  rule: '[int(self.split(''/'')[1])].all(x, x <= 29
-                                    && x >= 0)'
-                                - message: a valid IPv4 address must contain 4 octets
-                                  rule: self.split('/')[0].split('.').size() == 4
-                                - message: first IP address octet must not contain
-                                    leading zeros, must be greater than 0 and less
-                                    or equal to 255
-                                  rule: '[self.findAll(''[0-9]+'')[0]].all(x, x !=
-                                    ''0'' && int(x) <= 255 && !x.startsWith(''0''))'
-                                - message: IP address octets must not contain leading
-                                    zeros, and must be less or equal to 255
-                                  rule: '[self.findAll(''[0-9]+'')[1], self.findAll(''[0-9]+'')[2],
-                                    self.findAll(''[0-9]+'')[3]].all(x, int(x) <=
-                                    255 && (x == ''0'' || !x.startsWith(''0'')))'
+                                  rule: isCIDR(self) && cidr(self).prefixLength()
+                                    <= 29
+                                - message: first IP address octet must not be 0
+                                  rule: isCIDR(self) && int(self.split('.')[0]) >
+                                    0
                             type: object
                           ipv6:
                             description: ipv6 allows users to configure IP settings
@@ -320,80 +312,13 @@ spec:
                                   Note that IPV6 dual addresses are not permitted
                                 type: string
                                 x-kubernetes-validations:
-                                - message: CIDR format must contain exactly one '/'
-                                  rule: self.indexOf('/') == self.lastIndexOf('/')
+                                - message: Subnet must be in valid IPV6 CIDR format
+                                  rule: isCIDR(self) && cidr(self).ip().family() ==
+                                    6
                                 - message: subnet must be in the range /0 to /125
                                     inclusive
-                                  rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x,
-                                    x <= 125 && x >= 0)
-                                - message: IPv6 addresses must contain at most one
-                                    '::' and may only be shortened once
-                                  rule: self.indexOf('::') == self.lastIndexOf('::')
-                                - message: a valid IPv6 address must contain 8 segments
-                                    unless elided (::), in which case it must contain
-                                    at most 6 non-empty segments
-                                  rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size()
-                                    <= 8 : self.split(''/'')[0].split('':'').size()
-                                    == 8'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 1
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=1 ? [self.split(''/'')[0].split('':'', 8)[0]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 2
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=2 ? [self.split(''/'')[0].split('':'', 8)[1]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 3
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=3 ? [self.split(''/'')[0].split('':'', 8)[2]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 4
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=4 ? [self.split(''/'')[0].split('':'', 8)[3]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 5
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=5 ? [self.split(''/'')[0].split('':'', 8)[4]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 6
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=6 ? [self.split(''/'')[0].split('':'', 8)[5]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 7
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=7 ? [self.split(''/'')[0].split('':'', 8)[6]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 8
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=8 ? [self.split(''/'')[0].split('':'', 8)[7]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: IPv6 dual addresses are not permitted,
-                                    value should not contain `.` characters
-                                  rule: '!self.contains(''.'')'
+                                  rule: isCIDR(self) && cidr(self).prefixLength()
+                                    <= 125
                             type: object
                           routingViaHost:
                             default: false
@@ -493,14 +418,10 @@ spec:
                             x-kubernetes-validations:
                             - message: Subnet must be in valid IPV4 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 4
-                            - message: first IP address octet must not contain leading
-                                zeros, must be greater than 0 and less or equal to
-                                255
-                              rule: '[self.findAll(''[0-9]+'')[0]].all(x, x != ''0''
-                                && int(x) <= 255 && !x.startsWith(''0''))'
                             - message: subnet must be in the range /0 to /30 inclusive
-                              rule: '[int(self.split(''/'')[1])].all(x, x <= 30 &&
-                                x >= 0)'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 30
+                            - message: first IP address octet must not be 0
+                              rule: isCIDR(self) && int(self.split('.')[0]) > 0
                           internalTransitSwitchSubnet:
                             description: internalTransitSwitchSubnet is a v4 subnet
                               in IPV4 CIDR format used internally by OVN-Kubernetes
@@ -521,14 +442,10 @@ spec:
                             x-kubernetes-validations:
                             - message: Subnet must be in valid IPV4 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 4
-                            - message: first IP address octet must not contain leading
-                                zeros, must be greater than 0 and less or equal to
-                                255
-                              rule: '[self.findAll(''[0-9]+'')[0]].all(x, x != ''0''
-                                && int(x) <= 255 && !x.startsWith(''0''))'
                             - message: subnet must be in the range /0 to /30 inclusive
-                              rule: '[int(self.split(''/'')[1])].all(x, x <= 30 &&
-                                x >= 0)'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 30
+                            - message: first IP address octet must not be 0
+                              rule: isCIDR(self) && int(self.split('.')[0]) > 0
                         type: object
                       ipv6:
                         description: ipv6 allows users to configure IP settings for
@@ -553,17 +470,7 @@ spec:
                             - message: Subnet must be in valid IPV6 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 6
                             - message: subnet must be in the range /0 to /125 inclusive
-                              rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x,
-                                x <= 125 && x >= 0)
-                            - message: a valid IPv6 address must contain 8 segments
-                                unless elided (::), in which case it must contain
-                                at most 6 non-empty segments
-                              rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size()
-                                <= 8 : self.split(''/'')[0].split('':'').size() ==
-                                8'
-                            - message: IPv6 dual addresses are not permitted, value
-                                should not contain `.` characters
-                              rule: '!self.contains(''.'')'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                           internalTransitSwitchSubnet:
                             description: internalTransitSwitchSubnet is a v4 subnet
                               in IPV4 CIDR format used internally by OVN-Kubernetes
@@ -586,17 +493,7 @@ spec:
                             - message: Subnet must be in valid IPV6 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 6
                             - message: subnet must be in the range /0 to /125 inclusive
-                              rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x,
-                                x <= 125 && x >= 0)
-                            - message: a valid IPv6 address must contain 8 segments
-                                unless elided (::), in which case it must contain
-                                at most 6 non-empty segments
-                              rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size()
-                                <= 8 : self.split(''/'')[0].split('':'').size() ==
-                                8'
-                            - message: IPv6 dual addresses are not permitted, value
-                                should not contain `.` characters
-                              rule: '!self.contains(''.'')'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                         type: object
                       mtu:
                         description: mtu is the MTU to use for the tunnel interface.
@@ -891,7 +788,7 @@ spec:
                 - message: networkType migration in mode other than 'Live' may not
                     be configured at the same time as mtu migration
                   rule: '!has(self.mtu) || !has(self.networkType) || self.networkType
-                    == '''' || has(self.mode) && self.mode == ''Live'''
+                    == "" || has(self.mode) && self.mode == ''Live'''
               observedConfig:
                 description: observedConfig holds a sparse config that controller
                   has observed from the cluster state.  It exists in spec because

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
@@ -281,23 +281,15 @@ spec:
                                 maxLength: 18
                                 type: string
                                 x-kubernetes-validations:
-                                - message: CIDR format must contain exactly one '/'
-                                  rule: self.indexOf('/') == self.lastIndexOf('/')
+                                - message: Subnet must be in valid IPV4 CIDR format
+                                  rule: isCIDR(self) && cidr(self).ip().family() ==
+                                    4
                                 - message: subnet must be in the range /0 to /29 inclusive
-                                  rule: '[int(self.split(''/'')[1])].all(x, x <= 29
-                                    && x >= 0)'
-                                - message: a valid IPv4 address must contain 4 octets
-                                  rule: self.split('/')[0].split('.').size() == 4
-                                - message: first IP address octet must not contain
-                                    leading zeros, must be greater than 0 and less
-                                    or equal to 255
-                                  rule: '[self.findAll(''[0-9]+'')[0]].all(x, x !=
-                                    ''0'' && int(x) <= 255 && !x.startsWith(''0''))'
-                                - message: IP address octets must not contain leading
-                                    zeros, and must be less or equal to 255
-                                  rule: '[self.findAll(''[0-9]+'')[1], self.findAll(''[0-9]+'')[2],
-                                    self.findAll(''[0-9]+'')[3]].all(x, int(x) <=
-                                    255 && (x == ''0'' || !x.startsWith(''0'')))'
+                                  rule: isCIDR(self) && cidr(self).prefixLength()
+                                    <= 29
+                                - message: first IP address octet must not be 0
+                                  rule: isCIDR(self) && int(self.split('.')[0]) >
+                                    0
                             type: object
                           ipv6:
                             description: ipv6 allows users to configure IP settings
@@ -323,80 +315,13 @@ spec:
                                   Note that IPV6 dual addresses are not permitted
                                 type: string
                                 x-kubernetes-validations:
-                                - message: CIDR format must contain exactly one '/'
-                                  rule: self.indexOf('/') == self.lastIndexOf('/')
+                                - message: Subnet must be in valid IPV6 CIDR format
+                                  rule: isCIDR(self) && cidr(self).ip().family() ==
+                                    6
                                 - message: subnet must be in the range /0 to /125
                                     inclusive
-                                  rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x,
-                                    x <= 125 && x >= 0)
-                                - message: IPv6 addresses must contain at most one
-                                    '::' and may only be shortened once
-                                  rule: self.indexOf('::') == self.lastIndexOf('::')
-                                - message: a valid IPv6 address must contain 8 segments
-                                    unless elided (::), in which case it must contain
-                                    at most 6 non-empty segments
-                                  rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size()
-                                    <= 8 : self.split(''/'')[0].split('':'').size()
-                                    == 8'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 1
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=1 ? [self.split(''/'')[0].split('':'', 8)[0]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 2
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=2 ? [self.split(''/'')[0].split('':'', 8)[1]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 3
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=3 ? [self.split(''/'')[0].split('':'', 8)[2]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 4
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=4 ? [self.split(''/'')[0].split('':'', 8)[3]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 5
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=5 ? [self.split(''/'')[0].split('':'', 8)[4]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 6
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=6 ? [self.split(''/'')[0].split('':'', 8)[5]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 7
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=7 ? [self.split(''/'')[0].split('':'', 8)[6]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 8
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=8 ? [self.split(''/'')[0].split('':'', 8)[7]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: IPv6 dual addresses are not permitted,
-                                    value should not contain `.` characters
-                                  rule: '!self.contains(''.'')'
+                                  rule: isCIDR(self) && cidr(self).prefixLength()
+                                    <= 125
                             type: object
                           routingViaHost:
                             default: false
@@ -496,14 +421,10 @@ spec:
                             x-kubernetes-validations:
                             - message: Subnet must be in valid IPV4 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 4
-                            - message: first IP address octet must not contain leading
-                                zeros, must be greater than 0 and less or equal to
-                                255
-                              rule: '[self.findAll(''[0-9]+'')[0]].all(x, x != ''0''
-                                && int(x) <= 255 && !x.startsWith(''0''))'
                             - message: subnet must be in the range /0 to /30 inclusive
-                              rule: '[int(self.split(''/'')[1])].all(x, x <= 30 &&
-                                x >= 0)'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 30
+                            - message: first IP address octet must not be 0
+                              rule: isCIDR(self) && int(self.split('.')[0]) > 0
                           internalTransitSwitchSubnet:
                             description: internalTransitSwitchSubnet is a v4 subnet
                               in IPV4 CIDR format used internally by OVN-Kubernetes
@@ -524,14 +445,10 @@ spec:
                             x-kubernetes-validations:
                             - message: Subnet must be in valid IPV4 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 4
-                            - message: first IP address octet must not contain leading
-                                zeros, must be greater than 0 and less or equal to
-                                255
-                              rule: '[self.findAll(''[0-9]+'')[0]].all(x, x != ''0''
-                                && int(x) <= 255 && !x.startsWith(''0''))'
                             - message: subnet must be in the range /0 to /30 inclusive
-                              rule: '[int(self.split(''/'')[1])].all(x, x <= 30 &&
-                                x >= 0)'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 30
+                            - message: first IP address octet must not be 0
+                              rule: isCIDR(self) && int(self.split('.')[0]) > 0
                         type: object
                       ipv6:
                         description: ipv6 allows users to configure IP settings for
@@ -556,17 +473,7 @@ spec:
                             - message: Subnet must be in valid IPV6 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 6
                             - message: subnet must be in the range /0 to /125 inclusive
-                              rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x,
-                                x <= 125 && x >= 0)
-                            - message: a valid IPv6 address must contain 8 segments
-                                unless elided (::), in which case it must contain
-                                at most 6 non-empty segments
-                              rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size()
-                                <= 8 : self.split(''/'')[0].split('':'').size() ==
-                                8'
-                            - message: IPv6 dual addresses are not permitted, value
-                                should not contain `.` characters
-                              rule: '!self.contains(''.'')'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                           internalTransitSwitchSubnet:
                             description: internalTransitSwitchSubnet is a v4 subnet
                               in IPV4 CIDR format used internally by OVN-Kubernetes
@@ -589,17 +496,7 @@ spec:
                             - message: Subnet must be in valid IPV6 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 6
                             - message: subnet must be in the range /0 to /125 inclusive
-                              rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x,
-                                x <= 125 && x >= 0)
-                            - message: a valid IPv6 address must contain 8 segments
-                                unless elided (::), in which case it must contain
-                                at most 6 non-empty segments
-                              rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size()
-                                <= 8 : self.split(''/'')[0].split('':'').size() ==
-                                8'
-                            - message: IPv6 dual addresses are not permitted, value
-                                should not contain `.` characters
-                              rule: '!self.contains(''.'')'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                         type: object
                       mtu:
                         description: mtu is the MTU to use for the tunnel interface.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
@@ -281,23 +281,15 @@ spec:
                                 maxLength: 18
                                 type: string
                                 x-kubernetes-validations:
-                                - message: CIDR format must contain exactly one '/'
-                                  rule: self.indexOf('/') == self.lastIndexOf('/')
+                                - message: Subnet must be in valid IPV4 CIDR format
+                                  rule: isCIDR(self) && cidr(self).ip().family() ==
+                                    4
                                 - message: subnet must be in the range /0 to /29 inclusive
-                                  rule: '[int(self.split(''/'')[1])].all(x, x <= 29
-                                    && x >= 0)'
-                                - message: a valid IPv4 address must contain 4 octets
-                                  rule: self.split('/')[0].split('.').size() == 4
-                                - message: first IP address octet must not contain
-                                    leading zeros, must be greater than 0 and less
-                                    or equal to 255
-                                  rule: '[self.findAll(''[0-9]+'')[0]].all(x, x !=
-                                    ''0'' && int(x) <= 255 && !x.startsWith(''0''))'
-                                - message: IP address octets must not contain leading
-                                    zeros, and must be less or equal to 255
-                                  rule: '[self.findAll(''[0-9]+'')[1], self.findAll(''[0-9]+'')[2],
-                                    self.findAll(''[0-9]+'')[3]].all(x, int(x) <=
-                                    255 && (x == ''0'' || !x.startsWith(''0'')))'
+                                  rule: isCIDR(self) && cidr(self).prefixLength()
+                                    <= 29
+                                - message: first IP address octet must not be 0
+                                  rule: isCIDR(self) && int(self.split('.')[0]) >
+                                    0
                             type: object
                           ipv6:
                             description: ipv6 allows users to configure IP settings
@@ -323,80 +315,13 @@ spec:
                                   Note that IPV6 dual addresses are not permitted
                                 type: string
                                 x-kubernetes-validations:
-                                - message: CIDR format must contain exactly one '/'
-                                  rule: self.indexOf('/') == self.lastIndexOf('/')
+                                - message: Subnet must be in valid IPV6 CIDR format
+                                  rule: isCIDR(self) && cidr(self).ip().family() ==
+                                    6
                                 - message: subnet must be in the range /0 to /125
                                     inclusive
-                                  rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x,
-                                    x <= 125 && x >= 0)
-                                - message: IPv6 addresses must contain at most one
-                                    '::' and may only be shortened once
-                                  rule: self.indexOf('::') == self.lastIndexOf('::')
-                                - message: a valid IPv6 address must contain 8 segments
-                                    unless elided (::), in which case it must contain
-                                    at most 6 non-empty segments
-                                  rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size()
-                                    <= 8 : self.split(''/'')[0].split('':'').size()
-                                    == 8'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 1
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=1 ? [self.split(''/'')[0].split('':'', 8)[0]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 2
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=2 ? [self.split(''/'')[0].split('':'', 8)[1]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 3
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=3 ? [self.split(''/'')[0].split('':'', 8)[2]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 4
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=4 ? [self.split(''/'')[0].split('':'', 8)[3]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 5
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=5 ? [self.split(''/'')[0].split('':'', 8)[4]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 6
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=6 ? [self.split(''/'')[0].split('':'', 8)[5]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 7
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=7 ? [self.split(''/'')[0].split('':'', 8)[6]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: each segment of an IPv6 address must be
-                                    a hexadecimal number between 0 and FFFF, failed
-                                    on segment 8
-                                  rule: 'self.split(''/'')[0].split('':'').size()
-                                    >=8 ? [self.split(''/'')[0].split('':'', 8)[7]].all(x,
-                                    x == '''' || (x.matches(''^[0-9A-Fa-f]{1,4}$''))
-                                    && size(x)<5 ) : true'
-                                - message: IPv6 dual addresses are not permitted,
-                                    value should not contain `.` characters
-                                  rule: '!self.contains(''.'')'
+                                  rule: isCIDR(self) && cidr(self).prefixLength()
+                                    <= 125
                             type: object
                           routingViaHost:
                             default: false
@@ -496,14 +421,10 @@ spec:
                             x-kubernetes-validations:
                             - message: Subnet must be in valid IPV4 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 4
-                            - message: first IP address octet must not contain leading
-                                zeros, must be greater than 0 and less or equal to
-                                255
-                              rule: '[self.findAll(''[0-9]+'')[0]].all(x, x != ''0''
-                                && int(x) <= 255 && !x.startsWith(''0''))'
                             - message: subnet must be in the range /0 to /30 inclusive
-                              rule: '[int(self.split(''/'')[1])].all(x, x <= 30 &&
-                                x >= 0)'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 30
+                            - message: first IP address octet must not be 0
+                              rule: isCIDR(self) && int(self.split('.')[0]) > 0
                           internalTransitSwitchSubnet:
                             description: internalTransitSwitchSubnet is a v4 subnet
                               in IPV4 CIDR format used internally by OVN-Kubernetes
@@ -524,14 +445,10 @@ spec:
                             x-kubernetes-validations:
                             - message: Subnet must be in valid IPV4 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 4
-                            - message: first IP address octet must not contain leading
-                                zeros, must be greater than 0 and less or equal to
-                                255
-                              rule: '[self.findAll(''[0-9]+'')[0]].all(x, x != ''0''
-                                && int(x) <= 255 && !x.startsWith(''0''))'
                             - message: subnet must be in the range /0 to /30 inclusive
-                              rule: '[int(self.split(''/'')[1])].all(x, x <= 30 &&
-                                x >= 0)'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 30
+                            - message: first IP address octet must not be 0
+                              rule: isCIDR(self) && int(self.split('.')[0]) > 0
                         type: object
                       ipv6:
                         description: ipv6 allows users to configure IP settings for
@@ -556,17 +473,7 @@ spec:
                             - message: Subnet must be in valid IPV6 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 6
                             - message: subnet must be in the range /0 to /125 inclusive
-                              rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x,
-                                x <= 125 && x >= 0)
-                            - message: a valid IPv6 address must contain 8 segments
-                                unless elided (::), in which case it must contain
-                                at most 6 non-empty segments
-                              rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size()
-                                <= 8 : self.split(''/'')[0].split('':'').size() ==
-                                8'
-                            - message: IPv6 dual addresses are not permitted, value
-                                should not contain `.` characters
-                              rule: '!self.contains(''.'')'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                           internalTransitSwitchSubnet:
                             description: internalTransitSwitchSubnet is a v4 subnet
                               in IPV4 CIDR format used internally by OVN-Kubernetes
@@ -589,17 +496,7 @@ spec:
                             - message: Subnet must be in valid IPV6 CIDR format
                               rule: isCIDR(self) && cidr(self).ip().family() == 6
                             - message: subnet must be in the range /0 to /125 inclusive
-                              rule: self.split('/').size() == 2 && [int(self.split('/')[1])].all(x,
-                                x <= 125 && x >= 0)
-                            - message: a valid IPv6 address must contain 8 segments
-                                unless elided (::), in which case it must contain
-                                at most 6 non-empty segments
-                              rule: 'self.contains(''::'') ? self.split(''/'')[0].split('':'').size()
-                                <= 8 : self.split(''/'')[0].split('':'').size() ==
-                                8'
-                            - message: IPv6 dual addresses are not permitted, value
-                                should not contain `.` characters
-                              rule: '!self.contains(''.'')'
+                              rule: isCIDR(self) && cidr(self).prefixLength() <= 125
                         type: object
                       mtu:
                         description: mtu is the MTU to use for the tunnel interface.
@@ -894,7 +791,7 @@ spec:
                 - message: networkType migration in mode other than 'Live' may not
                     be configured at the same time as mtu migration
                   rule: '!has(self.mtu) || !has(self.networkType) || self.networkType
-                    == '''' || has(self.mode) && self.mode == ''Live'''
+                    == "" || has(self.mode) && self.mode == ''Live'''
               observedConfig:
                 description: observedConfig holds a sparse config that controller
                   has observed from the cluster state.  It exists in spec because


### PR DESCRIPTION
New IP and CIDR CEL validations for 4.16 mean we can drop a bunch of complex and hard to reason about CEL introduced over the last release.

The majority of the tests we added are testing basic IPv6 parsing, which is now deferred to `netip.ParseAddr`. There's one case we had that fails, where you have a fully qualified address but with an elided final segment, this appears to be valid so I think we can actually drop that test.

Finally, the only cases I can see where the CEL IP stuff doesn't account, is for the non-zero first octet, which I've added a separate validation for.

CC @bpickard22 @knobunc 