### PR TITLE
OPNET-512: config/v1/types_infrastructure: change set to atomic for networks

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -825,7 +825,7 @@ type BareMetalPlatformSpec struct {
 	//
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:XValidation:rule="size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true",message="apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address"
-	// +listType=set
+	// +listType=atomic
 	// +optional
 	APIServerInternalIPs []IP `json:"apiServerInternalIPs"`
 
@@ -840,15 +840,16 @@ type BareMetalPlatformSpec struct {
 	//
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:XValidation:rule="size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true",message="ingressIPs must contain at most one IPv4 address and at most one IPv6 address"
-	// +listType=set
+	// +listType=atomic
 	// +optional
 	IngressIPs []IP `json:"ingressIPs"`
 
 	// machineNetworks are IP networks used to connect all the OpenShift cluster
 	// nodes. Each network is provided in the CIDR format and should be IPv4 or IPv6,
 	// for example "10.0.0.0/8" or "fd00::/8".
-	// +listType=set
+	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, x == y))"
 	// +optional
 	MachineNetworks []CIDR `json:"machineNetworks"`
 }
@@ -873,7 +874,8 @@ type BareMetalPlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
-	// +listType=set
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address"
+	// +listType=atomic
 	APIServerInternalIPs []string `json:"apiServerInternalIPs"`
 
 	// ingressIP is an external IP which routes to the default ingress controller.
@@ -889,7 +891,8 @@ type BareMetalPlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
-	// +listType=set
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="ingressIPs must contain at most one IPv4 address and at most one IPv6 address"
+	// +listType=atomic
 	IngressIPs []string `json:"ingressIPs"`
 
 	// nodeDNSIP is the IP address for the internal DNS used by the
@@ -908,8 +911,9 @@ type BareMetalPlatformStatus struct {
 	LoadBalancer *BareMetalPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 
 	// machineNetworks are IP networks used to connect all the OpenShift cluster nodes.
-	// +listType=set
+	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, x == y))"
 	// +optional
 	MachineNetworks []CIDR `json:"machineNetworks"`
 }
@@ -952,7 +956,7 @@ type OpenStackPlatformSpec struct {
 	//
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:XValidation:rule="size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true",message="apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address"
-	// +listType=set
+	// +listType=atomic
 	// +optional
 	APIServerInternalIPs []IP `json:"apiServerInternalIPs"`
 
@@ -967,15 +971,16 @@ type OpenStackPlatformSpec struct {
 	//
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:XValidation:rule="size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true",message="ingressIPs must contain at most one IPv4 address and at most one IPv6 address"
-	// +listType=set
+	// +listType=atomic
 	// +optional
 	IngressIPs []IP `json:"ingressIPs"`
 
 	// machineNetworks are IP networks used to connect all the OpenShift cluster
 	// nodes. Each network is provided in the CIDR format and should be IPv4 or IPv6,
 	// for example "10.0.0.0/8" or "fd00::/8".
-	// +listType=set
+	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, x == y))"
 	// +optional
 	MachineNetworks []CIDR `json:"machineNetworks"`
 }
@@ -998,7 +1003,8 @@ type OpenStackPlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
-	// +listType=set
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address"
+	// +listType=atomic
 	APIServerInternalIPs []string `json:"apiServerInternalIPs"`
 
 	// cloudName is the name of the desired OpenStack cloud in the
@@ -1018,7 +1024,8 @@ type OpenStackPlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
-	// +listType=set
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="ingressIPs must contain at most one IPv4 address and at most one IPv6 address"
+	// +listType=atomic
 	IngressIPs []string `json:"ingressIPs"`
 
 	// nodeDNSIP is the IP address for the internal DNS used by the
@@ -1036,8 +1043,9 @@ type OpenStackPlatformStatus struct {
 	LoadBalancer *OpenStackPlatformLoadBalancer `json:"loadBalancer,omitempty"`
 
 	// machineNetworks are IP networks used to connect all the OpenShift cluster nodes.
-	// +listType=set
+	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, x == y))"
 	// +optional
 	MachineNetworks []CIDR `json:"machineNetworks"`
 }
@@ -1085,6 +1093,7 @@ type OvirtPlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address"
 	// +listType=set
 	APIServerInternalIPs []string `json:"apiServerInternalIPs"`
 
@@ -1101,6 +1110,7 @@ type OvirtPlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="ingressIPs must contain at most one IPv4 address and at most one IPv6 address"
 	// +listType=set
 	IngressIPs []string `json:"ingressIPs"`
 
@@ -1366,7 +1376,7 @@ type VSpherePlatformSpec struct {
 	//
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:XValidation:rule="size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true",message="apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address"
-	// +listType=set
+	// +listType=atomic
 	// +optional
 	APIServerInternalIPs []IP `json:"apiServerInternalIPs"`
 
@@ -1381,15 +1391,16 @@ type VSpherePlatformSpec struct {
 	//
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:XValidation:rule="size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true",message="ingressIPs must contain at most one IPv4 address and at most one IPv6 address"
-	// +listType=set
+	// +listType=atomic
 	// +optional
 	IngressIPs []IP `json:"ingressIPs"`
 
 	// machineNetworks are IP networks used to connect all the OpenShift cluster
 	// nodes. Each network is provided in the CIDR format and should be IPv4 or IPv6,
 	// for example "10.0.0.0/8" or "fd00::/8".
-	// +listType=set
+	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, x == y))"
 	// +optional
 	MachineNetworks []CIDR `json:"machineNetworks"`
 }
@@ -1412,7 +1423,8 @@ type VSpherePlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
-	// +listType=set
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address"
+	// +listType=atomic
 	APIServerInternalIPs []string `json:"apiServerInternalIPs"`
 
 	// ingressIP is an external IP which routes to the default ingress controller.
@@ -1428,7 +1440,8 @@ type VSpherePlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
-	// +listType=set
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="ingressIPs must contain at most one IPv4 address and at most one IPv6 address"
+	// +listType=atomic
 	IngressIPs []string `json:"ingressIPs"`
 
 	// nodeDNSIP is the IP address for the internal DNS used by the
@@ -1447,8 +1460,9 @@ type VSpherePlatformStatus struct {
 	LoadBalancer *VSpherePlatformLoadBalancer `json:"loadBalancer,omitempty"`
 
 	// machineNetworks are IP networks used to connect all the OpenShift cluster nodes.
-	// +listType=set
+	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, x == y))"
 	// +optional
 	MachineNetworks []CIDR `json:"machineNetworks"`
 }
@@ -1813,6 +1827,7 @@ type NutanixPlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="apiServerInternalIPs must contain at most one IPv4 address and at most one IPv6 address"
 	// +listType=set
 	APIServerInternalIPs []string `json:"apiServerInternalIPs"`
 
@@ -1829,6 +1844,7 @@ type NutanixPlatformStatus struct {
 	//
 	// +kubebuilder:validation:Format=ip
 	// +kubebuilder:validation:MaxItems=2
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (size(self) == 2 && isIP(self[0]) && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family() : true)",message="ingressIPs must contain at most one IPv4 address and at most one IPv6 address"
 	// +listType=set
 	IngressIPs []string `json:"ingressIPs"`
 

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -750,7 +754,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -772,7 +776,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1213,7 +1219,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1231,7 +1243,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1274,7 +1292,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1708,6 +1728,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1726,6 +1752,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1781,7 +1813,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1803,7 +1841,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1846,7 +1890,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1884,6 +1930,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1902,6 +1954,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2066,7 +2124,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -2084,7 +2148,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2127,7 +2197,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -750,7 +754,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -772,7 +776,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1213,7 +1219,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1231,7 +1243,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1274,7 +1292,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1480,6 +1500,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1498,6 +1524,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1553,7 +1585,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1575,7 +1613,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1618,7 +1662,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1656,6 +1702,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1674,6 +1726,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1838,7 +1896,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1856,7 +1920,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1899,7 +1969,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -750,7 +754,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -772,7 +776,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1213,7 +1219,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1231,7 +1243,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1274,7 +1292,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1708,6 +1728,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1726,6 +1752,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1781,7 +1813,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1803,7 +1841,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1846,7 +1890,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1884,6 +1930,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1902,6 +1954,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2066,7 +2124,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -2084,7 +2148,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2127,7 +2197,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -750,7 +754,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -772,7 +776,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1213,7 +1219,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1231,7 +1243,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1274,7 +1292,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1708,6 +1728,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1726,6 +1752,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1781,7 +1813,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1803,7 +1841,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1846,7 +1890,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1884,6 +1930,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1902,6 +1954,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2066,7 +2124,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -2084,7 +2148,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2127,7 +2197,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -730,7 +734,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -752,7 +756,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1185,7 +1191,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1203,7 +1215,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1218,7 +1236,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1424,6 +1444,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1442,6 +1468,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                     type: object
                   openstack:
                     description: OpenStack contains settings specific to the OpenStack
@@ -1469,7 +1501,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1491,7 +1529,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1534,7 +1578,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1572,6 +1618,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1590,6 +1642,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       nodeDNSIP:
                         description: 'deprecated: as of 4.6, this field is no longer
                           set or honored.  It will be removed in a future release.'
@@ -1726,7 +1784,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1744,7 +1808,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1759,7 +1829,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -730,7 +734,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -752,7 +756,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1185,7 +1191,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1203,7 +1215,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1246,7 +1264,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1452,6 +1472,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1470,6 +1496,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1525,7 +1557,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1547,7 +1585,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1590,7 +1634,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1628,6 +1674,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1646,6 +1698,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1810,7 +1868,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1828,7 +1892,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1871,7 +1941,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -730,7 +734,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -752,7 +756,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1185,7 +1191,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1203,7 +1215,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1218,7 +1236,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1535,6 +1555,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1553,6 +1579,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                     type: object
                   openstack:
                     description: OpenStack contains settings specific to the OpenStack
@@ -1580,7 +1612,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1602,7 +1640,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1645,7 +1689,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1683,6 +1729,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1701,6 +1753,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       nodeDNSIP:
                         description: 'deprecated: as of 4.6, this field is no longer
                           set or honored.  It will be removed in a future release.'
@@ -1837,7 +1895,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1855,7 +1919,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1870,7 +1940,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -730,7 +734,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -752,7 +756,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1185,7 +1191,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1203,7 +1215,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1218,7 +1236,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1541,6 +1561,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1559,6 +1585,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                     type: object
                   openstack:
                     description: OpenStack contains settings specific to the OpenStack
@@ -1586,7 +1618,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1608,7 +1646,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1651,7 +1695,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1689,6 +1735,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1707,6 +1759,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       nodeDNSIP:
                         description: 'deprecated: as of 4.6, this field is no longer
                           set or honored.  It will be removed in a future release.'
@@ -1843,7 +1901,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1861,7 +1925,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1876,7 +1946,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -746,7 +750,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -768,7 +772,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1201,7 +1207,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1219,7 +1231,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1234,7 +1252,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1440,6 +1460,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1458,6 +1484,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                     type: object
                   openstack:
                     description: OpenStack contains settings specific to the OpenStack
@@ -1485,7 +1517,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1507,7 +1545,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1550,7 +1594,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1588,6 +1634,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1606,6 +1658,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       nodeDNSIP:
                         description: 'deprecated: as of 4.6, this field is no longer
                           set or honored.  It will be removed in a future release.'
@@ -1742,7 +1800,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1760,7 +1824,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       machineNetworks:
                         description: machineNetworks are IP networks used to connect
                           all the OpenShift cluster nodes.
@@ -1775,7 +1845,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -385,7 +385,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -414,7 +414,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -437,7 +437,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -714,7 +716,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -743,7 +745,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -766,7 +768,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -874,7 +878,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -1041,7 +1045,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -1064,7 +1068,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeNetworking:
                                 description: nodeNetworking contains the definition
                                   of internal and external network constraints for
@@ -1530,7 +1536,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1550,7 +1562,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1595,7 +1613,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -2059,6 +2079,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2079,6 +2105,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2138,7 +2170,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               cloudName:
                                 description: cloudName is the name of the desired
                                   OpenStack cloud in the client configuration file
@@ -2163,7 +2201,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2208,7 +2252,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -2249,6 +2295,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2269,6 +2321,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2443,7 +2501,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2463,7 +2527,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2508,7 +2578,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -385,7 +385,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -414,7 +414,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -437,7 +437,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -714,7 +716,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -743,7 +745,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -766,7 +768,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -874,7 +878,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -1041,7 +1045,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -1064,7 +1068,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeNetworking:
                                 description: nodeNetworking contains the definition
                                   of internal and external network constraints for
@@ -1530,7 +1536,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1550,7 +1562,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1595,7 +1613,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -1811,6 +1831,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1831,6 +1857,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1890,7 +1922,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               cloudName:
                                 description: cloudName is the name of the desired
                                   OpenStack cloud in the client configuration file
@@ -1915,7 +1953,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1960,7 +2004,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -2001,6 +2047,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2021,6 +2073,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2195,7 +2253,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2215,7 +2279,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2260,7 +2330,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -385,7 +385,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -414,7 +414,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -437,7 +437,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -714,7 +716,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -743,7 +745,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -766,7 +768,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -874,7 +878,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -1041,7 +1045,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -1064,7 +1068,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeNetworking:
                                 description: nodeNetworking contains the definition
                                   of internal and external network constraints for
@@ -1530,7 +1536,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1550,7 +1562,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1595,7 +1613,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -2059,6 +2079,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2079,6 +2105,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2138,7 +2170,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               cloudName:
                                 description: cloudName is the name of the desired
                                   OpenStack cloud in the client configuration file
@@ -2163,7 +2201,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2208,7 +2252,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -2249,6 +2295,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2269,6 +2321,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2443,7 +2501,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2463,7 +2527,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2508,7 +2578,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -385,7 +385,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -414,7 +414,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -437,7 +437,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -714,7 +716,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -743,7 +745,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -766,7 +768,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -874,7 +878,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -1041,7 +1045,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -1064,7 +1068,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeNetworking:
                                 description: nodeNetworking contains the definition
                                   of internal and external network constraints for
@@ -1530,7 +1536,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1550,7 +1562,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1595,7 +1613,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -2059,6 +2079,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2079,6 +2105,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2138,7 +2170,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               cloudName:
                                 description: cloudName is the name of the desired
                                   OpenStack cloud in the client configuration file
@@ -2163,7 +2201,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2208,7 +2252,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -2249,6 +2295,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2269,6 +2321,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2443,7 +2501,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2463,7 +2527,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2508,7 +2578,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
@@ -385,7 +385,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -414,7 +414,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -437,7 +437,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -714,7 +716,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -743,7 +745,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -766,7 +768,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -874,7 +878,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -1024,7 +1028,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -1047,7 +1051,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeNetworking:
                                 description: nodeNetworking contains the definition
                                   of internal and external network constraints for
@@ -1513,7 +1519,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1533,7 +1545,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.
@@ -1548,7 +1566,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -1764,6 +1784,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1784,6 +1810,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                             type: object
                           openstack:
                             description: OpenStack contains settings specific to the
@@ -1813,7 +1845,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               cloudName:
                                 description: cloudName is the name of the desired
                                   OpenStack cloud in the client configuration file
@@ -1838,7 +1876,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1883,7 +1927,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -1924,6 +1970,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1944,6 +1996,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               nodeDNSIP:
                                 description: 'deprecated: as of 4.6, this field is
                                   no longer set or honored.  It will be removed in
@@ -2088,7 +2146,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2108,7 +2172,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.
@@ -2123,7 +2193,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
@@ -385,7 +385,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -414,7 +414,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -437,7 +437,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -714,7 +716,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -743,7 +745,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -766,7 +768,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -874,7 +878,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -1024,7 +1028,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -1047,7 +1051,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeNetworking:
                                 description: nodeNetworking contains the definition
                                   of internal and external network constraints for
@@ -1513,7 +1519,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1533,7 +1545,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1578,7 +1596,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -1794,6 +1814,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1814,6 +1840,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1873,7 +1905,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               cloudName:
                                 description: cloudName is the name of the desired
                                   OpenStack cloud in the client configuration file
@@ -1898,7 +1936,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1943,7 +1987,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -1984,6 +2030,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2004,6 +2056,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2178,7 +2236,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2198,7 +2262,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2243,7 +2313,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
@@ -385,7 +385,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -414,7 +414,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -437,7 +437,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -714,7 +716,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -743,7 +745,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -766,7 +768,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -874,7 +878,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -1024,7 +1028,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -1047,7 +1051,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeNetworking:
                                 description: nodeNetworking contains the definition
                                   of internal and external network constraints for
@@ -1513,7 +1519,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1533,7 +1545,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.
@@ -1548,7 +1566,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -1882,6 +1902,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1902,6 +1928,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                             type: object
                           openstack:
                             description: OpenStack contains settings specific to the
@@ -1931,7 +1963,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               cloudName:
                                 description: cloudName is the name of the desired
                                   OpenStack cloud in the client configuration file
@@ -1956,7 +1994,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2001,7 +2045,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -2042,6 +2088,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2062,6 +2114,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               nodeDNSIP:
                                 description: 'deprecated: as of 4.6, this field is
                                   no longer set or honored.  It will be removed in
@@ -2206,7 +2264,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2226,7 +2290,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.
@@ -2241,7 +2311,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
@@ -385,7 +385,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -414,7 +414,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -437,7 +437,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -714,7 +716,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -743,7 +745,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -766,7 +768,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -874,7 +878,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -1024,7 +1028,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -1047,7 +1051,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeNetworking:
                                 description: nodeNetworking contains the definition
                                   of internal and external network constraints for
@@ -1513,7 +1519,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1533,7 +1545,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.
@@ -1548,7 +1566,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -1894,6 +1914,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1914,6 +1940,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                             type: object
                           openstack:
                             description: OpenStack contains settings specific to the
@@ -1943,7 +1975,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               cloudName:
                                 description: cloudName is the name of the desired
                                   OpenStack cloud in the client configuration file
@@ -1968,7 +2006,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -2013,7 +2057,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -2054,6 +2100,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2074,6 +2126,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               nodeDNSIP:
                                 description: 'deprecated: as of 4.6, this field is
                                   no longer set or honored.  It will be removed in
@@ -2218,7 +2276,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2238,7 +2302,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.
@@ -2253,7 +2323,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -385,7 +385,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -414,7 +414,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -437,7 +437,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -714,7 +716,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -743,7 +745,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -766,7 +768,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                             type: object
                             x-kubernetes-validations:
                             - message: apiServerInternalIPs list is required once
@@ -874,7 +878,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: apiServerInternalIPs must contain at most
                                     one IPv4 address and at most one IPv6 address
@@ -1041,7 +1045,7 @@ spec:
                                     rule: isIP(self)
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
                                 x-kubernetes-validations:
                                 - message: ingressIPs must contain at most one IPv4
                                     address and at most one IPv6 address
@@ -1064,7 +1068,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeNetworking:
                                 description: nodeNetworking contains the definition
                                   of internal and external network constraints for
@@ -1530,7 +1536,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1550,7 +1562,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.
@@ -1565,7 +1583,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -1781,6 +1801,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1801,6 +1827,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                             type: object
                           openstack:
                             description: OpenStack contains settings specific to the
@@ -1830,7 +1862,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               cloudName:
                                 description: cloudName is the name of the desired
                                   OpenStack cloud in the client configuration file
@@ -1855,7 +1893,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               loadBalancer:
                                 default:
                                   type: OpenShiftManagedDefault
@@ -1900,7 +1944,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by
@@ -1941,6 +1987,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -1961,6 +2013,12 @@ spec:
                                 maxItems: 2
                                 type: array
                                 x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               nodeDNSIP:
                                 description: 'deprecated: as of 4.6, this field is
                                   no longer set or honored.  It will be removed in
@@ -2105,7 +2163,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               ingressIP:
                                 description: "ingressIP is an external IP which routes
                                   to the default ingress controller. The IP is a suitable
@@ -2125,7 +2189,13 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
                               machineNetworks:
                                 description: machineNetworks are IP networks used
                                   to connect all the OpenShift cluster nodes.
@@ -2140,7 +2210,9 @@ spec:
                                     rule: isCIDR(self)
                                 maxItems: 32
                                 type: array
-                                x-kubernetes-list-type: set
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
                               nodeDNSIP:
                                 description: nodeDNSIP is the IP address for the internal
                                   DNS used by the nodes. Unlike the one managed by

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -9351,7 +9351,7 @@ func schema_openshift_api_config_v1_BareMetalPlatformSpec(ref common.ReferenceCa
 					"apiServerInternalIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -9371,7 +9371,7 @@ func schema_openshift_api_config_v1_BareMetalPlatformSpec(ref common.ReferenceCa
 					"ingressIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -9391,7 +9391,7 @@ func schema_openshift_api_config_v1_BareMetalPlatformSpec(ref common.ReferenceCa
 					"machineNetworks": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -9431,7 +9431,7 @@ func schema_openshift_api_config_v1_BareMetalPlatformStatus(ref common.Reference
 					"apiServerInternalIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -9458,7 +9458,7 @@ func schema_openshift_api_config_v1_BareMetalPlatformStatus(ref common.Reference
 					"ingressIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -9492,7 +9492,7 @@ func schema_openshift_api_config_v1_BareMetalPlatformStatus(ref common.Reference
 					"machineNetworks": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -16582,7 +16582,7 @@ func schema_openshift_api_config_v1_OpenStackPlatformSpec(ref common.ReferenceCa
 					"apiServerInternalIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -16602,7 +16602,7 @@ func schema_openshift_api_config_v1_OpenStackPlatformSpec(ref common.ReferenceCa
 					"ingressIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -16622,7 +16622,7 @@ func schema_openshift_api_config_v1_OpenStackPlatformSpec(ref common.ReferenceCa
 					"machineNetworks": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -16662,7 +16662,7 @@ func schema_openshift_api_config_v1_OpenStackPlatformStatus(ref common.Reference
 					"apiServerInternalIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -16696,7 +16696,7 @@ func schema_openshift_api_config_v1_OpenStackPlatformStatus(ref common.Reference
 					"ingressIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -16730,7 +16730,7 @@ func schema_openshift_api_config_v1_OpenStackPlatformStatus(ref common.Reference
 					"machineNetworks": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -19492,7 +19492,7 @@ func schema_openshift_api_config_v1_VSpherePlatformSpec(ref common.ReferenceCall
 					"apiServerInternalIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -19512,7 +19512,7 @@ func schema_openshift_api_config_v1_VSpherePlatformSpec(ref common.ReferenceCall
 					"ingressIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -19532,7 +19532,7 @@ func schema_openshift_api_config_v1_VSpherePlatformSpec(ref common.ReferenceCall
 					"machineNetworks": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -19574,7 +19574,7 @@ func schema_openshift_api_config_v1_VSpherePlatformStatus(ref common.ReferenceCa
 					"apiServerInternalIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -19601,7 +19601,7 @@ func schema_openshift_api_config_v1_VSpherePlatformStatus(ref common.ReferenceCa
 					"ingressIPs": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -19635,7 +19635,7 @@ func schema_openshift_api_config_v1_VSpherePlatformStatus(ref common.ReferenceCa
 					"machineNetworks": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4669,7 +4669,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "ingressIPs": {
           "description": "ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IP addresses, one from IPv4 family and one from IPv6. In single stack clusters a single IP address is expected. When omitted, values from the status.ingressIPs will be used. Once set, the list cannot be completely removed (but its second entry can).",
@@ -4678,7 +4678,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "machineNetworks": {
           "description": "machineNetworks are IP networks used to connect all the OpenShift cluster nodes. Each network is provided in the CIDR format and should be IPv4 or IPv6, for example \"10.0.0.0/8\" or \"fd00::/8\".",
@@ -4687,7 +4687,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -4710,7 +4710,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -4723,7 +4723,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "loadBalancer": {
           "description": "loadBalancer defines how the load balancer used by the cluster is configured.",
@@ -4739,7 +4739,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "nodeDNSIP": {
           "description": "nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for BareMetal deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.",
@@ -8908,7 +8908,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "ingressIPs": {
           "description": "ingressIPs are the external IPs which route to the default ingress controller. The IPs are suitable targets of a wildcard DNS record used to resolve default route host names. In dual stack clusters this list contains two IP addresses, one from IPv4 family and one from IPv6. In single stack clusters a single IP address is expected. When omitted, values from the status.ingressIPs will be used. Once set, the list cannot be completely removed (but its second entry can).",
@@ -8917,7 +8917,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "machineNetworks": {
           "description": "machineNetworks are IP networks used to connect all the OpenShift cluster nodes. Each network is provided in the CIDR format and should be IPv4 or IPv6, for example \"10.0.0.0/8\" or \"fd00::/8\".",
@@ -8926,7 +8926,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -8949,7 +8949,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "cloudName": {
           "description": "cloudName is the name of the desired OpenStack cloud in the client configuration file (`clouds.yaml`).",
@@ -8966,7 +8966,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "loadBalancer": {
           "description": "loadBalancer defines how the load balancer used by the cluster is configured.",
@@ -8982,7 +8982,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "nodeDNSIP": {
           "description": "nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for OpenStack deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.",
@@ -10598,7 +10598,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "failureDomains": {
           "description": "failureDomains contains the definition of region, zone and the vCenter topology. If this is omitted failure domains (regions and zones) will not be used.",
@@ -10619,7 +10619,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "machineNetworks": {
           "description": "machineNetworks are IP networks used to connect all the OpenShift cluster nodes. Each network is provided in the CIDR format and should be IPv4 or IPv6, for example \"10.0.0.0/8\" or \"fd00::/8\".",
@@ -10628,7 +10628,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "nodeNetworking": {
           "description": "nodeNetworking contains the definition of internal and external network constraints for assigning the node's networking. If this field is omitted, networking defaults to the legacy address selection behavior which is to only support a single address and return the first one found.",
@@ -10665,7 +10665,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -10678,7 +10678,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "loadBalancer": {
           "description": "loadBalancer defines how the load balancer used by the cluster is configured.",
@@ -10694,7 +10694,7 @@
             "type": "string",
             "default": ""
           },
-          "x-kubernetes-list-type": "set"
+          "x-kubernetes-list-type": "atomic"
         },
         "nodeDNSIP": {
           "description": "nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for vSphere deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.",

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -750,7 +754,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -772,7 +776,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1213,7 +1219,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1231,7 +1243,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1274,7 +1292,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1708,6 +1728,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1726,6 +1752,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1781,7 +1813,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1803,7 +1841,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1846,7 +1890,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1884,6 +1930,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1902,6 +1954,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2066,7 +2124,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -2084,7 +2148,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2127,7 +2197,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -750,7 +754,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -772,7 +776,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1213,7 +1219,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1231,7 +1243,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1274,7 +1292,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1480,6 +1500,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1498,6 +1524,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1553,7 +1585,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1575,7 +1613,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1618,7 +1662,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1656,6 +1702,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1674,6 +1726,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1838,7 +1896,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1856,7 +1920,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1899,7 +1969,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -750,7 +754,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -772,7 +776,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1213,7 +1219,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1231,7 +1243,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1274,7 +1292,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1708,6 +1728,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1726,6 +1752,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1781,7 +1813,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1803,7 +1841,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1846,7 +1890,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1884,6 +1930,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1902,6 +1954,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2066,7 +2124,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -2084,7 +2148,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2127,7 +2197,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -130,7 +130,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -157,7 +157,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -179,7 +179,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -441,7 +443,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -468,7 +470,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -490,7 +492,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                     type: object
                     x-kubernetes-validations:
                     - message: apiServerInternalIPs list is required once set
@@ -595,7 +599,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: apiServerInternalIPs must contain at most one IPv4
                             address and at most one IPv6 address
@@ -750,7 +754,7 @@ spec:
                             rule: isIP(self)
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
                         x-kubernetes-validations:
                         - message: ingressIPs must contain at most one IPv4 address
                             and at most one IPv6 address
@@ -772,7 +776,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeNetworking:
                         description: nodeNetworking contains the definition of internal
                           and external network constraints for assigning the node's
@@ -1213,7 +1219,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1231,7 +1243,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1274,7 +1292,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1708,6 +1728,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1726,6 +1752,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1781,7 +1813,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       cloudName:
                         description: cloudName is the name of the desired OpenStack
                           cloud in the client configuration file (`clouds.yaml`).
@@ -1803,7 +1841,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -1846,7 +1890,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS
@@ -1884,6 +1930,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -1902,6 +1954,12 @@ spec:
                         maxItems: 2
                         type: array
                         x-kubernetes-list-type: set
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2066,7 +2124,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: apiServerInternalIPs must contain at most one IPv4
+                            address and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       ingressIP:
                         description: "ingressIP is an external IP which routes to
                           the default ingress controller. The IP is a suitable target
@@ -2084,7 +2148,13 @@ spec:
                           type: string
                         maxItems: 2
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: ingressIPs must contain at most one IPv4 address
+                            and at most one IPv6 address
+                          rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                            && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                            : true)'
                       loadBalancer:
                         default:
                           type: OpenShiftManagedDefault
@@ -2127,7 +2197,9 @@ spec:
                             rule: isCIDR(self)
                         maxItems: 32
                         type: array
-                        x-kubernetes-list-type: set
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - rule: self.all(x, self.exists_one(y, x == y))
                       nodeDNSIP:
                         description: nodeDNSIP is the IP address for the internal
                           DNS used by the nodes. Unlike the one managed by the DNS


### PR DESCRIPTION
In order to handle ownership of network addresses in a more elegant way,
we are switching list type from `set` to `atomic`. Thanks to this the
whole list will be managed as one, instead of different owners for every
entry on the list.

We are adding CEL validation to fields in PlatformStatus for the
consistency. As this field has already been validated by o/installer,
this should not affect CRs with PlatformStatus already populated.