### PR TITLE
OCPBUGS-41642: config/v1/types_cluster_version: Add v4.17 capability set

### DIFF
--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -428,7 +428,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 }
 
 // ClusterVersionCapabilitySet defines sets of cluster version capabilities.
-// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;v4.14;v4.15;v4.16;vCurrent
+// +kubebuilder:validation:Enum=None;v4.11;v4.12;v4.13;v4.14;v4.15;v4.16;v4.17;vCurrent
 type ClusterVersionCapabilitySet string
 
 const (
@@ -471,6 +471,12 @@ const (
 	// OpenShift.  This list will remain the same no matter which
 	// version of OpenShift is installed.
 	ClusterVersionCapabilitySet4_16 ClusterVersionCapabilitySet = "v4.16"
+
+	// ClusterVersionCapabilitySet4_17 is the recommended set of
+	// optional capabilities to enable for the 4.17 version of
+	// OpenShift.  This list will remain the same no matter which
+	// version of OpenShift is installed.
+	ClusterVersionCapabilitySet4_17 ClusterVersionCapabilitySet = "v4.17"
 
 	// ClusterVersionCapabilitySetCurrent is the recommended set
 	// of optional capabilities to enable for the cluster's
@@ -539,6 +545,24 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityCloudCredential,
 	},
 	ClusterVersionCapabilitySet4_16: {
+		ClusterVersionCapabilityBaremetal,
+		ClusterVersionCapabilityConsole,
+		ClusterVersionCapabilityInsights,
+		ClusterVersionCapabilityMarketplace,
+		ClusterVersionCapabilityStorage,
+		ClusterVersionCapabilityOpenShiftSamples,
+		ClusterVersionCapabilityCSISnapshot,
+		ClusterVersionCapabilityNodeTuning,
+		ClusterVersionCapabilityMachineAPI,
+		ClusterVersionCapabilityBuild,
+		ClusterVersionCapabilityDeploymentConfig,
+		ClusterVersionCapabilityImageRegistry,
+		ClusterVersionCapabilityOperatorLifecycleManager,
+		ClusterVersionCapabilityCloudCredential,
+		ClusterVersionCapabilityIngress,
+		ClusterVersionCapabilityCloudControllerManager,
+	},
+	ClusterVersionCapabilitySet4_17: {
 		ClusterVersionCapabilityBaremetal,
 		ClusterVersionCapabilityConsole,
 		ClusterVersionCapabilityInsights,

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-CustomNoUpgrade.crd.yaml
@@ -101,6 +101,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-Default.crd.yaml
@@ -101,6 +101,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-DevPreviewNoUpgrade.crd.yaml
@@ -101,6 +101,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-TechPreviewNoUpgrade.crd.yaml
@@ -101,6 +101,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object

--- a/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/AAA_ungated.yaml
@@ -103,6 +103,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object

--- a/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/SignatureStores.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/SignatureStores.yaml
@@ -103,6 +103,7 @@ spec:
                     - v4.14
                     - v4.15
                     - v4.16
+                    - v4.17
                     - vCurrent
                     type: string
                 type: object


### PR DESCRIPTION
This is a synonym for v4.16, because there have not been capability-recommendation changes since that release.  4.17 is about to go Generally Available, which means v4.17 will always be a synonym for v4.16.  I think defining synonym capability sets is busywork that takes developer time without adding customer value, but [OCPBUGS-41111][1] points out that so far every 4.y release has had a v4.y capability set string associated with it, and folks might find adjustments to that pattern surprising.  I'm declaring the v4.17 set to continue the existing set-for-each-4.y pattern (and breaking the
set-for-each-4.y-with-a-different-default pattern) to unblock 4.17's GA, but we may revisit this approach in the future with more lead time.  This commit backports (without v4.18) #2022 to `release-4.17`.

[1]: https://issues.redhat.com/browse/OCPBUGS-41111