### PR TITLE
API-1835: make operator generations behave as a map list type

### DIFF
--- a/imageregistry/v1/zz_generated.crd-manifests/00_configs.crd.yaml
+++ b/imageregistry/v1/zz_generated.crd-manifests/00_configs.crd.yaml
@@ -1987,9 +1987,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/imageregistry/v1/zz_generated.featuregated-crd-manifests/configs.imageregistry.operator.openshift.io/AAA_ungated.yaml
+++ b/imageregistry/v1/zz_generated.featuregated-crd-manifests/configs.imageregistry.operator.openshift.io/AAA_ungated.yaml
@@ -1958,9 +1958,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/imageregistry/v1/zz_generated.featuregated-crd-manifests/configs.imageregistry.operator.openshift.io/ChunkSizeMiB.yaml
+++ b/imageregistry/v1/zz_generated.featuregated-crd-manifests/configs.imageregistry.operator.openshift.io/ChunkSizeMiB.yaml
@@ -1971,9 +1971,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -44570,7 +44570,13 @@ func schema_openshift_api_operator_v1_AuthenticationStatus(ref common.ReferenceC
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -44931,7 +44937,13 @@ func schema_openshift_api_operator_v1_CSISnapshotControllerStatus(ref common.Ref
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -45282,7 +45294,13 @@ func schema_openshift_api_operator_v1_CloudCredentialStatus(ref common.Reference
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -45528,7 +45546,13 @@ func schema_openshift_api_operator_v1_ClusterCSIDriverStatus(ref common.Referenc
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -45786,7 +45810,13 @@ func schema_openshift_api_operator_v1_ConfigStatus(ref common.ReferenceCallback)
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -46225,7 +46255,13 @@ func schema_openshift_api_operator_v1_ConsoleStatus(ref common.ReferenceCallback
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -47214,7 +47250,13 @@ func schema_openshift_api_operator_v1_EtcdStatus(ref common.ReferenceCallback) c
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -49163,7 +49205,13 @@ func schema_openshift_api_operator_v1_InsightsOperatorStatus(ref common.Referenc
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -49471,7 +49519,13 @@ func schema_openshift_api_operator_v1_KubeAPIServerStatus(ref common.ReferenceCa
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -49782,7 +49836,13 @@ func schema_openshift_api_operator_v1_KubeControllerManagerStatus(ref common.Ref
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -50071,7 +50131,13 @@ func schema_openshift_api_operator_v1_KubeSchedulerStatus(ref common.ReferenceCa
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -50336,7 +50402,13 @@ func schema_openshift_api_operator_v1_KubeStorageVersionMigratorStatus(ref commo
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -51034,7 +51106,13 @@ func schema_openshift_api_operator_v1_MyOperatorResourceStatus(ref common.Refere
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -51457,7 +51535,13 @@ func schema_openshift_api_operator_v1_NetworkStatus(ref common.ReferenceCallback
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -52445,7 +52529,13 @@ func schema_openshift_api_operator_v1_OpenShiftAPIServerStatus(ref common.Refere
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -52681,7 +52771,13 @@ func schema_openshift_api_operator_v1_OpenShiftControllerManagerStatus(ref commo
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -52909,7 +53005,13 @@ func schema_openshift_api_operator_v1_OperatorStatus(ref common.ReferenceCallbac
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -53736,7 +53838,13 @@ func schema_openshift_api_operator_v1_ServiceCAStatus(ref common.ReferenceCallba
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -53965,7 +54073,13 @@ func schema_openshift_api_operator_v1_ServiceCatalogAPIServerStatus(ref common.R
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -54194,7 +54308,13 @@ func schema_openshift_api_operator_v1_ServiceCatalogControllerManagerStatus(ref 
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -54565,7 +54685,13 @@ func schema_openshift_api_operator_v1_StaticPodOperatorStatus(ref common.Referen
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -54863,7 +54989,13 @@ func schema_openshift_api_operator_v1_StorageStatus(ref common.ReferenceCallback
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -55838,7 +55970,13 @@ func schema_openshift_api_operator_v1alpha1_OLMStatus(ref common.ReferenceCallba
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -61533,7 +61671,13 @@ func schema_openshift_api_servicecertsigner_v1alpha1_ServiceCertSignerOperatorCo
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "atomic",
+								"x-kubernetes-list-map-keys": []interface{}{
+									"group",
+									"resource",
+									"namespace",
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -25889,7 +25889,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "oauthAPIServer": {
           "description": "OAuthAPIServer holds status specific only to oauth-apiserver",
@@ -26114,7 +26120,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -26324,7 +26336,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -26471,7 +26489,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -26627,7 +26651,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -26886,7 +26916,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -27476,7 +27512,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "latestAvailableRevision": {
           "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
@@ -28615,7 +28657,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "insightsReport": {
           "description": "insightsReport provides general Insights analysis results. When omitted, this means no data gathering has taken place yet.",
@@ -28795,7 +28843,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "latestAvailableRevision": {
           "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
@@ -28985,7 +29039,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "latestAvailableRevision": {
           "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
@@ -29161,7 +29221,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "latestAvailableRevision": {
           "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
@@ -29319,7 +29385,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -29741,7 +29813,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -29981,7 +30059,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -30549,7 +30633,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "latestAvailableRevision": {
           "description": "latestAvailableRevision is the latest revision used as suffix of revisioned secrets like encryption-config. A new revision causes a new deployment of pods.",
@@ -30691,7 +30781,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -30827,7 +30923,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -31307,7 +31409,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -31443,7 +31551,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -31580,7 +31694,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -31785,7 +31905,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "latestAvailableRevision": {
           "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
@@ -31963,7 +32089,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -32558,7 +32690,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -35984,7 +36122,13 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.GenerationStatus"
           },
-          "x-kubernetes-list-type": "atomic"
+          "x-kubernetes-list-map-keys": [
+            "group",
+            "resource",
+            "namespace",
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -128,7 +128,11 @@ type OperatorStatus struct {
 	ReadyReplicas int32 `json:"readyReplicas"`
 
 	// generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
-	// +listType=atomic
+	// +listType=map
+	// +listMapKey=group
+	// +listMapKey=resource
+	// +listMapKey=namespace
+	// +listMapKey=name
 	// +optional
 	Generations []GenerationStatus `json:"generations,omitempty"`
 }
@@ -136,12 +140,16 @@ type OperatorStatus struct {
 // GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
 type GenerationStatus struct {
 	// group is the group of the thing you're tracking
+	// +kubebuilder:validation:Required
 	Group string `json:"group"`
 	// resource is the resource type of the thing you're tracking
+	// +kubebuilder:validation:Required
 	Resource string `json:"resource"`
 	// namespace is where the thing you're tracking is
+	// +kubebuilder:validation:Required
 	Namespace string `json:"namespace"`
 	// name is the name of the thing you're tracking
+	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 	// lastGeneration is the last generation of the workload controller involved
 	LastGeneration int64 `json:"lastGeneration"`

--- a/operator/v1/zz_generated.crd-manifests/0000_10_config-operator_01_configs.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_10_config-operator_01_configs.crd.yaml
@@ -152,9 +152,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -198,9 +198,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -186,9 +186,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -198,9 +198,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -198,9 +198,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -169,9 +169,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -179,9 +179,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -169,9 +169,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
@@ -150,9 +150,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the latest revision used as
                   suffix of revisioned secrets like encryption-config. A new revision

--- a/operator/v1/zz_generated.crd-manifests/0000_40_cloud-credential_00_cloudcredentials.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_40_cloud-credential_00_cloudcredentials.crd.yaml
@@ -165,9 +165,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_40_kube-storage-version-migrator_00_kubestorageversionmigrators.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_40_kube-storage-version-migrator_00_kubestorageversionmigrators.crd.yaml
@@ -145,9 +145,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_50_authentication_01_authentications.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_authentication_01_authentications.crd.yaml
@@ -143,9 +143,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               oauthAPIServer:
                 description: OAuthAPIServer holds status specific only to oauth-apiserver
                 properties:

--- a/operator/v1/zz_generated.crd-manifests/0000_50_console_01_consoles.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_console_01_consoles.crd.yaml
@@ -697,9 +697,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_50_insights_00_insightsoperators.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_insights_00_insightsoperators.crd.yaml
@@ -269,9 +269,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               insightsReport:
                 description: insightsReport provides general Insights analysis results.
                   When omitted, this means no data gathering has taken place yet.

--- a/operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
@@ -147,9 +147,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_50_service-ca_02_servicecas.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_service-ca_02_servicecas.crd.yaml
@@ -147,9 +147,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_50_storage_01_storages.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_storage_01_storages.crd.yaml
@@ -163,9 +163,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-CustomNoUpgrade.crd.yaml
@@ -969,9 +969,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-Default.crd.yaml
@@ -914,9 +914,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-DevPreviewNoUpgrade.crd.yaml
@@ -969,9 +969,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-TechPreviewNoUpgrade.crd.yaml
@@ -969,9 +969,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_80_csi-snapshot-controller_01_csisnapshotcontrollers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_csi-snapshot-controller_01_csisnapshotcontrollers.crd.yaml
@@ -148,9 +148,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers.crd.yaml
@@ -431,9 +431,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/authentications.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/authentications.operator.openshift.io/AAA_ungated.yaml
@@ -146,9 +146,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               oauthAPIServer:
                 description: OAuthAPIServer holds status specific only to oauth-apiserver
                 properties:

--- a/operator/v1/zz_generated.featuregated-crd-manifests/cloudcredentials.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/cloudcredentials.operator.openshift.io/AAA_ungated.yaml
@@ -166,9 +166,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AAA_ungated.yaml
@@ -329,9 +329,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AWSEFSDriverVolumeMetrics.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AWSEFSDriverVolumeMetrics.yaml
@@ -378,9 +378,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/VSphereDriverConfiguration.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/VSphereDriverConfiguration.yaml
@@ -362,9 +362,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/configs.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/configs.operator.openshift.io/AAA_ungated.yaml
@@ -153,9 +153,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/consoles.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/consoles.operator.openshift.io/AAA_ungated.yaml
@@ -698,9 +698,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/csisnapshotcontrollers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/csisnapshotcontrollers.operator.openshift.io/AAA_ungated.yaml
@@ -149,9 +149,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
@@ -174,9 +174,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
@@ -186,9 +186,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/HardwareSpeed.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/HardwareSpeed.yaml
@@ -186,9 +186,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/insightsoperators.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/insightsoperators.operator.openshift.io/AAA_ungated.yaml
@@ -270,9 +270,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               insightsReport:
                 description: insightsReport provides general Insights analysis results.
                   When omitted, this means no data gathering has taken place yet.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -170,9 +170,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
@@ -180,9 +180,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
@@ -170,9 +170,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubestorageversionmigrators.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubestorageversionmigrators.operator.openshift.io/AAA_ungated.yaml
@@ -146,9 +146,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
@@ -909,9 +909,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
@@ -948,9 +948,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
@@ -914,9 +914,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/RouteAdvertisements.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/RouteAdvertisements.yaml
@@ -925,9 +925,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/openshiftapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/openshiftapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -151,9 +151,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the latest revision used as
                   suffix of revisioned secrets like encryption-config. A new revision

--- a/operator/v1/zz_generated.featuregated-crd-manifests/openshiftcontrollermanagers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/openshiftcontrollermanagers.operator.openshift.io/AAA_ungated.yaml
@@ -148,9 +148,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/servicecas.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/servicecas.operator.openshift.io/AAA_ungated.yaml
@@ -148,9 +148,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/storages.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/storages.operator.openshift.io/AAA_ungated.yaml
@@ -164,9 +164,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-CustomNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-CustomNoUpgrade.crd.yaml
@@ -149,9 +149,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-DevPreviewNoUpgrade.crd.yaml
@@ -149,9 +149,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-TechPreviewNoUpgrade.crd.yaml
@@ -149,9 +149,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1alpha1/zz_generated.featuregated-crd-manifests/olms.operator.openshift.io/NewOLM.yaml
+++ b/operator/v1alpha1/zz_generated.featuregated-crd-manifests/olms.operator.openshift.io/NewOLM.yaml
@@ -149,9 +149,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/payload-manifests/crds/0000_10_config-operator_01_configs.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_configs.crd.yaml
@@ -152,9 +152,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -198,9 +198,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -186,9 +186,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -198,9 +198,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -198,9 +198,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -169,9 +169,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -179,9 +179,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -169,9 +169,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the deploymentID of the most
                   recent deployment

--- a/payload-manifests/crds/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
+++ b/payload-manifests/crds/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
@@ -150,9 +150,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               latestAvailableRevision:
                 description: latestAvailableRevision is the latest revision used as
                   suffix of revisioned secrets like encryption-config. A new revision

--- a/payload-manifests/crds/0000_50_authentication_01_authentications.crd.yaml
+++ b/payload-manifests/crds/0000_50_authentication_01_authentications.crd.yaml
@@ -143,9 +143,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               oauthAPIServer:
                 description: OAuthAPIServer holds status specific only to oauth-apiserver
                 properties:

--- a/payload-manifests/crds/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
+++ b/payload-manifests/crds/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
@@ -147,9 +147,19 @@ spec:
                       description: resource is the resource type of the thing you're
                         tracking
                       type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
                 type: array
-                x-kubernetes-list-type: atomic
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with


### PR DESCRIPTION
This will allow coordination between different observers watching the various generations.  For instance, what if you want to track different deployments.

Need to vendor into storage, auth, and openshift-apiserver  to prove it works ok.


/assign @bertinatto @p0lyn0mial 