### PR TITLE
add MachineConfiguration conditions for boot image updates

### DIFF
--- a/operator/v1/types_machineconfiguration.go
+++ b/operator/v1/types_machineconfiguration.go
@@ -494,3 +494,16 @@ const (
 	// Special represents an action that is internal to the MCO, and is not allowed in user defined NodeDisruption policies.
 	SpecialStatusAction NodeDisruptionPolicyStatusActionType = "Special"
 )
+
+// These strings will be used for MachineConfiguration Status conditions.
+const (
+	// MachineConfigurationBootImageUpdateDegraded means that the MCO ran into an error while reconciling boot images. This
+	// will cause the clusteroperators.config.openshift.io/machine-config to degrade. This  condition will indicate the cause
+	// of the degrade, the progress of the update and the generation of the boot images configmap that it degraded on.
+	MachineConfigurationBootImageUpdateDegraded string = "BootImageUpdateDegraded"
+
+	// MachineConfigurationBootImageUpdateProgressing means that the MCO is in the process of reconciling boot images. This
+	// will cause the clusteroperators.config.openshift.io/machine-config to be in a Progressing state. This condition will
+	// indicate the progress of the update and the generation of the boot images configmap that triggered this update.
+	MachineConfigurationBootImageUpdateProgressing string = "BootImageUpdateProgressing"
+)


### PR DESCRIPTION
This PR adds a few new `MachineConfiguration` conditions, which will be used by the MSBIC to inform the user of the results of the boot image reconciliation loop. These conditions will be behind the ManagedBootImages feature gate.

More info:

- [Failure conditions for boot image updates](https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/manage-boot-images.md#error--alert-mechanism)