### PR TITLE
OCPBUGS-36213: Remove the conversion webhook reference from the ConsolePlugin CRD spec

### DIFF
--- a/console/v1/manual-override-crd-manifests/consoleplugins.console.openshift.io/AAA_ungated.yaml
+++ b/console/v1/manual-override-crd-manifests/consoleplugins.console.openshift.io/AAA_ungated.yaml
@@ -5,18 +5,6 @@ metadata:
     feature-gate.release.openshift.io/: "true"
   name: consoleplugins.console.openshift.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: webhook
-          namespace: openshift-console-operator
-          path: /crdconvert
-          port: 9443
-      conversionReviewVersions:
-      - v1
-      - v1alpha1
   versions:
   - name: v1alpha1
     schema:

--- a/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
@@ -12,18 +12,6 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
   name: consoleplugins.console.openshift.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: webhook
-          namespace: openshift-console-operator
-          path: /crdconvert
-          port: 9443
-      conversionReviewVersions:
-      - v1
-      - v1alpha1
   group: console.openshift.io
   names:
     kind: ConsolePlugin


### PR DESCRIPTION
We forgot to remove these two references of the conversion webhook server for v1 <-> v1alpha1 conversions.

/assign @deads2k @JoelSpeed 