### PR TITLE
Added Feature Gate for Bootc Update Path

### DIFF
--- a/features.md
+++ b/features.md
@@ -10,6 +10,7 @@
 | MultiArchInstallGCP| | | | | |  |
 | GatewayAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | AutomatedEtcdBackup| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| BootcNodeManagement| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | CSIDriverSharedResource| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ChunkSizeMiB| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ClusterAPIInstallAzure| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -348,6 +348,13 @@ var (
 					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
+	FeatureGateBootcNodeManagement = newFeatureGate("BootcNodeManagement").
+					reportProblemsToJiraComponent("MachineConfigOperator").
+					contactPerson("inesqyx").
+					productScope(ocpSpecific).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
+
 	FeatureGateSignatureStores = newFeatureGate("SignatureStores").
 					reportProblemsToJiraComponent("Cluster Version Operator").
 					contactPerson("lmohanty").

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -17,6 +17,9 @@
                         "name": "AutomatedEtcdBackup"
                     },
                     {
+                        "name": "BootcNodeManagement"
+                    },
+                    {
                         "name": "CSIDriverSharedResource"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -57,6 +57,9 @@
                         "name": "BareMetalLoadBalancer"
                     },
                     {
+                        "name": "BootcNodeManagement"
+                    },
+                    {
                         "name": "BuildCSIVolumes"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -60,6 +60,9 @@
                         "name": "BareMetalLoadBalancer"
                     },
                     {
+                        "name": "BootcNodeManagement"
+                    },
+                    {
                         "name": "BuildCSIVolumes"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -17,6 +17,9 @@
                         "name": "AutomatedEtcdBackup"
                     },
                     {
+                        "name": "BootcNodeManagement"
+                    },
+                    {
                         "name": "CSIDriverSharedResource"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -57,6 +57,9 @@
                         "name": "BareMetalLoadBalancer"
                     },
                     {
+                        "name": "BootcNodeManagement"
+                    },
+                    {
                         "name": "BuildCSIVolumes"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -60,6 +60,9 @@
                         "name": "BareMetalLoadBalancer"
                     },
                     {
+                        "name": "BootcNodeManagement"
+                    },
+                    {
                         "name": "BuildCSIVolumes"
                     },
                     {


### PR DESCRIPTION
This is for https://github.com/openshift/enhancements/pull/1631
The MCO is experimenting a bootc based OS content update path, to prepare for the deprecation of rpm-ostree. Before bootc is fully ready, we need to gate the path from default mainly for testing purposes. 