### PR TITLE
OCPBUGS-33882: Streamline bootstrap crds

### DIFF
--- a/authorization/v1/generated.proto
+++ b/authorization/v1/generated.proto
@@ -372,6 +372,7 @@ message RoleBindingList {
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/470
 // +openshift:file-pattern=cvoRunLevel=0000_03,operatorName=config-operator,operatorOrdering=01
 // +openshift:compatibility-gen:level=1
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 message RoleBindingRestriction {
   // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/authorization/v1/types.go
+++ b/authorization/v1/types.go
@@ -537,6 +537,7 @@ type ClusterRoleList struct {
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/470
 // +openshift:file-pattern=cvoRunLevel=0000_03,operatorName=config-operator,operatorOrdering=01
 // +openshift:compatibility-gen:level=1
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type RoleBindingRestriction struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/authorization/v1/zz_generated.crd-manifests/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
+++ b/authorization/v1/zz_generated.crd-manifests/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: rolebindingrestrictions.authorization.openshift.io
 spec:
   group: authorization.openshift.io

--- a/authorization/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/authorization/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -1,5 +1,6 @@
 rolebindingrestrictions.authorization.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: rolebindingrestrictions.authorization.openshift.io
   Capability: ""

--- a/authorization/v1/zz_generated.featuregated-crd-manifests/rolebindingrestrictions.authorization.openshift.io/AAA_ungated.yaml
+++ b/authorization/v1/zz_generated.featuregated-crd-manifests/rolebindingrestrictions.authorization.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: rolebindingrestrictions.authorization.openshift.io
 spec:
   group: authorization.openshift.io

--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -19,6 +19,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=apiservers,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type APIServer struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -17,6 +17,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=authentications,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Authentication struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_console.go
+++ b/config/v1/types_console.go
@@ -19,6 +19,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=consoles,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Console struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_dns.go
+++ b/config/v1/types_dns.go
@@ -15,6 +15,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=dnses,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type DNS struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -17,6 +17,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=featuregates,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type FeatureGate struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_image.go
+++ b/config/v1/types_image.go
@@ -20,6 +20,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=images,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Image struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_image_content_policy.go
+++ b/config/v1/types_image_content_policy.go
@@ -16,6 +16,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=imagecontentpolicies,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type ImageContentPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_image_digest_mirror_set.go
+++ b/config/v1/types_image_digest_mirror_set.go
@@ -16,6 +16,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=imagedigestmirrorsets,scope=Cluster,shortName=idms
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type ImageDigestMirrorSet struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_image_tag_mirror_set.go
+++ b/config/v1/types_image_tag_mirror_set.go
@@ -16,6 +16,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=imagetagmirrorsets,scope=Cluster,shortName=itms
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type ImageTagMirrorSet struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -18,6 +18,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=infrastructures,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Infrastructure struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -18,6 +18,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=ingresses,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Ingress struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_network.go
+++ b/config/v1/types_network.go
@@ -18,6 +18,7 @@ import (
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=config-operator,operatorOrdering=01
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=networks,scope=Cluster
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Network struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_node.go
+++ b/config/v1/types_node.go
@@ -19,6 +19,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=nodes,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Node struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_oauth.go
+++ b/config/v1/types_oauth.go
@@ -19,6 +19,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=oauths,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type OAuth struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_project.go
+++ b/config/v1/types_project.go
@@ -15,6 +15,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=projects,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Project struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_proxy.go
+++ b/config/v1/types_proxy.go
@@ -17,6 +17,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=proxies,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Proxy struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/types_scheduling.go
+++ b/config/v1/types_scheduling.go
@@ -16,6 +16,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=schedulers,scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type Scheduler struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/config/v1/zz_generated.crd-manifests/0000_03_config-operator_01_proxies.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_03_config-operator_01_proxies.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: proxies.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: apiservers.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: authentications.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: CustomNoUpgrade
   name: authentications.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-Default.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: Default
   name: authentications.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: authentications.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: authentications.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_consoles.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_consoles.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: consoles.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: dnses.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: featuregates.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagecontentpolicies.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagecontentpolicies.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagecontentpolicies.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagedigestmirrorsets.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_images.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_images.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: images.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagetagmirrorsets.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagetagmirrorsets.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagetagmirrorsets.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: CustomNoUpgrade
   name: infrastructures.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: Default
   name: infrastructures.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: ingresses.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: networks.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: nodes.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_oauths.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_oauths.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: oauths.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_projects.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_projects.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: projects.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-CustomNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: CustomNoUpgrade
   name: schedulers.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-Default.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: Default
   name: schedulers.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-DevPreviewNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: schedulers.config.openshift.io
 spec:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-TechPreviewNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: schedulers.config.openshift.io
 spec:

--- a/config/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -1,5 +1,6 @@
 apiservers.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: apiservers.config.openshift.io
   Capability: ""
@@ -20,7 +21,8 @@ apiservers.config.openshift.io:
   Version: v1
 
 authentications.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: authentications.config.openshift.io
   Capability: ""
@@ -144,7 +146,8 @@ clusterversions.config.openshift.io:
   Version: v1
 
 consoles.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: consoles.config.openshift.io
   Capability: ""
@@ -165,7 +168,8 @@ consoles.config.openshift.io:
   Version: v1
 
 dnses.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: dnses.config.openshift.io
   Capability: ""
@@ -186,7 +190,8 @@ dnses.config.openshift.io:
   Version: v1
 
 featuregates.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: featuregates.config.openshift.io
   Capability: ""
@@ -207,7 +212,8 @@ featuregates.config.openshift.io:
   Version: v1
 
 images.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: images.config.openshift.io
   Capability: ""
@@ -228,7 +234,8 @@ images.config.openshift.io:
   Version: v1
 
 imagecontentpolicies.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/874
   CRDName: imagecontentpolicies.config.openshift.io
   Capability: ""
@@ -249,7 +256,8 @@ imagecontentpolicies.config.openshift.io:
   Version: v1
 
 imagedigestmirrorsets.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/1126
   CRDName: imagedigestmirrorsets.config.openshift.io
   Capability: ""
@@ -271,7 +279,8 @@ imagedigestmirrorsets.config.openshift.io:
   Version: v1
 
 imagetagmirrorsets.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/1126
   CRDName: imagetagmirrorsets.config.openshift.io
   Capability: ""
@@ -293,7 +302,8 @@ imagetagmirrorsets.config.openshift.io:
   Version: v1
 
 infrastructures.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: infrastructures.config.openshift.io
   Capability: ""
@@ -319,7 +329,8 @@ infrastructures.config.openshift.io:
   Version: v1
 
 ingresses.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: ingresses.config.openshift.io
   Capability: ""
@@ -340,7 +351,8 @@ ingresses.config.openshift.io:
   Version: v1
 
 networks.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: networks.config.openshift.io
   Capability: ""
@@ -363,7 +375,8 @@ networks.config.openshift.io:
   Version: v1
 
 nodes.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/1107
   CRDName: nodes.config.openshift.io
   Capability: ""
@@ -384,7 +397,8 @@ nodes.config.openshift.io:
   Version: v1
 
 oauths.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: oauths.config.openshift.io
   Capability: ""
@@ -426,7 +440,8 @@ operatorhubs.config.openshift.io:
   Version: v1
 
 projects.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: projects.config.openshift.io
   Capability: ""
@@ -447,7 +462,8 @@ projects.config.openshift.io:
   Version: v1
 
 proxies.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: proxies.config.openshift.io
   Capability: ""
@@ -468,7 +484,8 @@ proxies.config.openshift.io:
   Version: v1
 
 schedulers.config.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: schedulers.config.openshift.io
   Capability: ""

--- a/config/v1/zz_generated.featuregated-crd-manifests/apiservers.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/apiservers.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: apiservers.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: authentications.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/ExternalOIDC.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/ExternalOIDC.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/ExternalOIDC: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: authentications.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/consoles.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/consoles.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: consoles.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/dnses.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/dnses.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: dnses.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/featuregates.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/featuregates.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: featuregates.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/imagecontentpolicies.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/imagecontentpolicies.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagecontentpolicies.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/imagedigestmirrorsets.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/imagedigestmirrorsets.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagedigestmirrorsets.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/images.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/images.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: images.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/imagetagmirrorsets.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/imagetagmirrorsets.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagetagmirrorsets.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/BareMetalLoadBalancer: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/GCPClusterHostedDNS: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/GCPLabelsTags: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/VSphereControlPlaneMachineSet: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/VSphereMultiVCenters: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: infrastructures.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/ingresses.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/ingresses.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: ingresses.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/networks.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/networks.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: networks.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/networks.config.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/networks.config.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/NetworkDiagnosticsConfig: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: networks.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/networks.config.openshift.io/NetworkLiveMigration.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/networks.config.openshift.io/NetworkLiveMigration.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/NetworkLiveMigration: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: networks.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/nodes.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/nodes.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: nodes.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/oauths.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/oauths.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: oauths.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/projects.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/projects.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: projects.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/proxies.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/proxies.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: proxies.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/schedulers.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/schedulers.config.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: schedulers.config.openshift.io
 spec:
   group: config.openshift.io

--- a/config/v1/zz_generated.featuregated-crd-manifests/schedulers.config.openshift.io/DynamicResourceAllocation.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/schedulers.config.openshift.io/DynamicResourceAllocation.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/DynamicResourceAllocation: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: schedulers.config.openshift.io
 spec:
   group: config.openshift.io

--- a/operator/v1alpha1/types_image_content_source_policy.go
+++ b/operator/v1alpha1/types_image_content_source_policy.go
@@ -16,6 +16,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/470
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=config-operator,operatorOrdering=01
 // +openshift:compatibility-gen:level=4
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type ImageContentSourcePolicy struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagecontentsourcepolicies.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagecontentsourcepolicies.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagecontentsourcepolicies.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/operator/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
+++ b/operator/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
@@ -22,7 +22,8 @@ etcdbackups.operator.openshift.io:
   Version: v1alpha1
 
 imagecontentsourcepolicies.operator.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: imagecontentsourcepolicies.operator.openshift.io
   Capability: ""

--- a/operator/v1alpha1/zz_generated.featuregated-crd-manifests/imagecontentsourcepolicies.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1alpha1/zz_generated.featuregated-crd-manifests/imagecontentsourcepolicies.operator.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagecontentsourcepolicies.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/payload-command/render/renderassets/assets.go
+++ b/payload-command/render/renderassets/assets.go
@@ -187,7 +187,15 @@ func BootstrapRequiredCRD() FileContentsPredicate {
 		}
 
 		isBootstrapCRD := uncastObj.(*unstructured.Unstructured).GetAnnotations()["release.openshift.io/bootstrap-required"]
+		isCapabilityCRD := uncastObj.(*unstructured.Unstructured).GetAnnotations()["capability.openshift.io/name"]
+
 		if isBootstrapCRD == "true" {
+			if isCapabilityCRD != "" {
+				// Until Cluster Bootstrap can understand the capability annotation, we should error if a CRD has both annotations.
+				// Target to remove this before 4.17 closes out.
+				panic(fmt.Errorf("CRD %s has both bootstrap-required and capability annotations. These are currently not compatible annotations.", uncastObj.(*unstructured.Unstructured).GetName()))
+			}
+
 			return true, nil
 		}
 		return false, nil

--- a/payload-command/render/renderassets/write.go
+++ b/payload-command/render/renderassets/write.go
@@ -11,6 +11,7 @@ func SubstituteAndCopyFiles(assetInputDir, assetOutputDir, featureSet, clusterPr
 	manifestPredicates := []FileContentsPredicate{
 		InstallerFeatureSet(featureSet),
 		ClusterProfile(clusterProfile),
+		BootstrapRequiredCRD(),
 	}
 
 	// write assets

--- a/payload-manifests/crds/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: clusterresourcequotas.quota.openshift.io
 spec:
   group: quota.openshift.io

--- a/payload-manifests/crds/0000_03_config-operator_01_proxies.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_proxies.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: proxies.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: rolebindingrestrictions.authorization.openshift.io
 spec:
   group: authorization.openshift.io

--- a/payload-manifests/crds/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: securitycontextconstraints.security.openshift.io
 spec:
   group: security.openshift.io

--- a/payload-manifests/crds/0000_03_config-operator_02_rangeallocations.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_02_rangeallocations.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: rangeallocations.security.internal.openshift.io
 spec:
   group: security.internal.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_apiservers.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_apiservers.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: apiservers.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: authentications.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: CustomNoUpgrade
   name: authentications.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-Default.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: Default
   name: authentications.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: authentications.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -5,6 +5,7 @@ metadata:
     api-approved.openshift.io: https://github.com/openshift/api/pull/470
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: authentications.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_consoles.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_consoles.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: consoles.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_dnses.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_dnses.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: dnses.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_featuregates.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_featuregates.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: featuregates.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_imagecontentpolicies.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagecontentpolicies.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagecontentpolicies.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_imagecontentsourcepolicies.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagecontentsourcepolicies.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagecontentsourcepolicies.operator.openshift.io
 spec:
   group: operator.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagedigestmirrorsets.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_images.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_images.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: images.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_imagetagmirrorsets.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagetagmirrorsets.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: imagetagmirrorsets.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: CustomNoUpgrade
   name: infrastructures.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: Default
   name: infrastructures.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: infrastructures.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_ingresses.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_ingresses.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: ingresses.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_networks.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_networks.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: networks.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_nodes.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_nodes.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: nodes.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_oauths.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_oauths.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: oauths.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_projects.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_projects.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: projects.config.openshift.io
 spec:
   group: config.openshift.io

--- a/payload-manifests/crds/0000_10_config-operator_01_schedulers-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_schedulers-CustomNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: CustomNoUpgrade
   name: schedulers.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_schedulers-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_schedulers-Default.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: Default
   name: schedulers.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_schedulers-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_schedulers-DevPreviewNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: schedulers.config.openshift.io
 spec:

--- a/payload-manifests/crds/0000_10_config-operator_01_schedulers-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_schedulers-TechPreviewNoUpgrade.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
     release.openshift.io/feature-set: TechPreviewNoUpgrade
   name: schedulers.config.openshift.io
 spec:

--- a/quota/v1/generated.proto
+++ b/quota/v1/generated.proto
@@ -53,6 +53,7 @@ message AppliedClusterResourceQuotaList {
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/470
 // +openshift:file-pattern=cvoRunLevel=0000_03,operatorName=config-operator,operatorOrdering=01
 // +openshift:compatibility-gen:level=1
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 message ClusterResourceQuota {
   // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/quota/v1/types.go
+++ b/quota/v1/types.go
@@ -19,6 +19,7 @@ import (
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/470
 // +openshift:file-pattern=cvoRunLevel=0000_03,operatorName=config-operator,operatorOrdering=01
 // +openshift:compatibility-gen:level=1
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type ClusterResourceQuota struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/quota/v1/zz_generated.crd-manifests/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
+++ b/quota/v1/zz_generated.crd-manifests/0000_03_config-operator_01_clusterresourcequotas.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: clusterresourcequotas.quota.openshift.io
 spec:
   group: quota.openshift.io

--- a/quota/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/quota/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -1,5 +1,6 @@
 clusterresourcequotas.quota.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: clusterresourcequotas.quota.openshift.io
   Capability: ""

--- a/quota/v1/zz_generated.featuregated-crd-manifests/clusterresourcequotas.quota.openshift.io/AAA_ungated.yaml
+++ b/quota/v1/zz_generated.featuregated-crd-manifests/clusterresourcequotas.quota.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: clusterresourcequotas.quota.openshift.io
 spec:
   group: quota.openshift.io

--- a/security/v1/generated.proto
+++ b/security/v1/generated.proto
@@ -210,6 +210,7 @@ message SELinuxContextStrategyOptions {
 // +kubebuilder:printcolumn:name="Volumes",type=string,JSONPath=.volumes,description="White list of allowed volume plugins"
 // +kubebuilder:singular=securitycontextconstraint
 // +openshift:compatibility-gen:level=1
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 message SecurityContextConstraints {
   // metadata is the standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata

--- a/security/v1/types.go
+++ b/security/v1/types.go
@@ -37,6 +37,7 @@ var AllowAllCapabilities corev1.Capability = "*"
 // +kubebuilder:printcolumn:name="Volumes",type=string,JSONPath=.volumes,description="White list of allowed volume plugins"
 // +kubebuilder:singular=securitycontextconstraint
 // +openshift:compatibility-gen:level=1
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 type SecurityContextConstraints struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/security/v1/zz_generated.crd-manifests/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
+++ b/security/v1/zz_generated.crd-manifests/0000_03_config-operator_01_securitycontextconstraints.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: securitycontextconstraints.security.openshift.io
 spec:
   group: security.openshift.io

--- a/security/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/security/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -1,5 +1,6 @@
 securitycontextconstraints.security.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/470
   CRDName: securitycontextconstraints.security.openshift.io
   Capability: ""

--- a/security/v1/zz_generated.featuregated-crd-manifests/securitycontextconstraints.security.openshift.io/AAA_ungated.yaml
+++ b/security/v1/zz_generated.featuregated-crd-manifests/securitycontextconstraints.security.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: securitycontextconstraints.security.openshift.io
 spec:
   group: security.openshift.io

--- a/securityinternal/v1/types.go
+++ b/securityinternal/v1/types.go
@@ -16,6 +16,7 @@ import (
 // +kubebuilder:resource:path=rangeallocations,scope=Cluster
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/751
 // +openshift:file-pattern=cvoRunLevel=0000_03,operatorName=config-operator,operatorOrdering=02
+// +kubebuilder:metadata:annotations=release.openshift.io/bootstrap-required=true
 // +openshift:compatibility-gen:level=1
 type RangeAllocation struct {
 	metav1.TypeMeta `json:",inline"`

--- a/securityinternal/v1/zz_generated.crd-manifests/0000_03_config-operator_02_rangeallocations.crd.yaml
+++ b/securityinternal/v1/zz_generated.crd-manifests/0000_03_config-operator_02_rangeallocations.crd.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: rangeallocations.security.internal.openshift.io
 spec:
   group: security.internal.openshift.io

--- a/securityinternal/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/securityinternal/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -1,5 +1,6 @@
 rangeallocations.security.internal.openshift.io:
-  Annotations: {}
+  Annotations:
+    release.openshift.io/bootstrap-required: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/751
   CRDName: rangeallocations.security.internal.openshift.io
   Capability: ""

--- a/securityinternal/v1/zz_generated.featuregated-crd-manifests/rangeallocations.security.internal.openshift.io/AAA_ungated.yaml
+++ b/securityinternal/v1/zz_generated.featuregated-crd-manifests/rangeallocations.security.internal.openshift.io/AAA_ungated.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "02"
     feature-gate.release.openshift.io/: "true"
+    release.openshift.io/bootstrap-required: "true"
   name: rangeallocations.security.internal.openshift.io
 spec:
   group: security.internal.openshift.io


### PR DESCRIPTION
Now that we are adding additional CRDs to the API image, they are presently being added via the bootstrap rendering to the bootstrap node installation of manifests.
This does not presently account for the fact that some CRDs may not want to be installed (eg capability disabled).

To mitigate this, this PR is reducing the number of PRs installed at the bootstrap time by restricting the CRDs rendered at the installation time, and deferring all other CRDs to be installed by the CVO, which is already aware of capabilities.

This will also help reduce the bootstrap node responsibilities and footprint.

After discussion with @deads2k, keeping all the existing config v1 CRDs plus the minimal set outside of that group that are needed, so, the ones being dropped from bootstrap are:
* RangeAllocation
* Config (operator v1)
* ImageContentSourcePolicies (operator v1)
* CPMS (was never meant to be)