### PR TITLE
NE-1530: Fix empty subnet list CEL validation

### DIFF
--- a/operator/v1/tests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
+++ b/operator/v1/tests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
@@ -318,7 +318,7 @@ tests:
                       - subnet00000000000000010
                       - subnet00000000000000011
       expectedError: "spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.classicLoadBalancer.subnets.names: Too many: 11: must have at most 10 items"
-    - name: Should not be able to create ingresscontroller with spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.subnets specified, but no ids or names.
+    - name: Should not be able to create ingresscontroller with spec.endpointPublishingStrategy.loadBalancer.providerParameters.classicLoadBalancer.aws.subnets specified, but no ids or names.
       initial: |
         apiVersion: operator.openshift.io/v1
         kind: IngressController
@@ -333,6 +333,24 @@ tests:
                   type: Classic
                   classicLoadBalancer:
                     subnets: {}
+      expectedError: "must specify at least 1 subnet name or id"
+    - name: Should not be able to create ingresscontroller with spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.classicLoadBalancer.subnets specified, but empty ids and names.
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        spec:
+          endpointPublishingStrategy:
+            type: LoadBalancerService
+            loadBalancer:
+              scope: External
+              providerParameters:
+                type: AWS
+                aws:
+                  type: Classic
+                  classicLoadBalancer:
+                    subnets:
+                      ids: []
+                      names: []
       expectedError: "must specify at least 1 subnet name or id"
     - name: Should not be able to create ingresscontroller with subnet id less than 24 characters.
       initial: |

--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -561,7 +561,7 @@ const (
 // AWSSubnets contains a list of references to AWS subnets by
 // ID or name.
 // +kubebuilder:validation:XValidation:rule=`has(self.ids) && has(self.names) ? size(self.ids + self.names) <= 10 : true`,message="the total number of subnets cannot exceed 10"
-// +kubebuilder:validation:XValidation:rule=`has(self.ids) || has(self.names)`,message="must specify at least 1 subnet name or id"
+// +kubebuilder:validation:XValidation:rule=`has(self.ids) && self.ids.size() > 0 || has(self.names) && self.names.size() > 0`,message="must specify at least 1 subnet name or id"
 type AWSSubnets struct {
 	// ids specifies a list of AWS subnets by subnet ID.
 	// Subnet IDs must start with "subnet-", consist only

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-CustomNoUpgrade.crd.yaml
@@ -360,7 +360,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               networkLoadBalancer:
                                 description: networkLoadBalancerParameters holds configuration
@@ -440,7 +441,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               type:
                                 description: "type is the type of AWS load balancer
@@ -2162,7 +2164,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               networkLoadBalancer:
                                 description: networkLoadBalancerParameters holds configuration
@@ -2242,7 +2245,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               type:
                                 description: "type is the type of AWS load balancer

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-DevPreviewNoUpgrade.crd.yaml
@@ -360,7 +360,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               networkLoadBalancer:
                                 description: networkLoadBalancerParameters holds configuration
@@ -440,7 +441,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               type:
                                 description: "type is the type of AWS load balancer
@@ -2162,7 +2164,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               networkLoadBalancer:
                                 description: networkLoadBalancerParameters holds configuration
@@ -2242,7 +2245,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               type:
                                 description: "type is the type of AWS load balancer

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers-TechPreviewNoUpgrade.crd.yaml
@@ -360,7 +360,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               networkLoadBalancer:
                                 description: networkLoadBalancerParameters holds configuration
@@ -440,7 +441,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               type:
                                 description: "type is the type of AWS load balancer
@@ -2162,7 +2164,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               networkLoadBalancer:
                                 description: networkLoadBalancerParameters holds configuration
@@ -2242,7 +2245,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               type:
                                 description: "type is the type of AWS load balancer

--- a/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
@@ -360,7 +360,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               networkLoadBalancer:
                                 description: networkLoadBalancerParameters holds configuration
@@ -440,7 +441,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               type:
                                 description: "type is the type of AWS load balancer
@@ -2144,7 +2146,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               networkLoadBalancer:
                                 description: networkLoadBalancerParameters holds configuration
@@ -2224,7 +2227,8 @@ spec:
                                         + self.names) <= 10 : true'
                                     - message: must specify at least 1 subnet name
                                         or id
-                                      rule: has(self.ids) || has(self.names)
+                                      rule: has(self.ids) && self.ids.size() > 0 ||
+                                        has(self.names) && self.names.size() > 0
                                 type: object
                               type:
                                 description: "type is the type of AWS load balancer


### PR DESCRIPTION
The CEL validation for AWSSubnets enforcing at least 1 subnet to be specified was not correct as it still allowed for empty [] ID and name slices. This fix ensures that at least 1 subnet ID or name is specified if the subnets struct is not nil.