### PR TITLE
featuregate analyzer: use correct platform name

### DIFF
--- a/tools/codegen/cmd/featuregate-test-analyzer.go
+++ b/tools/codegen/cmd/featuregate-test-analyzer.go
@@ -342,7 +342,7 @@ var (
 			Topology:     "ha",
 		},
 		{
-			Cloud:        "vsphere-ipi",
+			Cloud:        "vsphere",
 			Architecture: "amd64",
 			Topology:     "ha",
 		},


### PR DESCRIPTION
vsphere-ipi is now just vsphere for the platform name after the move to the variant registry.