### PR TITLE
NO-JIRA: Enable the ibm-cloud-managed cluster profile on network.operator CRD

### DIFF
--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -11,7 +11,6 @@ import (
 // +kubebuilder:resource:path=networks,scope=Cluster
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/475
 // +openshift:file-pattern=cvoRunLevel=0000_70,operatorName=network,operatorOrdering=01
-// +kubebuilder:metadata:annotations=include.release.openshift.io/self-managed-high-availability=true
 
 // Network describes the cluster's desired network configuration. It is
 // consumed by the cluster-network-operator.

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/475
     api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: networks.operator.openshift.io
 spec:

--- a/operator/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -320,8 +320,7 @@ machineconfigurations.operator.openshift.io:
   Version: v1
 
 networks.operator.openshift.io:
-  Annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
+  Annotations: {}
   ApprovedPRNumber: https://github.com/openshift/api/pull/475
   CRDName: networks.operator.openshift.io
   Capability: ""

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
@@ -7,7 +7,6 @@ metadata:
     api.openshift.io/filename-operator: network
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
   name: networks.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
@@ -7,7 +7,6 @@ metadata:
     api.openshift.io/filename-operator: network
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/NetworkLiveMigration: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
   name: networks.operator.openshift.io
 spec:
   group: operator.openshift.io


### PR DESCRIPTION
By removing the annotation from types_network.go we can rely on the generators to add the cluster profiles.
This commit doesn't introduce any functional changes as CNO was already annotating that CRD with the ibm-cloud-managed cluster profile:
https://github.com/openshift/cluster-network-operator/blob/019fa77b2afb6186320ebe15604f7d26d76bcfab/manifests/0000_70_network_01_networks.crd.yaml#L7
https://github.com/openshift/cluster-network-operator/blob/019fa77b2afb6186320ebe15604f7d26d76bcfab/hack/update-codegen.sh#L63

