### PR TITLE
CFE-1063: remove kubebuilder validation for placementGroupPartition

### DIFF
--- a/machine/v1beta1/types_awsprovider.go
+++ b/machine/v1beta1/types_awsprovider.go
@@ -87,8 +87,6 @@ type AWSMachineProviderConfig struct {
 	// placementGroupPartition is the partition number within the placement group in which to launch the instance.
 	// This must be an integer value between 1 and 7. It is only valid if the placement group, referred in
 	// `PlacementGroupName` was created with strategy set to partition.
-	// +kubebuilder:validation:Minimum:=1
-	// +kubebuilder:validation:Maximum:=7
 	// +optional
 	PlacementGroupPartition int32 `json:"placementGroupPartition,omitempty"`
 }


### PR DESCRIPTION
As per https://github.com/openshift/api/pull/1897#discussion_r1658841416
 Kubebuilder validations won't work on this particular API,  we will need to add them in webhook validation.