### PR TITLE
OSASINFRA-3689: Deprecate unused MAPO fields

### DIFF
--- a/machine/v1alpha1/types_openstack.go
+++ b/machine/v1alpha1/types_openstack.go
@@ -51,6 +51,7 @@ type OpenstackProviderSpec struct {
 	KeyName string `json:"keyName,omitempty"`
 
 	// The machine ssh username
+	// Deprecated: sshUserName is silently ignored.
 	SshUserName string `json:"sshUserName,omitempty"`
 
 	// A networks object. Required parameter when there are multiple networks defined for the tenant.
@@ -108,6 +109,7 @@ type OpenstackProviderSpec struct {
 	ServerGroupName string `json:"serverGroupName,omitempty"`
 
 	// The subnet that a set of machines will get ingress/egress traffic from
+	// Deprecated: primarySubnet is silently ignored. Use subnets instead.
 	PrimarySubnet string `json:"primarySubnet,omitempty"`
 }
 
@@ -161,6 +163,7 @@ type NetworkParam struct {
 	// The UUID of the network. Required if you omit the port attribute.
 	UUID string `json:"uuid,omitempty"`
 	// A fixed IPv4 address for the NIC.
+	// Deprecated: fixedIP is silently ignored. Use subnets instead.
 	FixedIp string `json:"fixedIp,omitempty"`
 	// Filters for optional network query
 	Filter Filter `json:"filter,omitempty"`
@@ -233,6 +236,7 @@ type SubnetParam struct {
 	PortTags []string `json:"portTags,omitempty"`
 
 	// portSecurity optionally enables or disables security on ports managed by OpenStack
+	// Deprecated: portSecurity is silently ignored. Set portSecurity on the parent network instead.
 	PortSecurity *bool `json:"portSecurity,omitempty"`
 }
 
@@ -263,6 +267,7 @@ type SubnetFilter struct {
 	// ipv6RaMode filters subnets by IPv6 router adversiement mode.
 	IPv6RAMode string `json:"ipv6RaMode,omitempty"`
 	// subnetpoolId filters subnets by subnet pool ID.
+	// Deprecated: subnetpoolId is silently ignored.
 	SubnetPoolID string `json:"subnetpoolId,omitempty"`
 	// tags filters by subnets containing all specified tags.
 	// Multiple tags are comma separated.
@@ -307,11 +312,12 @@ type PortOpts struct {
 	// tenantID specifies the tenant ID of the created port. Note that this
 	// requires OpenShift to have administrative permissions, which is
 	// typically not the case. Use of this field is not recommended.
-	// Deprecated: use projectID instead. It will be ignored if projectID is set.
+	// Deprecated: tenantID is silently ignored.
 	TenantID string `json:"tenantID,omitempty"`
 	// projectID specifies the project ID of the created port. Note that this
 	// requires OpenShift to have administrative permissions, which is
 	// typically not the case. Use of this field is not recommended.
+	// Deprecated: projectID is silently ignored.
 	ProjectID string `json:"projectID,omitempty"`
 	// securityGroups specifies a set of security group UUIDs to use instead
 	// of the machine's default security groups. The default security groups

--- a/machine/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -76,7 +76,7 @@ func (FixedIPs) SwaggerDoc() map[string]string {
 
 var map_NetworkParam = map[string]string{
 	"uuid":                  "The UUID of the network. Required if you omit the port attribute.",
-	"fixedIp":               "A fixed IPv4 address for the NIC.",
+	"fixedIp":               "A fixed IPv4 address for the NIC. Deprecated: fixedIP is silently ignored. Use subnets instead.",
 	"filter":                "Filters for optional network query",
 	"subnets":               "Subnet within a network to use",
 	"noAllowedAddressPairs": "noAllowedAddressPairs disables creation of allowed address pairs for the network ports",
@@ -98,7 +98,7 @@ var map_OpenstackProviderSpec = map[string]string{
 	"flavor":                 "The flavor reference for the flavor for your server instance.",
 	"image":                  "The name of the image to use for your server instance. If the RootVolume is specified, this will be ignored and use rootVolume directly.",
 	"keyName":                "The ssh key to inject in the instance",
-	"sshUserName":            "The machine ssh username",
+	"sshUserName":            "The machine ssh username Deprecated: sshUserName is silently ignored.",
 	"networks":               "A networks object. Required parameter when there are multiple networks defined for the tenant. When you do not specify the networks parameter, the server attaches to the only network created for the current tenant.",
 	"ports":                  "Create and assign additional ports to instances",
 	"floatingIP":             "floatingIP specifies a floating IP to be associated with the machine. Note that it is not safe to use this parameter in a MachineSet, as only one Machine may be assigned the same floating IP.\n\nDeprecated: floatingIP will be removed in a future release as it cannot be implemented correctly.",
@@ -113,7 +113,7 @@ var map_OpenstackProviderSpec = map[string]string{
 	"additionalBlockDevices": "additionalBlockDevices is a list of specifications for additional block devices to attach to the server instance",
 	"serverGroupID":          "The server group to assign the machine to.",
 	"serverGroupName":        "The server group to assign the machine to. A server group with that name will be created if it does not exist. If both ServerGroupID and ServerGroupName are non-empty, they must refer to the same OpenStack resource.",
-	"primarySubnet":          "The subnet that a set of machines will get ingress/egress traffic from",
+	"primarySubnet":          "The subnet that a set of machines will get ingress/egress traffic from Deprecated: primarySubnet is silently ignored. Use subnets instead.",
 }
 
 func (OpenstackProviderSpec) SwaggerDoc() map[string]string {
@@ -127,8 +127,8 @@ var map_PortOpts = map[string]string{
 	"adminStateUp":        "adminStateUp sets the administrative state of the created port to up (true), or down (false).",
 	"macAddress":          "macAddress specifies the MAC address of the created port.",
 	"fixedIPs":            "fixedIPs specifies a set of fixed IPs to assign to the port. They must all be valid for the port's network.",
-	"tenantID":            "tenantID specifies the tenant ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: use projectID instead. It will be ignored if projectID is set.",
-	"projectID":           "projectID specifies the project ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended.",
+	"tenantID":            "tenantID specifies the tenant ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: tenantID is silently ignored.",
+	"projectID":           "projectID specifies the project ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: projectID is silently ignored.",
 	"securityGroups":      "securityGroups specifies a set of security group UUIDs to use instead of the machine's default security groups. The default security groups will be used if this is left empty or not specified.",
 	"allowedAddressPairs": "allowedAddressPairs specifies a set of allowed address pairs to add to the port.",
 	"tags":                "tags species a set of tags to add to the port.",
@@ -198,7 +198,7 @@ var map_SubnetFilter = map[string]string{
 	"cidr":            "cidr filters subnets by CIDR.",
 	"ipv6AddressMode": "ipv6AddressMode filters subnets by IPv6 address mode.",
 	"ipv6RaMode":      "ipv6RaMode filters subnets by IPv6 router adversiement mode.",
-	"subnetpoolId":    "subnetpoolId filters subnets by subnet pool ID.",
+	"subnetpoolId":    "subnetpoolId filters subnets by subnet pool ID. Deprecated: subnetpoolId is silently ignored.",
 	"tags":            "tags filters by subnets containing all specified tags. Multiple tags are comma separated.",
 	"tagsAny":         "tagsAny filters by subnets containing any specified tags. Multiple tags are comma separated.",
 	"notTags":         "notTags filters by subnets which don't match all specified tags. NOT (t1 AND t2...) Multiple tags are comma separated.",
@@ -218,7 +218,7 @@ var map_SubnetParam = map[string]string{
 	"uuid":         "The UUID of the network. Required if you omit the port attribute.",
 	"filter":       "Filters for optional network query",
 	"portTags":     "portTags are tags that are added to ports created on this subnet",
-	"portSecurity": "portSecurity optionally enables or disables security on ports managed by OpenStack",
+	"portSecurity": "portSecurity optionally enables or disables security on ports managed by OpenStack Deprecated: portSecurity is silently ignored. Set portSecurity on the parent network instead.",
 }
 
 func (SubnetParam) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -34586,7 +34586,7 @@ func schema_openshift_api_machine_v1alpha1_NetworkParam(ref common.ReferenceCall
 					},
 					"fixedIp": {
 						SchemaProps: spec.SchemaProps{
-							Description: "A fixed IPv4 address for the NIC.",
+							Description: "A fixed IPv4 address for the NIC. Deprecated: fixedIP is silently ignored. Use subnets instead.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -34739,7 +34739,7 @@ func schema_openshift_api_machine_v1alpha1_OpenstackProviderSpec(ref common.Refe
 					},
 					"sshUserName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The machine ssh username",
+							Description: "The machine ssh username Deprecated: sshUserName is silently ignored.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -34895,7 +34895,7 @@ func schema_openshift_api_machine_v1alpha1_OpenstackProviderSpec(ref common.Refe
 					},
 					"primarySubnet": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The subnet that a set of machines will get ingress/egress traffic from",
+							Description: "The subnet that a set of machines will get ingress/egress traffic from Deprecated: primarySubnet is silently ignored. Use subnets instead.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -34967,14 +34967,14 @@ func schema_openshift_api_machine_v1alpha1_PortOpts(ref common.ReferenceCallback
 					},
 					"tenantID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "tenantID specifies the tenant ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: use projectID instead. It will be ignored if projectID is set.",
+							Description: "tenantID specifies the tenant ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: tenantID is silently ignored.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"projectID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "projectID specifies the project ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended.",
+							Description: "projectID specifies the project ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: projectID is silently ignored.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -35353,7 +35353,7 @@ func schema_openshift_api_machine_v1alpha1_SubnetFilter(ref common.ReferenceCall
 					},
 					"subnetpoolId": {
 						SchemaProps: spec.SchemaProps{
-							Description: "subnetpoolId filters subnets by subnet pool ID.",
+							Description: "subnetpoolId filters subnets by subnet pool ID. Deprecated: subnetpoolId is silently ignored.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -35464,7 +35464,7 @@ func schema_openshift_api_machine_v1alpha1_SubnetParam(ref common.ReferenceCallb
 					},
 					"portSecurity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "portSecurity optionally enables or disables security on ports managed by OpenStack",
+							Description: "portSecurity optionally enables or disables security on ports managed by OpenStack Deprecated: portSecurity is silently ignored. Set portSecurity on the parent network instead.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -19965,7 +19965,7 @@
           "$ref": "#/definitions/com.github.openshift.api.machine.v1alpha1.Filter"
         },
         "fixedIp": {
-          "description": "A fixed IPv4 address for the NIC.",
+          "description": "A fixed IPv4 address for the NIC. Deprecated: fixedIP is silently ignored. Use subnets instead.",
           "type": "string"
         },
         "noAllowedAddressPairs": {
@@ -20097,7 +20097,7 @@
           }
         },
         "primarySubnet": {
-          "description": "The subnet that a set of machines will get ingress/egress traffic from",
+          "description": "The subnet that a set of machines will get ingress/egress traffic from Deprecated: primarySubnet is silently ignored. Use subnets instead.",
           "type": "string"
         },
         "rootVolume": {
@@ -20129,7 +20129,7 @@
           }
         },
         "sshUserName": {
-          "description": "The machine ssh username",
+          "description": "The machine ssh username Deprecated: sshUserName is silently ignored.",
           "type": "string"
         },
         "tags": {
@@ -20210,7 +20210,7 @@
           }
         },
         "projectID": {
-          "description": "projectID specifies the project ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended.",
+          "description": "projectID specifies the project ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: projectID is silently ignored.",
           "type": "string"
         },
         "securityGroups": {
@@ -20230,7 +20230,7 @@
           }
         },
         "tenantID": {
-          "description": "tenantID specifies the tenant ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: use projectID instead. It will be ignored if projectID is set.",
+          "description": "tenantID specifies the tenant ID of the created port. Note that this requires OpenShift to have administrative permissions, which is typically not the case. Use of this field is not recommended. Deprecated: tenantID is silently ignored.",
           "type": "string"
         },
         "trunk": {
@@ -20423,7 +20423,7 @@
           "type": "string"
         },
         "subnetpoolId": {
-          "description": "subnetpoolId filters subnets by subnet pool ID.",
+          "description": "subnetpoolId filters subnets by subnet pool ID. Deprecated: subnetpoolId is silently ignored.",
           "type": "string"
         },
         "tags": {
@@ -20449,7 +20449,7 @@
           "$ref": "#/definitions/com.github.openshift.api.machine.v1alpha1.SubnetFilter"
         },
         "portSecurity": {
-          "description": "portSecurity optionally enables or disables security on ports managed by OpenStack",
+          "description": "portSecurity optionally enables or disables security on ports managed by OpenStack Deprecated: portSecurity is silently ignored. Set portSecurity on the parent network instead.",
           "type": "boolean"
         },
         "portTags": {


### PR DESCRIPTION
This has no real impact on end-users but it is useful flag for reviewers as we start translating from MAPO<->CAPO. Some of these issues - such as `SecurityGroupFilter.TenantID` being ignored rather than "coalesced" with the `ProjectID` field - are likely bugs, but we're not going to fix these at this stage of MAPO's lifecycle.
    
This was generated via manual inspection of MAPO, most significantly the https://github.com/openshift/machine-api-provider-openstack/blob/release-4.18/pkg/machine/convert.go file.