### PR TITLE
AUTH-527: security/v1 - add constant for enforcing psa annotation

### DIFF
--- a/security/v1/consts.go
+++ b/security/v1/consts.go
@@ -10,4 +10,7 @@ const (
 	// This annotation pins required SCCs for core OpenShift workloads to prevent preemption of custom SCCs.
 	// It is being used in the SCC admission plugin.
 	RequiredSCCAnnotation = "openshift.io/required-scc"
+
+	// MinimallySufficientPodSecurityStandard indicates the PodSecurityStandard that matched the SCCs available to the users of the namespace.
+	MinimallySufficientPodSecurityStandard = "security.openshift.io/psa"
 )

--- a/security/v1/consts.go
+++ b/security/v1/consts.go
@@ -12,5 +12,5 @@ const (
 	RequiredSCCAnnotation = "openshift.io/required-scc"
 
 	// MinimallySufficientPodSecurityStandard indicates the PodSecurityStandard that matched the SCCs available to the users of the namespace.
-	MinimallySufficientPodSecurityStandard = "security.openshift.io/psa"
+	MinimallySufficientPodSecurityStandard = "security.openshift.io/MinimallySufficientPodSecurityStandard"
 )


### PR DESCRIPTION
## What

Add an annotation constant that reveals what the label syncer would enforce.

## Why

It is unclear what the label syncer would set, if alert labels are set or the syncer is turned off.
