### PR TITLE
WRKLDS-1380: DeploymentConfig: drop capability from the enabled-by-default set

### DIFF
--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -567,7 +567,6 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityNodeTuning,
 		ClusterVersionCapabilityMachineAPI,
 		ClusterVersionCapabilityBuild,
-		ClusterVersionCapabilityDeploymentConfig,
 		ClusterVersionCapabilityImageRegistry,
 		ClusterVersionCapabilityOperatorLifecycleManager,
 		ClusterVersionCapabilityCloudCredential,


### PR DESCRIPTION
DeploymentConfigs are deprecated. They will not get removed from 4.Y. Users are expected to migrate to Deployments wherever possible. Disabling the capability by default is part of making the default installation smaller while providing only the necessary key components.

Removal tested in https://github.com/openshift/cluster-version-operator/pull/1066.