### PR TITLE
Feature gates for platforms, architecture, and installs

### DIFF
--- a/tools/codegen/cmd/featuregate-test-analyzer_test.go
+++ b/tools/codegen/cmd/featuregate-test-analyzer_test.go
@@ -22,8 +22,8 @@ func Test_listTestResultFor(t *testing.T) {
 		{
 			name: "test example",
 			args: args{
-				featureGate:    "SelfManagedHA",
-				clusterProfile: "Example",
+				clusterProfile: "SelfManagedHA",
+				featureGate:    "Example",
 			},
 			want:    nil,
 			wantErr: false,
@@ -31,8 +31,8 @@ func Test_listTestResultFor(t *testing.T) {
 		{
 			name: "platform example",
 			args: args{
-				featureGate:    "VSphereGate",
-				clusterProfile: "Example",
+				clusterProfile: "VSphereGate",
+				featureGate:    "Example",
 			},
 			want:    nil,
 			wantErr: false,

--- a/tools/codegen/cmd/featuregate-test-analyzer_test.go
+++ b/tools/codegen/cmd/featuregate-test-analyzer_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func Test_listTestResultFor(t *testing.T) {
@@ -20,8 +22,35 @@ func Test_listTestResultFor(t *testing.T) {
 		{
 			name: "test example",
 			args: args{
+				featureGate:    "SelfManagedHA",
+				clusterProfile: "Example",
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "platform example",
+			args: args{
+				featureGate:    "VSphereGate",
+				clusterProfile: "Example",
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "optional platform example",
+			args: args{
+				featureGate:    "NutanixGate",
 				clusterProfile: "SelfManagedHA",
-				featureGate:    "Example",
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "install example",
+			args: args{
+				featureGate:    "FooBarInstall",
+				clusterProfile: "Example",
 			},
 			want:    nil,
 			wantErr: false,
@@ -31,7 +60,7 @@ func Test_listTestResultFor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Skip("this is for ease of manual testing")
 
-			got, err := listTestResultFor(tt.args.clusterProfile, tt.args.featureGate)
+			got, err := listTestResultFor(tt.args.featureGate, sets.New[string](tt.args.clusterProfile))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("listTestResultFor() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/tools/codegen/pkg/sippy/json_types.go
+++ b/tools/codegen/pkg/sippy/json_types.go
@@ -81,35 +81,6 @@ func QueriesFor(cloud, architecture, topology, testPattern string) []*SippyQuery
 			},
 			LinkOperator: "and",
 		},
-		{
-			Items: []SippyQueryItem{
-				{
-					ColumnField:   "variants",
-					Not:           false,
-					OperatorValue: "contains",
-					Value:         cloud,
-				},
-				{
-					ColumnField:   "variants",
-					Not:           false,
-					OperatorValue: "contains",
-					Value:         architecture,
-				},
-				{
-					ColumnField:   "variants",
-					Not:           false,
-					OperatorValue: "contains",
-					Value:         topology,
-				},
-				{
-					ColumnField:   "name",
-					Not:           false,
-					OperatorValue: "contains",
-					Value:         testPattern,
-				},
-			},
-			LinkOperator: "and",
-		},
 	}
 
 }

--- a/tools/codegen/pkg/sippy/json_types.go
+++ b/tools/codegen/pkg/sippy/json_types.go
@@ -1,7 +1,5 @@
 package sippy
 
-import "fmt"
-
 type SippyQueryStruct struct {
 	Items        []SippyQueryItem `json:"items"`
 	LinkOperator string           `json:"linkOperator"`
@@ -46,10 +44,16 @@ type SippyTestInfo struct {
 	OpenBugs                  int         `json:"open_bugs"`
 }
 
-func QueriesFor(cloud, architecture, topology, featureGate string) []*SippyQueryStruct {
+func QueriesFor(cloud, architecture, topology, testPattern string) []*SippyQueryStruct {
 	return []*SippyQueryStruct{
 		{
 			Items: []SippyQueryItem{
+				{
+					ColumnField:   "variants",
+					Not:           false,
+					OperatorValue: "contains",
+					Value:         "techpreview",
+				},
 				{
 					ColumnField:   "variants",
 					Not:           false,
@@ -72,7 +76,7 @@ func QueriesFor(cloud, architecture, topology, featureGate string) []*SippyQuery
 					ColumnField:   "name",
 					Not:           false,
 					OperatorValue: "contains",
-					Value:         fmt.Sprintf("[OCPFeatureGate:%s]", featureGate),
+					Value:         testPattern,
 				},
 			},
 			LinkOperator: "and",
@@ -101,7 +105,7 @@ func QueriesFor(cloud, architecture, topology, featureGate string) []*SippyQuery
 					ColumnField:   "name",
 					Not:           false,
 					OperatorValue: "contains",
-					Value:         fmt.Sprintf("[FeatureGate:%s]", featureGate),
+					Value:         testPattern,
 				},
 			},
 			LinkOperator: "and",


### PR DESCRIPTION
When validating a feature gate has tests, try to determine if the
feature gate is specific to a platform or architecture and only query
those results.

If it's an installer feature gate, then we don't require specific tests;
use the existing `cluster install` tests.