### PR TITLE
OCPBUGS-36469: Update placementGroupPartition to pointer

### DIFF
--- a/machine/v1beta1/types_awsprovider.go
+++ b/machine/v1beta1/types_awsprovider.go
@@ -90,7 +90,7 @@ type AWSMachineProviderConfig struct {
 	// +kubebuilder:validation:Minimum:=1
 	// +kubebuilder:validation:Maximum:=7
 	// +optional
-	PlacementGroupPartition int32 `json:"placementGroupPartition,omitempty"`
+	PlacementGroupPartition *int32 `json:"placementGroupPartition,omitempty"`
 }
 
 // BlockDeviceMappingSpec describes a block device mapping

--- a/machine/v1beta1/zz_generated.deepcopy.go
+++ b/machine/v1beta1/zz_generated.deepcopy.go
@@ -75,6 +75,11 @@ func (in *AWSMachineProviderConfig) DeepCopyInto(out *AWSMachineProviderConfig) 
 		(*in).DeepCopyInto(*out)
 	}
 	out.MetadataServiceOptions = in.MetadataServiceOptions
+	if in.PlacementGroupPartition != nil {
+		in, out := &in.PlacementGroupPartition, &out.PlacementGroupPartition
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Since this API does not support kubebuilder marker validations, we added the [range validation (1-7)](https://github.com/openshift/machine-api-operator/pull/1265) as a webhook validation, which will run after that value got defaulted to 0.

However, as discussed in https://issues.redhat.com/browse/CFE-1066, there is a semantic difference between unset and 0

Making this field as pointer would help differentiate between unset and `0`