### PR TITLE
features: add multi-arch feature gate per platform

### DIFF
--- a/features.md
+++ b/features.md
@@ -6,6 +6,9 @@
 | EventedPLEG| | | | | |  |
 | MachineAPIMigration| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
+| MultiArchInstallAWS| | | | | |  |
+| MultiArchInstallAzure| | | | | |  |
+| MultiArchInstallGCP| | | | | |  |
 | GatewayAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | AutomatedEtcdBackup| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | CSIDriverSharedResource| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -548,4 +548,22 @@ var (
 						productScope(ocpSpecific).
 						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
+
+	FeatureGateMultiArchInstallAWS = newFeatureGate("MultiArchInstallAWS").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("r4f4").
+					productScope(ocpSpecific).
+					mustRegister()
+
+	FeatureGateMultiArchInstallAzure = newFeatureGate("MultiArchInstallAzure").
+						reportProblemsToJiraComponent("Installer").
+						contactPerson("r4f4").
+						productScope(ocpSpecific).
+						mustRegister()
+
+	FeatureGateMultiArchInstallGCP = newFeatureGate("MultiArchInstallGCP").
+					reportProblemsToJiraComponent("Installer").
+					contactPerson("r4f4").
+					productScope(ocpSpecific).
+					mustRegister()
 )

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -107,6 +107,15 @@
                         "name": "MixedCPUsAllocation"
                     },
                     {
+                        "name": "MultiArchInstallAWS"
+                    },
+                    {
+                        "name": "MultiArchInstallAzure"
+                    },
+                    {
+                        "name": "MultiArchInstallGCP"
+                    },
+                    {
                         "name": "NetworkSegmentation"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -32,6 +32,15 @@
                     },
                     {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
+                    },
+                    {
+                        "name": "MultiArchInstallAWS"
+                    },
+                    {
+                        "name": "MultiArchInstallAzure"
+                    },
+                    {
+                        "name": "MultiArchInstallGCP"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -35,6 +35,15 @@
                     },
                     {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
+                    },
+                    {
+                        "name": "MultiArchInstallAWS"
+                    },
+                    {
+                        "name": "MultiArchInstallAzure"
+                    },
+                    {
+                        "name": "MultiArchInstallGCP"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -110,6 +110,15 @@
                         "name": "MixedCPUsAllocation"
                     },
                     {
+                        "name": "MultiArchInstallAWS"
+                    },
+                    {
+                        "name": "MultiArchInstallAzure"
+                    },
+                    {
+                        "name": "MultiArchInstallGCP"
+                    },
+                    {
                         "name": "NetworkSegmentation"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -32,6 +32,15 @@
                     },
                     {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
+                    },
+                    {
+                        "name": "MultiArchInstallAWS"
+                    },
+                    {
+                        "name": "MultiArchInstallAzure"
+                    },
+                    {
+                        "name": "MultiArchInstallGCP"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -35,6 +35,15 @@
                     },
                     {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
+                    },
+                    {
+                        "name": "MultiArchInstallAWS"
+                    },
+                    {
+                        "name": "MultiArchInstallAzure"
+                    },
+                    {
+                        "name": "MultiArchInstallGCP"
                     }
                 ],
                 "enabled": [


### PR DESCRIPTION
Adds a day-0 multi-arch cluster installer feature gate per platform.

AWS: https://issues.redhat.com/browse/OCPSTRAT-1472
Azure: https://issues.redhat.com/browse/OCPSTRAT-1476
GCP: https://issues.redhat.com/browse/OCPSTRAT-1477