### PR TITLE
OpenShiftControllerManagerConfig: add serviceAccountSigningPublicKeyFile

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -42678,6 +42678,13 @@ func schema_openshift_api_openshiftcontrolplane_v1_DockerPullSecretControllerCon
 							Format:      "",
 						},
 					},
+					"serviceAccountSigningPublicKeyFile": {
+						SchemaProps: spec.SchemaProps{
+							Description: "serviceAccountSigningPublicKeyFile specifies the path to a file that contains the current public key of the service account token issuer. This field should be specified if the controller cannot automatically locate the service account token issuer key. The issuer signs issued ID tokens using the corresponding private key.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"registryURLs", "internalRegistryHostname"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -24779,6 +24779,10 @@
             "type": "string",
             "default": ""
           }
+        },
+        "serviceAccountSigningPublicKeyFile": {
+          "description": "serviceAccountSigningPublicKeyFile specifies the path to a file that contains the current public key of the service account token issuer. This field should be specified if the controller cannot automatically locate the service account token issuer key. The issuer signs issued ID tokens using the corresponding private key.",
+          "type": "string"
         }
       }
     },

--- a/openshiftcontrolplane/v1/types.go
+++ b/openshiftcontrolplane/v1/types.go
@@ -312,6 +312,12 @@ type DockerPullSecretControllerConfig struct {
 	// registry. The value must be in "hostname[:port]" format.  Docker pull secrets
 	// will be generated for this registry.
 	InternalRegistryHostname string `json:"internalRegistryHostname"`
+
+	// serviceAccountSigningPublicKeyFile specifies the path to a file that contains the current public key of the
+	// service account token issuer. This field should be specified if the controller cannot automatically locate
+	// the service account token issuer key. The issuer signs issued ID tokens using the corresponding private key.
+	// +optional
+	ServiceAccountSigningPublicKeyFile string `json:"serviceAccountSigningPublicKeyFile,omitempty"`
 }
 
 type ImageImportControllerConfig struct {

--- a/openshiftcontrolplane/v1/zz_generated.swagger_doc_generated.go
+++ b/openshiftcontrolplane/v1/zz_generated.swagger_doc_generated.go
@@ -68,8 +68,9 @@ func (ClusterNetworkEntry) SwaggerDoc() map[string]string {
 }
 
 var map_DockerPullSecretControllerConfig = map[string]string{
-	"registryURLs":             "registryURLs is a list of urls that the docker pull secrets should be valid for.",
-	"internalRegistryHostname": "internalRegistryHostname is the hostname for the default internal image registry. The value must be in \"hostname[:port]\" format.  Docker pull secrets will be generated for this registry.",
+	"registryURLs":                       "registryURLs is a list of urls that the docker pull secrets should be valid for.",
+	"internalRegistryHostname":           "internalRegistryHostname is the hostname for the default internal image registry. The value must be in \"hostname[:port]\" format.  Docker pull secrets will be generated for this registry.",
+	"serviceAccountSigningPublicKeyFile": "serviceAccountSigningPublicKeyFile specifies the path to a file that contains the current public key of the service account token issuer. This field should be specified if the controller cannot automatically locate the service account token issuer key. The issuer signs issued ID tokens using the corresponding private key.",
 }
 
 func (DockerPullSecretControllerConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
OCM needs access to the service account bound API token signing public key. On standalone, the crypto materials are available in a secret. On Hypershift, the secret is not made available to the hosted clusters. KCM has a similar requirement, which hypershift satisfies by projecting the secret into a volume on the KCM pod and then specifying the appropriate file name via a cli parameter. OCM is completey configured via a config file. This PR adds the serviceAccountSigningPublicKeyFile field to the OCM config file.