### PR TITLE
Update envtest publishing to create index file

### DIFF
--- a/envtest-releases.yaml
+++ b/envtest-releases.yaml
@@ -1,0 +1,14 @@
+releases:
+    v1.30.3:
+        envtest-v1.30.3-darwin-amd64.tar.gz:
+            hash: 81ab2ad5841522976d9a5fc58642b745cf308230b0f2e634acfb2d5c8f288ef837f7b82144a5e91db607d86885101e06dd473a68bcac0d71be2297edc4aaa92e
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.30.3-darwin-amd64.tar.gz
+        envtest-v1.30.3-darwin-arm64.tar.gz:
+            hash: 8913c1e2e4b6eab0c92d9ddc611cea1b8a5173374e7544a667366ea66bc98a7d3442f21d34e7da65ba2dbe8e5778b2b0497943514b7b3639fc793bd0e98086f5
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.30.3-darwin-arm64.tar.gz
+        envtest-v1.30.3-linux-amd64.tar.gz:
+            hash: 6e81caf1d20c608b0149f36ca8dc6d68e97b22e07f69f1f0788d6c0057ae92fcaae402d26b6766819a31dac1911c6d07bf0328f152d6dd52dcebee94009de024
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.30.3-linux-amd64.tar.gz
+        envtest-v1.30.3-linux-arm64.tar.gz:
+            hash: deb395d5e9578a58786c42b4e7d878b4aef984ac2dce510031fbecf12092162a4aee1cde774f1527cfae90f6885382dc7b3d79ec379b7f4160c3a35fad7cbc3b
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.30.3-linux-arm64.tar.gz

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -33,9 +33,9 @@ PULL_SECRET?=${PULL_SECRET:-$(HOME)/pull-secret.txt}
 publish-kubebuilder-tools:
 	@# This should only need to be run once per combination of args.
 	@# Make sure to update the `-version` to the full semver (x.y.z) of the Kube version that the release is based on (check o/k).
-	@# The payload should be any nightly or EC build published in the CI registry that matches the defined version.
+	@# The payload should be any CI build (not nightly/EC) published in the CI registry that matches the defined version.
 	@# Pull secret should be the standard pull secret used for spinning up OpenShift clusters, if you do not have one, follow https://docs.google.com/document/d/1ez2jrjiIQJChobfSu2ISJ5uM_-3HGouamL_xIa2_1W4/edit#heading=h.me93l6citmsq
-	go run ./publish-kubebuilder-tools/main.go -version 1.30.1 -output-dir /tmp/kubebuilder-tools -payload=registry.ci.openshift.org/ocp/release:4.17.0-0.ci-2024-06-11-041713 -pull-secret $(PULL_SECRET)
+	go run ./publish-kubebuilder-tools/main.go -version v1.30.3 -output-dir /tmp/kubebuilder-tools -payload=registry.ci.openshift.org/ocp/release:4.17.0-0.ci-2024-08-15-064358 -pull-secret $(PULL_SECRET) -index-file ../envtest-releases.yaml
 
 #############################################
 #

--- a/tools/publish-kubebuilder-tools/README.md
+++ b/tools/publish-kubebuilder-tools/README.md
@@ -10,10 +10,13 @@ The archives are then optionally published to the release buck `openshift-kubebu
 ## Usage
 
 `-pull-secret <string>`: The path to an OpenShift pull secret file that can pull from `registry.ci.openshift.org`
-`-payload <string>`: The payload image that should be used to create the artifacts. This should be from the CI or nightly streams. The format will be `registry.ci.openshift.org/ocp/release:<version>`
+`-payload <string>`: The payload image that should be used to create the artifacts. This should be from the CI stream. The format will be `registry.ci.openshift.org/ocp/release:<version>`
 `-version <string>`: The Kubernetes version to represent in the archives. This should be the Kubernetes release version from the payload, eg `1.29.1`.
 `-output-dir <string>`: A working directory to store the archives. The binaries will be extracted here and the archives will be created here.
 `-skip-upload <bool>`: Skip uploading the artifacts to the GCS bucket. This can be used if you are not authenticated to GCP.
+`-index-file <string>`: The path to the index file that should be updated with the new archives. This is optional and will default to `./envtest-releases.yaml`.
+
+```bash
 
 ## Archive uploads
 


### PR DESCRIPTION
The newest versions of envtest rely on a published index file to identify and download archives containing the relevant KAS and etcd binaries.

This PR introduces this from 1.30.3 (4.17) so that those updating controller runtime can move away from the deprecated GCS discovery and into this brave new world.

The tooling for publishing kubebuilder artifacts now publishes the binaries as it did before, but, calculates the hash of the archive and adds a new entry to the `envtest-releases.yaml` file in the root of this repo.

This will be used in repositories across OpenShift to use an OpenShift build of KAS, by adding the following flag
```
--index https://raw.githubusercontent.com/openshift/api/master/envtest-releases.yaml
```

They can now drop the `remote-bucket` and `-use-deprecated-gcs` flags.

Demo in a real repo https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/361