### PR TITLE
featuregate analyzer: fix platform name for metal

### DIFF
--- a/tools/codegen/cmd/featuregate-test-analyzer.go
+++ b/tools/codegen/cmd/featuregate-test-analyzer.go
@@ -275,7 +275,11 @@ func writeTestingMarkDown(testingResults map[JobVariant]*TestingResults, md *uti
 	md.Exact("Test ")
 	for _, jobVariant := range jobVariants {
 		md.NextTableColumn()
-		md.Exact(fmt.Sprintf("%v <br/> %v <br/> %v ", jobVariant.Topology, jobVariant.Cloud, jobVariant.Architecture))
+		columnHeader := fmt.Sprintf("%v <br/> %v <br/> %v ", jobVariant.Topology, jobVariant.Cloud, jobVariant.Architecture)
+		if jobVariant.NetworkStack != "" {
+			columnHeader = columnHeader + fmt.Sprintf("<br/> %v ", jobVariant.NetworkStack)
+		}
+		md.Exact(columnHeader)
 	}
 	md.EndTableRow()
 	md.NextTableColumn()

--- a/tools/codegen/cmd/featuregate-test-analyzer.go
+++ b/tools/codegen/cmd/featuregate-test-analyzer.go
@@ -347,19 +347,19 @@ var (
 			Topology:     "ha",
 		},
 		{
-			Cloud:        "metal-ipi",
+			Cloud:        "metal",
 			Architecture: "amd64",
 			Topology:     "ha",
 			NetworkStack: "ipv4",
 		},
 		{
-			Cloud:        "metal-ipi",
+			Cloud:        "metal",
 			Architecture: "amd64",
 			Topology:     "ha",
 			NetworkStack: "ipv6",
 		},
 		{
-			Cloud:        "metal-ipi",
+			Cloud:        "metal",
 			Architecture: "amd64",
 			Topology:     "ha",
 			NetworkStack: "dual",


### PR DESCRIPTION
Like vsphere, metal-ipi is now just metal in Sippy. Also show network stack in the summary page

Example: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_api/2003/pull-ci-openshift-api-master-verify/1824454654252027904/artifacts/test/artifacts/feature-promotion-summary.html

