### PR TITLE
OCPNODE-2357: machineconfiguration: make crun as the default container runtime

### DIFF
--- a/machineconfiguration/v1/types.go
+++ b/machineconfiguration/v1/types.go
@@ -841,7 +841,7 @@ const (
 	ContainerRuntimeDefaultRuntimeEmpty   = ""
 	ContainerRuntimeDefaultRuntimeRunc    = "runc"
 	ContainerRuntimeDefaultRuntimeCrun    = "crun"
-	ContainerRuntimeDefaultRuntimeDefault = ContainerRuntimeDefaultRuntimeRunc
+	ContainerRuntimeDefaultRuntimeDefault = ContainerRuntimeDefaultRuntimeCrun
 )
 
 // ContainerRuntimeConfigStatus defines the observed state of a ContainerRuntimeConfig


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/OCPNODE-2217

This commit sets crun as the default container runtime in OCP for 4.17