### PR TITLE
MULTIARCH-4559: config/v1/types_cluster_version.go: Add 'architecture' to the release structure

### DIFF
--- a/config/v1/tests/clusterversions.config.openshift.io/ImageStreamImportMode.yaml
+++ b/config/v1/tests/clusterversions.config.openshift.io/ImageStreamImportMode.yaml
@@ -1,0 +1,441 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "ClusterVersion"
+crdName: clusterversions.config.openshift.io
+featureGate: ImageStreamImportMode
+tests:
+  onCreate:
+    - name: Should be able to create a minimal ClusterVersion
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+    - name: Should allow image to be set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            image: bar
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            image: bar
+    - name: Should allow version to be set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            version: 4.11.1
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            version: 4.11.1
+    - name: Should allow architecture to be empty
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            architecture: ""
+            version: 4.11.1
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            architecture: ""
+            version: 4.11.1
+    - name: Should allow architecture and version to be set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            architecture: Multi
+            version: 4.11.1
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            architecture: Multi
+            version: 4.11.1
+    - name: Version must be set if architecture is set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            architecture: Multi
+      expectedError: "Version must be set if Architecture is set"
+    - name: Should not allow image and architecture to be set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            architecture: Multi
+            version: 4.11.1
+            image: bar
+      expectedError: "cannot set both Architecture and Image"
+    - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities baremetal and MachineAPI
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+            - MachineAPI
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+            - MachineAPI
+    - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities baremetal without MachineAPI
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+    - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities marketplace and OperatorLifecycleManager
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - marketplace
+            - OperatorLifecycleManager
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - marketplace
+            - OperatorLifecycleManager
+    - name: Should not be able to create a ClusterVersion with base capability None, and additional capabilities marketplace without OperatorLifecycleManager
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - marketplace
+      expectedError: the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability
+  onUpdate:
+    - name: Should not allow image to be set if architecture set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            architecture: Multi
+            version: 4.11.1
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            architecture: Multi
+            version: 4.11.1
+            image: bar
+      expectedError: "cannot set both Architecture and Image"
+    - name: Should not allow architecture to be set if image set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            image: bar
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          desiredUpdate:
+            architecture: Multi
+            version: 4.11.1
+            image: bar
+      expectedError: "cannot set both Architecture and Image"
+    - name: Should be able to add the baremetal capability with a ClusterVersion with base capability None, and implicitly enabled MachineAPI
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+        status:
+          desired:
+            version: foo
+            image: foo
+            architecture: Multi
+          observedGeneration: 1
+          versionHash: foo
+          availableUpdates:
+          - version: foo
+            image: foo
+          capabilities:
+            enabledCapabilities:
+            - MachineAPI
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+        status:
+          desired:
+            version: foo
+            image: foo
+            architecture: Multi
+          observedGeneration: 1
+          versionHash: foo
+          availableUpdates:
+          - version: foo
+            image: foo
+          capabilities:
+            enabledCapabilities:
+            - MachineAPI
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+        status:
+          desired:
+            version: foo
+            image: foo
+            architecture: Multi
+          observedGeneration: 1
+          versionHash: foo
+          availableUpdates:
+          - version: foo
+            image: foo
+          capabilities:
+            enabledCapabilities:
+            - MachineAPI
+    - name: Should be able to add the baremetal capability with a ClusterVersion with base capability None, with the Machine API capability
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+            - MachineAPI
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+            - MachineAPI
+    - name: Should be able to add the baremetal capability without MachineAPI with a ClusterVersion with base capability None
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - baremetal
+    - name: Should be able to add the marketplace capability with a ClusterVersion with base capability None, and implicitly enabled OperatorLifecycleManager
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+        status:
+          desired:
+            version: foo
+            image: foo
+            architecture: Multi
+          observedGeneration: 1
+          versionHash: foo
+          availableUpdates:
+          - version: foo
+            image: foo
+          capabilities:
+            enabledCapabilities:
+            - OperatorLifecycleManager
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - marketplace
+        status:
+          desired:
+            version: foo
+            image: foo
+            architecture: Multi
+          observedGeneration: 1
+          versionHash: foo
+          availableUpdates:
+          - version: foo
+            image: foo
+          capabilities:
+            enabledCapabilities:
+            - OperatorLifecycleManager
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - marketplace
+        status:
+          desired:
+            version: foo
+            image: foo
+            architecture: Multi
+          observedGeneration: 1
+          versionHash: foo
+          availableUpdates:
+          - version: foo
+            image: foo
+          capabilities:
+            enabledCapabilities:
+            - OperatorLifecycleManager
+    - name: Should be able to add the marketplace capability with a ClusterVersion with base capability None, with the OperatorLifecycleManager capability
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - marketplace
+            - OperatorLifecycleManager
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - marketplace
+            - OperatorLifecycleManager
+    - name: Should not be able to add the marketplace capability with a ClusterVersion with base capability None, and without OperatorLifecycleManager
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - marketplace
+      expectedError: the `marketplace` capability requires the `OperatorLifecycleManager` capability, which is neither explicitly or implicitly enabled in this cluster, please enable the `OperatorLifecycleManager` capability

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -746,6 +746,16 @@ type Update struct {
 // Release represents an OpenShift release image and associated metadata.
 // +k8s:deepcopy-gen=true
 type Release struct {
+	// architecture is an optional field that indicates the
+	// value of the cluster architecture. In this context cluster
+	// architecture means either a single architecture or a multi
+	// architecture.
+	// Valid values are 'Multi' and empty.
+	//
+	// +openshift:enable:FeatureGate=ImageStreamImportMode
+	// +optional
+	Architecture ClusterVersionArchitecture `json:"architecture,omitempty"`
+
 	// version is a semantic version identifying the update version. When this
 	// field is part of spec, version is optional if image is specified.
 	// +required

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-DevPreviewNoUpgrade.crd.yaml
@@ -318,6 +318,17 @@ spec:
                   description: Release represents an OpenShift release image and associated
                     metadata.
                   properties:
+                    architecture:
+                      description: |-
+                        architecture is an optional field that indicates the
+                        value of the cluster architecture. In this context cluster
+                        architecture means either a single architecture or a multi
+                        architecture.
+                        Valid values are 'Multi' and empty.
+                      enum:
+                      - Multi
+                      - ""
+                      type: string
                     channels:
                       description: |-
                         channels is the set of Cincinnati channels to which the release
@@ -493,6 +504,17 @@ spec:
                     release:
                       description: release is the target of the update.
                       properties:
+                        architecture:
+                          description: |-
+                            architecture is an optional field that indicates the
+                            value of the cluster architecture. In this context cluster
+                            architecture means either a single architecture or a multi
+                            architecture.
+                            Valid values are 'Multi' and empty.
+                          enum:
+                          - Multi
+                          - ""
+                          type: string
                         channels:
                           description: |-
                             channels is the set of Cincinnati channels to which the release
@@ -668,6 +690,17 @@ spec:
                   If the cluster is not yet fully initialized desired will be set
                   with the information available, which may be an image or a tag.
                 properties:
+                  architecture:
+                    description: |-
+                      architecture is an optional field that indicates the
+                      value of the cluster architecture. In this context cluster
+                      architecture means either a single architecture or a multi
+                      architecture.
+                      Valid values are 'Multi' and empty.
+                    enum:
+                    - Multi
+                    - ""
+                    type: string
                   channels:
                     description: |-
                       channels is the set of Cincinnati channels to which the release

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-TechPreviewNoUpgrade.crd.yaml
@@ -318,6 +318,17 @@ spec:
                   description: Release represents an OpenShift release image and associated
                     metadata.
                   properties:
+                    architecture:
+                      description: |-
+                        architecture is an optional field that indicates the
+                        value of the cluster architecture. In this context cluster
+                        architecture means either a single architecture or a multi
+                        architecture.
+                        Valid values are 'Multi' and empty.
+                      enum:
+                      - Multi
+                      - ""
+                      type: string
                     channels:
                       description: |-
                         channels is the set of Cincinnati channels to which the release
@@ -493,6 +504,17 @@ spec:
                     release:
                       description: release is the target of the update.
                       properties:
+                        architecture:
+                          description: |-
+                            architecture is an optional field that indicates the
+                            value of the cluster architecture. In this context cluster
+                            architecture means either a single architecture or a multi
+                            architecture.
+                            Valid values are 'Multi' and empty.
+                          enum:
+                          - Multi
+                          - ""
+                          type: string
                         channels:
                           description: |-
                             channels is the set of Cincinnati channels to which the release
@@ -668,6 +690,17 @@ spec:
                   If the cluster is not yet fully initialized desired will be set
                   with the information available, which may be an image or a tag.
                 properties:
+                  architecture:
+                    description: |-
+                      architecture is an optional field that indicates the
+                      value of the cluster architecture. In this context cluster
+                      architecture means either a single architecture or a multi
+                      architecture.
+                      Valid values are 'Multi' and empty.
+                    enum:
+                    - Multi
+                    - ""
+                    type: string
                   channels:
                     description: |-
                       channels is the set of Cincinnati channels to which the release

--- a/config/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -115,6 +115,7 @@ clusterversions.config.openshift.io:
   Capability: ""
   Category: ""
   FeatureGates:
+  - ImageStreamImportMode
   - SignatureStores
   FilenameOperatorName: cluster-version-operator
   FilenameOperatorOrdering: "01"

--- a/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/ImageStreamImportMode.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/ImageStreamImportMode.yaml
@@ -3,9 +3,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/495
-    api.openshift.io/merged-by-featuregates: "true"
+    api.openshift.io/filename-cvo-runlevel: "0000_00"
+    api.openshift.io/filename-operator: cluster-version-operator
+    api.openshift.io/filename-ordering: "01"
+    feature-gate.release.openshift.io/ImageStreamImportMode: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade
   name: clusterversions.config.openshift.io
 spec:
   group: config.openshift.io
@@ -242,57 +244,6 @@ spec:
                 - group
                 - namespace
                 - name
-                x-kubernetes-list-type: map
-              signatureStores:
-                description: |-
-                  signatureStores contains the upstream URIs to verify release signatures and optional
-                  reference to a config map by name containing the PEM-encoded CA bundle.
-
-                  By default, CVO will use existing signature stores if this property is empty.
-                  The CVO will check the release signatures in the local ConfigMaps first. It will search for a valid signature
-                  in these stores in parallel only when local ConfigMaps did not include a valid signature.
-                  Validation will fail if none of the signature stores reply with valid signature before timeout.
-                  Setting signatureStores will replace the default signature stores with custom signature stores.
-                  Default stores can be used with custom signature stores by adding them manually.
-
-                  A maximum of 32 signature stores may be configured.
-                items:
-                  description: SignatureStore represents the URL of custom Signature
-                    Store
-                  properties:
-                    ca:
-                      description: |-
-                        ca is an optional reference to a config map by name containing the PEM-encoded CA bundle.
-                        It is used as a trust anchor to validate the TLS certificate presented by the remote server.
-                        The key "ca.crt" is used to locate the data.
-                        If specified and the config map or expected key is not found, the signature store is not honored.
-                        If the specified ca data is not valid, the signature store is not honored.
-                        If empty, we fall back to the CA configured via Proxy, which is appended to the default system roots.
-                        The namespace for this config map is openshift-config.
-                      properties:
-                        name:
-                          description: name is the metadata.name of the referenced
-                            config map
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    url:
-                      description: |-
-                        url contains the upstream custom signature store URL.
-                        url should be a valid absolute http/https URI of an upstream signature store as per rfc1738.
-                        This must be provided and cannot be empty.
-                      type: string
-                      x-kubernetes-validations:
-                      - message: url must be a valid absolute URL
-                        rule: isURL(self)
-                  required:
-                  - url
-                  type: object
-                maxItems: 32
-                type: array
-                x-kubernetes-list-map-keys:
-                - url
                 x-kubernetes-list-type: map
               upstream:
                 description: |-

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -772,11 +772,12 @@ func (PromQLClusterCondition) SwaggerDoc() map[string]string {
 }
 
 var map_Release = map[string]string{
-	"":         "Release represents an OpenShift release image and associated metadata.",
-	"version":  "version is a semantic version identifying the update version. When this field is part of spec, version is optional if image is specified.",
-	"image":    "image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.",
-	"url":      "url contains information about this release. This URL is set by the 'url' metadata property on a release or the metadata returned by the update API and should be displayed as a link in user interfaces. The URL field may not be set for test or nightly releases.",
-	"channels": "channels is the set of Cincinnati channels to which the release currently belongs.",
+	"":             "Release represents an OpenShift release image and associated metadata.",
+	"architecture": "architecture is an optional field that indicates the value of the cluster architecture. In this context cluster architecture means either a single architecture or a multi architecture. Valid values are 'Multi' and empty.",
+	"version":      "version is a semantic version identifying the update version. When this field is part of spec, version is optional if image is specified.",
+	"image":        "image is a container image location that contains the update. When this field is part of spec, image is optional if version is specified and the availableUpdates field contains a matching version.",
+	"url":          "url contains information about this release. This URL is set by the 'url' metadata property on a release or the metadata returned by the update API and should be displayed as a link in user interfaces. The URL field may not be set for test or nightly releases.",
+	"channels":     "channels is the set of Cincinnati channels to which the release currently belongs.",
 }
 
 func (Release) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -18128,6 +18128,13 @@ func schema_openshift_api_config_v1_Release(ref common.ReferenceCallback) common
 				Description: "Release represents an OpenShift release image and associated metadata.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"architecture": {
+						SchemaProps: spec.SchemaProps{
+							Description: "architecture is an optional field that indicates the value of the cluster architecture. In this context cluster architecture means either a single architecture or a multi architecture. Valid values are 'Multi' and empty.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
 							Description: "version is a semantic version identifying the update version. When this field is part of spec, version is optional if image is specified.",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -9765,6 +9765,10 @@
         "image"
       ],
       "properties": {
+        "architecture": {
+          "description": "architecture is an optional field that indicates the value of the cluster architecture. In this context cluster architecture means either a single architecture or a multi architecture. Valid values are 'Multi' and empty.",
+          "type": "string"
+        },
         "channels": {
           "description": "channels is the set of Cincinnati channels to which the release currently belongs.",
           "type": "array",


### PR DESCRIPTION
As [requested in the enhancement][1].  [Motivation for the new property from the enhancement][2]:

> There were a few options discussed in lieu of introducing a new ClusterVersion status field and the potential risks for doing so. The alternatives are highlighted with reasoning given for why they were not pursued:
> * Default ImportMode to PreserveOriginal everywhere: single-arch-release users maybe concerned about import size and the lack of metadata like `dockerImageLayers` and `dockerImageMetadata` for manifestlisted imagestream tags.
> * Clusters with homogeneous nodes running the multi payload who do not want to import manifestlists: The clusters can either migrate to single arch payloads or manually toggle the importMode through the image config CRD.
> * CVO provides architecural knowledge to the cluster-image-registry-operator through a configmap or the image config CRD: To limit the risk of many external consumers using CVO's status field to determine that their cluster is multi-arch ready, the idea was to expose this information to the specific controller. This solution is not necessary as we let other controller implementers decide if the CVO's new status field is the best fit for their use case.

[1]: https://github.com/openshift/enhancements/blob/36ef3f51e5b7bfb2d4af18d415ba762e0a0431ac/enhancements/multi-arch/dynamic-imagestream-importmode-setting.md#api-extensions
[2]: https://github.com/openshift/enhancements/blob/36ef3f51e5b7bfb2d4af18d415ba762e0a0431ac/enhancements/multi-arch/dynamic-imagestream-importmode-setting.md#motivations-for-a-new-clusterversion-status-property