### PR TITLE
OCPBUGS-33727: Fix Gateway API Feature Gate

### DIFF
--- a/features.md
+++ b/features.md
@@ -5,6 +5,7 @@
 | ClusterAPIInstallIBMCloud| | | | | |  |
 | EventedPLEG| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
+| GatewayAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | AutomatedEtcdBackup| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | CSIDriverSharedResource| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ChunkSizeMiB| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
@@ -21,7 +22,6 @@
 | ExternalRouteCertificate| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | GCPClusterHostedDNS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | GCPLabelsTags| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
-| GatewayAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | HardwareSpeed| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ImagePolicy| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | InsightsConfig| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -68,7 +68,7 @@ var (
 				reportProblemsToJiraComponent("Routing").
 				contactPerson("miciah").
 				productScope(ocpSpecific).
-				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				enableIn(configv1.DevPreviewNoUpgrade).
 				mustRegister()
 
 	FeatureGateOpenShiftPodSecurityAdmission = newFeatureGate("OpenShiftPodSecurityAdmission").

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -28,6 +28,9 @@
                         "name": "EventedPLEG"
                     },
                     {
+                        "name": "GatewayAPI"
+                    },
+                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     }
                 ],
@@ -115,9 +118,6 @@
                     },
                     {
                         "name": "GCPLabelsTags"
-                    },
-                    {
-                        "name": "GatewayAPI"
                     },
                     {
                         "name": "HardwareSpeed"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -28,6 +28,9 @@
                         "name": "EventedPLEG"
                     },
                     {
+                        "name": "GatewayAPI"
+                    },
+                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     }
                 ],
@@ -115,9 +118,6 @@
                     },
                     {
                         "name": "GCPLabelsTags"
-                    },
-                    {
-                        "name": "GatewayAPI"
                     },
                     {
                         "name": "HardwareSpeed"


### PR DESCRIPTION
Update the feature gate framework to reflect that Gateway API is not yet a TechPreview feature. It is only a DevPreview feature.

Gateway API was added as a DevPreviewNoUpgrade feature before recent changes to the FeatureGate framework, and has not progressed to TechPreviewNoUpgrade.    When the FeatureGate framework changed, Gateway API was mistakenly listed as a TechPreviewNoUpgrade feature.

For 4.16 we are adding TechPreview testing to the cluster-ingress-operator for other features, and we do not want to test Gateway API as a tech preview feature.  In fact, it has its own separate test.

- features/features.go is the only edited file.  All other files were generated.