### PR TITLE
Add eligible CAPI-install platforms to TechPreview

### DIFF
--- a/features.md
+++ b/features.md
@@ -1,19 +1,19 @@
 | FeatureGate | Default on Hypershift | Default on SelfManagedHA | DevPreviewNoUpgrade on Hypershift | DevPreviewNoUpgrade on SelfManagedHA | TechPreviewNoUpgrade on Hypershift | TechPreviewNoUpgrade on SelfManagedHA  |
 | ------ | --- | --- | --- | --- | --- | ---  |
 | ClusterAPIInstall| | | | | |  |
-| ClusterAPIInstallAWS| | | | | |  |
 | ClusterAPIInstallAzure| | | | | |  |
 | ClusterAPIInstallGCP| | | | | |  |
 | ClusterAPIInstallIBMCloud| | | | | |  |
-| ClusterAPIInstallNutanix| | | | | |  |
-| ClusterAPIInstallOpenStack| | | | | |  |
-| ClusterAPIInstallPowerVS| | | | | |  |
-| ClusterAPIInstallVSphere| | | | | |  |
 | EventedPLEG| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | AutomatedEtcdBackup| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | CSIDriverSharedResource| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ChunkSizeMiB| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| ClusterAPIInstallAWS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| ClusterAPIInstallNutanix| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| ClusterAPIInstallOpenStack| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| ClusterAPIInstallPowerVS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| ClusterAPIInstallVSphere| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | DNSNameResolver| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | DynamicResourceAllocation| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | EtcdBackendQuota| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -472,6 +472,7 @@ var (
 					reportProblemsToJiraComponent("Installer").
 					contactPerson("r4f4").
 					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGateClusterAPIInstallAzure = newFeatureGate("ClusterAPIInstallAzure").
@@ -496,24 +497,28 @@ var (
 						reportProblemsToJiraComponent("Installer").
 						contactPerson("yanhua121").
 						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateClusterAPIInstallOpenStack = newFeatureGate("ClusterAPIInstallOpenStack").
 						reportProblemsToJiraComponent("Installer").
 						contactPerson("stephenfin").
 						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateClusterAPIInstallPowerVS = newFeatureGate("ClusterAPIInstallPowerVS").
 						reportProblemsToJiraComponent("Installer").
 						contactPerson("mjturek").
 						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateClusterAPIInstallVSphere = newFeatureGate("ClusterAPIInstallVSphere").
 						reportProblemsToJiraComponent("Installer").
 						contactPerson("rvanderp3").
 						productScope(ocpSpecific).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateChunkSizeMiB = newFeatureGate("ChunkSizeMiB").

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -19,9 +19,6 @@
                         "name": "ClusterAPIInstall"
                     },
                     {
-                        "name": "ClusterAPIInstallAWS"
-                    },
-                    {
                         "name": "ClusterAPIInstallAzure"
                     },
                     {
@@ -29,18 +26,6 @@
                     },
                     {
                         "name": "ClusterAPIInstallIBMCloud"
-                    },
-                    {
-                        "name": "ClusterAPIInstallNutanix"
-                    },
-                    {
-                        "name": "ClusterAPIInstallOpenStack"
-                    },
-                    {
-                        "name": "ClusterAPIInstallPowerVS"
-                    },
-                    {
-                        "name": "ClusterAPIInstallVSphere"
                     },
                     {
                         "name": "EventedPLEG"
@@ -76,6 +61,21 @@
                     },
                     {
                         "name": "CloudDualStackNodeIPs"
+                    },
+                    {
+                        "name": "ClusterAPIInstallAWS"
+                    },
+                    {
+                        "name": "ClusterAPIInstallNutanix"
+                    },
+                    {
+                        "name": "ClusterAPIInstallOpenStack"
+                    },
+                    {
+                        "name": "ClusterAPIInstallPowerVS"
+                    },
+                    {
+                        "name": "ClusterAPIInstallVSphere"
                     },
                     {
                         "name": "DNSNameResolver"

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -19,9 +19,6 @@
                         "name": "ClusterAPIInstall"
                     },
                     {
-                        "name": "ClusterAPIInstallAWS"
-                    },
-                    {
                         "name": "ClusterAPIInstallAzure"
                     },
                     {
@@ -29,18 +26,6 @@
                     },
                     {
                         "name": "ClusterAPIInstallIBMCloud"
-                    },
-                    {
-                        "name": "ClusterAPIInstallNutanix"
-                    },
-                    {
-                        "name": "ClusterAPIInstallOpenStack"
-                    },
-                    {
-                        "name": "ClusterAPIInstallPowerVS"
-                    },
-                    {
-                        "name": "ClusterAPIInstallVSphere"
                     },
                     {
                         "name": "EventedPLEG"
@@ -76,6 +61,21 @@
                     },
                     {
                         "name": "CloudDualStackNodeIPs"
+                    },
+                    {
+                        "name": "ClusterAPIInstallAWS"
+                    },
+                    {
+                        "name": "ClusterAPIInstallNutanix"
+                    },
+                    {
+                        "name": "ClusterAPIInstallOpenStack"
+                    },
+                    {
+                        "name": "ClusterAPIInstallPowerVS"
+                    },
+                    {
+                        "name": "ClusterAPIInstallVSphere"
                     },
                     {
                         "name": "DNSNameResolver"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -19,9 +19,6 @@
                         "name": "ClusterAPIInstall"
                     },
                     {
-                        "name": "ClusterAPIInstallAWS"
-                    },
-                    {
                         "name": "ClusterAPIInstallAzure"
                     },
                     {
@@ -29,18 +26,6 @@
                     },
                     {
                         "name": "ClusterAPIInstallIBMCloud"
-                    },
-                    {
-                        "name": "ClusterAPIInstallNutanix"
-                    },
-                    {
-                        "name": "ClusterAPIInstallOpenStack"
-                    },
-                    {
-                        "name": "ClusterAPIInstallPowerVS"
-                    },
-                    {
-                        "name": "ClusterAPIInstallVSphere"
                     },
                     {
                         "name": "EventedPLEG"
@@ -76,6 +61,21 @@
                     },
                     {
                         "name": "CloudDualStackNodeIPs"
+                    },
+                    {
+                        "name": "ClusterAPIInstallAWS"
+                    },
+                    {
+                        "name": "ClusterAPIInstallNutanix"
+                    },
+                    {
+                        "name": "ClusterAPIInstallOpenStack"
+                    },
+                    {
+                        "name": "ClusterAPIInstallPowerVS"
+                    },
+                    {
+                        "name": "ClusterAPIInstallVSphere"
                     },
                     {
                         "name": "DNSNameResolver"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -19,9 +19,6 @@
                         "name": "ClusterAPIInstall"
                     },
                     {
-                        "name": "ClusterAPIInstallAWS"
-                    },
-                    {
                         "name": "ClusterAPIInstallAzure"
                     },
                     {
@@ -29,18 +26,6 @@
                     },
                     {
                         "name": "ClusterAPIInstallIBMCloud"
-                    },
-                    {
-                        "name": "ClusterAPIInstallNutanix"
-                    },
-                    {
-                        "name": "ClusterAPIInstallOpenStack"
-                    },
-                    {
-                        "name": "ClusterAPIInstallPowerVS"
-                    },
-                    {
-                        "name": "ClusterAPIInstallVSphere"
                     },
                     {
                         "name": "EventedPLEG"
@@ -76,6 +61,21 @@
                     },
                     {
                         "name": "CloudDualStackNodeIPs"
+                    },
+                    {
+                        "name": "ClusterAPIInstallAWS"
+                    },
+                    {
+                        "name": "ClusterAPIInstallNutanix"
+                    },
+                    {
+                        "name": "ClusterAPIInstallOpenStack"
+                    },
+                    {
+                        "name": "ClusterAPIInstallPowerVS"
+                    },
+                    {
+                        "name": "ClusterAPIInstallVSphere"
                     },
                     {
                         "name": "DNSNameResolver"


### PR DESCRIPTION
- aws
- nutanix
- openstack
- powervs
- vsphere

Have all passed e2e tests using the capi installer.

Depends on https://github.com/openshift/installer/pull/8343
Depends on https://issues.redhat.com/browse/CORS-3477