### PR TITLE
Power VS: Use CEL to check if endpoint is valid or oldSelf 

### DIFF
--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -1568,7 +1568,8 @@ type PowerVSServiceEndpoint struct {
 	// Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern=`^[a-z0-9-]+$`
+	// +kubebuilder:validation:MaxLength=18
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || self in ['CIS', 'COS', 'COSConfig', 'DNSServices', 'GlobalCatalog', 'GlobalSearch', 'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect', 'Power', 'ResourceController', 'ResourceManager', 'VPC']",message="serviceEndpoint name is not CIS, COS, COSConfig, DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging, HyperProtect, IAM, KeyProtect, Power, ResourceController, ResourceManager, or VPC"
 	Name string `json:"name"`
 
 	// url is fully qualified URI with scheme https, that overrides the default generated

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -2043,8 +2053,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -1815,8 +1825,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -2043,8 +2053,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -2043,8 +2053,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -1703,8 +1713,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -1786,8 +1796,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -1813,8 +1823,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -1819,8 +1829,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -1718,8 +1728,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
@@ -524,8 +524,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -1703,8 +1713,18 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
+                              maxLength: 18
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2415,8 +2426,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2167,8 +2178,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2415,8 +2426,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2415,8 +2426,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2060,8 +2071,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2149,8 +2160,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2177,8 +2188,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2189,8 +2200,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2076,8 +2087,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
@@ -800,8 +800,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated
@@ -2060,8 +2071,19 @@ spec:
                                         service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                         ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                         Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                                      pattern: ^[a-z0-9-]+$
+                                      maxLength: 18
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: serviceEndpoint name is not CIS,
+                                          COS, COSConfig, DNSServices, GlobalCatalog,
+                                          GlobalSearch, GlobalTagging, HyperProtect,
+                                          IAM, KeyProtect, Power, ResourceController,
+                                          ResourceManager, or VPC
+                                        rule: self == oldSelf || self in ['CIS', 'COS',
+                                          'COSConfig', 'DNSServices', 'GlobalCatalog',
+                                          'GlobalSearch', 'GlobalTagging', 'HyperProtect',
+                                          'IAM', 'KeyProtect', 'Power', 'ResourceController',
+                                          'ResourceManager', 'VPC']
                                     url:
                                       description: url is fully qualified URI with
                                         scheme https, that overrides the default generated

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -524,8 +524,17 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -2043,8 +2052,17 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -524,8 +524,17 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -1815,8 +1824,17 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -524,8 +524,17 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -2043,8 +2052,17 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -524,8 +524,17 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint
@@ -2043,8 +2052,17 @@ spec:
                                 Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
                                 ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
                                 Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
-                              pattern: ^[a-z0-9-]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: serviceEndpoint name is not CIS, COS, COSConfig,
+                                  DNSServices, GlobalCatalog, GlobalSearch, GlobalTagging,
+                                  HyperProtect, IAM, KeyProtect, Power, ResourceController,
+                                  ResourceManager, or VPC
+                                rule: self == oldSelf || self in ['CIS', 'COS', 'COSConfig',
+                                  'DNSServices', 'GlobalCatalog', 'GlobalSearch',
+                                  'GlobalTagging', 'HyperProtect', 'IAM', 'KeyProtect',
+                                  'Power', 'ResourceController', 'ResourceManager',
+                                  'VPC']
                             url:
                               description: url is fully qualified URI with scheme
                                 https, that overrides the default generated endpoint


### PR DESCRIPTION
To allow us to match against valid endpoint names, we need to update the endpoint validation to check against the valid set of endpoint names. While endpoint overrides should be unused in previous releases, we'll also allow for legacy values in case they were used.