### PR TITLE
OCPBUGS-35906: a rule to check if the featureSet is one of the known set of features

### DIFF
--- a/config/v1/tests/featuregates.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/featuregates.config.openshift.io/AAA_ungated.yaml
@@ -23,6 +23,13 @@ tests:
         kind: FeatureGate
         spec:
           featureSet: TechPreviewNoUpgrade
+    - name: Must reject unsupported value of a FeatureGate
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: FeatureGate
+        spec:
+          featureSet: bar
+      expectedError: "spec.featureSet: Unsupported value: \"bar\": supported values: \"CustomNoUpgrade\", \"DevPreviewNoUpgrade\", \"TechPreviewNoUpgrade\", \"\""
   onUpdate:
     - name: Default to TechPreview
       initial: |
@@ -103,3 +110,15 @@ tests:
         spec:
           featureSet: ""
       expectedError: "CustomNoUpgrade may not be changed"
+    - name: Must reject an update if unsupported value of a FeatureGate is provided
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: FeatureGate
+        spec:
+          featureSet: ""
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: FeatureGate
+        spec:
+          featureSet: "bar"
+      expectedError: "spec.featureSet: Unsupported value: \"bar\": supported values: \"CustomNoUpgrade\", \"DevPreviewNoUpgrade\", \"TechPreviewNoUpgrade\", \"\""

--- a/config/v1/types_feature.go
+++ b/config/v1/types_feature.go
@@ -68,6 +68,7 @@ type FeatureGateSelection struct {
 	// Turning on or off features may cause irreversible changes in your cluster which cannot be undone.
 	// +unionDiscriminator
 	// +optional
+	// +kubebuilder:validation:Enum=CustomNoUpgrade;DevPreviewNoUpgrade;TechPreviewNoUpgrade;""
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'CustomNoUpgrade' ? self == 'CustomNoUpgrade' : true",message="CustomNoUpgrade may not be changed"
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'TechPreviewNoUpgrade' ? self == 'TechPreviewNoUpgrade' : true",message="TechPreviewNoUpgrade may not be changed"
 	// +kubebuilder:validation:XValidation:rule="oldSelf == 'DevPreviewNoUpgrade' ? self == 'DevPreviewNoUpgrade' : true",message="DevPreviewNoUpgrade may not be changed"

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
@@ -73,6 +73,11 @@ spec:
                   default is empty.  Be very careful adjusting this setting. Turning
                   on or off features may cause irreversible changes in your cluster
                   which cannot be undone.
+                enum:
+                - CustomNoUpgrade
+                - DevPreviewNoUpgrade
+                - TechPreviewNoUpgrade
+                - ""
                 type: string
                 x-kubernetes-validations:
                 - message: CustomNoUpgrade may not be changed

--- a/config/v1/zz_generated.featuregated-crd-manifests/featuregates.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/featuregates.config.openshift.io/AAA_ungated.yaml
@@ -74,6 +74,11 @@ spec:
                   default is empty.  Be very careful adjusting this setting. Turning
                   on or off features may cause irreversible changes in your cluster
                   which cannot be undone.
+                enum:
+                - CustomNoUpgrade
+                - DevPreviewNoUpgrade
+                - TechPreviewNoUpgrade
+                - ""
                 type: string
                 x-kubernetes-validations:
                 - message: CustomNoUpgrade may not be changed

--- a/payload-manifests/crds/0000_10_config-operator_01_featuregates.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_featuregates.crd.yaml
@@ -73,6 +73,11 @@ spec:
                   default is empty.  Be very careful adjusting this setting. Turning
                   on or off features may cause irreversible changes in your cluster
                   which cannot be undone.
+                enum:
+                - CustomNoUpgrade
+                - DevPreviewNoUpgrade
+                - TechPreviewNoUpgrade
+                - ""
                 type: string
                 x-kubernetes-validations:
                 - message: CustomNoUpgrade may not be changed


### PR DESCRIPTION
In the past, there was an admission plugin for checking if the value of the featureSet field matched a known one. 

With https://github.com/openshift/kubernetes/pull/1944, the validation was moved to CEL and the check was dropped. 
This PR adds the missing check. 

NOTE that there was an additional check that allowed updates to FG even with an invalid featureSet if the field wasn't modified. I haven't found a way to move this to CEL for kube < 1.30. 

The validation was moved in 4.16, and setting an invalid value breaks an operator and prevents upgrades. This PR allows transitioning from an invalid value to unblock upgrades.

For full backward compatibility we would have to bring back the admission plugin for 4.16 and use for 4.17 use `optionalOldSelf`.