### PR TITLE
NO-JIRA: Update runtime image and drop color in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: build
 update: update-codegen-crds
 
 RUNTIME ?= podman
-RUNTIME_IMAGE_NAME ?= registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.14
+RUNTIME_IMAGE_NAME ?= registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16
 
 EXCLUDE_DIRS := _output/ dependencymagnet/ hack/ third_party/ tls/ tools/ vendor/ tests/
 GO_PACKAGES :=$(addsuffix ...,$(addprefix ./,$(filter-out $(EXCLUDE_DIRS), $(wildcard */))))

--- a/tests/hack/test.sh
+++ b/tests/hack/test.sh
@@ -19,7 +19,7 @@ if [ $HOME == "/" ]; then
 fi
 
 if [ "$OPENSHIFT_CI" == "true" ] && [ -n "$ARTIFACT_DIR" ] && [ -d "$ARTIFACT_DIR" ]; then # detect ci environment there
-  GINKGO_ARGS="${GINKGO_ARGS} --junit-report=junit_api_example_tests.xml --cover --output-dir=${ARTIFACT_DIR}"
+  GINKGO_ARGS="${GINKGO_ARGS} --junit-report=junit_api_example_tests.xml --cover --output-dir=${ARTIFACT_DIR} --no-color"
 fi
 
 # Print the command we are going to run as Make would.


### PR DESCRIPTION
1. RUNTIME_IMAGE_NAME should match what we're running in CI, or .ci-operator.yaml, so make sure they do.

2. In OpenShift CI the colored ginkgo output is causing unnecessary noise, so just don't do it there.