### PR TITLE
ETCD-520: add BackendQuotaGiB example

### DIFF
--- a/example/v1/tests/stableconfigtypes.example.openshift.io/-Example.yaml
+++ b/example/v1/tests/stableconfigtypes.example.openshift.io/-Example.yaml
@@ -16,6 +16,7 @@ tests:
         kind: StableConfigType
         spec:
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an EvolvingUnion, Should not allow a TechPreview enum value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -40,6 +41,7 @@ tests:
           celUnion:
             type: EmptyMember
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should allow an empty member with the empty type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -55,6 +57,7 @@ tests:
           celUnion:
             type: EmptyMember
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should allow a required member with the required type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -72,6 +75,7 @@ tests:
             type: RequiredMember
             requiredMember: foo
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should not allow omitting required member with the required type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -118,6 +122,7 @@ tests:
             type: OptionalMember
             optionalMember: foo
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should allow omitting the optional member with the optional type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -133,6 +138,7 @@ tests:
           celUnion:
             type: OptionalMember
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should not allow the optional member without the optional type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -183,6 +189,7 @@ tests:
         spec:
           immutableField: foo
           optionalImmutableField: foo
+          nonZeroDefault: 8
     - name: Should not allow changing the optional immutable field
       initial: |
         apiVersion: example.openshift.io/v1

--- a/example/v1/tests/stableconfigtypes.example.openshift.io/AAA_ungated.yaml
+++ b/example/v1/tests/stableconfigtypes.example.openshift.io/AAA_ungated.yaml
@@ -16,6 +16,7 @@ tests:
         spec:
           stableField: "Allowed"
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an EvolvingUnion, Should allow an empty enum value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -31,6 +32,7 @@ tests:
           evolvingUnion:
             type: ""
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an EvolvingUnion, Should allow a Stable enum value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -46,6 +48,7 @@ tests:
           evolvingUnion:
             type: StableValue
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should allow an empty member with the empty type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -61,6 +64,7 @@ tests:
           celUnion:
             type: EmptyMember
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should allow an empty member with the empty type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -76,6 +80,7 @@ tests:
           celUnion:
             type: EmptyMember
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should allow a required member with the required type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -93,6 +98,7 @@ tests:
             type: RequiredMember
             requiredMember: foo
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should not allow omitting required member with the required type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -139,6 +145,7 @@ tests:
             type: OptionalMember
             optionalMember: foo
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should allow omitting the optional member with the optional type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -154,6 +161,7 @@ tests:
           celUnion:
             type: OptionalMember
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an CEL validated Discrminated union, should not allow the optional member without the optional type value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -204,6 +212,7 @@ tests:
         spec:
           immutableField: foo
           optionalImmutableField: foo
+          nonZeroDefault: 8
     - name: Should not allow changing the optional immutable field
       initial: |
         apiVersion: example.openshift.io/v1

--- a/example/v1/tests/stableconfigtypes.example.openshift.io/Example.yaml
+++ b/example/v1/tests/stableconfigtypes.example.openshift.io/Example.yaml
@@ -17,6 +17,7 @@ tests:
         spec:
           stableField: "Allowed"
           immutableField: foo
+          nonZeroDefault: 8
     - name: Should persist a tech preview field
       initial: |
         apiVersion: example.openshift.io/v1
@@ -30,6 +31,7 @@ tests:
         spec:
           coolNewField: "Invalid"
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an EvolvingUnion, Should allow an empty enum value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -45,6 +47,7 @@ tests:
           evolvingUnion:
             type: ""
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an EvolvingUnion, Should allow a Stable enum value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -60,6 +63,7 @@ tests:
           evolvingUnion:
             type: StableValue
           immutableField: foo
+          nonZeroDefault: 8
     - name: With an EvolvingUnion, Should allow a TechPreview enum value
       initial: |
         apiVersion: example.openshift.io/v1
@@ -75,6 +79,7 @@ tests:
           evolvingUnion:
             type: TechPreviewOnlyValue
           immutableField: foo
+          nonZeroDefault: 8
   onUpdate:
     - name: Should not allow removal of a tech preview field
       initial: |

--- a/example/v1/types_stable.go
+++ b/example/v1/types_stable.go
@@ -67,6 +67,15 @@ type StableConfigTypeSpec struct {
 	// celUnion demonstrates how to validate a discrminated union using CEL
 	// +optional
 	CELUnion CELUnion `json:"celUnion,omitempty"`
+
+	// nonZeroDefault is a demonstration of creating an integer field that has a non zero default.
+	// It required two default tags (one for CRD generation, one for client generation) and must have `omitempty` and be optional.
+	// A minimum value is added to demonstrate that a zero value would not be accepted.
+	// +kubebuilder:default:=8
+	// +default=8
+	// +kubebuilder:validation:Minimum:=8
+	// +optional
+	NonZeroDefault int32 `json:"nonZeroDefault,omitempty"`
 }
 
 type EvolvingUnion struct {

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-CustomNoUpgrade.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-CustomNoUpgrade.crd.yaml
@@ -91,6 +91,16 @@ spec:
                 x-kubernetes-validations:
                 - message: immutableField is immutable
                   rule: self == oldSelf
+              nonZeroDefault:
+                default: 8
+                description: nonZeroDefault is a demonstration of creating an integer
+                  field that has a non zero default. It required two default tags
+                  (one for CRD generation, one for client generation) and must have
+                  `omitempty` and be optional. A minimum value is added to demonstrate
+                  that a zero value would not be accepted.
+                format: int32
+                minimum: 8
+                type: integer
               optionalImmutableField:
                 description: optionalImmutableField is a field that is immutable once
                   set. It is optional but may not be changed once set.

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-Default.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-Default.crd.yaml
@@ -86,6 +86,16 @@ spec:
                 x-kubernetes-validations:
                 - message: immutableField is immutable
                   rule: self == oldSelf
+              nonZeroDefault:
+                default: 8
+                description: nonZeroDefault is a demonstration of creating an integer
+                  field that has a non zero default. It required two default tags
+                  (one for CRD generation, one for client generation) and must have
+                  `omitempty` and be optional. A minimum value is added to demonstrate
+                  that a zero value would not be accepted.
+                format: int32
+                minimum: 8
+                type: integer
               optionalImmutableField:
                 description: optionalImmutableField is a field that is immutable once
                   set. It is optional but may not be changed once set.

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-DevPreviewNoUpgrade.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-DevPreviewNoUpgrade.crd.yaml
@@ -91,6 +91,16 @@ spec:
                 x-kubernetes-validations:
                 - message: immutableField is immutable
                   rule: self == oldSelf
+              nonZeroDefault:
+                default: 8
+                description: nonZeroDefault is a demonstration of creating an integer
+                  field that has a non zero default. It required two default tags
+                  (one for CRD generation, one for client generation) and must have
+                  `omitempty` and be optional. A minimum value is added to demonstrate
+                  that a zero value would not be accepted.
+                format: int32
+                minimum: 8
+                type: integer
               optionalImmutableField:
                 description: optionalImmutableField is a field that is immutable once
                   set. It is optional but may not be changed once set.

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-TechPreviewNoUpgrade.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-TechPreviewNoUpgrade.crd.yaml
@@ -91,6 +91,16 @@ spec:
                 x-kubernetes-validations:
                 - message: immutableField is immutable
                   rule: self == oldSelf
+              nonZeroDefault:
+                default: 8
+                description: nonZeroDefault is a demonstration of creating an integer
+                  field that has a non zero default. It required two default tags
+                  (one for CRD generation, one for client generation) and must have
+                  `omitempty` and be optional. A minimum value is added to demonstrate
+                  that a zero value would not be accepted.
+                format: int32
+                minimum: 8
+                type: integer
               optionalImmutableField:
                 description: optionalImmutableField is a field that is immutable once
                   set. It is optional but may not be changed once set.

--- a/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/AAA_ungated.yaml
+++ b/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/AAA_ungated.yaml
@@ -86,6 +86,16 @@ spec:
                 x-kubernetes-validations:
                 - message: immutableField is immutable
                   rule: self == oldSelf
+              nonZeroDefault:
+                default: 8
+                description: nonZeroDefault is a demonstration of creating an integer
+                  field that has a non zero default. It required two default tags
+                  (one for CRD generation, one for client generation) and must have
+                  `omitempty` and be optional. A minimum value is added to demonstrate
+                  that a zero value would not be accepted.
+                format: int32
+                minimum: 8
+                type: integer
               optionalImmutableField:
                 description: optionalImmutableField is a field that is immutable once
                   set. It is optional but may not be changed once set.

--- a/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/Example.yaml
+++ b/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/Example.yaml
@@ -91,6 +91,16 @@ spec:
                 x-kubernetes-validations:
                 - message: immutableField is immutable
                   rule: self == oldSelf
+              nonZeroDefault:
+                default: 8
+                description: nonZeroDefault is a demonstration of creating an integer
+                  field that has a non zero default. It required two default tags
+                  (one for CRD generation, one for client generation) and must have
+                  `omitempty` and be optional. A minimum value is added to demonstrate
+                  that a zero value would not be accepted.
+                format: int32
+                minimum: 8
+                type: integer
               optionalImmutableField:
                 description: optionalImmutableField is a field that is immutable once
                   set. It is optional but may not be changed once set.

--- a/example/v1/zz_generated.swagger_doc_generated.go
+++ b/example/v1/zz_generated.swagger_doc_generated.go
@@ -58,6 +58,7 @@ var map_StableConfigTypeSpec = map[string]string{
 	"optionalImmutableField": "optionalImmutableField is a field that is immutable once set. It is optional but may not be changed once set.",
 	"evolvingUnion":          "evolvingUnion demonstrates how to phase in new values into discriminated union",
 	"celUnion":               "celUnion demonstrates how to validate a discrminated union using CEL",
+	"nonZeroDefault":         "nonZeroDefault is a demonstration of creating an integer field that has a non zero default. It required two default tags (one for CRD generation, one for client generation) and must have `omitempty` and be optional. A minimum value is added to demonstrate that a zero value would not be accepted.",
 }
 
 func (StableConfigTypeSpec) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -23289,6 +23289,14 @@ func schema_openshift_api_example_v1_StableConfigTypeSpec(ref common.ReferenceCa
 							Ref:         ref("github.com/openshift/api/example/v1.CELUnion"),
 						},
 					},
+					"nonZeroDefault": {
+						SchemaProps: spec.SchemaProps{
+							Description: "nonZeroDefault is a demonstration of creating an integer field that has a non zero default. It required two default tags (one for CRD generation, one for client generation) and must have `omitempty` and be optional. A minimum value is added to demonstrate that a zero value would not be accepted.",
+							Default:     8,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 				Required: []string{"immutableField"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -12914,6 +12914,12 @@
           "type": "string",
           "default": ""
         },
+        "nonZeroDefault": {
+          "description": "nonZeroDefault is a demonstration of creating an integer field that has a non zero default. It required two default tags (one for CRD generation, one for client generation) and must have `omitempty` and be optional. A minimum value is added to demonstrate that a zero value would not be accepted.",
+          "type": "integer",
+          "format": "int32",
+          "default": 8
+        },
         "optionalImmutableField": {
           "description": "optionalImmutableField is a field that is immutable once set. It is optional but may not be changed once set.",
           "type": "string",


### PR DESCRIPTION
This PR adds an example for a new field `BackendQuotaGiB` within `EtcdSpec` type. 

Example for https://github.com/openshift/api/pull/1736

see https://issues.redhat.com/browse/ETCD-513

cc @openshift/openshift-team-etcd  @JoelSpeed  @deads2k 