### PR TITLE
OCPBUGS-34907: prevent removing featureSet entirely

### DIFF
--- a/config/v1/tests/featuregates.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/featuregates.config.openshift.io/AAA_ungated.yaml
@@ -52,6 +52,17 @@ tests:
         spec:
           featureSet: ""
       expectedError: "TechPreviewNoUpgrade may not be changed"
+    - name: TechPreview to Removed
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: FeatureGate
+        spec:
+          featureSet: TechPreviewNoUpgrade
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: FeatureGate
+        spec: {}
+      expectedError: ".spec.featureSet cannot be removed"
     - name: TechPreview to Custom
       initial: |
         apiVersion: config.openshift.io/v1

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -28,6 +28,7 @@ type FeatureGate struct {
 	// spec holds user settable values for configuration
 	// +kubebuilder:validation:Required
 	// +required
+	// +kubebuilder:validation:XValidation:rule="has(oldSelf.featureSet) ? has(self.featureSet) : true",message=".spec.featureSet cannot be removed"
 	Spec FeatureGateSpec `json:"spec"`
 	// status holds observed values from the cluster. They may not be overridden.
 	// +optional

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
@@ -85,6 +85,9 @@ spec:
                   rule: 'oldSelf == ''DevPreviewNoUpgrade'' ? self == ''DevPreviewNoUpgrade''
                     : true'
             type: object
+            x-kubernetes-validations:
+            - message: .spec.featureSet cannot be removed
+              rule: 'has(oldSelf.featureSet) ? has(self.featureSet) : true'
           status:
             description: status holds observed values from the cluster. They may not
               be overridden.

--- a/config/v1/zz_generated.featuregated-crd-manifests/featuregates.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/featuregates.config.openshift.io/AAA_ungated.yaml
@@ -86,6 +86,9 @@ spec:
                   rule: 'oldSelf == ''DevPreviewNoUpgrade'' ? self == ''DevPreviewNoUpgrade''
                     : true'
             type: object
+            x-kubernetes-validations:
+            - message: .spec.featureSet cannot be removed
+              rule: 'has(oldSelf.featureSet) ? has(self.featureSet) : true'
           status:
             description: status holds observed values from the cluster. They may not
               be overridden.

--- a/payload-manifests/crds/0000_10_config-operator_01_featuregates.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_featuregates.crd.yaml
@@ -85,6 +85,9 @@ spec:
                   rule: 'oldSelf == ''DevPreviewNoUpgrade'' ? self == ''DevPreviewNoUpgrade''
                     : true'
             type: object
+            x-kubernetes-validations:
+            - message: .spec.featureSet cannot be removed
+              rule: 'has(oldSelf.featureSet) ? has(self.featureSet) : true'
           status:
             description: status holds observed values from the cluster. They may not
               be overridden.


### PR DESCRIPTION
This closes a hole where someone could move out of techpreview by deleting the entire key instead of simply resetting it.

/cherrypick release-4.16

/assign @JoelSpeed 