### PR TITLE
copy mco crds to be managed by openshfit/api

### DIFF
--- a/hack/update-payload-crds.sh
+++ b/hack/update-payload-crds.sh
@@ -21,6 +21,10 @@ crd_globs="\
     operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers*.crd.yaml
     config/v1/zz_generated.crd-manifests/0000_10_openshift-controller-manager_01_builds*.crd.yaml
     operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers*.crd.yaml
+    machineconfiguration/v1/zz_generated.crd-manifests/*.crd.yaml
+    machineconfiguration/v1alpha1/zz_generated.crd-manifests/*.crd.yaml
+    operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations*.crd.yaml
+    config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies*.crd.yaml
     "
 
 # To allow the crd_globs to be sourced in the verify script,

--- a/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,402 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: clusterimagepolicies.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: ClusterImagePolicy
+    listKind: ClusterImagePolicyList
+    plural: clusterimagepolicies
+    singular: clusterimagepolicy
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterImagePolicy holds cluster-wide configuration for image
+          signature verification \n Compatibility level 4: No compatibility is provided,
+          the API can change at any point for any reason. These capabilities should
+          not be used by applications needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec contains the configuration for the cluster image policy.
+            properties:
+              policy:
+                description: policy contains configuration to allow scopes to be verified,
+                  and defines how images not matching the verification policy will
+                  be treated.
+                properties:
+                  rootOfTrust:
+                    description: rootOfTrust specifies the root of trust for the policy.
+                    properties:
+                      fulcioCAWithRekor:
+                        description: 'fulcioCAWithRekor defines the root of trust
+                          based on the Fulcio certificate and the Rekor public key.
+                          For more information about Fulcio and Rekor, please refer
+                          to the document at: https://github.com/sigstore/fulcio and
+                          https://github.com/sigstore/rekor'
+                        properties:
+                          fulcioCAData:
+                            description: fulcioCAData contains inline base64-encoded
+                              data for the PEM format fulcio CA. fulcioCAData must
+                              be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                          fulcioSubject:
+                            description: fulcioSubject specifies OIDC issuer and the
+                              email of the Fulcio authentication configuration.
+                            properties:
+                              oidcIssuer:
+                                description: 'oidcIssuer contains the expected OIDC
+                                  issuer. It will be verified that the Fulcio-issued
+                                  certificate contains a (Fulcio-defined) certificate
+                                  extension pointing at this OIDC issuer URL. When
+                                  Fulcio issues certificates, it includes a value
+                                  based on an URL inside the client-provided ID token.
+                                  Example: "https://expected.OIDC.issuer/"'
+                                type: string
+                                x-kubernetes-validations:
+                                - message: oidcIssuer must be a valid URL
+                                  rule: isURL(self)
+                              signedEmail:
+                                description: 'signedEmail holds the email address
+                                  the the Fulcio certificate is issued for. Example:
+                                  "expected-signing-user@example.com"'
+                                type: string
+                                x-kubernetes-validations:
+                                - message: invalid email address
+                                  rule: self.matches('^\\S+@\\S+$')
+                            required:
+                            - oidcIssuer
+                            - signedEmail
+                            type: object
+                          rekorKeyData:
+                            description: rekorKeyData contains inline base64-encoded
+                              data for the PEM format from the Rekor public key. rekorKeyData
+                              must be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                        required:
+                        - fulcioCAData
+                        - fulcioSubject
+                        - rekorKeyData
+                        type: object
+                      policyType:
+                        description: policyType serves as the union's discriminator.
+                          Users are required to assign a value to this field, choosing
+                          one of the policy types that define the root of trust. "PublicKey"
+                          indicates that the policy relies on a sigstore publicKey
+                          and may optionally use a Rekor verification. "FulcioCAWithRekor"
+                          indicates that the policy is based on the Fulcio certification
+                          and incorporates a Rekor verification.
+                        enum:
+                        - PublicKey
+                        - FulcioCAWithRekor
+                        type: string
+                      publicKey:
+                        description: publicKey defines the root of trust based on
+                          a sigstore public key.
+                        properties:
+                          keyData:
+                            description: keyData contains inline base64-encoded data
+                              for the PEM format public key. KeyData must be at most
+                              8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                          rekorKeyData:
+                            description: rekorKeyData contains inline base64-encoded
+                              data for the PEM format from the Rekor public key. rekorKeyData
+                              must be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                        required:
+                        - keyData
+                        type: object
+                    required:
+                    - policyType
+                    type: object
+                    x-kubernetes-validations:
+                    - message: publicKey is required when policyType is PublicKey,
+                        and forbidden otherwise
+                      rule: 'has(self.policyType) && self.policyType == ''PublicKey''
+                        ? has(self.publicKey) : !has(self.publicKey)'
+                    - message: fulcioCAWithRekor is required when policyType is FulcioCAWithRekor,
+                        and forbidden otherwise
+                      rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
+                        ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
+                  signedIdentity:
+                    description: signedIdentity specifies what image identity the
+                      signature claims about the image. The required matchPolicy field
+                      specifies the approach used in the verification process to verify
+                      the identity in the signature and the actual image identity,
+                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    properties:
+                      exactRepository:
+                        description: exactRepository is required if matchPolicy is
+                          set to "ExactRepository".
+                        properties:
+                          repository:
+                            description: repository is the reference of the image
+                              identity to be matched. The value should be a repository
+                              name (by omitting the tag or digest) in a registry implementing
+                              the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                        required:
+                        - repository
+                        type: object
+                      matchPolicy:
+                        description: matchPolicy sets the type of matching to be used.
+                          Valid values are "MatchRepoDigestOrExact", "MatchRepository",
+                          "ExactRepository", "RemapIdentity". When omitted, the default
+                          value is "MatchRepoDigestOrExact". If set matchPolicy to
+                          ExactRepository, then the exactRepository must be specified.
+                          If set matchPolicy to RemapIdentity, then the remapIdentity
+                          must be specified. "MatchRepoDigestOrExact" means that the
+                          identity in the signature must be in the same repository
+                          as the image identity if the image identity is referenced
+                          by a digest. Otherwise, the identity in the signature must
+                          be the same as the image identity. "MatchRepository" means
+                          that the identity in the signature must be in the same repository
+                          as the image identity. "ExactRepository" means that the
+                          identity in the signature must be in the same repository
+                          as a specific identity specified by "repository". "RemapIdentity"
+                          means that the signature must be in the same as the remapped
+                          image identity. Remapped image identity is obtained by replacing
+                          the "prefix" with the specified “signedPrefix” if the the
+                          image identity matches the specified remapPrefix.
+                        enum:
+                        - MatchRepoDigestOrExact
+                        - MatchRepository
+                        - ExactRepository
+                        - RemapIdentity
+                        type: string
+                      remapIdentity:
+                        description: remapIdentity is required if matchPolicy is set
+                          to "RemapIdentity".
+                        properties:
+                          prefix:
+                            description: prefix is the prefix of the image identity
+                              to be matched. If the image identity matches the specified
+                              prefix, that prefix is replaced by the specified “signedPrefix”
+                              (otherwise it is used as unchanged and no remapping
+                              takes place). This useful when verifying signatures
+                              for a mirror of some other repository namespace that
+                              preserves the vendor’s repository structure. The prefix
+                              and signedPrefix values can be either host[:port] values
+                              (matching exactly the same host[:port], string), repository
+                              namespaces, or repositories (i.e. they must not contain
+                              tags/digests), and match as prefixes of the fully expanded
+                              form. For example, docker.io/library/busybox (not busybox)
+                              to specify that single repository, or docker.io/library
+                              (not an empty string) to specify the parent namespace
+                              of docker.io/library/busybox.
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                          signedPrefix:
+                            description: signedPrefix is the prefix of the image identity
+                              to be matched in the signature. The format is the same
+                              as "prefix". The values can be either host[:port] values
+                              (matching exactly the same host[:port], string), repository
+                              namespaces, or repositories (i.e. they must not contain
+                              tags/digests), and match as prefixes of the fully expanded
+                              form. For example, docker.io/library/busybox (not busybox)
+                              to specify that single repository, or docker.io/library
+                              (not an empty string) to specify the parent namespace
+                              of docker.io/library/busybox.
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                        required:
+                        - prefix
+                        - signedPrefix
+                        type: object
+                    required:
+                    - matchPolicy
+                    type: object
+                    x-kubernetes-validations:
+                    - message: exactRepository is required when matchPolicy is ExactRepository,
+                        and forbidden otherwise
+                      rule: '(has(self.matchPolicy) && self.matchPolicy == ''ExactRepository'')
+                        ? has(self.exactRepository) : !has(self.exactRepository)'
+                    - message: remapIdentity is required when matchPolicy is RemapIdentity,
+                        and forbidden otherwise
+                      rule: '(has(self.matchPolicy) && self.matchPolicy == ''RemapIdentity'')
+                        ? has(self.remapIdentity) : !has(self.remapIdentity)'
+                required:
+                - rootOfTrust
+                type: object
+              scopes:
+                description: 'scopes defines the list of image identities assigned
+                  to a policy. Each item refers to a scope in a registry implementing
+                  the "Docker Registry HTTP API V2". Scopes matching individual images
+                  are named Docker references in the fully expanded form, either using
+                  a tag or digest. For example, docker.io/library/busybox:latest (not
+                  busybox:latest). More general scopes are prefixes of individual-image
+                  scopes, and specify a repository (by omitting the tag or digest),
+                  a repository namespace, or a registry host (by only specifying the
+                  host name and possibly a port number) or a wildcard expression starting
+                  with `*.`, for matching all subdomains (not including a port number).
+                  Wildcards are only supported for subdomain matching, and may not
+                  be used in the middle of the host, i.e.  *.example.com is a valid
+                  case, but example*.*.com is not. If multiple scopes match a given
+                  image, only the policy requirements for the most specific scope
+                  apply. The policy requirements for more general scopes are ignored.
+                  In addition to setting a policy appropriate for your own deployed
+                  applications, make sure that a policy on the OpenShift image repositories
+                  quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev
+                  (or on a more general scope) allows deployment of the OpenShift
+                  images required for cluster operation. For additional details about
+                  the format, please refer to the document explaining the docker transport
+                  field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
+                items:
+                  maxLength: 512
+                  type: string
+                  x-kubernetes-validations:
+                  - message: invalid image scope format, scope must contain a fully
+                      qualified domain name or 'localhost'
+                    rule: 'size(self.split(''/'')[0].split(''.'')) == 1 ? self.split(''/'')[0].split(''.'')[0].split('':'')[0]
+                      == ''localhost'' : true'
+                  - message: invalid image scope with wildcard, a wildcard can only
+                      be at the start of the domain and is only supported for subdomain
+                      matching, not path matching
+                    rule: 'self.contains(''*'') ? self.matches(''^\\*(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$'')
+                      : true'
+                  - message: invalid repository namespace or image specification in
+                      the image scope
+                    rule: '!self.contains(''*'') ? self.matches(''^((((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?)(?::([\\w][\\w.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}))?$'')
+                      : true'
+                maxItems: 256
+                type: array
+                x-kubernetes-list-type: set
+            required:
+            - policy
+            - scopes
+            type: object
+          status:
+            description: status contains the observed state of the resource.
+            properties:
+              conditions:
+                description: conditions provide details on the status of this API
+                  Resource.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-DevPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,402 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  name: clusterimagepolicies.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: ClusterImagePolicy
+    listKind: ClusterImagePolicyList
+    plural: clusterimagepolicies
+    singular: clusterimagepolicy
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterImagePolicy holds cluster-wide configuration for image
+          signature verification \n Compatibility level 4: No compatibility is provided,
+          the API can change at any point for any reason. These capabilities should
+          not be used by applications needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec contains the configuration for the cluster image policy.
+            properties:
+              policy:
+                description: policy contains configuration to allow scopes to be verified,
+                  and defines how images not matching the verification policy will
+                  be treated.
+                properties:
+                  rootOfTrust:
+                    description: rootOfTrust specifies the root of trust for the policy.
+                    properties:
+                      fulcioCAWithRekor:
+                        description: 'fulcioCAWithRekor defines the root of trust
+                          based on the Fulcio certificate and the Rekor public key.
+                          For more information about Fulcio and Rekor, please refer
+                          to the document at: https://github.com/sigstore/fulcio and
+                          https://github.com/sigstore/rekor'
+                        properties:
+                          fulcioCAData:
+                            description: fulcioCAData contains inline base64-encoded
+                              data for the PEM format fulcio CA. fulcioCAData must
+                              be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                          fulcioSubject:
+                            description: fulcioSubject specifies OIDC issuer and the
+                              email of the Fulcio authentication configuration.
+                            properties:
+                              oidcIssuer:
+                                description: 'oidcIssuer contains the expected OIDC
+                                  issuer. It will be verified that the Fulcio-issued
+                                  certificate contains a (Fulcio-defined) certificate
+                                  extension pointing at this OIDC issuer URL. When
+                                  Fulcio issues certificates, it includes a value
+                                  based on an URL inside the client-provided ID token.
+                                  Example: "https://expected.OIDC.issuer/"'
+                                type: string
+                                x-kubernetes-validations:
+                                - message: oidcIssuer must be a valid URL
+                                  rule: isURL(self)
+                              signedEmail:
+                                description: 'signedEmail holds the email address
+                                  the the Fulcio certificate is issued for. Example:
+                                  "expected-signing-user@example.com"'
+                                type: string
+                                x-kubernetes-validations:
+                                - message: invalid email address
+                                  rule: self.matches('^\\S+@\\S+$')
+                            required:
+                            - oidcIssuer
+                            - signedEmail
+                            type: object
+                          rekorKeyData:
+                            description: rekorKeyData contains inline base64-encoded
+                              data for the PEM format from the Rekor public key. rekorKeyData
+                              must be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                        required:
+                        - fulcioCAData
+                        - fulcioSubject
+                        - rekorKeyData
+                        type: object
+                      policyType:
+                        description: policyType serves as the union's discriminator.
+                          Users are required to assign a value to this field, choosing
+                          one of the policy types that define the root of trust. "PublicKey"
+                          indicates that the policy relies on a sigstore publicKey
+                          and may optionally use a Rekor verification. "FulcioCAWithRekor"
+                          indicates that the policy is based on the Fulcio certification
+                          and incorporates a Rekor verification.
+                        enum:
+                        - PublicKey
+                        - FulcioCAWithRekor
+                        type: string
+                      publicKey:
+                        description: publicKey defines the root of trust based on
+                          a sigstore public key.
+                        properties:
+                          keyData:
+                            description: keyData contains inline base64-encoded data
+                              for the PEM format public key. KeyData must be at most
+                              8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                          rekorKeyData:
+                            description: rekorKeyData contains inline base64-encoded
+                              data for the PEM format from the Rekor public key. rekorKeyData
+                              must be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                        required:
+                        - keyData
+                        type: object
+                    required:
+                    - policyType
+                    type: object
+                    x-kubernetes-validations:
+                    - message: publicKey is required when policyType is PublicKey,
+                        and forbidden otherwise
+                      rule: 'has(self.policyType) && self.policyType == ''PublicKey''
+                        ? has(self.publicKey) : !has(self.publicKey)'
+                    - message: fulcioCAWithRekor is required when policyType is FulcioCAWithRekor,
+                        and forbidden otherwise
+                      rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
+                        ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
+                  signedIdentity:
+                    description: signedIdentity specifies what image identity the
+                      signature claims about the image. The required matchPolicy field
+                      specifies the approach used in the verification process to verify
+                      the identity in the signature and the actual image identity,
+                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    properties:
+                      exactRepository:
+                        description: exactRepository is required if matchPolicy is
+                          set to "ExactRepository".
+                        properties:
+                          repository:
+                            description: repository is the reference of the image
+                              identity to be matched. The value should be a repository
+                              name (by omitting the tag or digest) in a registry implementing
+                              the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                        required:
+                        - repository
+                        type: object
+                      matchPolicy:
+                        description: matchPolicy sets the type of matching to be used.
+                          Valid values are "MatchRepoDigestOrExact", "MatchRepository",
+                          "ExactRepository", "RemapIdentity". When omitted, the default
+                          value is "MatchRepoDigestOrExact". If set matchPolicy to
+                          ExactRepository, then the exactRepository must be specified.
+                          If set matchPolicy to RemapIdentity, then the remapIdentity
+                          must be specified. "MatchRepoDigestOrExact" means that the
+                          identity in the signature must be in the same repository
+                          as the image identity if the image identity is referenced
+                          by a digest. Otherwise, the identity in the signature must
+                          be the same as the image identity. "MatchRepository" means
+                          that the identity in the signature must be in the same repository
+                          as the image identity. "ExactRepository" means that the
+                          identity in the signature must be in the same repository
+                          as a specific identity specified by "repository". "RemapIdentity"
+                          means that the signature must be in the same as the remapped
+                          image identity. Remapped image identity is obtained by replacing
+                          the "prefix" with the specified “signedPrefix” if the the
+                          image identity matches the specified remapPrefix.
+                        enum:
+                        - MatchRepoDigestOrExact
+                        - MatchRepository
+                        - ExactRepository
+                        - RemapIdentity
+                        type: string
+                      remapIdentity:
+                        description: remapIdentity is required if matchPolicy is set
+                          to "RemapIdentity".
+                        properties:
+                          prefix:
+                            description: prefix is the prefix of the image identity
+                              to be matched. If the image identity matches the specified
+                              prefix, that prefix is replaced by the specified “signedPrefix”
+                              (otherwise it is used as unchanged and no remapping
+                              takes place). This useful when verifying signatures
+                              for a mirror of some other repository namespace that
+                              preserves the vendor’s repository structure. The prefix
+                              and signedPrefix values can be either host[:port] values
+                              (matching exactly the same host[:port], string), repository
+                              namespaces, or repositories (i.e. they must not contain
+                              tags/digests), and match as prefixes of the fully expanded
+                              form. For example, docker.io/library/busybox (not busybox)
+                              to specify that single repository, or docker.io/library
+                              (not an empty string) to specify the parent namespace
+                              of docker.io/library/busybox.
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                          signedPrefix:
+                            description: signedPrefix is the prefix of the image identity
+                              to be matched in the signature. The format is the same
+                              as "prefix". The values can be either host[:port] values
+                              (matching exactly the same host[:port], string), repository
+                              namespaces, or repositories (i.e. they must not contain
+                              tags/digests), and match as prefixes of the fully expanded
+                              form. For example, docker.io/library/busybox (not busybox)
+                              to specify that single repository, or docker.io/library
+                              (not an empty string) to specify the parent namespace
+                              of docker.io/library/busybox.
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                        required:
+                        - prefix
+                        - signedPrefix
+                        type: object
+                    required:
+                    - matchPolicy
+                    type: object
+                    x-kubernetes-validations:
+                    - message: exactRepository is required when matchPolicy is ExactRepository,
+                        and forbidden otherwise
+                      rule: '(has(self.matchPolicy) && self.matchPolicy == ''ExactRepository'')
+                        ? has(self.exactRepository) : !has(self.exactRepository)'
+                    - message: remapIdentity is required when matchPolicy is RemapIdentity,
+                        and forbidden otherwise
+                      rule: '(has(self.matchPolicy) && self.matchPolicy == ''RemapIdentity'')
+                        ? has(self.remapIdentity) : !has(self.remapIdentity)'
+                required:
+                - rootOfTrust
+                type: object
+              scopes:
+                description: 'scopes defines the list of image identities assigned
+                  to a policy. Each item refers to a scope in a registry implementing
+                  the "Docker Registry HTTP API V2". Scopes matching individual images
+                  are named Docker references in the fully expanded form, either using
+                  a tag or digest. For example, docker.io/library/busybox:latest (not
+                  busybox:latest). More general scopes are prefixes of individual-image
+                  scopes, and specify a repository (by omitting the tag or digest),
+                  a repository namespace, or a registry host (by only specifying the
+                  host name and possibly a port number) or a wildcard expression starting
+                  with `*.`, for matching all subdomains (not including a port number).
+                  Wildcards are only supported for subdomain matching, and may not
+                  be used in the middle of the host, i.e.  *.example.com is a valid
+                  case, but example*.*.com is not. If multiple scopes match a given
+                  image, only the policy requirements for the most specific scope
+                  apply. The policy requirements for more general scopes are ignored.
+                  In addition to setting a policy appropriate for your own deployed
+                  applications, make sure that a policy on the OpenShift image repositories
+                  quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev
+                  (or on a more general scope) allows deployment of the OpenShift
+                  images required for cluster operation. For additional details about
+                  the format, please refer to the document explaining the docker transport
+                  field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
+                items:
+                  maxLength: 512
+                  type: string
+                  x-kubernetes-validations:
+                  - message: invalid image scope format, scope must contain a fully
+                      qualified domain name or 'localhost'
+                    rule: 'size(self.split(''/'')[0].split(''.'')) == 1 ? self.split(''/'')[0].split(''.'')[0].split('':'')[0]
+                      == ''localhost'' : true'
+                  - message: invalid image scope with wildcard, a wildcard can only
+                      be at the start of the domain and is only supported for subdomain
+                      matching, not path matching
+                    rule: 'self.contains(''*'') ? self.matches(''^\\*(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$'')
+                      : true'
+                  - message: invalid repository namespace or image specification in
+                      the image scope
+                    rule: '!self.contains(''*'') ? self.matches(''^((((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?)(?::([\\w][\\w.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}))?$'')
+                      : true'
+                maxItems: 256
+                type: array
+                x-kubernetes-list-type: set
+            required:
+            - policy
+            - scopes
+            type: object
+          status:
+            description: status contains the observed state of the resource.
+            properties:
+              conditions:
+                description: conditions provide details on the status of this API
+                  Resource.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,402 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: clusterimagepolicies.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: ClusterImagePolicy
+    listKind: ClusterImagePolicyList
+    plural: clusterimagepolicies
+    singular: clusterimagepolicy
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "ClusterImagePolicy holds cluster-wide configuration for image
+          signature verification \n Compatibility level 4: No compatibility is provided,
+          the API can change at any point for any reason. These capabilities should
+          not be used by applications needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec contains the configuration for the cluster image policy.
+            properties:
+              policy:
+                description: policy contains configuration to allow scopes to be verified,
+                  and defines how images not matching the verification policy will
+                  be treated.
+                properties:
+                  rootOfTrust:
+                    description: rootOfTrust specifies the root of trust for the policy.
+                    properties:
+                      fulcioCAWithRekor:
+                        description: 'fulcioCAWithRekor defines the root of trust
+                          based on the Fulcio certificate and the Rekor public key.
+                          For more information about Fulcio and Rekor, please refer
+                          to the document at: https://github.com/sigstore/fulcio and
+                          https://github.com/sigstore/rekor'
+                        properties:
+                          fulcioCAData:
+                            description: fulcioCAData contains inline base64-encoded
+                              data for the PEM format fulcio CA. fulcioCAData must
+                              be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                          fulcioSubject:
+                            description: fulcioSubject specifies OIDC issuer and the
+                              email of the Fulcio authentication configuration.
+                            properties:
+                              oidcIssuer:
+                                description: 'oidcIssuer contains the expected OIDC
+                                  issuer. It will be verified that the Fulcio-issued
+                                  certificate contains a (Fulcio-defined) certificate
+                                  extension pointing at this OIDC issuer URL. When
+                                  Fulcio issues certificates, it includes a value
+                                  based on an URL inside the client-provided ID token.
+                                  Example: "https://expected.OIDC.issuer/"'
+                                type: string
+                                x-kubernetes-validations:
+                                - message: oidcIssuer must be a valid URL
+                                  rule: isURL(self)
+                              signedEmail:
+                                description: 'signedEmail holds the email address
+                                  the the Fulcio certificate is issued for. Example:
+                                  "expected-signing-user@example.com"'
+                                type: string
+                                x-kubernetes-validations:
+                                - message: invalid email address
+                                  rule: self.matches('^\\S+@\\S+$')
+                            required:
+                            - oidcIssuer
+                            - signedEmail
+                            type: object
+                          rekorKeyData:
+                            description: rekorKeyData contains inline base64-encoded
+                              data for the PEM format from the Rekor public key. rekorKeyData
+                              must be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                        required:
+                        - fulcioCAData
+                        - fulcioSubject
+                        - rekorKeyData
+                        type: object
+                      policyType:
+                        description: policyType serves as the union's discriminator.
+                          Users are required to assign a value to this field, choosing
+                          one of the policy types that define the root of trust. "PublicKey"
+                          indicates that the policy relies on a sigstore publicKey
+                          and may optionally use a Rekor verification. "FulcioCAWithRekor"
+                          indicates that the policy is based on the Fulcio certification
+                          and incorporates a Rekor verification.
+                        enum:
+                        - PublicKey
+                        - FulcioCAWithRekor
+                        type: string
+                      publicKey:
+                        description: publicKey defines the root of trust based on
+                          a sigstore public key.
+                        properties:
+                          keyData:
+                            description: keyData contains inline base64-encoded data
+                              for the PEM format public key. KeyData must be at most
+                              8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                          rekorKeyData:
+                            description: rekorKeyData contains inline base64-encoded
+                              data for the PEM format from the Rekor public key. rekorKeyData
+                              must be at most 8192 characters.
+                            format: byte
+                            maxLength: 8192
+                            type: string
+                        required:
+                        - keyData
+                        type: object
+                    required:
+                    - policyType
+                    type: object
+                    x-kubernetes-validations:
+                    - message: publicKey is required when policyType is PublicKey,
+                        and forbidden otherwise
+                      rule: 'has(self.policyType) && self.policyType == ''PublicKey''
+                        ? has(self.publicKey) : !has(self.publicKey)'
+                    - message: fulcioCAWithRekor is required when policyType is FulcioCAWithRekor,
+                        and forbidden otherwise
+                      rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
+                        ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
+                  signedIdentity:
+                    description: signedIdentity specifies what image identity the
+                      signature claims about the image. The required matchPolicy field
+                      specifies the approach used in the verification process to verify
+                      the identity in the signature and the actual image identity,
+                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    properties:
+                      exactRepository:
+                        description: exactRepository is required if matchPolicy is
+                          set to "ExactRepository".
+                        properties:
+                          repository:
+                            description: repository is the reference of the image
+                              identity to be matched. The value should be a repository
+                              name (by omitting the tag or digest) in a registry implementing
+                              the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                        required:
+                        - repository
+                        type: object
+                      matchPolicy:
+                        description: matchPolicy sets the type of matching to be used.
+                          Valid values are "MatchRepoDigestOrExact", "MatchRepository",
+                          "ExactRepository", "RemapIdentity". When omitted, the default
+                          value is "MatchRepoDigestOrExact". If set matchPolicy to
+                          ExactRepository, then the exactRepository must be specified.
+                          If set matchPolicy to RemapIdentity, then the remapIdentity
+                          must be specified. "MatchRepoDigestOrExact" means that the
+                          identity in the signature must be in the same repository
+                          as the image identity if the image identity is referenced
+                          by a digest. Otherwise, the identity in the signature must
+                          be the same as the image identity. "MatchRepository" means
+                          that the identity in the signature must be in the same repository
+                          as the image identity. "ExactRepository" means that the
+                          identity in the signature must be in the same repository
+                          as a specific identity specified by "repository". "RemapIdentity"
+                          means that the signature must be in the same as the remapped
+                          image identity. Remapped image identity is obtained by replacing
+                          the "prefix" with the specified “signedPrefix” if the the
+                          image identity matches the specified remapPrefix.
+                        enum:
+                        - MatchRepoDigestOrExact
+                        - MatchRepository
+                        - ExactRepository
+                        - RemapIdentity
+                        type: string
+                      remapIdentity:
+                        description: remapIdentity is required if matchPolicy is set
+                          to "RemapIdentity".
+                        properties:
+                          prefix:
+                            description: prefix is the prefix of the image identity
+                              to be matched. If the image identity matches the specified
+                              prefix, that prefix is replaced by the specified “signedPrefix”
+                              (otherwise it is used as unchanged and no remapping
+                              takes place). This useful when verifying signatures
+                              for a mirror of some other repository namespace that
+                              preserves the vendor’s repository structure. The prefix
+                              and signedPrefix values can be either host[:port] values
+                              (matching exactly the same host[:port], string), repository
+                              namespaces, or repositories (i.e. they must not contain
+                              tags/digests), and match as prefixes of the fully expanded
+                              form. For example, docker.io/library/busybox (not busybox)
+                              to specify that single repository, or docker.io/library
+                              (not an empty string) to specify the parent namespace
+                              of docker.io/library/busybox.
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                          signedPrefix:
+                            description: signedPrefix is the prefix of the image identity
+                              to be matched in the signature. The format is the same
+                              as "prefix". The values can be either host[:port] values
+                              (matching exactly the same host[:port], string), repository
+                              namespaces, or repositories (i.e. they must not contain
+                              tags/digests), and match as prefixes of the fully expanded
+                              form. For example, docker.io/library/busybox (not busybox)
+                              to specify that single repository, or docker.io/library
+                              (not an empty string) to specify the parent namespace
+                              of docker.io/library/busybox.
+                            maxLength: 512
+                            type: string
+                            x-kubernetes-validations:
+                            - message: invalid repository or prefix in the signedIdentity,
+                                should not include the tag or digest
+                              rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
+                                self.matches(''^(localhost:[0-9]+)$''): true'
+                            - message: invalid repository or prefix in the signedIdentity
+                              rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
+                        required:
+                        - prefix
+                        - signedPrefix
+                        type: object
+                    required:
+                    - matchPolicy
+                    type: object
+                    x-kubernetes-validations:
+                    - message: exactRepository is required when matchPolicy is ExactRepository,
+                        and forbidden otherwise
+                      rule: '(has(self.matchPolicy) && self.matchPolicy == ''ExactRepository'')
+                        ? has(self.exactRepository) : !has(self.exactRepository)'
+                    - message: remapIdentity is required when matchPolicy is RemapIdentity,
+                        and forbidden otherwise
+                      rule: '(has(self.matchPolicy) && self.matchPolicy == ''RemapIdentity'')
+                        ? has(self.remapIdentity) : !has(self.remapIdentity)'
+                required:
+                - rootOfTrust
+                type: object
+              scopes:
+                description: 'scopes defines the list of image identities assigned
+                  to a policy. Each item refers to a scope in a registry implementing
+                  the "Docker Registry HTTP API V2". Scopes matching individual images
+                  are named Docker references in the fully expanded form, either using
+                  a tag or digest. For example, docker.io/library/busybox:latest (not
+                  busybox:latest). More general scopes are prefixes of individual-image
+                  scopes, and specify a repository (by omitting the tag or digest),
+                  a repository namespace, or a registry host (by only specifying the
+                  host name and possibly a port number) or a wildcard expression starting
+                  with `*.`, for matching all subdomains (not including a port number).
+                  Wildcards are only supported for subdomain matching, and may not
+                  be used in the middle of the host, i.e.  *.example.com is a valid
+                  case, but example*.*.com is not. If multiple scopes match a given
+                  image, only the policy requirements for the most specific scope
+                  apply. The policy requirements for more general scopes are ignored.
+                  In addition to setting a policy appropriate for your own deployed
+                  applications, make sure that a policy on the OpenShift image repositories
+                  quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev
+                  (or on a more general scope) allows deployment of the OpenShift
+                  images required for cluster operation. For additional details about
+                  the format, please refer to the document explaining the docker transport
+                  field, which can be found at: https://github.com/containers/image/blob/main/docs/containers-policy.json.5.md#docker'
+                items:
+                  maxLength: 512
+                  type: string
+                  x-kubernetes-validations:
+                  - message: invalid image scope format, scope must contain a fully
+                      qualified domain name or 'localhost'
+                    rule: 'size(self.split(''/'')[0].split(''.'')) == 1 ? self.split(''/'')[0].split(''.'')[0].split('':'')[0]
+                      == ''localhost'' : true'
+                  - message: invalid image scope with wildcard, a wildcard can only
+                      be at the start of the domain and is only supported for subdomain
+                      matching, not path matching
+                    rule: 'self.contains(''*'') ? self.matches(''^\\*(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$'')
+                      : true'
+                  - message: invalid repository namespace or image specification in
+                      the image scope
+                    rule: '!self.contains(''*'') ? self.matches(''^((((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?)(?::([\\w][\\w.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}))?$'')
+                      : true'
+                maxItems: 256
+                type: array
+                x-kubernetes-list-type: set
+            required:
+            - policy
+            - scopes
+            type: object
+          status:
+            description: status contains the observed state of the resource.
+            properties:
+              conditions:
+                description: conditions provide details on the status of this API
+                  Resource.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_containerruntimeconfigs.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_containerruntimeconfigs.crd.yaml
@@ -1,0 +1,181 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    openshift.io/operator-managed: ""
+  name: containerruntimeconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: ContainerRuntimeConfig
+    listKind: ContainerRuntimeConfigList
+    plural: containerruntimeconfigs
+    shortNames:
+    - ctrcfg
+    singular: containerruntimeconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ContainerRuntimeConfig describes a customized Container Runtime
+          configuration. \n Compatibility level 1: Stable within a major release for
+          a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ContainerRuntimeConfigSpec defines the desired state of ContainerRuntimeConfig
+            properties:
+              containerRuntimeConfig:
+                description: ContainerRuntimeConfiguration defines the tuneables of
+                  the container runtime
+                properties:
+                  defaultRuntime:
+                    description: defaultRuntime is the name of the OCI runtime to
+                      be used as the default.
+                    type: string
+                  logLevel:
+                    description: logLevel specifies the verbosity of the logs based
+                      on the level it is set to. Options are fatal, panic, error,
+                      warn, info, and debug.
+                    type: string
+                  logSizeMax:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: logSizeMax specifies the Maximum size allowed for
+                      the container log file. Negative numbers indicate that no size
+                      limit is imposed. If it is positive, it must be >= 8192 to match/exceed
+                      conmon's read buffer.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  overlaySize:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'overlaySize specifies the maximum size of a container
+                      image. This flag can be used to set quota on the size of container
+                      images. (default: 10GB)'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  pidsLimit:
+                    description: pidsLimit specifies the maximum number of processes
+                      allowed in a container
+                    format: int64
+                    type: integer
+                type: object
+              machineConfigPoolSelector:
+                description: MachineConfigPoolSelector selects which pools the ContainerRuntimeConfig
+                  shoud apply to. A nil selector will result in no pools being selected.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - containerRuntimeConfig
+            type: object
+          status:
+            description: ContainerRuntimeConfigStatus defines the observed state of
+              a ContainerRuntimeConfig
+            properties:
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: ContainerRuntimeConfigCondition defines the state of
+                    the ContainerRuntimeConfig
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status object.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message provides additional information about the
+                        current condition. This is only to be consumed by humans.
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.  Reasons
+                        are PascalCase
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,2860 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: controllerconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: ControllerConfig
+    listKind: ControllerConfigList
+    plural: controllerconfigs
+    singular: controllerconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ControllerConfig describes configuration for MachineConfigController.
+          This is currently only used to drive the MachineConfig objects generated
+          by the TemplateController. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ControllerConfigSpec is the spec for ControllerConfig resource.
+            properties:
+              additionalTrustBundle:
+                description: additionalTrustBundle is a certificate bundle that will
+                  be added to the nodes trusted certificate store.
+                format: byte
+                nullable: true
+                type: string
+              baseOSContainerImage:
+                description: BaseOSContainerImage is the new-format container image
+                  for operating system updates.
+                type: string
+              baseOSExtensionsContainerImage:
+                description: BaseOSExtensionsContainerImage is the matching extensions
+                  container for the new-format container
+                type: string
+              cloudProviderCAData:
+                description: cloudProvider specifies the cloud provider CA data
+                format: byte
+                nullable: true
+                type: string
+              cloudProviderConfig:
+                description: cloudProviderConfig is the configuration for the given
+                  cloud provider
+                type: string
+              clusterDNSIP:
+                description: clusterDNSIP is the cluster DNS IP address
+                type: string
+              dns:
+                description: dns holds the cluster dns details
+                nullable: true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'metadata is the standard object''s metadata. More
+                      info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: spec holds user settable values for configuration
+                    properties:
+                      baseDomain:
+                        description: "baseDomain is the base domain of the cluster.
+                          All managed DNS records will be sub-domains of this base.
+                          \n For example, given the base domain `openshift.example.com`,
+                          an API server DNS record may be created for `cluster-api.openshift.example.com`.
+                          \n Once set, this field cannot be changed."
+                        type: string
+                      platform:
+                        description: platform holds configuration specific to the
+                          underlying infrastructure provider for DNS. When omitted,
+                          this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject
+                          to change over time.
+                        properties:
+                          aws:
+                            description: aws contains DNS configuration specific to
+                              the Amazon Web Services cloud provider.
+                            properties:
+                              privateZoneIAMRole:
+                                description: privateZoneIAMRole contains the ARN of
+                                  an IAM role that should be assumed when performing
+                                  operations on the cluster's private hosted zone
+                                  specified in the cluster DNS config. When left empty,
+                                  no role should be assumed.
+                                pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                                type: string
+                            type: object
+                          type:
+                            description: "type is the underlying infrastructure provider
+                              for the cluster. Allowed values: \"\", \"AWS\". \n Individual
+                              components may not support all platforms, and must handle
+                              unrecognized platforms with best-effort defaults."
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                            x-kubernetes-validations:
+                            - message: allowed values are '' and 'AWS'
+                              rule: self in ['','AWS']
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: aws configuration is required when platform is
+                            AWS, and forbidden otherwise
+                          rule: 'has(self.type) && self.type == ''AWS'' ?  has(self.aws)
+                            : !has(self.aws)'
+                      privateZone:
+                        description: "privateZone is the location where all the DNS
+                          records that are only available internally to the cluster
+                          exist. \n If this field is nil, no private records should
+                          be created. \n Once set, this field cannot be changed."
+                        properties:
+                          id:
+                            description: "id is the identifier that can be used to
+                              find the DNS hosted zone. \n on AWS zone can be fetched
+                              using `ID` as id in [1] on Azure zone can be fetched
+                              using `ID` as a pre-determined name in [2], on GCP zone
+                              can be fetched using `ID` as a pre-determined name in
+                              [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                              [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                              [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: "tags can be used to query the DNS hosted
+                              zone. \n on AWS, resourcegroupstaggingapi [1] can be
+                              used to fetch a zone using `Tags` as tag-filters, \n
+                              [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                            type: object
+                        type: object
+                      publicZone:
+                        description: "publicZone is the location where all the DNS
+                          records that are publicly accessible to the internet exist.
+                          \n If this field is nil, no public records should be created.
+                          \n Once set, this field cannot be changed."
+                        properties:
+                          id:
+                            description: "id is the identifier that can be used to
+                              find the DNS hosted zone. \n on AWS zone can be fetched
+                              using `ID` as id in [1] on Azure zone can be fetched
+                              using `ID` as a pre-determined name in [2], on GCP zone
+                              can be fetched using `ID` as a pre-determined name in
+                              [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                              [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                              [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: "tags can be used to query the DNS hosted
+                              zone. \n on AWS, resourcegroupstaggingapi [1] can be
+                              used to fetch a zone using `Tags` as tag-filters, \n
+                              [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                            type: object
+                        type: object
+                    type: object
+                  status:
+                    description: status holds observed values from the cluster. They
+                      may not be overridden.
+                    type: object
+                required:
+                - spec
+                type: object
+                x-kubernetes-embedded-resource: true
+              etcdDiscoveryDomain:
+                description: etcdDiscoveryDomain is deprecated, use Infra.Status.EtcdDiscoveryDomain
+                  instead
+                type: string
+              imageRegistryBundleData:
+                description: imageRegistryBundleData is the ImageRegistryData
+                items:
+                  description: ImageRegistryBundle contains information for writing
+                    image registry certificates
+                  properties:
+                    data:
+                      description: data holds the contents of the bundle that will
+                        be written to the file location
+                      format: byte
+                      type: string
+                    file:
+                      description: file holds the name of the file where the bundle
+                        will be written to disk
+                      type: string
+                  required:
+                  - data
+                  - file
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              imageRegistryBundleUserData:
+                description: imageRegistryBundleUserData is Image Registry Data provided
+                  by the user
+                items:
+                  description: ImageRegistryBundle contains information for writing
+                    image registry certificates
+                  properties:
+                    data:
+                      description: data holds the contents of the bundle that will
+                        be written to the file location
+                      format: byte
+                      type: string
+                    file:
+                      description: file holds the name of the file where the bundle
+                        will be written to disk
+                      type: string
+                  required:
+                  - data
+                  - file
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              images:
+                additionalProperties:
+                  type: string
+                description: images is map of images that are used by the controller
+                  to render templates under ./templates/
+                type: object
+              infra:
+                description: infra holds the infrastructure details
+                nullable: true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'metadata is the standard object''s metadata. More
+                      info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: spec holds user settable values for configuration
+                    properties:
+                      cloudConfig:
+                        description: "cloudConfig is a reference to a ConfigMap containing
+                          the cloud provider configuration file. This configuration
+                          file is used to configure the Kubernetes cloud provider
+                          integration when using the built-in cloud provider integration
+                          or the external cloud controller manager. The namespace
+                          for this config map is openshift-config. \n cloudConfig
+                          should only be consumed by the kube_cloud_config controller.
+                          The controller is responsible for using the user configuration
+                          in the spec for various platforms and combining that with
+                          the user provided ConfigMap in this field to create a stitched
+                          kube cloud config. The controller generates a ConfigMap
+                          `kube-cloud-config` in `openshift-config-managed` namespace
+                          with the kube cloud config is stored in `cloud.conf` key.
+                          All the clients are expected to use the generated ConfigMap
+                          only."
+                        properties:
+                          key:
+                            description: Key allows pointing to a specific key/value
+                              inside of the configmap.  This is useful for logical
+                              file references.
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      platformSpec:
+                        description: platformSpec holds desired information specific
+                          to the underlying infrastructure provider.
+                        properties:
+                          alibabaCloud:
+                            description: AlibabaCloud contains settings specific to
+                              the Alibaba Cloud infrastructure provider.
+                            type: object
+                          aws:
+                            description: AWS contains settings specific to the Amazon
+                              Web Services infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: serviceEndpoints list contains custom
+                                  endpoints which will override default service endpoint
+                                  of AWS Services. There must be only one ServiceEndpoint
+                                  for a service.
+                                items:
+                                  description: AWSServiceEndpoint store the configuration
+                                    of a custom url to override existing defaults
+                                    of AWS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the AWS service.
+                                        The list of all the service names can be found
+                                        at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                        This must be provided and cannot be empty.
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      pattern: ^https://
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          azure:
+                            description: Azure contains settings specific to the Azure
+                              infrastructure provider.
+                            type: object
+                          baremetal:
+                            description: BareMetal contains settings specific to the
+                              BareMetal platform.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                          equinixMetal:
+                            description: EquinixMetal contains settings specific to
+                              the Equinix Metal infrastructure provider.
+                            type: object
+                          external:
+                            description: ExternalPlatformType represents generic infrastructure
+                              provider. Platform-specific components should be supplemented
+                              separately.
+                            properties:
+                              platformName:
+                                default: Unknown
+                                description: PlatformName holds the arbitrary string
+                                  representing the infrastructure provider name, expected
+                                  to be set at the installation time. This field is
+                                  solely for informational and reporting purposes
+                                  and is not expected to be used for decision-making.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: platform name cannot be changed once set
+                                  rule: oldSelf == 'Unknown' || self == oldSelf
+                            type: object
+                          gcp:
+                            description: GCP contains settings specific to the Google
+                              Cloud Platform infrastructure provider.
+                            type: object
+                          ibmcloud:
+                            description: IBMCloud contains settings specific to the
+                              IBMCloud infrastructure provider.
+                            type: object
+                          kubevirt:
+                            description: Kubevirt contains settings specific to the
+                              kubevirt infrastructure provider.
+                            type: object
+                          nutanix:
+                            description: Nutanix contains settings specific to the
+                              Nutanix infrastructure provider.
+                            properties:
+                              failureDomains:
+                                description: failureDomains configures failure domains
+                                  information for the Nutanix platform. When set,
+                                  the failure domains defined here may be used to
+                                  spread Machines across prism element clusters to
+                                  improve fault tolerance of the cluster.
+                                items:
+                                  description: NutanixFailureDomain configures failure
+                                    domain information for the Nutanix platform.
+                                  properties:
+                                    cluster:
+                                      description: cluster is to identify the cluster
+                                        (the Prism Element under management of the
+                                        Prism Central), in which the Machine's VM
+                                        will be created. The cluster identifier (uuid
+                                        or name) can be obtained from the Prism Central
+                                        console or using the prism_central API.
+                                      properties:
+                                        name:
+                                          description: name is the resource name in
+                                            the PC. It cannot be empty if the type
+                                            is Name.
+                                          type: string
+                                        type:
+                                          description: type is the identifier type
+                                            to use for this resource.
+                                          enum:
+                                          - UUID
+                                          - Name
+                                          type: string
+                                        uuid:
+                                          description: uuid is the UUID of the resource
+                                            in the PC. It cannot be empty if the type
+                                            is UUID.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: uuid configuration is required when
+                                          type is UUID, and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''UUID''
+                                          ?  has(self.uuid) : !has(self.uuid)'
+                                      - message: name configuration is required when
+                                          type is Name, and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''Name''
+                                          ?  has(self.name) : !has(self.name)'
+                                    name:
+                                      description: name defines the unique name of
+                                        a failure domain. Name is required and must
+                                        be at most 64 characters in length. It must
+                                        consist of only lower case alphanumeric characters
+                                        and hyphens (-). It must start and end with
+                                        an alphanumeric character. This value is arbitrary
+                                        and is used to identify the failure domain
+                                        within the platform.
+                                      maxLength: 64
+                                      minLength: 1
+                                      pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                                      type: string
+                                    subnets:
+                                      description: subnets holds a list of identifiers
+                                        (one or more) of the cluster's network subnets
+                                        for the Machine's VM to connect to. The subnet
+                                        identifiers (uuid or name) can be obtained
+                                        from the Prism Central console or using the
+                                        prism_central API.
+                                      items:
+                                        description: NutanixResourceIdentifier holds
+                                          the identity of a Nutanix PC resource (cluster,
+                                          image, subnet, etc.)
+                                        properties:
+                                          name:
+                                            description: name is the resource name
+                                              in the PC. It cannot be empty if the
+                                              type is Name.
+                                            type: string
+                                          type:
+                                            description: type is the identifier type
+                                              to use for this resource.
+                                            enum:
+                                            - UUID
+                                            - Name
+                                            type: string
+                                          uuid:
+                                            description: uuid is the UUID of the resource
+                                              in the PC. It cannot be empty if the
+                                              type is UUID.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: uuid configuration is required
+                                            when type is UUID, and forbidden otherwise
+                                          rule: 'has(self.type) && self.type == ''UUID''
+                                            ?  has(self.uuid) : !has(self.uuid)'
+                                        - message: name configuration is required
+                                            when type is Name, and forbidden otherwise
+                                          rule: 'has(self.type) && self.type == ''Name''
+                                            ?  has(self.name) : !has(self.name)'
+                                      maxItems: 1
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - type
+                                      x-kubernetes-list-type: map
+                                  required:
+                                  - cluster
+                                  - name
+                                  - subnets
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              prismCentral:
+                                description: prismCentral holds the endpoint address
+                                  and port to access the Nutanix Prism Central. When
+                                  a cluster-wide proxy is installed, by default, this
+                                  endpoint will be accessed via the proxy. Should
+                                  you wish for communication with this endpoint not
+                                  to be proxied, please add the endpoint to the proxy
+                                  spec.noProxy list.
+                                properties:
+                                  address:
+                                    description: address is the endpoint address (DNS
+                                      name or IP address) of the Nutanix Prism Central
+                                      or Element (cluster)
+                                    maxLength: 256
+                                    type: string
+                                  port:
+                                    description: port is the port number to access
+                                      the Nutanix Prism Central or Element (cluster)
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - address
+                                - port
+                                type: object
+                              prismElements:
+                                description: prismElements holds one or more endpoint
+                                  address and port data to access the Nutanix Prism
+                                  Elements (clusters) of the Nutanix Prism Central.
+                                  Currently we only support one Prism Element (cluster)
+                                  for an OpenShift cluster, where all the Nutanix
+                                  resources (VMs, subnets, volumes, etc.) used in
+                                  the OpenShift cluster are located. In the future,
+                                  we may support Nutanix resources (VMs, etc.) spread
+                                  over multiple Prism Elements (clusters) of the Prism
+                                  Central.
+                                items:
+                                  description: NutanixPrismElementEndpoint holds the
+                                    name and endpoint data for a Prism Element (cluster)
+                                  properties:
+                                    endpoint:
+                                      description: endpoint holds the endpoint address
+                                        and port data of the Prism Element (cluster).
+                                        When a cluster-wide proxy is installed, by
+                                        default, this endpoint will be accessed via
+                                        the proxy. Should you wish for communication
+                                        with this endpoint not to be proxied, please
+                                        add the endpoint to the proxy spec.noProxy
+                                        list.
+                                      properties:
+                                        address:
+                                          description: address is the endpoint address
+                                            (DNS name or IP address) of the Nutanix
+                                            Prism Central or Element (cluster)
+                                          maxLength: 256
+                                          type: string
+                                        port:
+                                          description: port is the port number to
+                                            access the Nutanix Prism Central or Element
+                                            (cluster)
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - address
+                                      - port
+                                      type: object
+                                    name:
+                                      description: name is the name of the Prism Element
+                                        (cluster). This value will correspond with
+                                        the cluster field configured on other resources
+                                        (eg Machines, PVCs, etc).
+                                      maxLength: 256
+                                      type: string
+                                  required:
+                                  - endpoint
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            required:
+                            - prismCentral
+                            - prismElements
+                            type: object
+                          openstack:
+                            description: OpenStack contains settings specific to the
+                              OpenStack infrastructure provider.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                          ovirt:
+                            description: Ovirt contains settings specific to the oVirt
+                              infrastructure provider.
+                            type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              IBM Power Systems Virtual Servers infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of a Power VS service.
+                                items:
+                                  description: PowervsServiceEndpoint stores the configuration
+                                    of a custom url to override existing defaults
+                                    of PowerVS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the Power VS
+                                        service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                        ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                        Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      format: uri
+                                      pattern: ^https://
+                                      type: string
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: type is the underlying infrastructure provider
+                              for the cluster. This value controls whether infrastructure
+                              automation such as service load balancers, dynamic volume
+                              provisioning, machine creation and deletion, and other
+                              integrations are enabled. If None, no infrastructure
+                              automation is enabled. Allowed values are "AWS", "Azure",
+                              "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere",
+                              "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud",
+                              "Nutanix" and "None". Individual components may not
+                              support all platforms, and must handle unrecognized
+                              platforms as None if they do not support that platform.
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                          vsphere:
+                            description: VSphere contains settings specific to the
+                              VSphere infrastructure provider.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              failureDomains:
+                                description: failureDomains contains the definition
+                                  of region, zone and the vCenter topology. If this
+                                  is omitted failure domains (regions and zones) will
+                                  not be used.
+                                items:
+                                  description: VSpherePlatformFailureDomainSpec holds
+                                    the region and zone failure domain and the vCenter
+                                    topology of that failure domain.
+                                  properties:
+                                    name:
+                                      description: name defines the arbitrary but
+                                        unique name of a failure domain.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    region:
+                                      description: region defines the name of a region
+                                        tag that will be attached to a vCenter datacenter.
+                                        The tag category in vCenter must be named
+                                        openshift-region.
+                                      maxLength: 80
+                                      minLength: 1
+                                      type: string
+                                    server:
+                                      description: server is the fully-qualified domain
+                                        name or the IP address of the vCenter server.
+                                        ---
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    topology:
+                                      description: Topology describes a given failure
+                                        domain using vSphere constructs
+                                      properties:
+                                        computeCluster:
+                                          description: computeCluster the absolute
+                                            path of the vCenter cluster in which virtual
+                                            machine will be located. The absolute
+                                            path is of the form /<datacenter>/host/<cluster>.
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/host/.*?
+                                          type: string
+                                        datacenter:
+                                          description: datacenter is the name of vCenter
+                                            datacenter in which virtual machines will
+                                            be located. The maximum length of the
+                                            datacenter name is 80 characters.
+                                          maxLength: 80
+                                          type: string
+                                        datastore:
+                                          description: datastore is the absolute path
+                                            of the datastore in which the virtual
+                                            machine is located. The absolute path
+                                            is of the form /<datacenter>/datastore/<datastore>
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/datastore/.*?
+                                          type: string
+                                        folder:
+                                          description: folder is the absolute path
+                                            of the folder where virtual machines are
+                                            located. The absolute path is of the form
+                                            /<datacenter>/vm/<folder>. The maximum
+                                            length of the path is 2048 characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/vm/.*?
+                                          type: string
+                                        networks:
+                                          description: 'networks is the list of port
+                                            group network names within this failure
+                                            domain. If feature gate VSphereMultiNetworks
+                                            is enabled, up to 10 network adapters
+                                            may be defined. 10 is the maximum number
+                                            of virtual network devices which may be
+                                            attached to a VM as defined by: https://configmax.esp.vmware.com/guest?vmwareproduct=vSphere&release=vSphere%208.0&categories=1-0
+                                            The available networks (port groups) can
+                                            be listed using `govc ls ''network/*''`
+                                            Networks should be in the form of an absolute
+                                            path: /<datacenter>/network/<portgroup>.'
+                                          items:
+                                            type: string
+                                          maxItems: 10
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resourcePool:
+                                          description: resourcePool is the absolute
+                                            path of the resource pool where virtual
+                                            machines will be created. The absolute
+                                            path is of the form /<datacenter>/host/<cluster>/Resources/<resourcepool>.
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/host/.*?/Resources.*
+                                          type: string
+                                        template:
+                                          description: "template is the full inventory
+                                            path of the virtual machine or template
+                                            that will be cloned when creating new
+                                            machines in this failure domain. The maximum
+                                            length of the path is 2048 characters.
+                                            \n When omitted, the template will be
+                                            calculated by the control plane machineset
+                                            operator based on the region and zone
+                                            defined in VSpherePlatformFailureDomainSpec.
+                                            For example, for zone=zonea, region=region1,
+                                            and infrastructure name=test, the template
+                                            path would be calculated as /<datacenter>/vm/test-rhcos-region1-zonea."
+                                          maxLength: 2048
+                                          minLength: 1
+                                          pattern: ^/.*?/vm/.*?
+                                          type: string
+                                      required:
+                                      - computeCluster
+                                      - datacenter
+                                      - datastore
+                                      - networks
+                                      type: object
+                                    zone:
+                                      description: zone defines the name of a zone
+                                        tag that will be attached to a vCenter cluster.
+                                        The tag category in vCenter must be named
+                                        openshift-zone.
+                                      maxLength: 80
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - region
+                                  - server
+                                  - topology
+                                  - zone
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeNetworking:
+                                description: nodeNetworking contains the definition
+                                  of internal and external network constraints for
+                                  assigning the node's networking. If this field is
+                                  omitted, networking defaults to the legacy address
+                                  selection behavior which is to only support a single
+                                  address and return the first one found.
+                                properties:
+                                  external:
+                                    description: external represents the network configuration
+                                      of the node that is externally routable.
+                                    properties:
+                                      excludeNetworkSubnetCidr:
+                                        description: excludeNetworkSubnetCidr IP addresses
+                                          in subnet ranges will be excluded when selecting
+                                          the IP address from the VirtualMachine's
+                                          VM for use in the status.addresses fields.
+                                          ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      network:
+                                        description: network VirtualMachine's VM Network
+                                          names that will be used to when searching
+                                          for status.addresses fields. Note that if
+                                          internal.networkSubnetCIDR and external.networkSubnetCIDR
+                                          are not set, then the vNIC associated to
+                                          this network must only have a single IP
+                                          address assigned to it. The available networks
+                                          (port groups) can be listed using `govc
+                                          ls 'network/*'`
+                                        type: string
+                                      networkSubnetCidr:
+                                        description: networkSubnetCidr IP address
+                                          on VirtualMachine's network interfaces included
+                                          in the fields' CIDRs that will be used in
+                                          respective status.addresses fields. ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  internal:
+                                    description: internal represents the network configuration
+                                      of the node that is routable only within the
+                                      cluster.
+                                    properties:
+                                      excludeNetworkSubnetCidr:
+                                        description: excludeNetworkSubnetCidr IP addresses
+                                          in subnet ranges will be excluded when selecting
+                                          the IP address from the VirtualMachine's
+                                          VM for use in the status.addresses fields.
+                                          ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      network:
+                                        description: network VirtualMachine's VM Network
+                                          names that will be used to when searching
+                                          for status.addresses fields. Note that if
+                                          internal.networkSubnetCIDR and external.networkSubnetCIDR
+                                          are not set, then the vNIC associated to
+                                          this network must only have a single IP
+                                          address assigned to it. The available networks
+                                          (port groups) can be listed using `govc
+                                          ls 'network/*'`
+                                        type: string
+                                      networkSubnetCidr:
+                                        description: networkSubnetCidr IP address
+                                          on VirtualMachine's network interfaces included
+                                          in the fields' CIDRs that will be used in
+                                          respective status.addresses fields. ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                type: object
+                              vcenters:
+                                description: vcenters holds the connection details
+                                  for services to communicate with vCenter. Currently,
+                                  only a single vCenter is supported, but in tech
+                                  preview 3 vCenters are supported. Once the cluster
+                                  has been installed, you are unable to change the
+                                  current number of defined vCenters except in the
+                                  case where the cluster has been upgraded from a
+                                  version of OpenShift where the vsphere platform
+                                  spec was not present.  You may make modifications
+                                  to the existing vCenters that are defined in the
+                                  vcenters list in order to match with any added or
+                                  modified failure domains. ---
+                                items:
+                                  description: VSpherePlatformVCenterSpec stores the
+                                    vCenter connection fields. This is used by the
+                                    vSphere CCM.
+                                  properties:
+                                    datacenters:
+                                      description: The vCenter Datacenters in which
+                                        the RHCOS vm guests are located. This field
+                                        will be used by the Cloud Controller Manager.
+                                        Each datacenter listed here should be used
+                                        within a topology.
+                                      items:
+                                        type: string
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    port:
+                                      description: port is the TCP port that will
+                                        be used to communicate to the vCenter endpoint.
+                                        When omitted, this means the user has no opinion
+                                        and it is up to the platform to choose a sensible
+                                        default, which is subject to change over time.
+                                      format: int32
+                                      maximum: 32767
+                                      minimum: 1
+                                      type: integer
+                                    server:
+                                      description: server is the fully-qualified domain
+                                        name or the IP address of the vCenter server.
+                                        ---
+                                      maxLength: 255
+                                      type: string
+                                  required:
+                                  - datacenters
+                                  - server
+                                  type: object
+                                maxItems: 3
+                                minItems: 0
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                            - message: vcenters can have at most 1 item when configured
+                                post-install
+                              rule: '!has(oldSelf.vcenters) && has(self.vcenters)
+                                ? size(self.vcenters) < 2 : true'
+                        type: object
+                        x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? size(self.vsphere.vcenters)
+                            < 2 : true'
+                    type: object
+                  status:
+                    description: status holds observed values from the cluster. They
+                      may not be overridden.
+                    properties:
+                      apiServerInternalURI:
+                        description: apiServerInternalURL is a valid URI with scheme
+                          'https', address and optionally a port (defaulting to 443).  apiServerInternalURL
+                          can be used by components like kubelets, to contact the
+                          Kubernetes API server using the infrastructure provider
+                          rather than Kubernetes networking.
+                        type: string
+                      apiServerURL:
+                        description: apiServerURL is a valid URI with scheme 'https',
+                          address and optionally a port (defaulting to 443).  apiServerURL
+                          can be used by components like the web console to tell users
+                          where to find the Kubernetes API.
+                        type: string
+                      controlPlaneTopology:
+                        default: HighlyAvailable
+                        description: controlPlaneTopology expresses the expectations
+                          for operands that normally run on control nodes. The default
+                          is 'HighlyAvailable', which represents the behavior operators
+                          have in a "normal" cluster. The 'SingleReplica' mode will
+                          be used in single-node deployments and the operators should
+                          not configure the operand for highly-available operation
+                          The 'External' mode indicates that the control plane is
+                          hosted externally to the cluster and that its components
+                          are not visible within the cluster.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        - External
+                        type: string
+                      cpuPartitioning:
+                        default: None
+                        description: cpuPartitioning expresses if CPU partitioning
+                          is a currently enabled feature in the cluster. CPU Partitioning
+                          means that this cluster can support partitioning workloads
+                          to specific CPU Sets. Valid values are "None" and "AllNodes".
+                          When omitted, the default value is "None". The default value
+                          of "None" indicates that no nodes will be setup with CPU
+                          partitioning. The "AllNodes" value indicates that all nodes
+                          have been setup with CPU partitioning, and can then be further
+                          configured via the PerformanceProfile API.
+                        enum:
+                        - None
+                        - AllNodes
+                        type: string
+                      etcdDiscoveryDomain:
+                        description: 'etcdDiscoveryDomain is the domain used to fetch
+                          the SRV records for discovering etcd servers and clients.
+                          For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
+                          deprecated: as of 4.7, this field is no longer set or honored.  It
+                          will be removed in a future release.'
+                        type: string
+                      infrastructureName:
+                        description: infrastructureName uniquely identifies a cluster
+                          with a human friendly name. Once set it should not be changed.
+                          Must be of max length 27 and must have only alphanumeric
+                          or hyphen characters.
+                        type: string
+                      infrastructureTopology:
+                        default: HighlyAvailable
+                        description: 'infrastructureTopology expresses the expectations
+                          for infrastructure services that do not run on control plane
+                          nodes, usually indicated by a node selector for a `role`
+                          value other than `master`. The default is ''HighlyAvailable'',
+                          which represents the behavior operators have in a "normal"
+                          cluster. The ''SingleReplica'' mode will be used in single-node
+                          deployments and the operators should not configure the operand
+                          for highly-available operation NOTE: External topology mode
+                          is not applicable for this field.'
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        type: string
+                      platform:
+                        description: "platform is the underlying infrastructure provider
+                          for the cluster. \n Deprecated: Use platformStatus.type
+                          instead."
+                        enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                        type: string
+                      platformStatus:
+                        description: platformStatus holds status information specific
+                          to the underlying infrastructure provider.
+                        properties:
+                          alibabaCloud:
+                            description: AlibabaCloud contains settings specific to
+                              the Alibaba Cloud infrastructure provider.
+                            properties:
+                              region:
+                                description: region specifies the region for Alibaba
+                                  Cloud resources created for the cluster.
+                                pattern: ^[0-9A-Za-z-]+$
+                                type: string
+                              resourceGroupID:
+                                description: resourceGroupID is the ID of the resource
+                                  group for the cluster.
+                                pattern: ^(rg-[0-9A-Za-z]+)?$
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to Alibaba Cloud resources created
+                                  for the cluster.
+                                items:
+                                  description: AlibabaCloudResourceTag is the set
+                                    of tags to add to apply to resources.
+                                  properties:
+                                    key:
+                                      description: key is the key of the tag.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: value is the value of the tag.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 20
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                            required:
+                            - region
+                            type: object
+                          aws:
+                            description: AWS contains settings specific to the Amazon
+                              Web Services infrastructure provider.
+                            properties:
+                              region:
+                                description: region holds the default AWS region for
+                                  new AWS resources created by the cluster.
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to AWS resources created for the cluster.
+                                  See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                                  for information on tagging AWS resources. AWS supports
+                                  a maximum of 50 tags per resource. OpenShift reserves
+                                  25 tags for its use, leaving 25 tags available for
+                                  the user.
+                                items:
+                                  description: AWSResourceTag is a tag to apply to
+                                    AWS resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key of the tag
+                                      maxLength: 128
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                      type: string
+                                    value:
+                                      description: value is the value of the tag.
+                                        Some AWS service do not support empty values.
+                                        Since tags are added to resources in many
+                                        services, the length of the tag value must
+                                        meet the requirements of all services.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 25
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              serviceEndpoints:
+                                description: ServiceEndpoints list contains custom
+                                  endpoints which will override default service endpoint
+                                  of AWS Services. There must be only one ServiceEndpoint
+                                  for a service.
+                                items:
+                                  description: AWSServiceEndpoint store the configuration
+                                    of a custom url to override existing defaults
+                                    of AWS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the AWS service.
+                                        The list of all the service names can be found
+                                        at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                        This must be provided and cannot be empty.
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      pattern: ^https://
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          azure:
+                            description: Azure contains settings specific to the Azure
+                              infrastructure provider.
+                            properties:
+                              armEndpoint:
+                                description: armEndpoint specifies a URL to use for
+                                  resource management in non-soverign clouds such
+                                  as Azure Stack.
+                                type: string
+                              cloudName:
+                                description: cloudName is the name of the Azure cloud
+                                  environment which can be used to configure the Azure
+                                  SDK with the appropriate Azure API endpoints. If
+                                  empty, the value is equal to `AzurePublicCloud`.
+                                enum:
+                                - ""
+                                - AzurePublicCloud
+                                - AzureUSGovernmentCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureStackCloud
+                                type: string
+                              networkResourceGroupName:
+                                description: networkResourceGroupName is the Resource
+                                  Group for network resources like the Virtual Network
+                                  and Subnets used by the cluster. If empty, the value
+                                  is same as ResourceGroupName.
+                                type: string
+                              resourceGroupName:
+                                description: resourceGroupName is the Resource Group
+                                  for new Azure resources created for the cluster.
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to Azure resources created for the
+                                  cluster. See https://docs.microsoft.com/en-us/rest/api/resources/tags
+                                  for information on tagging Azure resources. Due
+                                  to limitations on Automation, Content Delivery Network,
+                                  DNS Azure resources, a maximum of 15 tags may be
+                                  applied. OpenShift reserves 5 tags for internal
+                                  use, allowing 10 tags for user configuration.
+                                items:
+                                  description: AzureResourceTag is a tag to apply
+                                    to Azure resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the tag.
+                                        A tag key can have a maximum of 128 characters
+                                        and cannot be empty. Key must begin with a
+                                        letter, end with a letter, number or underscore,
+                                        and must contain only alphanumeric characters
+                                        and the following special characters `_ .
+                                        -`.
+                                      maxLength: 128
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([0-9A-Za-z_.-]*[0-9A-Za-z_])?$
+                                      type: string
+                                    value:
+                                      description: 'value is the value part of the
+                                        tag. A tag value can have a maximum of 256
+                                        characters and cannot be empty. Value must
+                                        contain only alphanumeric characters and the
+                                        following special characters `_ + , - . /
+                                        : ; < = > ? @`.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.=+-@]+$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 10
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: resourceTags are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                            type: object
+                            x-kubernetes-validations:
+                            - message: resourceTags may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags)
+                                || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                          baremetal:
+                            description: BareMetal contains settings specific to the
+                              BareMetal platform.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on BareMetal platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for BareMetal deployments. In order to minimize
+                                  necessary changes to the datacenter DNS, a DNS service
+                                  is hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                          equinixMetal:
+                            description: EquinixMetal contains settings specific to
+                              the Equinix Metal infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers.
+                                type: string
+                              ingressIP:
+                                description: ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names.
+                                type: string
+                            type: object
+                          external:
+                            description: External contains settings specific to the
+                              generic External infrastructure provider.
+                            properties:
+                              cloudControllerManager:
+                                description: cloudControllerManager contains settings
+                                  specific to the external Cloud Controller Manager
+                                  (a.k.a. CCM or CPI). When omitted, new nodes will
+                                  be not tainted and no extra initialization from
+                                  the cloud controller manager is expected.
+                                properties:
+                                  state:
+                                    description: "state determines whether or not
+                                      an external Cloud Controller Manager is expected
+                                      to be installed within the cluster. https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager
+                                      \n Valid values are \"External\", \"None\" and
+                                      omitted. When set to \"External\", new nodes
+                                      will be tainted as uninitialized when created,
+                                      preventing them from running workloads until
+                                      they are initialized by the cloud controller
+                                      manager. When omitted or set to \"None\", new
+                                      nodes will be not tainted and no extra initialization
+                                      from the cloud controller manager is expected."
+                                    enum:
+                                    - ""
+                                    - External
+                                    - None
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: state is immutable once set
+                                      rule: self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: state may not be added or removed once
+                                    set
+                                  rule: (has(self.state) == has(oldSelf.state)) ||
+                                    (!has(oldSelf.state) && self.state != "External")
+                            type: object
+                            x-kubernetes-validations:
+                            - message: cloudControllerManager may not be added or
+                                removed once set
+                              rule: has(self.cloudControllerManager) == has(oldSelf.cloudControllerManager)
+                          gcp:
+                            description: GCP contains settings specific to the Google
+                              Cloud Platform infrastructure provider.
+                            properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: cloudLoadBalancerConfig is a union that
+                                  contains the IP addresses of API, API-Int and Ingress
+                                  Load Balancers created on the cloud platform. These
+                                  values would not be populated on on-prem platforms.
+                                  These Load Balancer IPs are used to configure the
+                                  in-cluster DNS instances for API, API-Int and Ingress
+                                  services. `dnsType` is expected to be set to `ClusterHosted`
+                                  when these Load Balancer IP addresses are populated
+                                  and used.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: clusterHosted holds the IP addresses
+                                      of API, API-Int and Ingress Load Balancers on
+                                      Cloud Platforms. The DNS solution hosted within
+                                      the cluster use these IP addresses to provide
+                                      resolution for API, API-Int and Ingress services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: apiIntLoadBalancerIPs holds Load
+                                          Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be
+                                          IPv4 and/or IPv6 addresses. Entries in the
+                                          apiIntLoadBalancerIPs must be unique. A
+                                          maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: apiLoadBalancerIPs holds Load
+                                          Balancer IPs for the API service. These
+                                          Load Balancer IP addresses can be IPv4 and/or
+                                          IPv6 addresses. Could be empty for private
+                                          clusters. Entries in the apiLoadBalancerIPs
+                                          must be unique. A maximum of 16 IP addresses
+                                          are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: ingressLoadBalancerIPs holds
+                                          IPs for Ingress Load Balancers. These Load
+                                          Balancer IP addresses can be IPv4 and/or
+                                          IPv6 addresses. Entries in the ingressLoadBalancerIPs
+                                          must be unique. A maximum of 16 IP addresses
+                                          are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: dnsType indicates the type of DNS
+                                      solution in use within the cluster. Its default
+                                      value of `PlatformDefault` indicates that the
+                                      cluster's DNS is the default provided by the
+                                      cloud platform. It can be set to `ClusterHosted`
+                                      to bypass the configuration of the cloud default
+                                      DNS. In this mode, the cluster needs to provide
+                                      a self-hosted DNS solution for the cluster's
+                                      installation to succeed. The cluster's use of
+                                      the cloud's Load Balancers is unaffected by
+                                      this setting. The value is immutable after it
+                                      has been set at install time. Currently, there
+                                      is no way for the customer to add additional
+                                      DNS entries into the cluster hosted DNS. Enabling
+                                      this functionality allows the user to start
+                                      their own DNS solution outside the cluster after
+                                      installation is complete. The customer would
+                                      be responsible for configuring this custom DNS
+                                      solution, and it can be run in addition to the
+                                      in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
+                              projectID:
+                                description: resourceGroupName is the Project ID for
+                                  new GCP resources created for the cluster.
+                                type: string
+                              region:
+                                description: region holds the region for new GCP resources
+                                  created for the cluster.
+                                type: string
+                              resourceLabels:
+                                description: resourceLabels is a list of additional
+                                  labels to apply to GCP resources created for the
+                                  cluster. See https://cloud.google.com/compute/docs/labeling-resources
+                                  for information on labeling GCP resources. GCP supports
+                                  a maximum of 64 labels per resource. OpenShift reserves
+                                  32 labels for internal use, allowing 32 labels for
+                                  user configuration.
+                                items:
+                                  description: GCPResourceLabel is a label to apply
+                                    to GCP resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the label.
+                                        A label key can have a maximum of 63 characters
+                                        and cannot be empty. Label key must begin
+                                        with a lowercase letter, and must contain
+                                        only lowercase letters, numeric characters,
+                                        and the following special characters `_-`.
+                                        Label key must not have the reserved prefixes
+                                        `kubernetes-io` and `openshift-io`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z][0-9a-z_-]{0,62}$
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: label keys must not start with either
+                                          `openshift-io` or `kubernetes-io`
+                                        rule: '!self.startsWith(''openshift-io'')
+                                          && !self.startsWith(''kubernetes-io'')'
+                                    value:
+                                      description: value is the value part of the
+                                        label. A label value can have a maximum of
+                                        63 characters and cannot be empty. Value must
+                                        contain only lowercase letters, numeric characters,
+                                        and the following special characters `_-`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[0-9a-z_-]{1,63}$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                                x-kubernetes-validations:
+                                - message: resourceLabels are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to GCP resources created for the cluster.
+                                  See https://cloud.google.com/resource-manager/docs/tags/tags-overview
+                                  for information on tagging GCP resources. GCP supports
+                                  a maximum of 50 tags per resource.
+                                items:
+                                  description: GCPResourceTag is a tag to apply to
+                                    GCP resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the tag.
+                                        A tag key can have a maximum of 63 characters
+                                        and cannot be empty. Tag key must begin and
+                                        end with an alphanumeric character, and must
+                                        contain only uppercase, lowercase alphanumeric
+                                        characters, and the following special characters
+                                        `._-`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.-]{0,61}[a-zA-Z0-9])?$
+                                      type: string
+                                    parentID:
+                                      description: 'parentID is the ID of the hierarchical
+                                        resource where the tags are defined, e.g.
+                                        at the Organization or the Project level.
+                                        To find the Organization or Project ID refer
+                                        to the following pages: https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id,
+                                        https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects.
+                                        An OrganizationID must consist of decimal
+                                        numbers, and cannot have leading zeroes. A
+                                        ProjectID must be 6 to 30 characters in length,
+                                        can only contain lowercase letters, numbers,
+                                        and hyphens, and must start with a letter,
+                                        and cannot end with a hyphen.'
+                                      maxLength: 32
+                                      minLength: 1
+                                      pattern: (^[1-9][0-9]{0,31}$)|(^[a-z][a-z0-9-]{4,28}[a-z0-9]$)
+                                      type: string
+                                    value:
+                                      description: value is the value part of the
+                                        tag. A tag value can have a maximum of 63
+                                        characters and cannot be empty. Tag value
+                                        must begin and end with an alphanumeric character,
+                                        and must contain only uppercase, lowercase
+                                        alphanumeric characters, and the following
+                                        special characters `_-.@%=+:,*#&(){}[]` and
+                                        spaces.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.@%=+:,*#&()\[\]{}\-\s]{0,61}[a-zA-Z0-9])?$
+                                      type: string
+                                  required:
+                                  - key
+                                  - parentID
+                                  - value
+                                  type: object
+                                maxItems: 50
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                                x-kubernetes-validations:
+                                - message: resourceTags are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                            type: object
+                            x-kubernetes-validations:
+                            - message: resourceLabels may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceLabels) && !has(self.resourceLabels)
+                                || has(oldSelf.resourceLabels) && has(self.resourceLabels)'
+                            - message: resourceTags may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags)
+                                || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                          ibmcloud:
+                            description: IBMCloud contains settings specific to the
+                              IBMCloud infrastructure provider.
+                            properties:
+                              cisInstanceCRN:
+                                description: CISInstanceCRN is the CRN of the Cloud
+                                  Internet Services instance managing the DNS zone
+                                  for the cluster's base domain
+                                type: string
+                              dnsInstanceCRN:
+                                description: DNSInstanceCRN is the CRN of the DNS
+                                  Services instance managing the DNS zone for the
+                                  cluster's base domain
+                                type: string
+                              location:
+                                description: Location is where the cluster has been
+                                  deployed
+                                type: string
+                              providerType:
+                                description: ProviderType indicates the type of cluster
+                                  that was created
+                                type: string
+                              resourceGroupName:
+                                description: ResourceGroupName is the Resource Group
+                                  for new IBMCloud resources created for the cluster.
+                                type: string
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of an IBM Cloud service. These endpoints
+                                  are consumed by components within the cluster to
+                                  reach the respective IBM Cloud Services.
+                                items:
+                                  description: IBMCloudServiceEndpoint stores the
+                                    configuration of a custom url to override existing
+                                    defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: 'name is the name of the IBM Cloud
+                                        service. Possible values are: CIS, COS, COSConfig,
+                                        DNSServices, GlobalCatalog, GlobalSearch,
+                                        GlobalTagging, HyperProtect, IAM, KeyProtect,
+                                        ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service
+                                        could be configured with the service `name`
+                                        of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service
+                                        for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url`
+                                        of `https://us.south.private.iaas.cloud.ibm.com`'
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          kubevirt:
+                            description: Kubevirt contains settings specific to the
+                              kubevirt infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers.
+                                type: string
+                              ingressIP:
+                                description: ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names.
+                                type: string
+                            type: object
+                          nutanix:
+                            description: Nutanix contains settings specific to the
+                              Nutanix infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Nutanix platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                            type: object
+                          openstack:
+                            description: OpenStack contains settings specific to the
+                              OpenStack infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              cloudName:
+                                description: cloudName is the name of the desired
+                                  OpenStack cloud in the client configuration file
+                                  (`clouds.yaml`).
+                                type: string
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on OpenStack platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for OpenStack deployments. In order to minimize
+                                  necessary changes to the datacenter DNS, a DNS service
+                                  is hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                          ovirt:
+                            description: Ovirt contains settings specific to the oVirt
+                              infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Ovirt platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              nodeDNSIP:
+                                description: 'deprecated: as of 4.6, this field is
+                                  no longer set or honored.  It will be removed in
+                                  a future release.'
+                                type: string
+                            type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              Power Systems Virtual Servers infrastructure provider.
+                            properties:
+                              cisInstanceCRN:
+                                description: CISInstanceCRN is the CRN of the Cloud
+                                  Internet Services instance managing the DNS zone
+                                  for the cluster's base domain
+                                type: string
+                              dnsInstanceCRN:
+                                description: DNSInstanceCRN is the CRN of the DNS
+                                  Services instance managing the DNS zone for the
+                                  cluster's base domain
+                                type: string
+                              region:
+                                description: region holds the default Power VS region
+                                  for new Power VS resources created by the cluster.
+                                type: string
+                              resourceGroup:
+                                description: 'resourceGroup is the resource group
+                                  name for new IBMCloud resources created for a cluster.
+                                  The resource group specified here will be used by
+                                  cluster-image-registry-operator to set up a COS
+                                  Instance in IBMCloud for the cluster registry. More
+                                  about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs.
+                                  When omitted, the image registry operator won''t
+                                  be able to configure storage, which results in the
+                                  image registry cluster operator not being in an
+                                  available state.'
+                                maxLength: 40
+                                pattern: ^[a-zA-Z0-9-_ ]+$
+                                type: string
+                                x-kubernetes-validations:
+                                - message: resourceGroup is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of a Power VS service.
+                                items:
+                                  description: PowervsServiceEndpoint stores the configuration
+                                    of a custom url to override existing defaults
+                                    of PowerVS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the Power VS
+                                        service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                        ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                        Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      format: uri
+                                      pattern: ^https://
+                                      type: string
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              zone:
+                                description: 'zone holds the default zone for the
+                                  new Power VS resources created by the cluster. Note:
+                                  Currently only single-zone OCP clusters are supported'
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: cannot unset resourceGroup once set
+                              rule: '!has(oldSelf.resourceGroup) || has(self.resourceGroup)'
+                          type:
+                            description: "type is the underlying infrastructure provider
+                              for the cluster. This value controls whether infrastructure
+                              automation such as service load balancers, dynamic volume
+                              provisioning, machine creation and deletion, and other
+                              integrations are enabled. If None, no infrastructure
+                              automation is enabled. Allowed values are \"AWS\", \"Azure\",
+                              \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\",
+                              \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\",
+                              \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual
+                              components may not support all platforms, and must handle
+                              unrecognized platforms as None if they do not support
+                              that platform. \n This value will be synced with to
+                              the `status.platform` and `status.platformStatus.type`.
+                              Currently this value cannot be changed once set."
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                          vsphere:
+                            description: VSphere contains settings specific to the
+                              VSphere infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on VSphere platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for vSphere deployments. In order to minimize necessary
+                                  changes to the datacenter DNS, a DNS service is
+                                  hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+                x-kubernetes-embedded-resource: true
+              internalRegistryPullSecret:
+                description: internalRegistryPullSecret is the pull secret for the
+                  internal registry, used by rpm-ostree to pull images from the internal
+                  registry if present
+                format: byte
+                nullable: true
+                type: string
+              ipFamilies:
+                description: ipFamilies indicates the IP families in use by the cluster
+                  network
+                type: string
+              kubeAPIServerServingCAData:
+                description: kubeAPIServerServingCAData managed Kubelet to API Server
+                  Cert... Rotated automatically
+                format: byte
+                type: string
+              network:
+                description: Network contains additional network related information
+                nullable: true
+                properties:
+                  mtuMigration:
+                    description: MTUMigration contains the MTU migration configuration.
+                    nullable: true
+                    properties:
+                      machine:
+                        description: Machine contains MTU migration configuration
+                          for the machine's uplink.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      network:
+                        description: Network contains MTU migration configuration
+                          for the default network.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - mtuMigration
+                type: object
+              networkType:
+                description: 'networkType holds the type of network the cluster is
+                  using XXX: this is temporary and will be dropped as soon as possible
+                  in favor of a better support to start network related services the
+                  proper way. Nobody is also changing this once the cluster is up
+                  and running the first time, so, disallow regeneration if this changes.'
+                type: string
+              osImageURL:
+                description: OSImageURL is the old-format container image that contains
+                  the OS update payload.
+                type: string
+              platform:
+                description: platform is deprecated, use Infra.Status.PlatformStatus.Type
+                  instead
+                type: string
+              proxy:
+                description: proxy holds the current proxy configuration for the nodes
+                nullable: true
+                properties:
+                  httpProxy:
+                    description: httpProxy is the URL of the proxy for HTTP requests.
+                    type: string
+                  httpsProxy:
+                    description: httpsProxy is the URL of the proxy for HTTPS requests.
+                    type: string
+                  noProxy:
+                    description: noProxy is a comma-separated list of hostnames and/or
+                      CIDRs for which the proxy should not be used.
+                    type: string
+                type: object
+              pullSecret:
+                description: pullSecret is the default pull secret that needs to be
+                  installed on all machines.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              releaseImage:
+                description: releaseImage is the image used when installing the cluster
+                type: string
+              rootCAData:
+                description: rootCAData specifies the root CA data
+                format: byte
+                type: string
+            required:
+            - additionalTrustBundle
+            - baseOSContainerImage
+            - cloudProviderCAData
+            - cloudProviderConfig
+            - clusterDNSIP
+            - dns
+            - images
+            - infra
+            - ipFamilies
+            - kubeAPIServerServingCAData
+            - network
+            - proxy
+            - releaseImage
+            - rootCAData
+            type: object
+          status:
+            description: ControllerConfigStatus is the status for ControllerConfig
+            properties:
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: ControllerConfigStatusCondition contains condition
+                    information for ControllerConfigStatus
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status object.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message provides additional information about the
+                        current condition. This is only to be consumed by humans.
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.  Reasons
+                        are PascalCase
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              controllerCertificates:
+                description: controllerCertificates represents the latest available
+                  observations of the automatically rotating certificates in the MCO.
+                items:
+                  description: ControllerCertificate contains info about a specific
+                    cert.
+                  properties:
+                    bundleFile:
+                      description: bundleFile is the larger bundle a cert comes from
+                      type: string
+                    notAfter:
+                      description: notAfter is the upper boundary for validity
+                      format: date-time
+                      type: string
+                    notBefore:
+                      description: notBefore is the lower boundary for validity
+                      format: date-time
+                      type: string
+                    signer:
+                      description: signer is the  cert Issuer
+                      type: string
+                    subject:
+                      description: subject is the cert subject
+                      type: string
+                  required:
+                  - bundleFile
+                  - signer
+                  - subject
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1,0 +1,2742 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: Default
+  labels:
+    openshift.io/operator-managed: ""
+  name: controllerconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: ControllerConfig
+    listKind: ControllerConfigList
+    plural: controllerconfigs
+    singular: controllerconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ControllerConfig describes configuration for MachineConfigController.
+          This is currently only used to drive the MachineConfig objects generated
+          by the TemplateController. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ControllerConfigSpec is the spec for ControllerConfig resource.
+            properties:
+              additionalTrustBundle:
+                description: additionalTrustBundle is a certificate bundle that will
+                  be added to the nodes trusted certificate store.
+                format: byte
+                nullable: true
+                type: string
+              baseOSContainerImage:
+                description: BaseOSContainerImage is the new-format container image
+                  for operating system updates.
+                type: string
+              baseOSExtensionsContainerImage:
+                description: BaseOSExtensionsContainerImage is the matching extensions
+                  container for the new-format container
+                type: string
+              cloudProviderCAData:
+                description: cloudProvider specifies the cloud provider CA data
+                format: byte
+                nullable: true
+                type: string
+              cloudProviderConfig:
+                description: cloudProviderConfig is the configuration for the given
+                  cloud provider
+                type: string
+              clusterDNSIP:
+                description: clusterDNSIP is the cluster DNS IP address
+                type: string
+              dns:
+                description: dns holds the cluster dns details
+                nullable: true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'metadata is the standard object''s metadata. More
+                      info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: spec holds user settable values for configuration
+                    properties:
+                      baseDomain:
+                        description: "baseDomain is the base domain of the cluster.
+                          All managed DNS records will be sub-domains of this base.
+                          \n For example, given the base domain `openshift.example.com`,
+                          an API server DNS record may be created for `cluster-api.openshift.example.com`.
+                          \n Once set, this field cannot be changed."
+                        type: string
+                      platform:
+                        description: platform holds configuration specific to the
+                          underlying infrastructure provider for DNS. When omitted,
+                          this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject
+                          to change over time.
+                        properties:
+                          aws:
+                            description: aws contains DNS configuration specific to
+                              the Amazon Web Services cloud provider.
+                            properties:
+                              privateZoneIAMRole:
+                                description: privateZoneIAMRole contains the ARN of
+                                  an IAM role that should be assumed when performing
+                                  operations on the cluster's private hosted zone
+                                  specified in the cluster DNS config. When left empty,
+                                  no role should be assumed.
+                                pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                                type: string
+                            type: object
+                          type:
+                            description: "type is the underlying infrastructure provider
+                              for the cluster. Allowed values: \"\", \"AWS\". \n Individual
+                              components may not support all platforms, and must handle
+                              unrecognized platforms with best-effort defaults."
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                            x-kubernetes-validations:
+                            - message: allowed values are '' and 'AWS'
+                              rule: self in ['','AWS']
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: aws configuration is required when platform is
+                            AWS, and forbidden otherwise
+                          rule: 'has(self.type) && self.type == ''AWS'' ?  has(self.aws)
+                            : !has(self.aws)'
+                      privateZone:
+                        description: "privateZone is the location where all the DNS
+                          records that are only available internally to the cluster
+                          exist. \n If this field is nil, no private records should
+                          be created. \n Once set, this field cannot be changed."
+                        properties:
+                          id:
+                            description: "id is the identifier that can be used to
+                              find the DNS hosted zone. \n on AWS zone can be fetched
+                              using `ID` as id in [1] on Azure zone can be fetched
+                              using `ID` as a pre-determined name in [2], on GCP zone
+                              can be fetched using `ID` as a pre-determined name in
+                              [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                              [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                              [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: "tags can be used to query the DNS hosted
+                              zone. \n on AWS, resourcegroupstaggingapi [1] can be
+                              used to fetch a zone using `Tags` as tag-filters, \n
+                              [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                            type: object
+                        type: object
+                      publicZone:
+                        description: "publicZone is the location where all the DNS
+                          records that are publicly accessible to the internet exist.
+                          \n If this field is nil, no public records should be created.
+                          \n Once set, this field cannot be changed."
+                        properties:
+                          id:
+                            description: "id is the identifier that can be used to
+                              find the DNS hosted zone. \n on AWS zone can be fetched
+                              using `ID` as id in [1] on Azure zone can be fetched
+                              using `ID` as a pre-determined name in [2], on GCP zone
+                              can be fetched using `ID` as a pre-determined name in
+                              [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                              [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                              [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: "tags can be used to query the DNS hosted
+                              zone. \n on AWS, resourcegroupstaggingapi [1] can be
+                              used to fetch a zone using `Tags` as tag-filters, \n
+                              [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                            type: object
+                        type: object
+                    type: object
+                  status:
+                    description: status holds observed values from the cluster. They
+                      may not be overridden.
+                    type: object
+                required:
+                - spec
+                type: object
+                x-kubernetes-embedded-resource: true
+              etcdDiscoveryDomain:
+                description: etcdDiscoveryDomain is deprecated, use Infra.Status.EtcdDiscoveryDomain
+                  instead
+                type: string
+              imageRegistryBundleData:
+                description: imageRegistryBundleData is the ImageRegistryData
+                items:
+                  description: ImageRegistryBundle contains information for writing
+                    image registry certificates
+                  properties:
+                    data:
+                      description: data holds the contents of the bundle that will
+                        be written to the file location
+                      format: byte
+                      type: string
+                    file:
+                      description: file holds the name of the file where the bundle
+                        will be written to disk
+                      type: string
+                  required:
+                  - data
+                  - file
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              imageRegistryBundleUserData:
+                description: imageRegistryBundleUserData is Image Registry Data provided
+                  by the user
+                items:
+                  description: ImageRegistryBundle contains information for writing
+                    image registry certificates
+                  properties:
+                    data:
+                      description: data holds the contents of the bundle that will
+                        be written to the file location
+                      format: byte
+                      type: string
+                    file:
+                      description: file holds the name of the file where the bundle
+                        will be written to disk
+                      type: string
+                  required:
+                  - data
+                  - file
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              images:
+                additionalProperties:
+                  type: string
+                description: images is map of images that are used by the controller
+                  to render templates under ./templates/
+                type: object
+              infra:
+                description: infra holds the infrastructure details
+                nullable: true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'metadata is the standard object''s metadata. More
+                      info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: spec holds user settable values for configuration
+                    properties:
+                      cloudConfig:
+                        description: "cloudConfig is a reference to a ConfigMap containing
+                          the cloud provider configuration file. This configuration
+                          file is used to configure the Kubernetes cloud provider
+                          integration when using the built-in cloud provider integration
+                          or the external cloud controller manager. The namespace
+                          for this config map is openshift-config. \n cloudConfig
+                          should only be consumed by the kube_cloud_config controller.
+                          The controller is responsible for using the user configuration
+                          in the spec for various platforms and combining that with
+                          the user provided ConfigMap in this field to create a stitched
+                          kube cloud config. The controller generates a ConfigMap
+                          `kube-cloud-config` in `openshift-config-managed` namespace
+                          with the kube cloud config is stored in `cloud.conf` key.
+                          All the clients are expected to use the generated ConfigMap
+                          only."
+                        properties:
+                          key:
+                            description: Key allows pointing to a specific key/value
+                              inside of the configmap.  This is useful for logical
+                              file references.
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      platformSpec:
+                        description: platformSpec holds desired information specific
+                          to the underlying infrastructure provider.
+                        properties:
+                          alibabaCloud:
+                            description: AlibabaCloud contains settings specific to
+                              the Alibaba Cloud infrastructure provider.
+                            type: object
+                          aws:
+                            description: AWS contains settings specific to the Amazon
+                              Web Services infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: serviceEndpoints list contains custom
+                                  endpoints which will override default service endpoint
+                                  of AWS Services. There must be only one ServiceEndpoint
+                                  for a service.
+                                items:
+                                  description: AWSServiceEndpoint store the configuration
+                                    of a custom url to override existing defaults
+                                    of AWS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the AWS service.
+                                        The list of all the service names can be found
+                                        at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                        This must be provided and cannot be empty.
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      pattern: ^https://
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          azure:
+                            description: Azure contains settings specific to the Azure
+                              infrastructure provider.
+                            type: object
+                          baremetal:
+                            description: BareMetal contains settings specific to the
+                              BareMetal platform.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                          equinixMetal:
+                            description: EquinixMetal contains settings specific to
+                              the Equinix Metal infrastructure provider.
+                            type: object
+                          external:
+                            description: ExternalPlatformType represents generic infrastructure
+                              provider. Platform-specific components should be supplemented
+                              separately.
+                            properties:
+                              platformName:
+                                default: Unknown
+                                description: PlatformName holds the arbitrary string
+                                  representing the infrastructure provider name, expected
+                                  to be set at the installation time. This field is
+                                  solely for informational and reporting purposes
+                                  and is not expected to be used for decision-making.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: platform name cannot be changed once set
+                                  rule: oldSelf == 'Unknown' || self == oldSelf
+                            type: object
+                          gcp:
+                            description: GCP contains settings specific to the Google
+                              Cloud Platform infrastructure provider.
+                            type: object
+                          ibmcloud:
+                            description: IBMCloud contains settings specific to the
+                              IBMCloud infrastructure provider.
+                            type: object
+                          kubevirt:
+                            description: Kubevirt contains settings specific to the
+                              kubevirt infrastructure provider.
+                            type: object
+                          nutanix:
+                            description: Nutanix contains settings specific to the
+                              Nutanix infrastructure provider.
+                            properties:
+                              failureDomains:
+                                description: failureDomains configures failure domains
+                                  information for the Nutanix platform. When set,
+                                  the failure domains defined here may be used to
+                                  spread Machines across prism element clusters to
+                                  improve fault tolerance of the cluster.
+                                items:
+                                  description: NutanixFailureDomain configures failure
+                                    domain information for the Nutanix platform.
+                                  properties:
+                                    cluster:
+                                      description: cluster is to identify the cluster
+                                        (the Prism Element under management of the
+                                        Prism Central), in which the Machine's VM
+                                        will be created. The cluster identifier (uuid
+                                        or name) can be obtained from the Prism Central
+                                        console or using the prism_central API.
+                                      properties:
+                                        name:
+                                          description: name is the resource name in
+                                            the PC. It cannot be empty if the type
+                                            is Name.
+                                          type: string
+                                        type:
+                                          description: type is the identifier type
+                                            to use for this resource.
+                                          enum:
+                                          - UUID
+                                          - Name
+                                          type: string
+                                        uuid:
+                                          description: uuid is the UUID of the resource
+                                            in the PC. It cannot be empty if the type
+                                            is UUID.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: uuid configuration is required when
+                                          type is UUID, and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''UUID''
+                                          ?  has(self.uuid) : !has(self.uuid)'
+                                      - message: name configuration is required when
+                                          type is Name, and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''Name''
+                                          ?  has(self.name) : !has(self.name)'
+                                    name:
+                                      description: name defines the unique name of
+                                        a failure domain. Name is required and must
+                                        be at most 64 characters in length. It must
+                                        consist of only lower case alphanumeric characters
+                                        and hyphens (-). It must start and end with
+                                        an alphanumeric character. This value is arbitrary
+                                        and is used to identify the failure domain
+                                        within the platform.
+                                      maxLength: 64
+                                      minLength: 1
+                                      pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                                      type: string
+                                    subnets:
+                                      description: subnets holds a list of identifiers
+                                        (one or more) of the cluster's network subnets
+                                        for the Machine's VM to connect to. The subnet
+                                        identifiers (uuid or name) can be obtained
+                                        from the Prism Central console or using the
+                                        prism_central API.
+                                      items:
+                                        description: NutanixResourceIdentifier holds
+                                          the identity of a Nutanix PC resource (cluster,
+                                          image, subnet, etc.)
+                                        properties:
+                                          name:
+                                            description: name is the resource name
+                                              in the PC. It cannot be empty if the
+                                              type is Name.
+                                            type: string
+                                          type:
+                                            description: type is the identifier type
+                                              to use for this resource.
+                                            enum:
+                                            - UUID
+                                            - Name
+                                            type: string
+                                          uuid:
+                                            description: uuid is the UUID of the resource
+                                              in the PC. It cannot be empty if the
+                                              type is UUID.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: uuid configuration is required
+                                            when type is UUID, and forbidden otherwise
+                                          rule: 'has(self.type) && self.type == ''UUID''
+                                            ?  has(self.uuid) : !has(self.uuid)'
+                                        - message: name configuration is required
+                                            when type is Name, and forbidden otherwise
+                                          rule: 'has(self.type) && self.type == ''Name''
+                                            ?  has(self.name) : !has(self.name)'
+                                      maxItems: 1
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - type
+                                      x-kubernetes-list-type: map
+                                  required:
+                                  - cluster
+                                  - name
+                                  - subnets
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              prismCentral:
+                                description: prismCentral holds the endpoint address
+                                  and port to access the Nutanix Prism Central. When
+                                  a cluster-wide proxy is installed, by default, this
+                                  endpoint will be accessed via the proxy. Should
+                                  you wish for communication with this endpoint not
+                                  to be proxied, please add the endpoint to the proxy
+                                  spec.noProxy list.
+                                properties:
+                                  address:
+                                    description: address is the endpoint address (DNS
+                                      name or IP address) of the Nutanix Prism Central
+                                      or Element (cluster)
+                                    maxLength: 256
+                                    type: string
+                                  port:
+                                    description: port is the port number to access
+                                      the Nutanix Prism Central or Element (cluster)
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - address
+                                - port
+                                type: object
+                              prismElements:
+                                description: prismElements holds one or more endpoint
+                                  address and port data to access the Nutanix Prism
+                                  Elements (clusters) of the Nutanix Prism Central.
+                                  Currently we only support one Prism Element (cluster)
+                                  for an OpenShift cluster, where all the Nutanix
+                                  resources (VMs, subnets, volumes, etc.) used in
+                                  the OpenShift cluster are located. In the future,
+                                  we may support Nutanix resources (VMs, etc.) spread
+                                  over multiple Prism Elements (clusters) of the Prism
+                                  Central.
+                                items:
+                                  description: NutanixPrismElementEndpoint holds the
+                                    name and endpoint data for a Prism Element (cluster)
+                                  properties:
+                                    endpoint:
+                                      description: endpoint holds the endpoint address
+                                        and port data of the Prism Element (cluster).
+                                        When a cluster-wide proxy is installed, by
+                                        default, this endpoint will be accessed via
+                                        the proxy. Should you wish for communication
+                                        with this endpoint not to be proxied, please
+                                        add the endpoint to the proxy spec.noProxy
+                                        list.
+                                      properties:
+                                        address:
+                                          description: address is the endpoint address
+                                            (DNS name or IP address) of the Nutanix
+                                            Prism Central or Element (cluster)
+                                          maxLength: 256
+                                          type: string
+                                        port:
+                                          description: port is the port number to
+                                            access the Nutanix Prism Central or Element
+                                            (cluster)
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - address
+                                      - port
+                                      type: object
+                                    name:
+                                      description: name is the name of the Prism Element
+                                        (cluster). This value will correspond with
+                                        the cluster field configured on other resources
+                                        (eg Machines, PVCs, etc).
+                                      maxLength: 256
+                                      type: string
+                                  required:
+                                  - endpoint
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            required:
+                            - prismCentral
+                            - prismElements
+                            type: object
+                          openstack:
+                            description: OpenStack contains settings specific to the
+                              OpenStack infrastructure provider.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                          ovirt:
+                            description: Ovirt contains settings specific to the oVirt
+                              infrastructure provider.
+                            type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              IBM Power Systems Virtual Servers infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of a Power VS service.
+                                items:
+                                  description: PowervsServiceEndpoint stores the configuration
+                                    of a custom url to override existing defaults
+                                    of PowerVS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the Power VS
+                                        service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                        ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                        Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      format: uri
+                                      pattern: ^https://
+                                      type: string
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: type is the underlying infrastructure provider
+                              for the cluster. This value controls whether infrastructure
+                              automation such as service load balancers, dynamic volume
+                              provisioning, machine creation and deletion, and other
+                              integrations are enabled. If None, no infrastructure
+                              automation is enabled. Allowed values are "AWS", "Azure",
+                              "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere",
+                              "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud",
+                              "Nutanix" and "None". Individual components may not
+                              support all platforms, and must handle unrecognized
+                              platforms as None if they do not support that platform.
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                          vsphere:
+                            description: VSphere contains settings specific to the
+                              VSphere infrastructure provider.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              failureDomains:
+                                description: failureDomains contains the definition
+                                  of region, zone and the vCenter topology. If this
+                                  is omitted failure domains (regions and zones) will
+                                  not be used.
+                                items:
+                                  description: VSpherePlatformFailureDomainSpec holds
+                                    the region and zone failure domain and the vCenter
+                                    topology of that failure domain.
+                                  properties:
+                                    name:
+                                      description: name defines the arbitrary but
+                                        unique name of a failure domain.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    region:
+                                      description: region defines the name of a region
+                                        tag that will be attached to a vCenter datacenter.
+                                        The tag category in vCenter must be named
+                                        openshift-region.
+                                      maxLength: 80
+                                      minLength: 1
+                                      type: string
+                                    server:
+                                      description: server is the fully-qualified domain
+                                        name or the IP address of the vCenter server.
+                                        ---
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    topology:
+                                      description: Topology describes a given failure
+                                        domain using vSphere constructs
+                                      properties:
+                                        computeCluster:
+                                          description: computeCluster the absolute
+                                            path of the vCenter cluster in which virtual
+                                            machine will be located. The absolute
+                                            path is of the form /<datacenter>/host/<cluster>.
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/host/.*?
+                                          type: string
+                                        datacenter:
+                                          description: datacenter is the name of vCenter
+                                            datacenter in which virtual machines will
+                                            be located. The maximum length of the
+                                            datacenter name is 80 characters.
+                                          maxLength: 80
+                                          type: string
+                                        datastore:
+                                          description: datastore is the absolute path
+                                            of the datastore in which the virtual
+                                            machine is located. The absolute path
+                                            is of the form /<datacenter>/datastore/<datastore>
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/datastore/.*?
+                                          type: string
+                                        folder:
+                                          description: folder is the absolute path
+                                            of the folder where virtual machines are
+                                            located. The absolute path is of the form
+                                            /<datacenter>/vm/<folder>. The maximum
+                                            length of the path is 2048 characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/vm/.*?
+                                          type: string
+                                        networks:
+                                          description: 'networks is the list of port
+                                            group network names within this failure
+                                            domain. If feature gate VSphereMultiNetworks
+                                            is enabled, up to 10 network adapters
+                                            may be defined. 10 is the maximum number
+                                            of virtual network devices which may be
+                                            attached to a VM as defined by: https://configmax.esp.vmware.com/guest?vmwareproduct=vSphere&release=vSphere%208.0&categories=1-0
+                                            The available networks (port groups) can
+                                            be listed using `govc ls ''network/*''`
+                                            Networks should be in the form of an absolute
+                                            path: /<datacenter>/network/<portgroup>.'
+                                          items:
+                                            type: string
+                                          maxItems: 1
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resourcePool:
+                                          description: resourcePool is the absolute
+                                            path of the resource pool where virtual
+                                            machines will be created. The absolute
+                                            path is of the form /<datacenter>/host/<cluster>/Resources/<resourcepool>.
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/host/.*?/Resources.*
+                                          type: string
+                                        template:
+                                          description: "template is the full inventory
+                                            path of the virtual machine or template
+                                            that will be cloned when creating new
+                                            machines in this failure domain. The maximum
+                                            length of the path is 2048 characters.
+                                            \n When omitted, the template will be
+                                            calculated by the control plane machineset
+                                            operator based on the region and zone
+                                            defined in VSpherePlatformFailureDomainSpec.
+                                            For example, for zone=zonea, region=region1,
+                                            and infrastructure name=test, the template
+                                            path would be calculated as /<datacenter>/vm/test-rhcos-region1-zonea."
+                                          maxLength: 2048
+                                          minLength: 1
+                                          pattern: ^/.*?/vm/.*?
+                                          type: string
+                                      required:
+                                      - computeCluster
+                                      - datacenter
+                                      - datastore
+                                      - networks
+                                      type: object
+                                    zone:
+                                      description: zone defines the name of a zone
+                                        tag that will be attached to a vCenter cluster.
+                                        The tag category in vCenter must be named
+                                        openshift-zone.
+                                      maxLength: 80
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - region
+                                  - server
+                                  - topology
+                                  - zone
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeNetworking:
+                                description: nodeNetworking contains the definition
+                                  of internal and external network constraints for
+                                  assigning the node's networking. If this field is
+                                  omitted, networking defaults to the legacy address
+                                  selection behavior which is to only support a single
+                                  address and return the first one found.
+                                properties:
+                                  external:
+                                    description: external represents the network configuration
+                                      of the node that is externally routable.
+                                    properties:
+                                      excludeNetworkSubnetCidr:
+                                        description: excludeNetworkSubnetCidr IP addresses
+                                          in subnet ranges will be excluded when selecting
+                                          the IP address from the VirtualMachine's
+                                          VM for use in the status.addresses fields.
+                                          ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      network:
+                                        description: network VirtualMachine's VM Network
+                                          names that will be used to when searching
+                                          for status.addresses fields. Note that if
+                                          internal.networkSubnetCIDR and external.networkSubnetCIDR
+                                          are not set, then the vNIC associated to
+                                          this network must only have a single IP
+                                          address assigned to it. The available networks
+                                          (port groups) can be listed using `govc
+                                          ls 'network/*'`
+                                        type: string
+                                      networkSubnetCidr:
+                                        description: networkSubnetCidr IP address
+                                          on VirtualMachine's network interfaces included
+                                          in the fields' CIDRs that will be used in
+                                          respective status.addresses fields. ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  internal:
+                                    description: internal represents the network configuration
+                                      of the node that is routable only within the
+                                      cluster.
+                                    properties:
+                                      excludeNetworkSubnetCidr:
+                                        description: excludeNetworkSubnetCidr IP addresses
+                                          in subnet ranges will be excluded when selecting
+                                          the IP address from the VirtualMachine's
+                                          VM for use in the status.addresses fields.
+                                          ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      network:
+                                        description: network VirtualMachine's VM Network
+                                          names that will be used to when searching
+                                          for status.addresses fields. Note that if
+                                          internal.networkSubnetCIDR and external.networkSubnetCIDR
+                                          are not set, then the vNIC associated to
+                                          this network must only have a single IP
+                                          address assigned to it. The available networks
+                                          (port groups) can be listed using `govc
+                                          ls 'network/*'`
+                                        type: string
+                                      networkSubnetCidr:
+                                        description: networkSubnetCidr IP address
+                                          on VirtualMachine's network interfaces included
+                                          in the fields' CIDRs that will be used in
+                                          respective status.addresses fields. ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                type: object
+                              vcenters:
+                                description: vcenters holds the connection details
+                                  for services to communicate with vCenter. Currently,
+                                  only a single vCenter is supported, but in tech
+                                  preview 3 vCenters are supported. Once the cluster
+                                  has been installed, you are unable to change the
+                                  current number of defined vCenters except in the
+                                  case where the cluster has been upgraded from a
+                                  version of OpenShift where the vsphere platform
+                                  spec was not present.  You may make modifications
+                                  to the existing vCenters that are defined in the
+                                  vcenters list in order to match with any added or
+                                  modified failure domains. ---
+                                items:
+                                  description: VSpherePlatformVCenterSpec stores the
+                                    vCenter connection fields. This is used by the
+                                    vSphere CCM.
+                                  properties:
+                                    datacenters:
+                                      description: The vCenter Datacenters in which
+                                        the RHCOS vm guests are located. This field
+                                        will be used by the Cloud Controller Manager.
+                                        Each datacenter listed here should be used
+                                        within a topology.
+                                      items:
+                                        type: string
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    port:
+                                      description: port is the TCP port that will
+                                        be used to communicate to the vCenter endpoint.
+                                        When omitted, this means the user has no opinion
+                                        and it is up to the platform to choose a sensible
+                                        default, which is subject to change over time.
+                                      format: int32
+                                      maximum: 32767
+                                      minimum: 1
+                                      type: integer
+                                    server:
+                                      description: server is the fully-qualified domain
+                                        name or the IP address of the vCenter server.
+                                        ---
+                                      maxLength: 255
+                                      type: string
+                                  required:
+                                  - datacenters
+                                  - server
+                                  type: object
+                                maxItems: 1
+                                minItems: 0
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                            - message: vcenters can have at most 1 item when configured
+                                post-install
+                              rule: '!has(oldSelf.vcenters) && has(self.vcenters)
+                                ? size(self.vcenters) < 2 : true'
+                        type: object
+                        x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? size(self.vsphere.vcenters)
+                            < 2 : true'
+                    type: object
+                  status:
+                    description: status holds observed values from the cluster. They
+                      may not be overridden.
+                    properties:
+                      apiServerInternalURI:
+                        description: apiServerInternalURL is a valid URI with scheme
+                          'https', address and optionally a port (defaulting to 443).  apiServerInternalURL
+                          can be used by components like kubelets, to contact the
+                          Kubernetes API server using the infrastructure provider
+                          rather than Kubernetes networking.
+                        type: string
+                      apiServerURL:
+                        description: apiServerURL is a valid URI with scheme 'https',
+                          address and optionally a port (defaulting to 443).  apiServerURL
+                          can be used by components like the web console to tell users
+                          where to find the Kubernetes API.
+                        type: string
+                      controlPlaneTopology:
+                        default: HighlyAvailable
+                        description: controlPlaneTopology expresses the expectations
+                          for operands that normally run on control nodes. The default
+                          is 'HighlyAvailable', which represents the behavior operators
+                          have in a "normal" cluster. The 'SingleReplica' mode will
+                          be used in single-node deployments and the operators should
+                          not configure the operand for highly-available operation
+                          The 'External' mode indicates that the control plane is
+                          hosted externally to the cluster and that its components
+                          are not visible within the cluster.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        - External
+                        type: string
+                      cpuPartitioning:
+                        default: None
+                        description: cpuPartitioning expresses if CPU partitioning
+                          is a currently enabled feature in the cluster. CPU Partitioning
+                          means that this cluster can support partitioning workloads
+                          to specific CPU Sets. Valid values are "None" and "AllNodes".
+                          When omitted, the default value is "None". The default value
+                          of "None" indicates that no nodes will be setup with CPU
+                          partitioning. The "AllNodes" value indicates that all nodes
+                          have been setup with CPU partitioning, and can then be further
+                          configured via the PerformanceProfile API.
+                        enum:
+                        - None
+                        - AllNodes
+                        type: string
+                      etcdDiscoveryDomain:
+                        description: 'etcdDiscoveryDomain is the domain used to fetch
+                          the SRV records for discovering etcd servers and clients.
+                          For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
+                          deprecated: as of 4.7, this field is no longer set or honored.  It
+                          will be removed in a future release.'
+                        type: string
+                      infrastructureName:
+                        description: infrastructureName uniquely identifies a cluster
+                          with a human friendly name. Once set it should not be changed.
+                          Must be of max length 27 and must have only alphanumeric
+                          or hyphen characters.
+                        type: string
+                      infrastructureTopology:
+                        default: HighlyAvailable
+                        description: 'infrastructureTopology expresses the expectations
+                          for infrastructure services that do not run on control plane
+                          nodes, usually indicated by a node selector for a `role`
+                          value other than `master`. The default is ''HighlyAvailable'',
+                          which represents the behavior operators have in a "normal"
+                          cluster. The ''SingleReplica'' mode will be used in single-node
+                          deployments and the operators should not configure the operand
+                          for highly-available operation NOTE: External topology mode
+                          is not applicable for this field.'
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        type: string
+                      platform:
+                        description: "platform is the underlying infrastructure provider
+                          for the cluster. \n Deprecated: Use platformStatus.type
+                          instead."
+                        enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                        type: string
+                      platformStatus:
+                        description: platformStatus holds status information specific
+                          to the underlying infrastructure provider.
+                        properties:
+                          alibabaCloud:
+                            description: AlibabaCloud contains settings specific to
+                              the Alibaba Cloud infrastructure provider.
+                            properties:
+                              region:
+                                description: region specifies the region for Alibaba
+                                  Cloud resources created for the cluster.
+                                pattern: ^[0-9A-Za-z-]+$
+                                type: string
+                              resourceGroupID:
+                                description: resourceGroupID is the ID of the resource
+                                  group for the cluster.
+                                pattern: ^(rg-[0-9A-Za-z]+)?$
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to Alibaba Cloud resources created
+                                  for the cluster.
+                                items:
+                                  description: AlibabaCloudResourceTag is the set
+                                    of tags to add to apply to resources.
+                                  properties:
+                                    key:
+                                      description: key is the key of the tag.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: value is the value of the tag.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 20
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                            required:
+                            - region
+                            type: object
+                          aws:
+                            description: AWS contains settings specific to the Amazon
+                              Web Services infrastructure provider.
+                            properties:
+                              region:
+                                description: region holds the default AWS region for
+                                  new AWS resources created by the cluster.
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to AWS resources created for the cluster.
+                                  See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                                  for information on tagging AWS resources. AWS supports
+                                  a maximum of 50 tags per resource. OpenShift reserves
+                                  25 tags for its use, leaving 25 tags available for
+                                  the user.
+                                items:
+                                  description: AWSResourceTag is a tag to apply to
+                                    AWS resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key of the tag
+                                      maxLength: 128
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                      type: string
+                                    value:
+                                      description: value is the value of the tag.
+                                        Some AWS service do not support empty values.
+                                        Since tags are added to resources in many
+                                        services, the length of the tag value must
+                                        meet the requirements of all services.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 25
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              serviceEndpoints:
+                                description: ServiceEndpoints list contains custom
+                                  endpoints which will override default service endpoint
+                                  of AWS Services. There must be only one ServiceEndpoint
+                                  for a service.
+                                items:
+                                  description: AWSServiceEndpoint store the configuration
+                                    of a custom url to override existing defaults
+                                    of AWS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the AWS service.
+                                        The list of all the service names can be found
+                                        at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                        This must be provided and cannot be empty.
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      pattern: ^https://
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          azure:
+                            description: Azure contains settings specific to the Azure
+                              infrastructure provider.
+                            properties:
+                              armEndpoint:
+                                description: armEndpoint specifies a URL to use for
+                                  resource management in non-soverign clouds such
+                                  as Azure Stack.
+                                type: string
+                              cloudName:
+                                description: cloudName is the name of the Azure cloud
+                                  environment which can be used to configure the Azure
+                                  SDK with the appropriate Azure API endpoints. If
+                                  empty, the value is equal to `AzurePublicCloud`.
+                                enum:
+                                - ""
+                                - AzurePublicCloud
+                                - AzureUSGovernmentCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureStackCloud
+                                type: string
+                              networkResourceGroupName:
+                                description: networkResourceGroupName is the Resource
+                                  Group for network resources like the Virtual Network
+                                  and Subnets used by the cluster. If empty, the value
+                                  is same as ResourceGroupName.
+                                type: string
+                              resourceGroupName:
+                                description: resourceGroupName is the Resource Group
+                                  for new Azure resources created for the cluster.
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to Azure resources created for the
+                                  cluster. See https://docs.microsoft.com/en-us/rest/api/resources/tags
+                                  for information on tagging Azure resources. Due
+                                  to limitations on Automation, Content Delivery Network,
+                                  DNS Azure resources, a maximum of 15 tags may be
+                                  applied. OpenShift reserves 5 tags for internal
+                                  use, allowing 10 tags for user configuration.
+                                items:
+                                  description: AzureResourceTag is a tag to apply
+                                    to Azure resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the tag.
+                                        A tag key can have a maximum of 128 characters
+                                        and cannot be empty. Key must begin with a
+                                        letter, end with a letter, number or underscore,
+                                        and must contain only alphanumeric characters
+                                        and the following special characters `_ .
+                                        -`.
+                                      maxLength: 128
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([0-9A-Za-z_.-]*[0-9A-Za-z_])?$
+                                      type: string
+                                    value:
+                                      description: 'value is the value part of the
+                                        tag. A tag value can have a maximum of 256
+                                        characters and cannot be empty. Value must
+                                        contain only alphanumeric characters and the
+                                        following special characters `_ + , - . /
+                                        : ; < = > ? @`.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.=+-@]+$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 10
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: resourceTags are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                            type: object
+                            x-kubernetes-validations:
+                            - message: resourceTags may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags)
+                                || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                          baremetal:
+                            description: BareMetal contains settings specific to the
+                              BareMetal platform.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on BareMetal platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for BareMetal deployments. In order to minimize
+                                  necessary changes to the datacenter DNS, a DNS service
+                                  is hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                          equinixMetal:
+                            description: EquinixMetal contains settings specific to
+                              the Equinix Metal infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers.
+                                type: string
+                              ingressIP:
+                                description: ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names.
+                                type: string
+                            type: object
+                          external:
+                            description: External contains settings specific to the
+                              generic External infrastructure provider.
+                            properties:
+                              cloudControllerManager:
+                                description: cloudControllerManager contains settings
+                                  specific to the external Cloud Controller Manager
+                                  (a.k.a. CCM or CPI). When omitted, new nodes will
+                                  be not tainted and no extra initialization from
+                                  the cloud controller manager is expected.
+                                properties:
+                                  state:
+                                    description: "state determines whether or not
+                                      an external Cloud Controller Manager is expected
+                                      to be installed within the cluster. https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager
+                                      \n Valid values are \"External\", \"None\" and
+                                      omitted. When set to \"External\", new nodes
+                                      will be tainted as uninitialized when created,
+                                      preventing them from running workloads until
+                                      they are initialized by the cloud controller
+                                      manager. When omitted or set to \"None\", new
+                                      nodes will be not tainted and no extra initialization
+                                      from the cloud controller manager is expected."
+                                    enum:
+                                    - ""
+                                    - External
+                                    - None
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: state is immutable once set
+                                      rule: self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: state may not be added or removed once
+                                    set
+                                  rule: (has(self.state) == has(oldSelf.state)) ||
+                                    (!has(oldSelf.state) && self.state != "External")
+                            type: object
+                            x-kubernetes-validations:
+                            - message: cloudControllerManager may not be added or
+                                removed once set
+                              rule: has(self.cloudControllerManager) == has(oldSelf.cloudControllerManager)
+                          gcp:
+                            description: GCP contains settings specific to the Google
+                              Cloud Platform infrastructure provider.
+                            properties:
+                              projectID:
+                                description: resourceGroupName is the Project ID for
+                                  new GCP resources created for the cluster.
+                                type: string
+                              region:
+                                description: region holds the region for new GCP resources
+                                  created for the cluster.
+                                type: string
+                              resourceLabels:
+                                description: resourceLabels is a list of additional
+                                  labels to apply to GCP resources created for the
+                                  cluster. See https://cloud.google.com/compute/docs/labeling-resources
+                                  for information on labeling GCP resources. GCP supports
+                                  a maximum of 64 labels per resource. OpenShift reserves
+                                  32 labels for internal use, allowing 32 labels for
+                                  user configuration.
+                                items:
+                                  description: GCPResourceLabel is a label to apply
+                                    to GCP resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the label.
+                                        A label key can have a maximum of 63 characters
+                                        and cannot be empty. Label key must begin
+                                        with a lowercase letter, and must contain
+                                        only lowercase letters, numeric characters,
+                                        and the following special characters `_-`.
+                                        Label key must not have the reserved prefixes
+                                        `kubernetes-io` and `openshift-io`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z][0-9a-z_-]{0,62}$
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: label keys must not start with either
+                                          `openshift-io` or `kubernetes-io`
+                                        rule: '!self.startsWith(''openshift-io'')
+                                          && !self.startsWith(''kubernetes-io'')'
+                                    value:
+                                      description: value is the value part of the
+                                        label. A label value can have a maximum of
+                                        63 characters and cannot be empty. Value must
+                                        contain only lowercase letters, numeric characters,
+                                        and the following special characters `_-`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[0-9a-z_-]{1,63}$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                                x-kubernetes-validations:
+                                - message: resourceLabels are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to GCP resources created for the cluster.
+                                  See https://cloud.google.com/resource-manager/docs/tags/tags-overview
+                                  for information on tagging GCP resources. GCP supports
+                                  a maximum of 50 tags per resource.
+                                items:
+                                  description: GCPResourceTag is a tag to apply to
+                                    GCP resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the tag.
+                                        A tag key can have a maximum of 63 characters
+                                        and cannot be empty. Tag key must begin and
+                                        end with an alphanumeric character, and must
+                                        contain only uppercase, lowercase alphanumeric
+                                        characters, and the following special characters
+                                        `._-`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.-]{0,61}[a-zA-Z0-9])?$
+                                      type: string
+                                    parentID:
+                                      description: 'parentID is the ID of the hierarchical
+                                        resource where the tags are defined, e.g.
+                                        at the Organization or the Project level.
+                                        To find the Organization or Project ID refer
+                                        to the following pages: https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id,
+                                        https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects.
+                                        An OrganizationID must consist of decimal
+                                        numbers, and cannot have leading zeroes. A
+                                        ProjectID must be 6 to 30 characters in length,
+                                        can only contain lowercase letters, numbers,
+                                        and hyphens, and must start with a letter,
+                                        and cannot end with a hyphen.'
+                                      maxLength: 32
+                                      minLength: 1
+                                      pattern: (^[1-9][0-9]{0,31}$)|(^[a-z][a-z0-9-]{4,28}[a-z0-9]$)
+                                      type: string
+                                    value:
+                                      description: value is the value part of the
+                                        tag. A tag value can have a maximum of 63
+                                        characters and cannot be empty. Tag value
+                                        must begin and end with an alphanumeric character,
+                                        and must contain only uppercase, lowercase
+                                        alphanumeric characters, and the following
+                                        special characters `_-.@%=+:,*#&(){}[]` and
+                                        spaces.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.@%=+:,*#&()\[\]{}\-\s]{0,61}[a-zA-Z0-9])?$
+                                      type: string
+                                  required:
+                                  - key
+                                  - parentID
+                                  - value
+                                  type: object
+                                maxItems: 50
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                                x-kubernetes-validations:
+                                - message: resourceTags are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                            type: object
+                            x-kubernetes-validations:
+                            - message: resourceLabels may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceLabels) && !has(self.resourceLabels)
+                                || has(oldSelf.resourceLabels) && has(self.resourceLabels)'
+                            - message: resourceTags may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags)
+                                || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                          ibmcloud:
+                            description: IBMCloud contains settings specific to the
+                              IBMCloud infrastructure provider.
+                            properties:
+                              cisInstanceCRN:
+                                description: CISInstanceCRN is the CRN of the Cloud
+                                  Internet Services instance managing the DNS zone
+                                  for the cluster's base domain
+                                type: string
+                              dnsInstanceCRN:
+                                description: DNSInstanceCRN is the CRN of the DNS
+                                  Services instance managing the DNS zone for the
+                                  cluster's base domain
+                                type: string
+                              location:
+                                description: Location is where the cluster has been
+                                  deployed
+                                type: string
+                              providerType:
+                                description: ProviderType indicates the type of cluster
+                                  that was created
+                                type: string
+                              resourceGroupName:
+                                description: ResourceGroupName is the Resource Group
+                                  for new IBMCloud resources created for the cluster.
+                                type: string
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of an IBM Cloud service. These endpoints
+                                  are consumed by components within the cluster to
+                                  reach the respective IBM Cloud Services.
+                                items:
+                                  description: IBMCloudServiceEndpoint stores the
+                                    configuration of a custom url to override existing
+                                    defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: 'name is the name of the IBM Cloud
+                                        service. Possible values are: CIS, COS, COSConfig,
+                                        DNSServices, GlobalCatalog, GlobalSearch,
+                                        GlobalTagging, HyperProtect, IAM, KeyProtect,
+                                        ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service
+                                        could be configured with the service `name`
+                                        of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service
+                                        for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url`
+                                        of `https://us.south.private.iaas.cloud.ibm.com`'
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          kubevirt:
+                            description: Kubevirt contains settings specific to the
+                              kubevirt infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers.
+                                type: string
+                              ingressIP:
+                                description: ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names.
+                                type: string
+                            type: object
+                          nutanix:
+                            description: Nutanix contains settings specific to the
+                              Nutanix infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Nutanix platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                            type: object
+                          openstack:
+                            description: OpenStack contains settings specific to the
+                              OpenStack infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              cloudName:
+                                description: cloudName is the name of the desired
+                                  OpenStack cloud in the client configuration file
+                                  (`clouds.yaml`).
+                                type: string
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on OpenStack platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for OpenStack deployments. In order to minimize
+                                  necessary changes to the datacenter DNS, a DNS service
+                                  is hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                          ovirt:
+                            description: Ovirt contains settings specific to the oVirt
+                              infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Ovirt platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              nodeDNSIP:
+                                description: 'deprecated: as of 4.6, this field is
+                                  no longer set or honored.  It will be removed in
+                                  a future release.'
+                                type: string
+                            type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              Power Systems Virtual Servers infrastructure provider.
+                            properties:
+                              cisInstanceCRN:
+                                description: CISInstanceCRN is the CRN of the Cloud
+                                  Internet Services instance managing the DNS zone
+                                  for the cluster's base domain
+                                type: string
+                              dnsInstanceCRN:
+                                description: DNSInstanceCRN is the CRN of the DNS
+                                  Services instance managing the DNS zone for the
+                                  cluster's base domain
+                                type: string
+                              region:
+                                description: region holds the default Power VS region
+                                  for new Power VS resources created by the cluster.
+                                type: string
+                              resourceGroup:
+                                description: 'resourceGroup is the resource group
+                                  name for new IBMCloud resources created for a cluster.
+                                  The resource group specified here will be used by
+                                  cluster-image-registry-operator to set up a COS
+                                  Instance in IBMCloud for the cluster registry. More
+                                  about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs.
+                                  When omitted, the image registry operator won''t
+                                  be able to configure storage, which results in the
+                                  image registry cluster operator not being in an
+                                  available state.'
+                                maxLength: 40
+                                pattern: ^[a-zA-Z0-9-_ ]+$
+                                type: string
+                                x-kubernetes-validations:
+                                - message: resourceGroup is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of a Power VS service.
+                                items:
+                                  description: PowervsServiceEndpoint stores the configuration
+                                    of a custom url to override existing defaults
+                                    of PowerVS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the Power VS
+                                        service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                        ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                        Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      format: uri
+                                      pattern: ^https://
+                                      type: string
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              zone:
+                                description: 'zone holds the default zone for the
+                                  new Power VS resources created by the cluster. Note:
+                                  Currently only single-zone OCP clusters are supported'
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: cannot unset resourceGroup once set
+                              rule: '!has(oldSelf.resourceGroup) || has(self.resourceGroup)'
+                          type:
+                            description: "type is the underlying infrastructure provider
+                              for the cluster. This value controls whether infrastructure
+                              automation such as service load balancers, dynamic volume
+                              provisioning, machine creation and deletion, and other
+                              integrations are enabled. If None, no infrastructure
+                              automation is enabled. Allowed values are \"AWS\", \"Azure\",
+                              \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\",
+                              \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\",
+                              \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual
+                              components may not support all platforms, and must handle
+                              unrecognized platforms as None if they do not support
+                              that platform. \n This value will be synced with to
+                              the `status.platform` and `status.platformStatus.type`.
+                              Currently this value cannot be changed once set."
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                          vsphere:
+                            description: VSphere contains settings specific to the
+                              VSphere infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on VSphere platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for vSphere deployments. In order to minimize necessary
+                                  changes to the datacenter DNS, a DNS service is
+                                  hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+                x-kubernetes-embedded-resource: true
+              internalRegistryPullSecret:
+                description: internalRegistryPullSecret is the pull secret for the
+                  internal registry, used by rpm-ostree to pull images from the internal
+                  registry if present
+                format: byte
+                nullable: true
+                type: string
+              ipFamilies:
+                description: ipFamilies indicates the IP families in use by the cluster
+                  network
+                type: string
+              kubeAPIServerServingCAData:
+                description: kubeAPIServerServingCAData managed Kubelet to API Server
+                  Cert... Rotated automatically
+                format: byte
+                type: string
+              network:
+                description: Network contains additional network related information
+                nullable: true
+                properties:
+                  mtuMigration:
+                    description: MTUMigration contains the MTU migration configuration.
+                    nullable: true
+                    properties:
+                      machine:
+                        description: Machine contains MTU migration configuration
+                          for the machine's uplink.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      network:
+                        description: Network contains MTU migration configuration
+                          for the default network.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - mtuMigration
+                type: object
+              networkType:
+                description: 'networkType holds the type of network the cluster is
+                  using XXX: this is temporary and will be dropped as soon as possible
+                  in favor of a better support to start network related services the
+                  proper way. Nobody is also changing this once the cluster is up
+                  and running the first time, so, disallow regeneration if this changes.'
+                type: string
+              osImageURL:
+                description: OSImageURL is the old-format container image that contains
+                  the OS update payload.
+                type: string
+              platform:
+                description: platform is deprecated, use Infra.Status.PlatformStatus.Type
+                  instead
+                type: string
+              proxy:
+                description: proxy holds the current proxy configuration for the nodes
+                nullable: true
+                properties:
+                  httpProxy:
+                    description: httpProxy is the URL of the proxy for HTTP requests.
+                    type: string
+                  httpsProxy:
+                    description: httpsProxy is the URL of the proxy for HTTPS requests.
+                    type: string
+                  noProxy:
+                    description: noProxy is a comma-separated list of hostnames and/or
+                      CIDRs for which the proxy should not be used.
+                    type: string
+                type: object
+              pullSecret:
+                description: pullSecret is the default pull secret that needs to be
+                  installed on all machines.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              releaseImage:
+                description: releaseImage is the image used when installing the cluster
+                type: string
+              rootCAData:
+                description: rootCAData specifies the root CA data
+                format: byte
+                type: string
+            required:
+            - additionalTrustBundle
+            - baseOSContainerImage
+            - cloudProviderCAData
+            - cloudProviderConfig
+            - clusterDNSIP
+            - dns
+            - images
+            - infra
+            - ipFamilies
+            - kubeAPIServerServingCAData
+            - network
+            - proxy
+            - releaseImage
+            - rootCAData
+            type: object
+          status:
+            description: ControllerConfigStatus is the status for ControllerConfig
+            properties:
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: ControllerConfigStatusCondition contains condition
+                    information for ControllerConfigStatus
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status object.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message provides additional information about the
+                        current condition. This is only to be consumed by humans.
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.  Reasons
+                        are PascalCase
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              controllerCertificates:
+                description: controllerCertificates represents the latest available
+                  observations of the automatically rotating certificates in the MCO.
+                items:
+                  description: ControllerCertificate contains info about a specific
+                    cert.
+                  properties:
+                    bundleFile:
+                      description: bundleFile is the larger bundle a cert comes from
+                      type: string
+                    notAfter:
+                      description: notAfter is the upper boundary for validity
+                      format: date-time
+                      type: string
+                    notBefore:
+                      description: notBefore is the lower boundary for validity
+                      format: date-time
+                      type: string
+                    signer:
+                      description: signer is the  cert Issuer
+                      type: string
+                    subject:
+                      description: subject is the cert subject
+                      type: string
+                  required:
+                  - bundleFile
+                  - signer
+                  - subject
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,2860 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: controllerconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: ControllerConfig
+    listKind: ControllerConfigList
+    plural: controllerconfigs
+    singular: controllerconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ControllerConfig describes configuration for MachineConfigController.
+          This is currently only used to drive the MachineConfig objects generated
+          by the TemplateController. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ControllerConfigSpec is the spec for ControllerConfig resource.
+            properties:
+              additionalTrustBundle:
+                description: additionalTrustBundle is a certificate bundle that will
+                  be added to the nodes trusted certificate store.
+                format: byte
+                nullable: true
+                type: string
+              baseOSContainerImage:
+                description: BaseOSContainerImage is the new-format container image
+                  for operating system updates.
+                type: string
+              baseOSExtensionsContainerImage:
+                description: BaseOSExtensionsContainerImage is the matching extensions
+                  container for the new-format container
+                type: string
+              cloudProviderCAData:
+                description: cloudProvider specifies the cloud provider CA data
+                format: byte
+                nullable: true
+                type: string
+              cloudProviderConfig:
+                description: cloudProviderConfig is the configuration for the given
+                  cloud provider
+                type: string
+              clusterDNSIP:
+                description: clusterDNSIP is the cluster DNS IP address
+                type: string
+              dns:
+                description: dns holds the cluster dns details
+                nullable: true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'metadata is the standard object''s metadata. More
+                      info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: spec holds user settable values for configuration
+                    properties:
+                      baseDomain:
+                        description: "baseDomain is the base domain of the cluster.
+                          All managed DNS records will be sub-domains of this base.
+                          \n For example, given the base domain `openshift.example.com`,
+                          an API server DNS record may be created for `cluster-api.openshift.example.com`.
+                          \n Once set, this field cannot be changed."
+                        type: string
+                      platform:
+                        description: platform holds configuration specific to the
+                          underlying infrastructure provider for DNS. When omitted,
+                          this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject
+                          to change over time.
+                        properties:
+                          aws:
+                            description: aws contains DNS configuration specific to
+                              the Amazon Web Services cloud provider.
+                            properties:
+                              privateZoneIAMRole:
+                                description: privateZoneIAMRole contains the ARN of
+                                  an IAM role that should be assumed when performing
+                                  operations on the cluster's private hosted zone
+                                  specified in the cluster DNS config. When left empty,
+                                  no role should be assumed.
+                                pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                                type: string
+                            type: object
+                          type:
+                            description: "type is the underlying infrastructure provider
+                              for the cluster. Allowed values: \"\", \"AWS\". \n Individual
+                              components may not support all platforms, and must handle
+                              unrecognized platforms with best-effort defaults."
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                            x-kubernetes-validations:
+                            - message: allowed values are '' and 'AWS'
+                              rule: self in ['','AWS']
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: aws configuration is required when platform is
+                            AWS, and forbidden otherwise
+                          rule: 'has(self.type) && self.type == ''AWS'' ?  has(self.aws)
+                            : !has(self.aws)'
+                      privateZone:
+                        description: "privateZone is the location where all the DNS
+                          records that are only available internally to the cluster
+                          exist. \n If this field is nil, no private records should
+                          be created. \n Once set, this field cannot be changed."
+                        properties:
+                          id:
+                            description: "id is the identifier that can be used to
+                              find the DNS hosted zone. \n on AWS zone can be fetched
+                              using `ID` as id in [1] on Azure zone can be fetched
+                              using `ID` as a pre-determined name in [2], on GCP zone
+                              can be fetched using `ID` as a pre-determined name in
+                              [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                              [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                              [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: "tags can be used to query the DNS hosted
+                              zone. \n on AWS, resourcegroupstaggingapi [1] can be
+                              used to fetch a zone using `Tags` as tag-filters, \n
+                              [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                            type: object
+                        type: object
+                      publicZone:
+                        description: "publicZone is the location where all the DNS
+                          records that are publicly accessible to the internet exist.
+                          \n If this field is nil, no public records should be created.
+                          \n Once set, this field cannot be changed."
+                        properties:
+                          id:
+                            description: "id is the identifier that can be used to
+                              find the DNS hosted zone. \n on AWS zone can be fetched
+                              using `ID` as id in [1] on Azure zone can be fetched
+                              using `ID` as a pre-determined name in [2], on GCP zone
+                              can be fetched using `ID` as a pre-determined name in
+                              [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                              [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                              [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: "tags can be used to query the DNS hosted
+                              zone. \n on AWS, resourcegroupstaggingapi [1] can be
+                              used to fetch a zone using `Tags` as tag-filters, \n
+                              [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                            type: object
+                        type: object
+                    type: object
+                  status:
+                    description: status holds observed values from the cluster. They
+                      may not be overridden.
+                    type: object
+                required:
+                - spec
+                type: object
+                x-kubernetes-embedded-resource: true
+              etcdDiscoveryDomain:
+                description: etcdDiscoveryDomain is deprecated, use Infra.Status.EtcdDiscoveryDomain
+                  instead
+                type: string
+              imageRegistryBundleData:
+                description: imageRegistryBundleData is the ImageRegistryData
+                items:
+                  description: ImageRegistryBundle contains information for writing
+                    image registry certificates
+                  properties:
+                    data:
+                      description: data holds the contents of the bundle that will
+                        be written to the file location
+                      format: byte
+                      type: string
+                    file:
+                      description: file holds the name of the file where the bundle
+                        will be written to disk
+                      type: string
+                  required:
+                  - data
+                  - file
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              imageRegistryBundleUserData:
+                description: imageRegistryBundleUserData is Image Registry Data provided
+                  by the user
+                items:
+                  description: ImageRegistryBundle contains information for writing
+                    image registry certificates
+                  properties:
+                    data:
+                      description: data holds the contents of the bundle that will
+                        be written to the file location
+                      format: byte
+                      type: string
+                    file:
+                      description: file holds the name of the file where the bundle
+                        will be written to disk
+                      type: string
+                  required:
+                  - data
+                  - file
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              images:
+                additionalProperties:
+                  type: string
+                description: images is map of images that are used by the controller
+                  to render templates under ./templates/
+                type: object
+              infra:
+                description: infra holds the infrastructure details
+                nullable: true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'metadata is the standard object''s metadata. More
+                      info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: spec holds user settable values for configuration
+                    properties:
+                      cloudConfig:
+                        description: "cloudConfig is a reference to a ConfigMap containing
+                          the cloud provider configuration file. This configuration
+                          file is used to configure the Kubernetes cloud provider
+                          integration when using the built-in cloud provider integration
+                          or the external cloud controller manager. The namespace
+                          for this config map is openshift-config. \n cloudConfig
+                          should only be consumed by the kube_cloud_config controller.
+                          The controller is responsible for using the user configuration
+                          in the spec for various platforms and combining that with
+                          the user provided ConfigMap in this field to create a stitched
+                          kube cloud config. The controller generates a ConfigMap
+                          `kube-cloud-config` in `openshift-config-managed` namespace
+                          with the kube cloud config is stored in `cloud.conf` key.
+                          All the clients are expected to use the generated ConfigMap
+                          only."
+                        properties:
+                          key:
+                            description: Key allows pointing to a specific key/value
+                              inside of the configmap.  This is useful for logical
+                              file references.
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      platformSpec:
+                        description: platformSpec holds desired information specific
+                          to the underlying infrastructure provider.
+                        properties:
+                          alibabaCloud:
+                            description: AlibabaCloud contains settings specific to
+                              the Alibaba Cloud infrastructure provider.
+                            type: object
+                          aws:
+                            description: AWS contains settings specific to the Amazon
+                              Web Services infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: serviceEndpoints list contains custom
+                                  endpoints which will override default service endpoint
+                                  of AWS Services. There must be only one ServiceEndpoint
+                                  for a service.
+                                items:
+                                  description: AWSServiceEndpoint store the configuration
+                                    of a custom url to override existing defaults
+                                    of AWS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the AWS service.
+                                        The list of all the service names can be found
+                                        at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                        This must be provided and cannot be empty.
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      pattern: ^https://
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          azure:
+                            description: Azure contains settings specific to the Azure
+                              infrastructure provider.
+                            type: object
+                          baremetal:
+                            description: BareMetal contains settings specific to the
+                              BareMetal platform.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                          equinixMetal:
+                            description: EquinixMetal contains settings specific to
+                              the Equinix Metal infrastructure provider.
+                            type: object
+                          external:
+                            description: ExternalPlatformType represents generic infrastructure
+                              provider. Platform-specific components should be supplemented
+                              separately.
+                            properties:
+                              platformName:
+                                default: Unknown
+                                description: PlatformName holds the arbitrary string
+                                  representing the infrastructure provider name, expected
+                                  to be set at the installation time. This field is
+                                  solely for informational and reporting purposes
+                                  and is not expected to be used for decision-making.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: platform name cannot be changed once set
+                                  rule: oldSelf == 'Unknown' || self == oldSelf
+                            type: object
+                          gcp:
+                            description: GCP contains settings specific to the Google
+                              Cloud Platform infrastructure provider.
+                            type: object
+                          ibmcloud:
+                            description: IBMCloud contains settings specific to the
+                              IBMCloud infrastructure provider.
+                            type: object
+                          kubevirt:
+                            description: Kubevirt contains settings specific to the
+                              kubevirt infrastructure provider.
+                            type: object
+                          nutanix:
+                            description: Nutanix contains settings specific to the
+                              Nutanix infrastructure provider.
+                            properties:
+                              failureDomains:
+                                description: failureDomains configures failure domains
+                                  information for the Nutanix platform. When set,
+                                  the failure domains defined here may be used to
+                                  spread Machines across prism element clusters to
+                                  improve fault tolerance of the cluster.
+                                items:
+                                  description: NutanixFailureDomain configures failure
+                                    domain information for the Nutanix platform.
+                                  properties:
+                                    cluster:
+                                      description: cluster is to identify the cluster
+                                        (the Prism Element under management of the
+                                        Prism Central), in which the Machine's VM
+                                        will be created. The cluster identifier (uuid
+                                        or name) can be obtained from the Prism Central
+                                        console or using the prism_central API.
+                                      properties:
+                                        name:
+                                          description: name is the resource name in
+                                            the PC. It cannot be empty if the type
+                                            is Name.
+                                          type: string
+                                        type:
+                                          description: type is the identifier type
+                                            to use for this resource.
+                                          enum:
+                                          - UUID
+                                          - Name
+                                          type: string
+                                        uuid:
+                                          description: uuid is the UUID of the resource
+                                            in the PC. It cannot be empty if the type
+                                            is UUID.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: uuid configuration is required when
+                                          type is UUID, and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''UUID''
+                                          ?  has(self.uuid) : !has(self.uuid)'
+                                      - message: name configuration is required when
+                                          type is Name, and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''Name''
+                                          ?  has(self.name) : !has(self.name)'
+                                    name:
+                                      description: name defines the unique name of
+                                        a failure domain. Name is required and must
+                                        be at most 64 characters in length. It must
+                                        consist of only lower case alphanumeric characters
+                                        and hyphens (-). It must start and end with
+                                        an alphanumeric character. This value is arbitrary
+                                        and is used to identify the failure domain
+                                        within the platform.
+                                      maxLength: 64
+                                      minLength: 1
+                                      pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                                      type: string
+                                    subnets:
+                                      description: subnets holds a list of identifiers
+                                        (one or more) of the cluster's network subnets
+                                        for the Machine's VM to connect to. The subnet
+                                        identifiers (uuid or name) can be obtained
+                                        from the Prism Central console or using the
+                                        prism_central API.
+                                      items:
+                                        description: NutanixResourceIdentifier holds
+                                          the identity of a Nutanix PC resource (cluster,
+                                          image, subnet, etc.)
+                                        properties:
+                                          name:
+                                            description: name is the resource name
+                                              in the PC. It cannot be empty if the
+                                              type is Name.
+                                            type: string
+                                          type:
+                                            description: type is the identifier type
+                                              to use for this resource.
+                                            enum:
+                                            - UUID
+                                            - Name
+                                            type: string
+                                          uuid:
+                                            description: uuid is the UUID of the resource
+                                              in the PC. It cannot be empty if the
+                                              type is UUID.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: uuid configuration is required
+                                            when type is UUID, and forbidden otherwise
+                                          rule: 'has(self.type) && self.type == ''UUID''
+                                            ?  has(self.uuid) : !has(self.uuid)'
+                                        - message: name configuration is required
+                                            when type is Name, and forbidden otherwise
+                                          rule: 'has(self.type) && self.type == ''Name''
+                                            ?  has(self.name) : !has(self.name)'
+                                      maxItems: 1
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - type
+                                      x-kubernetes-list-type: map
+                                  required:
+                                  - cluster
+                                  - name
+                                  - subnets
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              prismCentral:
+                                description: prismCentral holds the endpoint address
+                                  and port to access the Nutanix Prism Central. When
+                                  a cluster-wide proxy is installed, by default, this
+                                  endpoint will be accessed via the proxy. Should
+                                  you wish for communication with this endpoint not
+                                  to be proxied, please add the endpoint to the proxy
+                                  spec.noProxy list.
+                                properties:
+                                  address:
+                                    description: address is the endpoint address (DNS
+                                      name or IP address) of the Nutanix Prism Central
+                                      or Element (cluster)
+                                    maxLength: 256
+                                    type: string
+                                  port:
+                                    description: port is the port number to access
+                                      the Nutanix Prism Central or Element (cluster)
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - address
+                                - port
+                                type: object
+                              prismElements:
+                                description: prismElements holds one or more endpoint
+                                  address and port data to access the Nutanix Prism
+                                  Elements (clusters) of the Nutanix Prism Central.
+                                  Currently we only support one Prism Element (cluster)
+                                  for an OpenShift cluster, where all the Nutanix
+                                  resources (VMs, subnets, volumes, etc.) used in
+                                  the OpenShift cluster are located. In the future,
+                                  we may support Nutanix resources (VMs, etc.) spread
+                                  over multiple Prism Elements (clusters) of the Prism
+                                  Central.
+                                items:
+                                  description: NutanixPrismElementEndpoint holds the
+                                    name and endpoint data for a Prism Element (cluster)
+                                  properties:
+                                    endpoint:
+                                      description: endpoint holds the endpoint address
+                                        and port data of the Prism Element (cluster).
+                                        When a cluster-wide proxy is installed, by
+                                        default, this endpoint will be accessed via
+                                        the proxy. Should you wish for communication
+                                        with this endpoint not to be proxied, please
+                                        add the endpoint to the proxy spec.noProxy
+                                        list.
+                                      properties:
+                                        address:
+                                          description: address is the endpoint address
+                                            (DNS name or IP address) of the Nutanix
+                                            Prism Central or Element (cluster)
+                                          maxLength: 256
+                                          type: string
+                                        port:
+                                          description: port is the port number to
+                                            access the Nutanix Prism Central or Element
+                                            (cluster)
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - address
+                                      - port
+                                      type: object
+                                    name:
+                                      description: name is the name of the Prism Element
+                                        (cluster). This value will correspond with
+                                        the cluster field configured on other resources
+                                        (eg Machines, PVCs, etc).
+                                      maxLength: 256
+                                      type: string
+                                  required:
+                                  - endpoint
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            required:
+                            - prismCentral
+                            - prismElements
+                            type: object
+                          openstack:
+                            description: OpenStack contains settings specific to the
+                              OpenStack infrastructure provider.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                          ovirt:
+                            description: Ovirt contains settings specific to the oVirt
+                              infrastructure provider.
+                            type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              IBM Power Systems Virtual Servers infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of a Power VS service.
+                                items:
+                                  description: PowervsServiceEndpoint stores the configuration
+                                    of a custom url to override existing defaults
+                                    of PowerVS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the Power VS
+                                        service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                        ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                        Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      format: uri
+                                      pattern: ^https://
+                                      type: string
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: type is the underlying infrastructure provider
+                              for the cluster. This value controls whether infrastructure
+                              automation such as service load balancers, dynamic volume
+                              provisioning, machine creation and deletion, and other
+                              integrations are enabled. If None, no infrastructure
+                              automation is enabled. Allowed values are "AWS", "Azure",
+                              "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere",
+                              "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud",
+                              "Nutanix" and "None". Individual components may not
+                              support all platforms, and must handle unrecognized
+                              platforms as None if they do not support that platform.
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                          vsphere:
+                            description: VSphere contains settings specific to the
+                              VSphere infrastructure provider.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              failureDomains:
+                                description: failureDomains contains the definition
+                                  of region, zone and the vCenter topology. If this
+                                  is omitted failure domains (regions and zones) will
+                                  not be used.
+                                items:
+                                  description: VSpherePlatformFailureDomainSpec holds
+                                    the region and zone failure domain and the vCenter
+                                    topology of that failure domain.
+                                  properties:
+                                    name:
+                                      description: name defines the arbitrary but
+                                        unique name of a failure domain.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    region:
+                                      description: region defines the name of a region
+                                        tag that will be attached to a vCenter datacenter.
+                                        The tag category in vCenter must be named
+                                        openshift-region.
+                                      maxLength: 80
+                                      minLength: 1
+                                      type: string
+                                    server:
+                                      description: server is the fully-qualified domain
+                                        name or the IP address of the vCenter server.
+                                        ---
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    topology:
+                                      description: Topology describes a given failure
+                                        domain using vSphere constructs
+                                      properties:
+                                        computeCluster:
+                                          description: computeCluster the absolute
+                                            path of the vCenter cluster in which virtual
+                                            machine will be located. The absolute
+                                            path is of the form /<datacenter>/host/<cluster>.
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/host/.*?
+                                          type: string
+                                        datacenter:
+                                          description: datacenter is the name of vCenter
+                                            datacenter in which virtual machines will
+                                            be located. The maximum length of the
+                                            datacenter name is 80 characters.
+                                          maxLength: 80
+                                          type: string
+                                        datastore:
+                                          description: datastore is the absolute path
+                                            of the datastore in which the virtual
+                                            machine is located. The absolute path
+                                            is of the form /<datacenter>/datastore/<datastore>
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/datastore/.*?
+                                          type: string
+                                        folder:
+                                          description: folder is the absolute path
+                                            of the folder where virtual machines are
+                                            located. The absolute path is of the form
+                                            /<datacenter>/vm/<folder>. The maximum
+                                            length of the path is 2048 characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/vm/.*?
+                                          type: string
+                                        networks:
+                                          description: 'networks is the list of port
+                                            group network names within this failure
+                                            domain. If feature gate VSphereMultiNetworks
+                                            is enabled, up to 10 network adapters
+                                            may be defined. 10 is the maximum number
+                                            of virtual network devices which may be
+                                            attached to a VM as defined by: https://configmax.esp.vmware.com/guest?vmwareproduct=vSphere&release=vSphere%208.0&categories=1-0
+                                            The available networks (port groups) can
+                                            be listed using `govc ls ''network/*''`
+                                            Networks should be in the form of an absolute
+                                            path: /<datacenter>/network/<portgroup>.'
+                                          items:
+                                            type: string
+                                          maxItems: 10
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resourcePool:
+                                          description: resourcePool is the absolute
+                                            path of the resource pool where virtual
+                                            machines will be created. The absolute
+                                            path is of the form /<datacenter>/host/<cluster>/Resources/<resourcepool>.
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/host/.*?/Resources.*
+                                          type: string
+                                        template:
+                                          description: "template is the full inventory
+                                            path of the virtual machine or template
+                                            that will be cloned when creating new
+                                            machines in this failure domain. The maximum
+                                            length of the path is 2048 characters.
+                                            \n When omitted, the template will be
+                                            calculated by the control plane machineset
+                                            operator based on the region and zone
+                                            defined in VSpherePlatformFailureDomainSpec.
+                                            For example, for zone=zonea, region=region1,
+                                            and infrastructure name=test, the template
+                                            path would be calculated as /<datacenter>/vm/test-rhcos-region1-zonea."
+                                          maxLength: 2048
+                                          minLength: 1
+                                          pattern: ^/.*?/vm/.*?
+                                          type: string
+                                      required:
+                                      - computeCluster
+                                      - datacenter
+                                      - datastore
+                                      - networks
+                                      type: object
+                                    zone:
+                                      description: zone defines the name of a zone
+                                        tag that will be attached to a vCenter cluster.
+                                        The tag category in vCenter must be named
+                                        openshift-zone.
+                                      maxLength: 80
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - region
+                                  - server
+                                  - topology
+                                  - zone
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeNetworking:
+                                description: nodeNetworking contains the definition
+                                  of internal and external network constraints for
+                                  assigning the node's networking. If this field is
+                                  omitted, networking defaults to the legacy address
+                                  selection behavior which is to only support a single
+                                  address and return the first one found.
+                                properties:
+                                  external:
+                                    description: external represents the network configuration
+                                      of the node that is externally routable.
+                                    properties:
+                                      excludeNetworkSubnetCidr:
+                                        description: excludeNetworkSubnetCidr IP addresses
+                                          in subnet ranges will be excluded when selecting
+                                          the IP address from the VirtualMachine's
+                                          VM for use in the status.addresses fields.
+                                          ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      network:
+                                        description: network VirtualMachine's VM Network
+                                          names that will be used to when searching
+                                          for status.addresses fields. Note that if
+                                          internal.networkSubnetCIDR and external.networkSubnetCIDR
+                                          are not set, then the vNIC associated to
+                                          this network must only have a single IP
+                                          address assigned to it. The available networks
+                                          (port groups) can be listed using `govc
+                                          ls 'network/*'`
+                                        type: string
+                                      networkSubnetCidr:
+                                        description: networkSubnetCidr IP address
+                                          on VirtualMachine's network interfaces included
+                                          in the fields' CIDRs that will be used in
+                                          respective status.addresses fields. ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  internal:
+                                    description: internal represents the network configuration
+                                      of the node that is routable only within the
+                                      cluster.
+                                    properties:
+                                      excludeNetworkSubnetCidr:
+                                        description: excludeNetworkSubnetCidr IP addresses
+                                          in subnet ranges will be excluded when selecting
+                                          the IP address from the VirtualMachine's
+                                          VM for use in the status.addresses fields.
+                                          ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      network:
+                                        description: network VirtualMachine's VM Network
+                                          names that will be used to when searching
+                                          for status.addresses fields. Note that if
+                                          internal.networkSubnetCIDR and external.networkSubnetCIDR
+                                          are not set, then the vNIC associated to
+                                          this network must only have a single IP
+                                          address assigned to it. The available networks
+                                          (port groups) can be listed using `govc
+                                          ls 'network/*'`
+                                        type: string
+                                      networkSubnetCidr:
+                                        description: networkSubnetCidr IP address
+                                          on VirtualMachine's network interfaces included
+                                          in the fields' CIDRs that will be used in
+                                          respective status.addresses fields. ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                type: object
+                              vcenters:
+                                description: vcenters holds the connection details
+                                  for services to communicate with vCenter. Currently,
+                                  only a single vCenter is supported, but in tech
+                                  preview 3 vCenters are supported. Once the cluster
+                                  has been installed, you are unable to change the
+                                  current number of defined vCenters except in the
+                                  case where the cluster has been upgraded from a
+                                  version of OpenShift where the vsphere platform
+                                  spec was not present.  You may make modifications
+                                  to the existing vCenters that are defined in the
+                                  vcenters list in order to match with any added or
+                                  modified failure domains. ---
+                                items:
+                                  description: VSpherePlatformVCenterSpec stores the
+                                    vCenter connection fields. This is used by the
+                                    vSphere CCM.
+                                  properties:
+                                    datacenters:
+                                      description: The vCenter Datacenters in which
+                                        the RHCOS vm guests are located. This field
+                                        will be used by the Cloud Controller Manager.
+                                        Each datacenter listed here should be used
+                                        within a topology.
+                                      items:
+                                        type: string
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    port:
+                                      description: port is the TCP port that will
+                                        be used to communicate to the vCenter endpoint.
+                                        When omitted, this means the user has no opinion
+                                        and it is up to the platform to choose a sensible
+                                        default, which is subject to change over time.
+                                      format: int32
+                                      maximum: 32767
+                                      minimum: 1
+                                      type: integer
+                                    server:
+                                      description: server is the fully-qualified domain
+                                        name or the IP address of the vCenter server.
+                                        ---
+                                      maxLength: 255
+                                      type: string
+                                  required:
+                                  - datacenters
+                                  - server
+                                  type: object
+                                maxItems: 3
+                                minItems: 0
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                            - message: vcenters can have at most 1 item when configured
+                                post-install
+                              rule: '!has(oldSelf.vcenters) && has(self.vcenters)
+                                ? size(self.vcenters) < 2 : true'
+                        type: object
+                        x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? size(self.vsphere.vcenters)
+                            < 2 : true'
+                    type: object
+                  status:
+                    description: status holds observed values from the cluster. They
+                      may not be overridden.
+                    properties:
+                      apiServerInternalURI:
+                        description: apiServerInternalURL is a valid URI with scheme
+                          'https', address and optionally a port (defaulting to 443).  apiServerInternalURL
+                          can be used by components like kubelets, to contact the
+                          Kubernetes API server using the infrastructure provider
+                          rather than Kubernetes networking.
+                        type: string
+                      apiServerURL:
+                        description: apiServerURL is a valid URI with scheme 'https',
+                          address and optionally a port (defaulting to 443).  apiServerURL
+                          can be used by components like the web console to tell users
+                          where to find the Kubernetes API.
+                        type: string
+                      controlPlaneTopology:
+                        default: HighlyAvailable
+                        description: controlPlaneTopology expresses the expectations
+                          for operands that normally run on control nodes. The default
+                          is 'HighlyAvailable', which represents the behavior operators
+                          have in a "normal" cluster. The 'SingleReplica' mode will
+                          be used in single-node deployments and the operators should
+                          not configure the operand for highly-available operation
+                          The 'External' mode indicates that the control plane is
+                          hosted externally to the cluster and that its components
+                          are not visible within the cluster.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        - External
+                        type: string
+                      cpuPartitioning:
+                        default: None
+                        description: cpuPartitioning expresses if CPU partitioning
+                          is a currently enabled feature in the cluster. CPU Partitioning
+                          means that this cluster can support partitioning workloads
+                          to specific CPU Sets. Valid values are "None" and "AllNodes".
+                          When omitted, the default value is "None". The default value
+                          of "None" indicates that no nodes will be setup with CPU
+                          partitioning. The "AllNodes" value indicates that all nodes
+                          have been setup with CPU partitioning, and can then be further
+                          configured via the PerformanceProfile API.
+                        enum:
+                        - None
+                        - AllNodes
+                        type: string
+                      etcdDiscoveryDomain:
+                        description: 'etcdDiscoveryDomain is the domain used to fetch
+                          the SRV records for discovering etcd servers and clients.
+                          For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
+                          deprecated: as of 4.7, this field is no longer set or honored.  It
+                          will be removed in a future release.'
+                        type: string
+                      infrastructureName:
+                        description: infrastructureName uniquely identifies a cluster
+                          with a human friendly name. Once set it should not be changed.
+                          Must be of max length 27 and must have only alphanumeric
+                          or hyphen characters.
+                        type: string
+                      infrastructureTopology:
+                        default: HighlyAvailable
+                        description: 'infrastructureTopology expresses the expectations
+                          for infrastructure services that do not run on control plane
+                          nodes, usually indicated by a node selector for a `role`
+                          value other than `master`. The default is ''HighlyAvailable'',
+                          which represents the behavior operators have in a "normal"
+                          cluster. The ''SingleReplica'' mode will be used in single-node
+                          deployments and the operators should not configure the operand
+                          for highly-available operation NOTE: External topology mode
+                          is not applicable for this field.'
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        type: string
+                      platform:
+                        description: "platform is the underlying infrastructure provider
+                          for the cluster. \n Deprecated: Use platformStatus.type
+                          instead."
+                        enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                        type: string
+                      platformStatus:
+                        description: platformStatus holds status information specific
+                          to the underlying infrastructure provider.
+                        properties:
+                          alibabaCloud:
+                            description: AlibabaCloud contains settings specific to
+                              the Alibaba Cloud infrastructure provider.
+                            properties:
+                              region:
+                                description: region specifies the region for Alibaba
+                                  Cloud resources created for the cluster.
+                                pattern: ^[0-9A-Za-z-]+$
+                                type: string
+                              resourceGroupID:
+                                description: resourceGroupID is the ID of the resource
+                                  group for the cluster.
+                                pattern: ^(rg-[0-9A-Za-z]+)?$
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to Alibaba Cloud resources created
+                                  for the cluster.
+                                items:
+                                  description: AlibabaCloudResourceTag is the set
+                                    of tags to add to apply to resources.
+                                  properties:
+                                    key:
+                                      description: key is the key of the tag.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: value is the value of the tag.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 20
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                            required:
+                            - region
+                            type: object
+                          aws:
+                            description: AWS contains settings specific to the Amazon
+                              Web Services infrastructure provider.
+                            properties:
+                              region:
+                                description: region holds the default AWS region for
+                                  new AWS resources created by the cluster.
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to AWS resources created for the cluster.
+                                  See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                                  for information on tagging AWS resources. AWS supports
+                                  a maximum of 50 tags per resource. OpenShift reserves
+                                  25 tags for its use, leaving 25 tags available for
+                                  the user.
+                                items:
+                                  description: AWSResourceTag is a tag to apply to
+                                    AWS resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key of the tag
+                                      maxLength: 128
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                      type: string
+                                    value:
+                                      description: value is the value of the tag.
+                                        Some AWS service do not support empty values.
+                                        Since tags are added to resources in many
+                                        services, the length of the tag value must
+                                        meet the requirements of all services.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 25
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              serviceEndpoints:
+                                description: ServiceEndpoints list contains custom
+                                  endpoints which will override default service endpoint
+                                  of AWS Services. There must be only one ServiceEndpoint
+                                  for a service.
+                                items:
+                                  description: AWSServiceEndpoint store the configuration
+                                    of a custom url to override existing defaults
+                                    of AWS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the AWS service.
+                                        The list of all the service names can be found
+                                        at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                        This must be provided and cannot be empty.
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      pattern: ^https://
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          azure:
+                            description: Azure contains settings specific to the Azure
+                              infrastructure provider.
+                            properties:
+                              armEndpoint:
+                                description: armEndpoint specifies a URL to use for
+                                  resource management in non-soverign clouds such
+                                  as Azure Stack.
+                                type: string
+                              cloudName:
+                                description: cloudName is the name of the Azure cloud
+                                  environment which can be used to configure the Azure
+                                  SDK with the appropriate Azure API endpoints. If
+                                  empty, the value is equal to `AzurePublicCloud`.
+                                enum:
+                                - ""
+                                - AzurePublicCloud
+                                - AzureUSGovernmentCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureStackCloud
+                                type: string
+                              networkResourceGroupName:
+                                description: networkResourceGroupName is the Resource
+                                  Group for network resources like the Virtual Network
+                                  and Subnets used by the cluster. If empty, the value
+                                  is same as ResourceGroupName.
+                                type: string
+                              resourceGroupName:
+                                description: resourceGroupName is the Resource Group
+                                  for new Azure resources created for the cluster.
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to Azure resources created for the
+                                  cluster. See https://docs.microsoft.com/en-us/rest/api/resources/tags
+                                  for information on tagging Azure resources. Due
+                                  to limitations on Automation, Content Delivery Network,
+                                  DNS Azure resources, a maximum of 15 tags may be
+                                  applied. OpenShift reserves 5 tags for internal
+                                  use, allowing 10 tags for user configuration.
+                                items:
+                                  description: AzureResourceTag is a tag to apply
+                                    to Azure resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the tag.
+                                        A tag key can have a maximum of 128 characters
+                                        and cannot be empty. Key must begin with a
+                                        letter, end with a letter, number or underscore,
+                                        and must contain only alphanumeric characters
+                                        and the following special characters `_ .
+                                        -`.
+                                      maxLength: 128
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([0-9A-Za-z_.-]*[0-9A-Za-z_])?$
+                                      type: string
+                                    value:
+                                      description: 'value is the value part of the
+                                        tag. A tag value can have a maximum of 256
+                                        characters and cannot be empty. Value must
+                                        contain only alphanumeric characters and the
+                                        following special characters `_ + , - . /
+                                        : ; < = > ? @`.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.=+-@]+$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 10
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: resourceTags are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                            type: object
+                            x-kubernetes-validations:
+                            - message: resourceTags may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags)
+                                || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                          baremetal:
+                            description: BareMetal contains settings specific to the
+                              BareMetal platform.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on BareMetal platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for BareMetal deployments. In order to minimize
+                                  necessary changes to the datacenter DNS, a DNS service
+                                  is hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                          equinixMetal:
+                            description: EquinixMetal contains settings specific to
+                              the Equinix Metal infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers.
+                                type: string
+                              ingressIP:
+                                description: ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names.
+                                type: string
+                            type: object
+                          external:
+                            description: External contains settings specific to the
+                              generic External infrastructure provider.
+                            properties:
+                              cloudControllerManager:
+                                description: cloudControllerManager contains settings
+                                  specific to the external Cloud Controller Manager
+                                  (a.k.a. CCM or CPI). When omitted, new nodes will
+                                  be not tainted and no extra initialization from
+                                  the cloud controller manager is expected.
+                                properties:
+                                  state:
+                                    description: "state determines whether or not
+                                      an external Cloud Controller Manager is expected
+                                      to be installed within the cluster. https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager
+                                      \n Valid values are \"External\", \"None\" and
+                                      omitted. When set to \"External\", new nodes
+                                      will be tainted as uninitialized when created,
+                                      preventing them from running workloads until
+                                      they are initialized by the cloud controller
+                                      manager. When omitted or set to \"None\", new
+                                      nodes will be not tainted and no extra initialization
+                                      from the cloud controller manager is expected."
+                                    enum:
+                                    - ""
+                                    - External
+                                    - None
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: state is immutable once set
+                                      rule: self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: state may not be added or removed once
+                                    set
+                                  rule: (has(self.state) == has(oldSelf.state)) ||
+                                    (!has(oldSelf.state) && self.state != "External")
+                            type: object
+                            x-kubernetes-validations:
+                            - message: cloudControllerManager may not be added or
+                                removed once set
+                              rule: has(self.cloudControllerManager) == has(oldSelf.cloudControllerManager)
+                          gcp:
+                            description: GCP contains settings specific to the Google
+                              Cloud Platform infrastructure provider.
+                            properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: cloudLoadBalancerConfig is a union that
+                                  contains the IP addresses of API, API-Int and Ingress
+                                  Load Balancers created on the cloud platform. These
+                                  values would not be populated on on-prem platforms.
+                                  These Load Balancer IPs are used to configure the
+                                  in-cluster DNS instances for API, API-Int and Ingress
+                                  services. `dnsType` is expected to be set to `ClusterHosted`
+                                  when these Load Balancer IP addresses are populated
+                                  and used.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: clusterHosted holds the IP addresses
+                                      of API, API-Int and Ingress Load Balancers on
+                                      Cloud Platforms. The DNS solution hosted within
+                                      the cluster use these IP addresses to provide
+                                      resolution for API, API-Int and Ingress services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: apiIntLoadBalancerIPs holds Load
+                                          Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be
+                                          IPv4 and/or IPv6 addresses. Entries in the
+                                          apiIntLoadBalancerIPs must be unique. A
+                                          maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: apiLoadBalancerIPs holds Load
+                                          Balancer IPs for the API service. These
+                                          Load Balancer IP addresses can be IPv4 and/or
+                                          IPv6 addresses. Could be empty for private
+                                          clusters. Entries in the apiLoadBalancerIPs
+                                          must be unique. A maximum of 16 IP addresses
+                                          are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: ingressLoadBalancerIPs holds
+                                          IPs for Ingress Load Balancers. These Load
+                                          Balancer IP addresses can be IPv4 and/or
+                                          IPv6 addresses. Entries in the ingressLoadBalancerIPs
+                                          must be unique. A maximum of 16 IP addresses
+                                          are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: dnsType indicates the type of DNS
+                                      solution in use within the cluster. Its default
+                                      value of `PlatformDefault` indicates that the
+                                      cluster's DNS is the default provided by the
+                                      cloud platform. It can be set to `ClusterHosted`
+                                      to bypass the configuration of the cloud default
+                                      DNS. In this mode, the cluster needs to provide
+                                      a self-hosted DNS solution for the cluster's
+                                      installation to succeed. The cluster's use of
+                                      the cloud's Load Balancers is unaffected by
+                                      this setting. The value is immutable after it
+                                      has been set at install time. Currently, there
+                                      is no way for the customer to add additional
+                                      DNS entries into the cluster hosted DNS. Enabling
+                                      this functionality allows the user to start
+                                      their own DNS solution outside the cluster after
+                                      installation is complete. The customer would
+                                      be responsible for configuring this custom DNS
+                                      solution, and it can be run in addition to the
+                                      in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
+                              projectID:
+                                description: resourceGroupName is the Project ID for
+                                  new GCP resources created for the cluster.
+                                type: string
+                              region:
+                                description: region holds the region for new GCP resources
+                                  created for the cluster.
+                                type: string
+                              resourceLabels:
+                                description: resourceLabels is a list of additional
+                                  labels to apply to GCP resources created for the
+                                  cluster. See https://cloud.google.com/compute/docs/labeling-resources
+                                  for information on labeling GCP resources. GCP supports
+                                  a maximum of 64 labels per resource. OpenShift reserves
+                                  32 labels for internal use, allowing 32 labels for
+                                  user configuration.
+                                items:
+                                  description: GCPResourceLabel is a label to apply
+                                    to GCP resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the label.
+                                        A label key can have a maximum of 63 characters
+                                        and cannot be empty. Label key must begin
+                                        with a lowercase letter, and must contain
+                                        only lowercase letters, numeric characters,
+                                        and the following special characters `_-`.
+                                        Label key must not have the reserved prefixes
+                                        `kubernetes-io` and `openshift-io`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z][0-9a-z_-]{0,62}$
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: label keys must not start with either
+                                          `openshift-io` or `kubernetes-io`
+                                        rule: '!self.startsWith(''openshift-io'')
+                                          && !self.startsWith(''kubernetes-io'')'
+                                    value:
+                                      description: value is the value part of the
+                                        label. A label value can have a maximum of
+                                        63 characters and cannot be empty. Value must
+                                        contain only lowercase letters, numeric characters,
+                                        and the following special characters `_-`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[0-9a-z_-]{1,63}$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                                x-kubernetes-validations:
+                                - message: resourceLabels are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to GCP resources created for the cluster.
+                                  See https://cloud.google.com/resource-manager/docs/tags/tags-overview
+                                  for information on tagging GCP resources. GCP supports
+                                  a maximum of 50 tags per resource.
+                                items:
+                                  description: GCPResourceTag is a tag to apply to
+                                    GCP resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the tag.
+                                        A tag key can have a maximum of 63 characters
+                                        and cannot be empty. Tag key must begin and
+                                        end with an alphanumeric character, and must
+                                        contain only uppercase, lowercase alphanumeric
+                                        characters, and the following special characters
+                                        `._-`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.-]{0,61}[a-zA-Z0-9])?$
+                                      type: string
+                                    parentID:
+                                      description: 'parentID is the ID of the hierarchical
+                                        resource where the tags are defined, e.g.
+                                        at the Organization or the Project level.
+                                        To find the Organization or Project ID refer
+                                        to the following pages: https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id,
+                                        https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects.
+                                        An OrganizationID must consist of decimal
+                                        numbers, and cannot have leading zeroes. A
+                                        ProjectID must be 6 to 30 characters in length,
+                                        can only contain lowercase letters, numbers,
+                                        and hyphens, and must start with a letter,
+                                        and cannot end with a hyphen.'
+                                      maxLength: 32
+                                      minLength: 1
+                                      pattern: (^[1-9][0-9]{0,31}$)|(^[a-z][a-z0-9-]{4,28}[a-z0-9]$)
+                                      type: string
+                                    value:
+                                      description: value is the value part of the
+                                        tag. A tag value can have a maximum of 63
+                                        characters and cannot be empty. Tag value
+                                        must begin and end with an alphanumeric character,
+                                        and must contain only uppercase, lowercase
+                                        alphanumeric characters, and the following
+                                        special characters `_-.@%=+:,*#&(){}[]` and
+                                        spaces.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.@%=+:,*#&()\[\]{}\-\s]{0,61}[a-zA-Z0-9])?$
+                                      type: string
+                                  required:
+                                  - key
+                                  - parentID
+                                  - value
+                                  type: object
+                                maxItems: 50
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                                x-kubernetes-validations:
+                                - message: resourceTags are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                            type: object
+                            x-kubernetes-validations:
+                            - message: resourceLabels may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceLabels) && !has(self.resourceLabels)
+                                || has(oldSelf.resourceLabels) && has(self.resourceLabels)'
+                            - message: resourceTags may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags)
+                                || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                          ibmcloud:
+                            description: IBMCloud contains settings specific to the
+                              IBMCloud infrastructure provider.
+                            properties:
+                              cisInstanceCRN:
+                                description: CISInstanceCRN is the CRN of the Cloud
+                                  Internet Services instance managing the DNS zone
+                                  for the cluster's base domain
+                                type: string
+                              dnsInstanceCRN:
+                                description: DNSInstanceCRN is the CRN of the DNS
+                                  Services instance managing the DNS zone for the
+                                  cluster's base domain
+                                type: string
+                              location:
+                                description: Location is where the cluster has been
+                                  deployed
+                                type: string
+                              providerType:
+                                description: ProviderType indicates the type of cluster
+                                  that was created
+                                type: string
+                              resourceGroupName:
+                                description: ResourceGroupName is the Resource Group
+                                  for new IBMCloud resources created for the cluster.
+                                type: string
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of an IBM Cloud service. These endpoints
+                                  are consumed by components within the cluster to
+                                  reach the respective IBM Cloud Services.
+                                items:
+                                  description: IBMCloudServiceEndpoint stores the
+                                    configuration of a custom url to override existing
+                                    defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: 'name is the name of the IBM Cloud
+                                        service. Possible values are: CIS, COS, COSConfig,
+                                        DNSServices, GlobalCatalog, GlobalSearch,
+                                        GlobalTagging, HyperProtect, IAM, KeyProtect,
+                                        ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service
+                                        could be configured with the service `name`
+                                        of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service
+                                        for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url`
+                                        of `https://us.south.private.iaas.cloud.ibm.com`'
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          kubevirt:
+                            description: Kubevirt contains settings specific to the
+                              kubevirt infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers.
+                                type: string
+                              ingressIP:
+                                description: ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names.
+                                type: string
+                            type: object
+                          nutanix:
+                            description: Nutanix contains settings specific to the
+                              Nutanix infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Nutanix platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                            type: object
+                          openstack:
+                            description: OpenStack contains settings specific to the
+                              OpenStack infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              cloudName:
+                                description: cloudName is the name of the desired
+                                  OpenStack cloud in the client configuration file
+                                  (`clouds.yaml`).
+                                type: string
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on OpenStack platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for OpenStack deployments. In order to minimize
+                                  necessary changes to the datacenter DNS, a DNS service
+                                  is hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                          ovirt:
+                            description: Ovirt contains settings specific to the oVirt
+                              infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Ovirt platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              nodeDNSIP:
+                                description: 'deprecated: as of 4.6, this field is
+                                  no longer set or honored.  It will be removed in
+                                  a future release.'
+                                type: string
+                            type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              Power Systems Virtual Servers infrastructure provider.
+                            properties:
+                              cisInstanceCRN:
+                                description: CISInstanceCRN is the CRN of the Cloud
+                                  Internet Services instance managing the DNS zone
+                                  for the cluster's base domain
+                                type: string
+                              dnsInstanceCRN:
+                                description: DNSInstanceCRN is the CRN of the DNS
+                                  Services instance managing the DNS zone for the
+                                  cluster's base domain
+                                type: string
+                              region:
+                                description: region holds the default Power VS region
+                                  for new Power VS resources created by the cluster.
+                                type: string
+                              resourceGroup:
+                                description: 'resourceGroup is the resource group
+                                  name for new IBMCloud resources created for a cluster.
+                                  The resource group specified here will be used by
+                                  cluster-image-registry-operator to set up a COS
+                                  Instance in IBMCloud for the cluster registry. More
+                                  about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs.
+                                  When omitted, the image registry operator won''t
+                                  be able to configure storage, which results in the
+                                  image registry cluster operator not being in an
+                                  available state.'
+                                maxLength: 40
+                                pattern: ^[a-zA-Z0-9-_ ]+$
+                                type: string
+                                x-kubernetes-validations:
+                                - message: resourceGroup is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of a Power VS service.
+                                items:
+                                  description: PowervsServiceEndpoint stores the configuration
+                                    of a custom url to override existing defaults
+                                    of PowerVS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the Power VS
+                                        service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                        ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                        Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      format: uri
+                                      pattern: ^https://
+                                      type: string
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              zone:
+                                description: 'zone holds the default zone for the
+                                  new Power VS resources created by the cluster. Note:
+                                  Currently only single-zone OCP clusters are supported'
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: cannot unset resourceGroup once set
+                              rule: '!has(oldSelf.resourceGroup) || has(self.resourceGroup)'
+                          type:
+                            description: "type is the underlying infrastructure provider
+                              for the cluster. This value controls whether infrastructure
+                              automation such as service load balancers, dynamic volume
+                              provisioning, machine creation and deletion, and other
+                              integrations are enabled. If None, no infrastructure
+                              automation is enabled. Allowed values are \"AWS\", \"Azure\",
+                              \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\",
+                              \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\",
+                              \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual
+                              components may not support all platforms, and must handle
+                              unrecognized platforms as None if they do not support
+                              that platform. \n This value will be synced with to
+                              the `status.platform` and `status.platformStatus.type`.
+                              Currently this value cannot be changed once set."
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                          vsphere:
+                            description: VSphere contains settings specific to the
+                              VSphere infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on VSphere platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for vSphere deployments. In order to minimize necessary
+                                  changes to the datacenter DNS, a DNS service is
+                                  hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+                x-kubernetes-embedded-resource: true
+              internalRegistryPullSecret:
+                description: internalRegistryPullSecret is the pull secret for the
+                  internal registry, used by rpm-ostree to pull images from the internal
+                  registry if present
+                format: byte
+                nullable: true
+                type: string
+              ipFamilies:
+                description: ipFamilies indicates the IP families in use by the cluster
+                  network
+                type: string
+              kubeAPIServerServingCAData:
+                description: kubeAPIServerServingCAData managed Kubelet to API Server
+                  Cert... Rotated automatically
+                format: byte
+                type: string
+              network:
+                description: Network contains additional network related information
+                nullable: true
+                properties:
+                  mtuMigration:
+                    description: MTUMigration contains the MTU migration configuration.
+                    nullable: true
+                    properties:
+                      machine:
+                        description: Machine contains MTU migration configuration
+                          for the machine's uplink.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      network:
+                        description: Network contains MTU migration configuration
+                          for the default network.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - mtuMigration
+                type: object
+              networkType:
+                description: 'networkType holds the type of network the cluster is
+                  using XXX: this is temporary and will be dropped as soon as possible
+                  in favor of a better support to start network related services the
+                  proper way. Nobody is also changing this once the cluster is up
+                  and running the first time, so, disallow regeneration if this changes.'
+                type: string
+              osImageURL:
+                description: OSImageURL is the old-format container image that contains
+                  the OS update payload.
+                type: string
+              platform:
+                description: platform is deprecated, use Infra.Status.PlatformStatus.Type
+                  instead
+                type: string
+              proxy:
+                description: proxy holds the current proxy configuration for the nodes
+                nullable: true
+                properties:
+                  httpProxy:
+                    description: httpProxy is the URL of the proxy for HTTP requests.
+                    type: string
+                  httpsProxy:
+                    description: httpsProxy is the URL of the proxy for HTTPS requests.
+                    type: string
+                  noProxy:
+                    description: noProxy is a comma-separated list of hostnames and/or
+                      CIDRs for which the proxy should not be used.
+                    type: string
+                type: object
+              pullSecret:
+                description: pullSecret is the default pull secret that needs to be
+                  installed on all machines.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              releaseImage:
+                description: releaseImage is the image used when installing the cluster
+                type: string
+              rootCAData:
+                description: rootCAData specifies the root CA data
+                format: byte
+                type: string
+            required:
+            - additionalTrustBundle
+            - baseOSContainerImage
+            - cloudProviderCAData
+            - cloudProviderConfig
+            - clusterDNSIP
+            - dns
+            - images
+            - infra
+            - ipFamilies
+            - kubeAPIServerServingCAData
+            - network
+            - proxy
+            - releaseImage
+            - rootCAData
+            type: object
+          status:
+            description: ControllerConfigStatus is the status for ControllerConfig
+            properties:
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: ControllerConfigStatusCondition contains condition
+                    information for ControllerConfigStatus
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status object.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message provides additional information about the
+                        current condition. This is only to be consumed by humans.
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.  Reasons
+                        are PascalCase
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              controllerCertificates:
+                description: controllerCertificates represents the latest available
+                  observations of the automatically rotating certificates in the MCO.
+                items:
+                  description: ControllerCertificate contains info about a specific
+                    cert.
+                  properties:
+                    bundleFile:
+                      description: bundleFile is the larger bundle a cert comes from
+                      type: string
+                    notAfter:
+                      description: notAfter is the upper boundary for validity
+                      format: date-time
+                      type: string
+                    notBefore:
+                      description: notBefore is the lower boundary for validity
+                      format: date-time
+                      type: string
+                    signer:
+                      description: signer is the  cert Issuer
+                      type: string
+                    subject:
+                      description: subject is the cert subject
+                      type: string
+                  required:
+                  - bundleFile
+                  - signer
+                  - subject
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,2860 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: controllerconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: ControllerConfig
+    listKind: ControllerConfigList
+    plural: controllerconfigs
+    singular: controllerconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "ControllerConfig describes configuration for MachineConfigController.
+          This is currently only used to drive the MachineConfig objects generated
+          by the TemplateController. \n Compatibility level 1: Stable within a major
+          release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ControllerConfigSpec is the spec for ControllerConfig resource.
+            properties:
+              additionalTrustBundle:
+                description: additionalTrustBundle is a certificate bundle that will
+                  be added to the nodes trusted certificate store.
+                format: byte
+                nullable: true
+                type: string
+              baseOSContainerImage:
+                description: BaseOSContainerImage is the new-format container image
+                  for operating system updates.
+                type: string
+              baseOSExtensionsContainerImage:
+                description: BaseOSExtensionsContainerImage is the matching extensions
+                  container for the new-format container
+                type: string
+              cloudProviderCAData:
+                description: cloudProvider specifies the cloud provider CA data
+                format: byte
+                nullable: true
+                type: string
+              cloudProviderConfig:
+                description: cloudProviderConfig is the configuration for the given
+                  cloud provider
+                type: string
+              clusterDNSIP:
+                description: clusterDNSIP is the cluster DNS IP address
+                type: string
+              dns:
+                description: dns holds the cluster dns details
+                nullable: true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'metadata is the standard object''s metadata. More
+                      info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: spec holds user settable values for configuration
+                    properties:
+                      baseDomain:
+                        description: "baseDomain is the base domain of the cluster.
+                          All managed DNS records will be sub-domains of this base.
+                          \n For example, given the base domain `openshift.example.com`,
+                          an API server DNS record may be created for `cluster-api.openshift.example.com`.
+                          \n Once set, this field cannot be changed."
+                        type: string
+                      platform:
+                        description: platform holds configuration specific to the
+                          underlying infrastructure provider for DNS. When omitted,
+                          this means the user has no opinion and the platform is left
+                          to choose reasonable defaults. These defaults are subject
+                          to change over time.
+                        properties:
+                          aws:
+                            description: aws contains DNS configuration specific to
+                              the Amazon Web Services cloud provider.
+                            properties:
+                              privateZoneIAMRole:
+                                description: privateZoneIAMRole contains the ARN of
+                                  an IAM role that should be assumed when performing
+                                  operations on the cluster's private hosted zone
+                                  specified in the cluster DNS config. When left empty,
+                                  no role should be assumed.
+                                pattern: ^arn:(aws|aws-cn|aws-us-gov):iam::[0-9]{12}:role\/.*$
+                                type: string
+                            type: object
+                          type:
+                            description: "type is the underlying infrastructure provider
+                              for the cluster. Allowed values: \"\", \"AWS\". \n Individual
+                              components may not support all platforms, and must handle
+                              unrecognized platforms with best-effort defaults."
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                            x-kubernetes-validations:
+                            - message: allowed values are '' and 'AWS'
+                              rule: self in ['','AWS']
+                        required:
+                        - type
+                        type: object
+                        x-kubernetes-validations:
+                        - message: aws configuration is required when platform is
+                            AWS, and forbidden otherwise
+                          rule: 'has(self.type) && self.type == ''AWS'' ?  has(self.aws)
+                            : !has(self.aws)'
+                      privateZone:
+                        description: "privateZone is the location where all the DNS
+                          records that are only available internally to the cluster
+                          exist. \n If this field is nil, no private records should
+                          be created. \n Once set, this field cannot be changed."
+                        properties:
+                          id:
+                            description: "id is the identifier that can be used to
+                              find the DNS hosted zone. \n on AWS zone can be fetched
+                              using `ID` as id in [1] on Azure zone can be fetched
+                              using `ID` as a pre-determined name in [2], on GCP zone
+                              can be fetched using `ID` as a pre-determined name in
+                              [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                              [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                              [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: "tags can be used to query the DNS hosted
+                              zone. \n on AWS, resourcegroupstaggingapi [1] can be
+                              used to fetch a zone using `Tags` as tag-filters, \n
+                              [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                            type: object
+                        type: object
+                      publicZone:
+                        description: "publicZone is the location where all the DNS
+                          records that are publicly accessible to the internet exist.
+                          \n If this field is nil, no public records should be created.
+                          \n Once set, this field cannot be changed."
+                        properties:
+                          id:
+                            description: "id is the identifier that can be used to
+                              find the DNS hosted zone. \n on AWS zone can be fetched
+                              using `ID` as id in [1] on Azure zone can be fetched
+                              using `ID` as a pre-determined name in [2], on GCP zone
+                              can be fetched using `ID` as a pre-determined name in
+                              [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                              [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                              [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: "tags can be used to query the DNS hosted
+                              zone. \n on AWS, resourcegroupstaggingapi [1] can be
+                              used to fetch a zone using `Tags` as tag-filters, \n
+                              [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                            type: object
+                        type: object
+                    type: object
+                  status:
+                    description: status holds observed values from the cluster. They
+                      may not be overridden.
+                    type: object
+                required:
+                - spec
+                type: object
+                x-kubernetes-embedded-resource: true
+              etcdDiscoveryDomain:
+                description: etcdDiscoveryDomain is deprecated, use Infra.Status.EtcdDiscoveryDomain
+                  instead
+                type: string
+              imageRegistryBundleData:
+                description: imageRegistryBundleData is the ImageRegistryData
+                items:
+                  description: ImageRegistryBundle contains information for writing
+                    image registry certificates
+                  properties:
+                    data:
+                      description: data holds the contents of the bundle that will
+                        be written to the file location
+                      format: byte
+                      type: string
+                    file:
+                      description: file holds the name of the file where the bundle
+                        will be written to disk
+                      type: string
+                  required:
+                  - data
+                  - file
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              imageRegistryBundleUserData:
+                description: imageRegistryBundleUserData is Image Registry Data provided
+                  by the user
+                items:
+                  description: ImageRegistryBundle contains information for writing
+                    image registry certificates
+                  properties:
+                    data:
+                      description: data holds the contents of the bundle that will
+                        be written to the file location
+                      format: byte
+                      type: string
+                    file:
+                      description: file holds the name of the file where the bundle
+                        will be written to disk
+                      type: string
+                  required:
+                  - data
+                  - file
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              images:
+                additionalProperties:
+                  type: string
+                description: images is map of images that are used by the controller
+                  to render templates under ./templates/
+                type: object
+              infra:
+                description: infra holds the infrastructure details
+                nullable: true
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    description: 'metadata is the standard object''s metadata. More
+                      info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: spec holds user settable values for configuration
+                    properties:
+                      cloudConfig:
+                        description: "cloudConfig is a reference to a ConfigMap containing
+                          the cloud provider configuration file. This configuration
+                          file is used to configure the Kubernetes cloud provider
+                          integration when using the built-in cloud provider integration
+                          or the external cloud controller manager. The namespace
+                          for this config map is openshift-config. \n cloudConfig
+                          should only be consumed by the kube_cloud_config controller.
+                          The controller is responsible for using the user configuration
+                          in the spec for various platforms and combining that with
+                          the user provided ConfigMap in this field to create a stitched
+                          kube cloud config. The controller generates a ConfigMap
+                          `kube-cloud-config` in `openshift-config-managed` namespace
+                          with the kube cloud config is stored in `cloud.conf` key.
+                          All the clients are expected to use the generated ConfigMap
+                          only."
+                        properties:
+                          key:
+                            description: Key allows pointing to a specific key/value
+                              inside of the configmap.  This is useful for logical
+                              file references.
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      platformSpec:
+                        description: platformSpec holds desired information specific
+                          to the underlying infrastructure provider.
+                        properties:
+                          alibabaCloud:
+                            description: AlibabaCloud contains settings specific to
+                              the Alibaba Cloud infrastructure provider.
+                            type: object
+                          aws:
+                            description: AWS contains settings specific to the Amazon
+                              Web Services infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: serviceEndpoints list contains custom
+                                  endpoints which will override default service endpoint
+                                  of AWS Services. There must be only one ServiceEndpoint
+                                  for a service.
+                                items:
+                                  description: AWSServiceEndpoint store the configuration
+                                    of a custom url to override existing defaults
+                                    of AWS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the AWS service.
+                                        The list of all the service names can be found
+                                        at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                        This must be provided and cannot be empty.
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      pattern: ^https://
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          azure:
+                            description: Azure contains settings specific to the Azure
+                              infrastructure provider.
+                            type: object
+                          baremetal:
+                            description: BareMetal contains settings specific to the
+                              BareMetal platform.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                          equinixMetal:
+                            description: EquinixMetal contains settings specific to
+                              the Equinix Metal infrastructure provider.
+                            type: object
+                          external:
+                            description: ExternalPlatformType represents generic infrastructure
+                              provider. Platform-specific components should be supplemented
+                              separately.
+                            properties:
+                              platformName:
+                                default: Unknown
+                                description: PlatformName holds the arbitrary string
+                                  representing the infrastructure provider name, expected
+                                  to be set at the installation time. This field is
+                                  solely for informational and reporting purposes
+                                  and is not expected to be used for decision-making.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: platform name cannot be changed once set
+                                  rule: oldSelf == 'Unknown' || self == oldSelf
+                            type: object
+                          gcp:
+                            description: GCP contains settings specific to the Google
+                              Cloud Platform infrastructure provider.
+                            type: object
+                          ibmcloud:
+                            description: IBMCloud contains settings specific to the
+                              IBMCloud infrastructure provider.
+                            type: object
+                          kubevirt:
+                            description: Kubevirt contains settings specific to the
+                              kubevirt infrastructure provider.
+                            type: object
+                          nutanix:
+                            description: Nutanix contains settings specific to the
+                              Nutanix infrastructure provider.
+                            properties:
+                              failureDomains:
+                                description: failureDomains configures failure domains
+                                  information for the Nutanix platform. When set,
+                                  the failure domains defined here may be used to
+                                  spread Machines across prism element clusters to
+                                  improve fault tolerance of the cluster.
+                                items:
+                                  description: NutanixFailureDomain configures failure
+                                    domain information for the Nutanix platform.
+                                  properties:
+                                    cluster:
+                                      description: cluster is to identify the cluster
+                                        (the Prism Element under management of the
+                                        Prism Central), in which the Machine's VM
+                                        will be created. The cluster identifier (uuid
+                                        or name) can be obtained from the Prism Central
+                                        console or using the prism_central API.
+                                      properties:
+                                        name:
+                                          description: name is the resource name in
+                                            the PC. It cannot be empty if the type
+                                            is Name.
+                                          type: string
+                                        type:
+                                          description: type is the identifier type
+                                            to use for this resource.
+                                          enum:
+                                          - UUID
+                                          - Name
+                                          type: string
+                                        uuid:
+                                          description: uuid is the UUID of the resource
+                                            in the PC. It cannot be empty if the type
+                                            is UUID.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: uuid configuration is required when
+                                          type is UUID, and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''UUID''
+                                          ?  has(self.uuid) : !has(self.uuid)'
+                                      - message: name configuration is required when
+                                          type is Name, and forbidden otherwise
+                                        rule: 'has(self.type) && self.type == ''Name''
+                                          ?  has(self.name) : !has(self.name)'
+                                    name:
+                                      description: name defines the unique name of
+                                        a failure domain. Name is required and must
+                                        be at most 64 characters in length. It must
+                                        consist of only lower case alphanumeric characters
+                                        and hyphens (-). It must start and end with
+                                        an alphanumeric character. This value is arbitrary
+                                        and is used to identify the failure domain
+                                        within the platform.
+                                      maxLength: 64
+                                      minLength: 1
+                                      pattern: '[a-z0-9]([-a-z0-9]*[a-z0-9])?'
+                                      type: string
+                                    subnets:
+                                      description: subnets holds a list of identifiers
+                                        (one or more) of the cluster's network subnets
+                                        for the Machine's VM to connect to. The subnet
+                                        identifiers (uuid or name) can be obtained
+                                        from the Prism Central console or using the
+                                        prism_central API.
+                                      items:
+                                        description: NutanixResourceIdentifier holds
+                                          the identity of a Nutanix PC resource (cluster,
+                                          image, subnet, etc.)
+                                        properties:
+                                          name:
+                                            description: name is the resource name
+                                              in the PC. It cannot be empty if the
+                                              type is Name.
+                                            type: string
+                                          type:
+                                            description: type is the identifier type
+                                              to use for this resource.
+                                            enum:
+                                            - UUID
+                                            - Name
+                                            type: string
+                                          uuid:
+                                            description: uuid is the UUID of the resource
+                                              in the PC. It cannot be empty if the
+                                              type is UUID.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                        x-kubernetes-validations:
+                                        - message: uuid configuration is required
+                                            when type is UUID, and forbidden otherwise
+                                          rule: 'has(self.type) && self.type == ''UUID''
+                                            ?  has(self.uuid) : !has(self.uuid)'
+                                        - message: name configuration is required
+                                            when type is Name, and forbidden otherwise
+                                          rule: 'has(self.type) && self.type == ''Name''
+                                            ?  has(self.name) : !has(self.name)'
+                                      maxItems: 1
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - type
+                                      x-kubernetes-list-type: map
+                                  required:
+                                  - cluster
+                                  - name
+                                  - subnets
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              prismCentral:
+                                description: prismCentral holds the endpoint address
+                                  and port to access the Nutanix Prism Central. When
+                                  a cluster-wide proxy is installed, by default, this
+                                  endpoint will be accessed via the proxy. Should
+                                  you wish for communication with this endpoint not
+                                  to be proxied, please add the endpoint to the proxy
+                                  spec.noProxy list.
+                                properties:
+                                  address:
+                                    description: address is the endpoint address (DNS
+                                      name or IP address) of the Nutanix Prism Central
+                                      or Element (cluster)
+                                    maxLength: 256
+                                    type: string
+                                  port:
+                                    description: port is the port number to access
+                                      the Nutanix Prism Central or Element (cluster)
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - address
+                                - port
+                                type: object
+                              prismElements:
+                                description: prismElements holds one or more endpoint
+                                  address and port data to access the Nutanix Prism
+                                  Elements (clusters) of the Nutanix Prism Central.
+                                  Currently we only support one Prism Element (cluster)
+                                  for an OpenShift cluster, where all the Nutanix
+                                  resources (VMs, subnets, volumes, etc.) used in
+                                  the OpenShift cluster are located. In the future,
+                                  we may support Nutanix resources (VMs, etc.) spread
+                                  over multiple Prism Elements (clusters) of the Prism
+                                  Central.
+                                items:
+                                  description: NutanixPrismElementEndpoint holds the
+                                    name and endpoint data for a Prism Element (cluster)
+                                  properties:
+                                    endpoint:
+                                      description: endpoint holds the endpoint address
+                                        and port data of the Prism Element (cluster).
+                                        When a cluster-wide proxy is installed, by
+                                        default, this endpoint will be accessed via
+                                        the proxy. Should you wish for communication
+                                        with this endpoint not to be proxied, please
+                                        add the endpoint to the proxy spec.noProxy
+                                        list.
+                                      properties:
+                                        address:
+                                          description: address is the endpoint address
+                                            (DNS name or IP address) of the Nutanix
+                                            Prism Central or Element (cluster)
+                                          maxLength: 256
+                                          type: string
+                                        port:
+                                          description: port is the port number to
+                                            access the Nutanix Prism Central or Element
+                                            (cluster)
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                          type: integer
+                                      required:
+                                      - address
+                                      - port
+                                      type: object
+                                    name:
+                                      description: name is the name of the Prism Element
+                                        (cluster). This value will correspond with
+                                        the cluster field configured on other resources
+                                        (eg Machines, PVCs, etc).
+                                      maxLength: 256
+                                      type: string
+                                  required:
+                                  - endpoint
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            required:
+                            - prismCentral
+                            - prismElements
+                            type: object
+                          openstack:
+                            description: OpenStack contains settings specific to the
+                              OpenStack infrastructure provider.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                          ovirt:
+                            description: Ovirt contains settings specific to the oVirt
+                              infrastructure provider.
+                            type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              IBM Power Systems Virtual Servers infrastructure provider.
+                            properties:
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of a Power VS service.
+                                items:
+                                  description: PowervsServiceEndpoint stores the configuration
+                                    of a custom url to override existing defaults
+                                    of PowerVS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the Power VS
+                                        service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                        ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                        Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      format: uri
+                                      pattern: ^https://
+                                      type: string
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          type:
+                            description: type is the underlying infrastructure provider
+                              for the cluster. This value controls whether infrastructure
+                              automation such as service load balancers, dynamic volume
+                              provisioning, machine creation and deletion, and other
+                              integrations are enabled. If None, no infrastructure
+                              automation is enabled. Allowed values are "AWS", "Azure",
+                              "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere",
+                              "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud",
+                              "Nutanix" and "None". Individual components may not
+                              support all platforms, and must handle unrecognized
+                              platforms as None if they do not support that platform.
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                          vsphere:
+                            description: VSphere contains settings specific to the
+                              VSphere infrastructure provider.
+                            properties:
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IP addresses,
+                                  one from IPv4 family and one from IPv6. In single
+                                  stack clusters a single IP address is expected.
+                                  When omitted, values from the status.apiServerInternalIPs
+                                  will be used. Once set, the list cannot be completely
+                                  removed (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              failureDomains:
+                                description: failureDomains contains the definition
+                                  of region, zone and the vCenter topology. If this
+                                  is omitted failure domains (regions and zones) will
+                                  not be used.
+                                items:
+                                  description: VSpherePlatformFailureDomainSpec holds
+                                    the region and zone failure domain and the vCenter
+                                    topology of that failure domain.
+                                  properties:
+                                    name:
+                                      description: name defines the arbitrary but
+                                        unique name of a failure domain.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    region:
+                                      description: region defines the name of a region
+                                        tag that will be attached to a vCenter datacenter.
+                                        The tag category in vCenter must be named
+                                        openshift-region.
+                                      maxLength: 80
+                                      minLength: 1
+                                      type: string
+                                    server:
+                                      description: server is the fully-qualified domain
+                                        name or the IP address of the vCenter server.
+                                        ---
+                                      maxLength: 255
+                                      minLength: 1
+                                      type: string
+                                    topology:
+                                      description: Topology describes a given failure
+                                        domain using vSphere constructs
+                                      properties:
+                                        computeCluster:
+                                          description: computeCluster the absolute
+                                            path of the vCenter cluster in which virtual
+                                            machine will be located. The absolute
+                                            path is of the form /<datacenter>/host/<cluster>.
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/host/.*?
+                                          type: string
+                                        datacenter:
+                                          description: datacenter is the name of vCenter
+                                            datacenter in which virtual machines will
+                                            be located. The maximum length of the
+                                            datacenter name is 80 characters.
+                                          maxLength: 80
+                                          type: string
+                                        datastore:
+                                          description: datastore is the absolute path
+                                            of the datastore in which the virtual
+                                            machine is located. The absolute path
+                                            is of the form /<datacenter>/datastore/<datastore>
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/datastore/.*?
+                                          type: string
+                                        folder:
+                                          description: folder is the absolute path
+                                            of the folder where virtual machines are
+                                            located. The absolute path is of the form
+                                            /<datacenter>/vm/<folder>. The maximum
+                                            length of the path is 2048 characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/vm/.*?
+                                          type: string
+                                        networks:
+                                          description: 'networks is the list of port
+                                            group network names within this failure
+                                            domain. If feature gate VSphereMultiNetworks
+                                            is enabled, up to 10 network adapters
+                                            may be defined. 10 is the maximum number
+                                            of virtual network devices which may be
+                                            attached to a VM as defined by: https://configmax.esp.vmware.com/guest?vmwareproduct=vSphere&release=vSphere%208.0&categories=1-0
+                                            The available networks (port groups) can
+                                            be listed using `govc ls ''network/*''`
+                                            Networks should be in the form of an absolute
+                                            path: /<datacenter>/network/<portgroup>.'
+                                          items:
+                                            type: string
+                                          maxItems: 10
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resourcePool:
+                                          description: resourcePool is the absolute
+                                            path of the resource pool where virtual
+                                            machines will be created. The absolute
+                                            path is of the form /<datacenter>/host/<cluster>/Resources/<resourcepool>.
+                                            The maximum length of the path is 2048
+                                            characters.
+                                          maxLength: 2048
+                                          pattern: ^/.*?/host/.*?/Resources.*
+                                          type: string
+                                        template:
+                                          description: "template is the full inventory
+                                            path of the virtual machine or template
+                                            that will be cloned when creating new
+                                            machines in this failure domain. The maximum
+                                            length of the path is 2048 characters.
+                                            \n When omitted, the template will be
+                                            calculated by the control plane machineset
+                                            operator based on the region and zone
+                                            defined in VSpherePlatformFailureDomainSpec.
+                                            For example, for zone=zonea, region=region1,
+                                            and infrastructure name=test, the template
+                                            path would be calculated as /<datacenter>/vm/test-rhcos-region1-zonea."
+                                          maxLength: 2048
+                                          minLength: 1
+                                          pattern: ^/.*?/vm/.*?
+                                          type: string
+                                      required:
+                                      - computeCluster
+                                      - datacenter
+                                      - datastore
+                                      - networks
+                                      type: object
+                                    zone:
+                                      description: zone defines the name of a zone
+                                        tag that will be attached to a vCenter cluster.
+                                        The tag category in vCenter must be named
+                                        openshift-zone.
+                                      maxLength: 80
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - region
+                                  - server
+                                  - topology
+                                  - zone
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IP addresses, one
+                                  from IPv4 family and one from IPv6. In single stack
+                                  clusters a single IP address is expected. When omitted,
+                                  values from the status.ingressIPs will be used.
+                                  Once set, the list cannot be completely removed
+                                  (but its second entry can).
+                                items:
+                                  description: IP is an IP address (for example, "10.0.0.0"
+                                    or "fd00::").
+                                  maxLength: 39
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid IP address
+                                    rule: isIP(self)
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'size(self) == 2 && isIP(self[0]) && isIP(self[1])
+                                    ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true'
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes. Each
+                                  network is provided in the CIDR format and should
+                                  be IPv4 or IPv6, for example "10.0.0.0/8" or "fd00::/8".
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeNetworking:
+                                description: nodeNetworking contains the definition
+                                  of internal and external network constraints for
+                                  assigning the node's networking. If this field is
+                                  omitted, networking defaults to the legacy address
+                                  selection behavior which is to only support a single
+                                  address and return the first one found.
+                                properties:
+                                  external:
+                                    description: external represents the network configuration
+                                      of the node that is externally routable.
+                                    properties:
+                                      excludeNetworkSubnetCidr:
+                                        description: excludeNetworkSubnetCidr IP addresses
+                                          in subnet ranges will be excluded when selecting
+                                          the IP address from the VirtualMachine's
+                                          VM for use in the status.addresses fields.
+                                          ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      network:
+                                        description: network VirtualMachine's VM Network
+                                          names that will be used to when searching
+                                          for status.addresses fields. Note that if
+                                          internal.networkSubnetCIDR and external.networkSubnetCIDR
+                                          are not set, then the vNIC associated to
+                                          this network must only have a single IP
+                                          address assigned to it. The available networks
+                                          (port groups) can be listed using `govc
+                                          ls 'network/*'`
+                                        type: string
+                                      networkSubnetCidr:
+                                        description: networkSubnetCidr IP address
+                                          on VirtualMachine's network interfaces included
+                                          in the fields' CIDRs that will be used in
+                                          respective status.addresses fields. ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  internal:
+                                    description: internal represents the network configuration
+                                      of the node that is routable only within the
+                                      cluster.
+                                    properties:
+                                      excludeNetworkSubnetCidr:
+                                        description: excludeNetworkSubnetCidr IP addresses
+                                          in subnet ranges will be excluded when selecting
+                                          the IP address from the VirtualMachine's
+                                          VM for use in the status.addresses fields.
+                                          ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      network:
+                                        description: network VirtualMachine's VM Network
+                                          names that will be used to when searching
+                                          for status.addresses fields. Note that if
+                                          internal.networkSubnetCIDR and external.networkSubnetCIDR
+                                          are not set, then the vNIC associated to
+                                          this network must only have a single IP
+                                          address assigned to it. The available networks
+                                          (port groups) can be listed using `govc
+                                          ls 'network/*'`
+                                        type: string
+                                      networkSubnetCidr:
+                                        description: networkSubnetCidr IP address
+                                          on VirtualMachine's network interfaces included
+                                          in the fields' CIDRs that will be used in
+                                          respective status.addresses fields. ---
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                type: object
+                              vcenters:
+                                description: vcenters holds the connection details
+                                  for services to communicate with vCenter. Currently,
+                                  only a single vCenter is supported, but in tech
+                                  preview 3 vCenters are supported. Once the cluster
+                                  has been installed, you are unable to change the
+                                  current number of defined vCenters except in the
+                                  case where the cluster has been upgraded from a
+                                  version of OpenShift where the vsphere platform
+                                  spec was not present.  You may make modifications
+                                  to the existing vCenters that are defined in the
+                                  vcenters list in order to match with any added or
+                                  modified failure domains. ---
+                                items:
+                                  description: VSpherePlatformVCenterSpec stores the
+                                    vCenter connection fields. This is used by the
+                                    vSphere CCM.
+                                  properties:
+                                    datacenters:
+                                      description: The vCenter Datacenters in which
+                                        the RHCOS vm guests are located. This field
+                                        will be used by the Cloud Controller Manager.
+                                        Each datacenter listed here should be used
+                                        within a topology.
+                                      items:
+                                        type: string
+                                      minItems: 1
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    port:
+                                      description: port is the TCP port that will
+                                        be used to communicate to the vCenter endpoint.
+                                        When omitted, this means the user has no opinion
+                                        and it is up to the platform to choose a sensible
+                                        default, which is subject to change over time.
+                                      format: int32
+                                      maximum: 32767
+                                      minimum: 1
+                                      type: integer
+                                    server:
+                                      description: server is the fully-qualified domain
+                                        name or the IP address of the vCenter server.
+                                        ---
+                                      maxLength: 255
+                                      type: string
+                                  required:
+                                  - datacenters
+                                  - server
+                                  type: object
+                                maxItems: 3
+                                minItems: 0
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: vcenters cannot be added or removed once
+                                    set
+                                  rule: 'size(self) != size(oldSelf) ? size(oldSelf)
+                                    == 0 && size(self) < 2 : true'
+                            type: object
+                            x-kubernetes-validations:
+                            - message: apiServerInternalIPs list is required once
+                                set
+                              rule: '!has(oldSelf.apiServerInternalIPs) || has(self.apiServerInternalIPs)'
+                            - message: ingressIPs list is required once set
+                              rule: '!has(oldSelf.ingressIPs) || has(self.ingressIPs)'
+                            - message: vcenters can have at most 1 item when configured
+                                post-install
+                              rule: '!has(oldSelf.vcenters) && has(self.vcenters)
+                                ? size(self.vcenters) < 2 : true'
+                        type: object
+                        x-kubernetes-validations:
+                        - message: vcenters can have at most 1 item when configured
+                            post-install
+                          rule: '!has(oldSelf.vsphere) && has(self.vsphere) ? size(self.vsphere.vcenters)
+                            < 2 : true'
+                    type: object
+                  status:
+                    description: status holds observed values from the cluster. They
+                      may not be overridden.
+                    properties:
+                      apiServerInternalURI:
+                        description: apiServerInternalURL is a valid URI with scheme
+                          'https', address and optionally a port (defaulting to 443).  apiServerInternalURL
+                          can be used by components like kubelets, to contact the
+                          Kubernetes API server using the infrastructure provider
+                          rather than Kubernetes networking.
+                        type: string
+                      apiServerURL:
+                        description: apiServerURL is a valid URI with scheme 'https',
+                          address and optionally a port (defaulting to 443).  apiServerURL
+                          can be used by components like the web console to tell users
+                          where to find the Kubernetes API.
+                        type: string
+                      controlPlaneTopology:
+                        default: HighlyAvailable
+                        description: controlPlaneTopology expresses the expectations
+                          for operands that normally run on control nodes. The default
+                          is 'HighlyAvailable', which represents the behavior operators
+                          have in a "normal" cluster. The 'SingleReplica' mode will
+                          be used in single-node deployments and the operators should
+                          not configure the operand for highly-available operation
+                          The 'External' mode indicates that the control plane is
+                          hosted externally to the cluster and that its components
+                          are not visible within the cluster.
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        - External
+                        type: string
+                      cpuPartitioning:
+                        default: None
+                        description: cpuPartitioning expresses if CPU partitioning
+                          is a currently enabled feature in the cluster. CPU Partitioning
+                          means that this cluster can support partitioning workloads
+                          to specific CPU Sets. Valid values are "None" and "AllNodes".
+                          When omitted, the default value is "None". The default value
+                          of "None" indicates that no nodes will be setup with CPU
+                          partitioning. The "AllNodes" value indicates that all nodes
+                          have been setup with CPU partitioning, and can then be further
+                          configured via the PerformanceProfile API.
+                        enum:
+                        - None
+                        - AllNodes
+                        type: string
+                      etcdDiscoveryDomain:
+                        description: 'etcdDiscoveryDomain is the domain used to fetch
+                          the SRV records for discovering etcd servers and clients.
+                          For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery
+                          deprecated: as of 4.7, this field is no longer set or honored.  It
+                          will be removed in a future release.'
+                        type: string
+                      infrastructureName:
+                        description: infrastructureName uniquely identifies a cluster
+                          with a human friendly name. Once set it should not be changed.
+                          Must be of max length 27 and must have only alphanumeric
+                          or hyphen characters.
+                        type: string
+                      infrastructureTopology:
+                        default: HighlyAvailable
+                        description: 'infrastructureTopology expresses the expectations
+                          for infrastructure services that do not run on control plane
+                          nodes, usually indicated by a node selector for a `role`
+                          value other than `master`. The default is ''HighlyAvailable'',
+                          which represents the behavior operators have in a "normal"
+                          cluster. The ''SingleReplica'' mode will be used in single-node
+                          deployments and the operators should not configure the operand
+                          for highly-available operation NOTE: External topology mode
+                          is not applicable for this field.'
+                        enum:
+                        - HighlyAvailable
+                        - SingleReplica
+                        type: string
+                      platform:
+                        description: "platform is the underlying infrastructure provider
+                          for the cluster. \n Deprecated: Use platformStatus.type
+                          instead."
+                        enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                        - Nutanix
+                        - External
+                        type: string
+                      platformStatus:
+                        description: platformStatus holds status information specific
+                          to the underlying infrastructure provider.
+                        properties:
+                          alibabaCloud:
+                            description: AlibabaCloud contains settings specific to
+                              the Alibaba Cloud infrastructure provider.
+                            properties:
+                              region:
+                                description: region specifies the region for Alibaba
+                                  Cloud resources created for the cluster.
+                                pattern: ^[0-9A-Za-z-]+$
+                                type: string
+                              resourceGroupID:
+                                description: resourceGroupID is the ID of the resource
+                                  group for the cluster.
+                                pattern: ^(rg-[0-9A-Za-z]+)?$
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to Alibaba Cloud resources created
+                                  for the cluster.
+                                items:
+                                  description: AlibabaCloudResourceTag is the set
+                                    of tags to add to apply to resources.
+                                  properties:
+                                    key:
+                                      description: key is the key of the tag.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: value is the value of the tag.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 20
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                            required:
+                            - region
+                            type: object
+                          aws:
+                            description: AWS contains settings specific to the Amazon
+                              Web Services infrastructure provider.
+                            properties:
+                              region:
+                                description: region holds the default AWS region for
+                                  new AWS resources created by the cluster.
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to AWS resources created for the cluster.
+                                  See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                                  for information on tagging AWS resources. AWS supports
+                                  a maximum of 50 tags per resource. OpenShift reserves
+                                  25 tags for its use, leaving 25 tags available for
+                                  the user.
+                                items:
+                                  description: AWSResourceTag is a tag to apply to
+                                    AWS resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key of the tag
+                                      maxLength: 128
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                      type: string
+                                    value:
+                                      description: value is the value of the tag.
+                                        Some AWS service do not support empty values.
+                                        Since tags are added to resources in many
+                                        services, the length of the tag value must
+                                        meet the requirements of all services.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 25
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              serviceEndpoints:
+                                description: ServiceEndpoints list contains custom
+                                  endpoints which will override default service endpoint
+                                  of AWS Services. There must be only one ServiceEndpoint
+                                  for a service.
+                                items:
+                                  description: AWSServiceEndpoint store the configuration
+                                    of a custom url to override existing defaults
+                                    of AWS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the AWS service.
+                                        The list of all the service names can be found
+                                        at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html
+                                        This must be provided and cannot be empty.
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      pattern: ^https://
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          azure:
+                            description: Azure contains settings specific to the Azure
+                              infrastructure provider.
+                            properties:
+                              armEndpoint:
+                                description: armEndpoint specifies a URL to use for
+                                  resource management in non-soverign clouds such
+                                  as Azure Stack.
+                                type: string
+                              cloudName:
+                                description: cloudName is the name of the Azure cloud
+                                  environment which can be used to configure the Azure
+                                  SDK with the appropriate Azure API endpoints. If
+                                  empty, the value is equal to `AzurePublicCloud`.
+                                enum:
+                                - ""
+                                - AzurePublicCloud
+                                - AzureUSGovernmentCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureStackCloud
+                                type: string
+                              networkResourceGroupName:
+                                description: networkResourceGroupName is the Resource
+                                  Group for network resources like the Virtual Network
+                                  and Subnets used by the cluster. If empty, the value
+                                  is same as ResourceGroupName.
+                                type: string
+                              resourceGroupName:
+                                description: resourceGroupName is the Resource Group
+                                  for new Azure resources created for the cluster.
+                                type: string
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to Azure resources created for the
+                                  cluster. See https://docs.microsoft.com/en-us/rest/api/resources/tags
+                                  for information on tagging Azure resources. Due
+                                  to limitations on Automation, Content Delivery Network,
+                                  DNS Azure resources, a maximum of 15 tags may be
+                                  applied. OpenShift reserves 5 tags for internal
+                                  use, allowing 10 tags for user configuration.
+                                items:
+                                  description: AzureResourceTag is a tag to apply
+                                    to Azure resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the tag.
+                                        A tag key can have a maximum of 128 characters
+                                        and cannot be empty. Key must begin with a
+                                        letter, end with a letter, number or underscore,
+                                        and must contain only alphanumeric characters
+                                        and the following special characters `_ .
+                                        -`.
+                                      maxLength: 128
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([0-9A-Za-z_.-]*[0-9A-Za-z_])?$
+                                      type: string
+                                    value:
+                                      description: 'value is the value part of the
+                                        tag. A tag value can have a maximum of 256
+                                        characters and cannot be empty. Value must
+                                        contain only alphanumeric characters and the
+                                        following special characters `_ + , - . /
+                                        : ; < = > ? @`.'
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[0-9A-Za-z_.=+-@]+$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 10
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: resourceTags are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                            type: object
+                            x-kubernetes-validations:
+                            - message: resourceTags may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags)
+                                || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                          baremetal:
+                            description: BareMetal contains settings specific to the
+                              BareMetal platform.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on BareMetal platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for BareMetal deployments. In order to minimize
+                                  necessary changes to the datacenter DNS, a DNS service
+                                  is hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                          equinixMetal:
+                            description: EquinixMetal contains settings specific to
+                              the Equinix Metal infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers.
+                                type: string
+                              ingressIP:
+                                description: ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names.
+                                type: string
+                            type: object
+                          external:
+                            description: External contains settings specific to the
+                              generic External infrastructure provider.
+                            properties:
+                              cloudControllerManager:
+                                description: cloudControllerManager contains settings
+                                  specific to the external Cloud Controller Manager
+                                  (a.k.a. CCM or CPI). When omitted, new nodes will
+                                  be not tainted and no extra initialization from
+                                  the cloud controller manager is expected.
+                                properties:
+                                  state:
+                                    description: "state determines whether or not
+                                      an external Cloud Controller Manager is expected
+                                      to be installed within the cluster. https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager
+                                      \n Valid values are \"External\", \"None\" and
+                                      omitted. When set to \"External\", new nodes
+                                      will be tainted as uninitialized when created,
+                                      preventing them from running workloads until
+                                      they are initialized by the cloud controller
+                                      manager. When omitted or set to \"None\", new
+                                      nodes will be not tainted and no extra initialization
+                                      from the cloud controller manager is expected."
+                                    enum:
+                                    - ""
+                                    - External
+                                    - None
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: state is immutable once set
+                                      rule: self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: state may not be added or removed once
+                                    set
+                                  rule: (has(self.state) == has(oldSelf.state)) ||
+                                    (!has(oldSelf.state) && self.state != "External")
+                            type: object
+                            x-kubernetes-validations:
+                            - message: cloudControllerManager may not be added or
+                                removed once set
+                              rule: has(self.cloudControllerManager) == has(oldSelf.cloudControllerManager)
+                          gcp:
+                            description: GCP contains settings specific to the Google
+                              Cloud Platform infrastructure provider.
+                            properties:
+                              cloudLoadBalancerConfig:
+                                default:
+                                  dnsType: PlatformDefault
+                                description: cloudLoadBalancerConfig is a union that
+                                  contains the IP addresses of API, API-Int and Ingress
+                                  Load Balancers created on the cloud platform. These
+                                  values would not be populated on on-prem platforms.
+                                  These Load Balancer IPs are used to configure the
+                                  in-cluster DNS instances for API, API-Int and Ingress
+                                  services. `dnsType` is expected to be set to `ClusterHosted`
+                                  when these Load Balancer IP addresses are populated
+                                  and used.
+                                nullable: true
+                                properties:
+                                  clusterHosted:
+                                    description: clusterHosted holds the IP addresses
+                                      of API, API-Int and Ingress Load Balancers on
+                                      Cloud Platforms. The DNS solution hosted within
+                                      the cluster use these IP addresses to provide
+                                      resolution for API, API-Int and Ingress services.
+                                    properties:
+                                      apiIntLoadBalancerIPs:
+                                        description: apiIntLoadBalancerIPs holds Load
+                                          Balancer IPs for the internal API service.
+                                          These Load Balancer IP addresses can be
+                                          IPv4 and/or IPv6 addresses. Entries in the
+                                          apiIntLoadBalancerIPs must be unique. A
+                                          maximum of 16 IP addresses are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      apiLoadBalancerIPs:
+                                        description: apiLoadBalancerIPs holds Load
+                                          Balancer IPs for the API service. These
+                                          Load Balancer IP addresses can be IPv4 and/or
+                                          IPv6 addresses. Could be empty for private
+                                          clusters. Entries in the apiLoadBalancerIPs
+                                          must be unique. A maximum of 16 IP addresses
+                                          are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      ingressLoadBalancerIPs:
+                                        description: ingressLoadBalancerIPs holds
+                                          IPs for Ingress Load Balancers. These Load
+                                          Balancer IP addresses can be IPv4 and/or
+                                          IPv6 addresses. Entries in the ingressLoadBalancerIPs
+                                          must be unique. A maximum of 16 IP addresses
+                                          are permitted.
+                                        format: ip
+                                        items:
+                                          description: IP is an IP address (for example,
+                                            "10.0.0.0" or "fd00::").
+                                          maxLength: 39
+                                          minLength: 1
+                                          type: string
+                                          x-kubernetes-validations:
+                                          - message: value must be a valid IP address
+                                            rule: isIP(self)
+                                        maxItems: 16
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    type: object
+                                  dnsType:
+                                    default: PlatformDefault
+                                    description: dnsType indicates the type of DNS
+                                      solution in use within the cluster. Its default
+                                      value of `PlatformDefault` indicates that the
+                                      cluster's DNS is the default provided by the
+                                      cloud platform. It can be set to `ClusterHosted`
+                                      to bypass the configuration of the cloud default
+                                      DNS. In this mode, the cluster needs to provide
+                                      a self-hosted DNS solution for the cluster's
+                                      installation to succeed. The cluster's use of
+                                      the cloud's Load Balancers is unaffected by
+                                      this setting. The value is immutable after it
+                                      has been set at install time. Currently, there
+                                      is no way for the customer to add additional
+                                      DNS entries into the cluster hosted DNS. Enabling
+                                      this functionality allows the user to start
+                                      their own DNS solution outside the cluster after
+                                      installation is complete. The customer would
+                                      be responsible for configuring this custom DNS
+                                      solution, and it can be run in addition to the
+                                      in-cluster DNS solution.
+                                    enum:
+                                    - ClusterHosted
+                                    - PlatformDefault
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: dnsType is immutable
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                                x-kubernetes-validations:
+                                - message: clusterHosted is permitted only when dnsType
+                                    is ClusterHosted
+                                  rule: 'has(self.dnsType) && self.dnsType != ''ClusterHosted''
+                                    ? !has(self.clusterHosted) : true'
+                              projectID:
+                                description: resourceGroupName is the Project ID for
+                                  new GCP resources created for the cluster.
+                                type: string
+                              region:
+                                description: region holds the region for new GCP resources
+                                  created for the cluster.
+                                type: string
+                              resourceLabels:
+                                description: resourceLabels is a list of additional
+                                  labels to apply to GCP resources created for the
+                                  cluster. See https://cloud.google.com/compute/docs/labeling-resources
+                                  for information on labeling GCP resources. GCP supports
+                                  a maximum of 64 labels per resource. OpenShift reserves
+                                  32 labels for internal use, allowing 32 labels for
+                                  user configuration.
+                                items:
+                                  description: GCPResourceLabel is a label to apply
+                                    to GCP resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the label.
+                                        A label key can have a maximum of 63 characters
+                                        and cannot be empty. Label key must begin
+                                        with a lowercase letter, and must contain
+                                        only lowercase letters, numeric characters,
+                                        and the following special characters `_-`.
+                                        Label key must not have the reserved prefixes
+                                        `kubernetes-io` and `openshift-io`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z][0-9a-z_-]{0,62}$
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: label keys must not start with either
+                                          `openshift-io` or `kubernetes-io`
+                                        rule: '!self.startsWith(''openshift-io'')
+                                          && !self.startsWith(''kubernetes-io'')'
+                                    value:
+                                      description: value is the value part of the
+                                        label. A label value can have a maximum of
+                                        63 characters and cannot be empty. Value must
+                                        contain only lowercase letters, numeric characters,
+                                        and the following special characters `_-`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[0-9a-z_-]{1,63}$
+                                      type: string
+                                  required:
+                                  - key
+                                  - value
+                                  type: object
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                                x-kubernetes-validations:
+                                - message: resourceLabels are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                              resourceTags:
+                                description: resourceTags is a list of additional
+                                  tags to apply to GCP resources created for the cluster.
+                                  See https://cloud.google.com/resource-manager/docs/tags/tags-overview
+                                  for information on tagging GCP resources. GCP supports
+                                  a maximum of 50 tags per resource.
+                                items:
+                                  description: GCPResourceTag is a tag to apply to
+                                    GCP resources created for the cluster.
+                                  properties:
+                                    key:
+                                      description: key is the key part of the tag.
+                                        A tag key can have a maximum of 63 characters
+                                        and cannot be empty. Tag key must begin and
+                                        end with an alphanumeric character, and must
+                                        contain only uppercase, lowercase alphanumeric
+                                        characters, and the following special characters
+                                        `._-`.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.-]{0,61}[a-zA-Z0-9])?$
+                                      type: string
+                                    parentID:
+                                      description: 'parentID is the ID of the hierarchical
+                                        resource where the tags are defined, e.g.
+                                        at the Organization or the Project level.
+                                        To find the Organization or Project ID refer
+                                        to the following pages: https://cloud.google.com/resource-manager/docs/creating-managing-organization#retrieving_your_organization_id,
+                                        https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects.
+                                        An OrganizationID must consist of decimal
+                                        numbers, and cannot have leading zeroes. A
+                                        ProjectID must be 6 to 30 characters in length,
+                                        can only contain lowercase letters, numbers,
+                                        and hyphens, and must start with a letter,
+                                        and cannot end with a hyphen.'
+                                      maxLength: 32
+                                      minLength: 1
+                                      pattern: (^[1-9][0-9]{0,31}$)|(^[a-z][a-z0-9-]{4,28}[a-z0-9]$)
+                                      type: string
+                                    value:
+                                      description: value is the value part of the
+                                        tag. A tag value can have a maximum of 63
+                                        characters and cannot be empty. Tag value
+                                        must begin and end with an alphanumeric character,
+                                        and must contain only uppercase, lowercase
+                                        alphanumeric characters, and the following
+                                        special characters `_-.@%=+:,*#&(){}[]` and
+                                        spaces.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z0-9]([0-9A-Za-z_.@%=+:,*#&()\[\]{}\-\s]{0,61}[a-zA-Z0-9])?$
+                                      type: string
+                                  required:
+                                  - key
+                                  - parentID
+                                  - value
+                                  type: object
+                                maxItems: 50
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - key
+                                x-kubernetes-list-type: map
+                                x-kubernetes-validations:
+                                - message: resourceTags are immutable and may only
+                                    be configured during installation
+                                  rule: self.all(x, x in oldSelf) && oldSelf.all(x,
+                                    x in self)
+                            type: object
+                            x-kubernetes-validations:
+                            - message: resourceLabels may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceLabels) && !has(self.resourceLabels)
+                                || has(oldSelf.resourceLabels) && has(self.resourceLabels)'
+                            - message: resourceTags may only be configured during
+                                installation
+                              rule: '!has(oldSelf.resourceTags) && !has(self.resourceTags)
+                                || has(oldSelf.resourceTags) && has(self.resourceTags)'
+                          ibmcloud:
+                            description: IBMCloud contains settings specific to the
+                              IBMCloud infrastructure provider.
+                            properties:
+                              cisInstanceCRN:
+                                description: CISInstanceCRN is the CRN of the Cloud
+                                  Internet Services instance managing the DNS zone
+                                  for the cluster's base domain
+                                type: string
+                              dnsInstanceCRN:
+                                description: DNSInstanceCRN is the CRN of the DNS
+                                  Services instance managing the DNS zone for the
+                                  cluster's base domain
+                                type: string
+                              location:
+                                description: Location is where the cluster has been
+                                  deployed
+                                type: string
+                              providerType:
+                                description: ProviderType indicates the type of cluster
+                                  that was created
+                                type: string
+                              resourceGroupName:
+                                description: ResourceGroupName is the Resource Group
+                                  for new IBMCloud resources created for the cluster.
+                                type: string
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of an IBM Cloud service. These endpoints
+                                  are consumed by components within the cluster to
+                                  reach the respective IBM Cloud Services.
+                                items:
+                                  description: IBMCloudServiceEndpoint stores the
+                                    configuration of a custom url to override existing
+                                    defaults of IBM Cloud Services.
+                                  properties:
+                                    name:
+                                      description: 'name is the name of the IBM Cloud
+                                        service. Possible values are: CIS, COS, COSConfig,
+                                        DNSServices, GlobalCatalog, GlobalSearch,
+                                        GlobalTagging, HyperProtect, IAM, KeyProtect,
+                                        ResourceController, ResourceManager, or VPC.
+                                        For example, the IBM Cloud Private IAM service
+                                        could be configured with the service `name`
+                                        of `IAM` and `url` of `https://private.iam.cloud.ibm.com`
+                                        Whereas the IBM Cloud Private VPC service
+                                        for US South (Dallas) could be configured
+                                        with the service `name` of `VPC` and `url`
+                                        of `https://us.south.private.iaas.cloud.ibm.com`'
+                                      enum:
+                                      - CIS
+                                      - COS
+                                      - COSConfig
+                                      - DNSServices
+                                      - GlobalCatalog
+                                      - GlobalSearch
+                                      - GlobalTagging
+                                      - HyperProtect
+                                      - IAM
+                                      - KeyProtect
+                                      - ResourceController
+                                      - ResourceManager
+                                      - VPC
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: url must be a valid absolute URL
+                                        rule: isURL(self)
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          kubevirt:
+                            description: Kubevirt contains settings specific to the
+                              kubevirt infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers.
+                                type: string
+                              ingressIP:
+                                description: ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names.
+                                type: string
+                            type: object
+                          nutanix:
+                            description: Nutanix contains settings specific to the
+                              Nutanix infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Nutanix platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                            type: object
+                          openstack:
+                            description: OpenStack contains settings specific to the
+                              OpenStack infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              cloudName:
+                                description: cloudName is the name of the desired
+                                  OpenStack cloud in the client configuration file
+                                  (`clouds.yaml`).
+                                type: string
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on OpenStack platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for OpenStack deployments. In order to minimize
+                                  necessary changes to the datacenter DNS, a DNS service
+                                  is hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                          ovirt:
+                            description: Ovirt contains settings specific to the oVirt
+                              infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: set
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on Ovirt platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              nodeDNSIP:
+                                description: 'deprecated: as of 4.6, this field is
+                                  no longer set or honored.  It will be removed in
+                                  a future release.'
+                                type: string
+                            type: object
+                          powervs:
+                            description: PowerVS contains settings specific to the
+                              Power Systems Virtual Servers infrastructure provider.
+                            properties:
+                              cisInstanceCRN:
+                                description: CISInstanceCRN is the CRN of the Cloud
+                                  Internet Services instance managing the DNS zone
+                                  for the cluster's base domain
+                                type: string
+                              dnsInstanceCRN:
+                                description: DNSInstanceCRN is the CRN of the DNS
+                                  Services instance managing the DNS zone for the
+                                  cluster's base domain
+                                type: string
+                              region:
+                                description: region holds the default Power VS region
+                                  for new Power VS resources created by the cluster.
+                                type: string
+                              resourceGroup:
+                                description: 'resourceGroup is the resource group
+                                  name for new IBMCloud resources created for a cluster.
+                                  The resource group specified here will be used by
+                                  cluster-image-registry-operator to set up a COS
+                                  Instance in IBMCloud for the cluster registry. More
+                                  about resource groups can be found here: https://cloud.ibm.com/docs/account?topic=account-rgs.
+                                  When omitted, the image registry operator won''t
+                                  be able to configure storage, which results in the
+                                  image registry cluster operator not being in an
+                                  available state.'
+                                maxLength: 40
+                                pattern: ^[a-zA-Z0-9-_ ]+$
+                                type: string
+                                x-kubernetes-validations:
+                                - message: resourceGroup is immutable once set
+                                  rule: oldSelf == '' || self == oldSelf
+                              serviceEndpoints:
+                                description: serviceEndpoints is a list of custom
+                                  endpoints which will override the default service
+                                  endpoints of a Power VS service.
+                                items:
+                                  description: PowervsServiceEndpoint stores the configuration
+                                    of a custom url to override existing defaults
+                                    of PowerVS Services.
+                                  properties:
+                                    name:
+                                      description: name is the name of the Power VS
+                                        service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api
+                                        ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller
+                                        Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                    url:
+                                      description: url is fully qualified URI with
+                                        scheme https, that overrides the default generated
+                                        endpoint for a client. This must be provided
+                                        and cannot be empty.
+                                      format: uri
+                                      pattern: ^https://
+                                      type: string
+                                  required:
+                                  - name
+                                  - url
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              zone:
+                                description: 'zone holds the default zone for the
+                                  new Power VS resources created by the cluster. Note:
+                                  Currently only single-zone OCP clusters are supported'
+                                type: string
+                            type: object
+                            x-kubernetes-validations:
+                            - message: cannot unset resourceGroup once set
+                              rule: '!has(oldSelf.resourceGroup) || has(self.resourceGroup)'
+                          type:
+                            description: "type is the underlying infrastructure provider
+                              for the cluster. This value controls whether infrastructure
+                              automation such as service load balancers, dynamic volume
+                              provisioning, machine creation and deletion, and other
+                              integrations are enabled. If None, no infrastructure
+                              automation is enabled. Allowed values are \"AWS\", \"Azure\",
+                              \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\",
+                              \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\",
+                              \"AlibabaCloud\", \"Nutanix\" and \"None\". Individual
+                              components may not support all platforms, and must handle
+                              unrecognized platforms as None if they do not support
+                              that platform. \n This value will be synced with to
+                              the `status.platform` and `status.platformStatus.type`.
+                              Currently this value cannot be changed once set."
+                            enum:
+                            - ""
+                            - AWS
+                            - Azure
+                            - BareMetal
+                            - GCP
+                            - Libvirt
+                            - OpenStack
+                            - None
+                            - VSphere
+                            - oVirt
+                            - IBMCloud
+                            - KubeVirt
+                            - EquinixMetal
+                            - PowerVS
+                            - AlibabaCloud
+                            - Nutanix
+                            - External
+                            type: string
+                          vsphere:
+                            description: VSphere contains settings specific to the
+                              VSphere infrastructure provider.
+                            properties:
+                              apiServerInternalIP:
+                                description: "apiServerInternalIP is an IP address
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. It is the IP that the Infrastructure.status.apiServerInternalURI
+                                  points to. It is the IP for a self-hosted load balancer
+                                  in front of the API servers. \n Deprecated: Use
+                                  APIServerInternalIPs instead."
+                                type: string
+                              apiServerInternalIPs:
+                                description: apiServerInternalIPs are the IP addresses
+                                  to contact the Kubernetes API server that can be
+                                  used by components inside the cluster, like kubelets
+                                  using the infrastructure rather than Kubernetes
+                                  networking. These are the IPs for a self-hosted
+                                  load balancer in front of the API servers. In dual
+                                  stack clusters this list contains two IPs otherwise
+                                  only one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: apiServerInternalIPs must contain at most
+                                    one IPv4 address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              ingressIP:
+                                description: "ingressIP is an external IP which routes
+                                  to the default ingress controller. The IP is a suitable
+                                  target of a wildcard DNS record used to resolve
+                                  default route host names. \n Deprecated: Use IngressIPs
+                                  instead."
+                                type: string
+                              ingressIPs:
+                                description: ingressIPs are the external IPs which
+                                  route to the default ingress controller. The IPs
+                                  are suitable targets of a wildcard DNS record used
+                                  to resolve default route host names. In dual stack
+                                  clusters this list contains two IPs otherwise only
+                                  one.
+                                format: ip
+                                items:
+                                  type: string
+                                maxItems: 2
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - message: ingressIPs must contain at most one IPv4
+                                    address and at most one IPv6 address
+                                  rule: 'self == oldSelf || (size(self) == 2 && isIP(self[0])
+                                    && isIP(self[1]) ? ip(self[0]).family() != ip(self[1]).family()
+                                    : true)'
+                              loadBalancer:
+                                default:
+                                  type: OpenShiftManagedDefault
+                                description: loadBalancer defines how the load balancer
+                                  used by the cluster is configured.
+                                properties:
+                                  type:
+                                    default: OpenShiftManagedDefault
+                                    description: type defines the type of load balancer
+                                      used by the cluster on VSphere platform which
+                                      can be a user-managed or openshift-managed load
+                                      balancer that is to be used for the OpenShift
+                                      API and Ingress endpoints. When set to OpenShiftManagedDefault
+                                      the static pods in charge of API and Ingress
+                                      traffic load-balancing defined in the machine
+                                      config operator will be deployed. When set to
+                                      UserManaged these static pods will not be deployed
+                                      and it is expected that the load balancer is
+                                      configured out of band by the deployer. When
+                                      omitted, this means no opinion and the platform
+                                      is left to choose a reasonable default. The
+                                      default value is OpenShiftManagedDefault.
+                                    enum:
+                                    - OpenShiftManagedDefault
+                                    - UserManaged
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: type is immutable once set
+                                      rule: oldSelf == '' || self == oldSelf
+                                type: object
+                              machineNetworks:
+                                description: machineNetworks are IP networks used
+                                  to connect all the OpenShift cluster nodes.
+                                items:
+                                  description: CIDR is an IP address range in CIDR
+                                    notation (for example, "10.0.0.0/8" or "fd00::/8").
+                                  maxLength: 43
+                                  minLength: 1
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: value must be a valid CIDR network address
+                                    rule: isCIDR(self)
+                                maxItems: 32
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                x-kubernetes-validations:
+                                - rule: self.all(x, self.exists_one(y, x == y))
+                              nodeDNSIP:
+                                description: nodeDNSIP is the IP address for the internal
+                                  DNS used by the nodes. Unlike the one managed by
+                                  the DNS operator, `NodeDNSIP` provides name resolution
+                                  for the nodes themselves. There is no DNS-as-a-service
+                                  for vSphere deployments. In order to minimize necessary
+                                  changes to the datacenter DNS, a DNS service is
+                                  hosted as a static pod to serve those hostnames
+                                  to the nodes in the cluster.
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+                x-kubernetes-embedded-resource: true
+              internalRegistryPullSecret:
+                description: internalRegistryPullSecret is the pull secret for the
+                  internal registry, used by rpm-ostree to pull images from the internal
+                  registry if present
+                format: byte
+                nullable: true
+                type: string
+              ipFamilies:
+                description: ipFamilies indicates the IP families in use by the cluster
+                  network
+                type: string
+              kubeAPIServerServingCAData:
+                description: kubeAPIServerServingCAData managed Kubelet to API Server
+                  Cert... Rotated automatically
+                format: byte
+                type: string
+              network:
+                description: Network contains additional network related information
+                nullable: true
+                properties:
+                  mtuMigration:
+                    description: MTUMigration contains the MTU migration configuration.
+                    nullable: true
+                    properties:
+                      machine:
+                        description: Machine contains MTU migration configuration
+                          for the machine's uplink.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                      network:
+                        description: Network contains MTU migration configuration
+                          for the default network.
+                        properties:
+                          from:
+                            description: From is the MTU to migrate from.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          to:
+                            description: To is the MTU to migrate to.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                required:
+                - mtuMigration
+                type: object
+              networkType:
+                description: 'networkType holds the type of network the cluster is
+                  using XXX: this is temporary and will be dropped as soon as possible
+                  in favor of a better support to start network related services the
+                  proper way. Nobody is also changing this once the cluster is up
+                  and running the first time, so, disallow regeneration if this changes.'
+                type: string
+              osImageURL:
+                description: OSImageURL is the old-format container image that contains
+                  the OS update payload.
+                type: string
+              platform:
+                description: platform is deprecated, use Infra.Status.PlatformStatus.Type
+                  instead
+                type: string
+              proxy:
+                description: proxy holds the current proxy configuration for the nodes
+                nullable: true
+                properties:
+                  httpProxy:
+                    description: httpProxy is the URL of the proxy for HTTP requests.
+                    type: string
+                  httpsProxy:
+                    description: httpsProxy is the URL of the proxy for HTTPS requests.
+                    type: string
+                  noProxy:
+                    description: noProxy is a comma-separated list of hostnames and/or
+                      CIDRs for which the proxy should not be used.
+                    type: string
+                type: object
+              pullSecret:
+                description: pullSecret is the default pull secret that needs to be
+                  installed on all machines.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              releaseImage:
+                description: releaseImage is the image used when installing the cluster
+                type: string
+              rootCAData:
+                description: rootCAData specifies the root CA data
+                format: byte
+                type: string
+            required:
+            - additionalTrustBundle
+            - baseOSContainerImage
+            - cloudProviderCAData
+            - cloudProviderConfig
+            - clusterDNSIP
+            - dns
+            - images
+            - infra
+            - ipFamilies
+            - kubeAPIServerServingCAData
+            - network
+            - proxy
+            - releaseImage
+            - rootCAData
+            type: object
+          status:
+            description: ControllerConfigStatus is the status for ControllerConfig
+            properties:
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: ControllerConfigStatusCondition contains condition
+                    information for ControllerConfigStatus
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status object.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message provides additional information about the
+                        current condition. This is only to be consumed by humans.
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.  Reasons
+                        are PascalCase
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              controllerCertificates:
+                description: controllerCertificates represents the latest available
+                  observations of the automatically rotating certificates in the MCO.
+                items:
+                  description: ControllerCertificate contains info about a specific
+                    cert.
+                  properties:
+                    bundleFile:
+                      description: bundleFile is the larger bundle a cert comes from
+                      type: string
+                    notAfter:
+                      description: notAfter is the upper boundary for validity
+                      format: date-time
+                      type: string
+                    notBefore:
+                      description: notBefore is the lower boundary for validity
+                      format: date-time
+                      type: string
+                    signer:
+                      description: signer is the  cert Issuer
+                      type: string
+                    subject:
+                      description: subject is the cert subject
+                      type: string
+                  required:
+                  - bundleFile
+                  - signer
+                  - subject
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_kubeletconfigs.crd.yaml
@@ -1,0 +1,242 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    openshift.io/operator-managed: ""
+  name: kubeletconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: KubeletConfig
+    listKind: KubeletConfigList
+    plural: kubeletconfigs
+    singular: kubeletconfig
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "KubeletConfig describes a customized Kubelet configuration.
+          \n Compatibility level 1: Stable within a major release for a minimum of
+          12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeletConfigSpec defines the desired state of KubeletConfig
+            properties:
+              autoSizingReserved:
+                type: boolean
+              kubeletConfig:
+                description: kubeletConfig fields are defined in kubernetes upstream.
+                  Please refer to the types defined in the version/commit used by
+                  OpenShift of the upstream kubernetes. It's important to note that,
+                  since the fields of the kubelet configuration are directly fetched
+                  from upstream the validation of those values is handled directly
+                  by the kubelet. Please refer to the upstream version of the relevant
+                  kubernetes for the valid values of these fields. Invalid values
+                  of the kubelet configuration fields may render cluster nodes unusable.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              logLevel:
+                format: int32
+                type: integer
+              machineConfigPoolSelector:
+                description: MachineConfigPoolSelector selects which pools the KubeletConfig
+                  shoud apply to. A nil selector will result in no pools being selected.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              tlsSecurityProfile:
+                description: If unset, the default is based on the apiservers.config.openshift.io/cluster
+                  resource. Note that only Old and Intermediate profiles are currently
+                  supported, and the maximum available minTLSVersion is VersionTLS12.
+                properties:
+                  custom:
+                    description: "custom is a user-defined TLS security profile. Be
+                      extremely careful using a custom profile as invalid configurations
+                      can be catastrophic. An example custom profile looks like this:
+                      \n ciphers: \n - ECDHE-ECDSA-CHACHA20-POLY1305 \n - ECDHE-RSA-CHACHA20-POLY1305
+                      \n - ECDHE-RSA-AES128-GCM-SHA256 \n - ECDHE-ECDSA-AES128-GCM-SHA256
+                      \n minTLSVersion: VersionTLS11"
+                    nullable: true
+                    properties:
+                      ciphers:
+                        description: "ciphers is used to specify the cipher algorithms
+                          that are negotiated during the TLS handshake.  Operators
+                          may remove entries their operands do not support.  For example,
+                          to use DES-CBC3-SHA  (yaml): \n ciphers: - DES-CBC3-SHA"
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      minTLSVersion:
+                        description: "minTLSVersion is used to specify the minimal
+                          version of the TLS protocol that is negotiated during the
+                          TLS handshake. For example, to use TLS versions 1.1, 1.2
+                          and 1.3 (yaml): \n minTLSVersion: VersionTLS11 \n NOTE:
+                          currently the highest minTLSVersion allowed is VersionTLS12"
+                        enum:
+                        - VersionTLS10
+                        - VersionTLS11
+                        - VersionTLS12
+                        - VersionTLS13
+                        type: string
+                    type: object
+                  intermediate:
+                    description: "intermediate is a TLS security profile based on:
+                      \n https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+                      \n and looks like this (yaml): \n ciphers: \n - TLS_AES_128_GCM_SHA256
+                      \n - TLS_AES_256_GCM_SHA384 \n - TLS_CHACHA20_POLY1305_SHA256
+                      \n - ECDHE-ECDSA-AES128-GCM-SHA256 \n - ECDHE-RSA-AES128-GCM-SHA256
+                      \n - ECDHE-ECDSA-AES256-GCM-SHA384 \n - ECDHE-RSA-AES256-GCM-SHA384
+                      \n - ECDHE-ECDSA-CHACHA20-POLY1305 \n - ECDHE-RSA-CHACHA20-POLY1305
+                      \n - DHE-RSA-AES128-GCM-SHA256 \n - DHE-RSA-AES256-GCM-SHA384
+                      \n minTLSVersion: VersionTLS12"
+                    nullable: true
+                    type: object
+                  modern:
+                    description: "modern is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+                      \n and looks like this (yaml): \n ciphers: \n - TLS_AES_128_GCM_SHA256
+                      \n - TLS_AES_256_GCM_SHA384 \n - TLS_CHACHA20_POLY1305_SHA256
+                      \n minTLSVersion: VersionTLS13"
+                    nullable: true
+                    type: object
+                  old:
+                    description: "old is a TLS security profile based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+                      \n and looks like this (yaml): \n ciphers: \n - TLS_AES_128_GCM_SHA256
+                      \n - TLS_AES_256_GCM_SHA384 \n - TLS_CHACHA20_POLY1305_SHA256
+                      \n - ECDHE-ECDSA-AES128-GCM-SHA256 \n - ECDHE-RSA-AES128-GCM-SHA256
+                      \n - ECDHE-ECDSA-AES256-GCM-SHA384 \n - ECDHE-RSA-AES256-GCM-SHA384
+                      \n - ECDHE-ECDSA-CHACHA20-POLY1305 \n - ECDHE-RSA-CHACHA20-POLY1305
+                      \n - DHE-RSA-AES128-GCM-SHA256 \n - DHE-RSA-AES256-GCM-SHA384
+                      \n - DHE-RSA-CHACHA20-POLY1305 \n - ECDHE-ECDSA-AES128-SHA256
+                      \n - ECDHE-RSA-AES128-SHA256 \n - ECDHE-ECDSA-AES128-SHA \n
+                      - ECDHE-RSA-AES128-SHA \n - ECDHE-ECDSA-AES256-SHA384 \n - ECDHE-RSA-AES256-SHA384
+                      \n - ECDHE-ECDSA-AES256-SHA \n - ECDHE-RSA-AES256-SHA \n - DHE-RSA-AES128-SHA256
+                      \n - DHE-RSA-AES256-SHA256 \n - AES128-GCM-SHA256 \n - AES256-GCM-SHA384
+                      \n - AES128-SHA256 \n - AES256-SHA256 \n - AES128-SHA \n - AES256-SHA
+                      \n - DES-CBC3-SHA \n minTLSVersion: VersionTLS10"
+                    nullable: true
+                    type: object
+                  type:
+                    description: "type is one of Old, Intermediate, Modern or Custom.
+                      Custom provides the ability to specify individual TLS security
+                      profile parameters. Old, Intermediate and Modern are TLS security
+                      profiles based on: \n https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+                      \n The profiles are intent based, so they may change over time
+                      as new ciphers are developed and existing ciphers are found
+                      to be insecure.  Depending on precisely which ciphers are available
+                      to a process, the list may be reduced. \n Note that the Modern
+                      profile is currently not supported because it is not yet well
+                      adopted by common software libraries."
+                    enum:
+                    - Old
+                    - Intermediate
+                    - Modern
+                    - Custom
+                    type: string
+                type: object
+            type: object
+          status:
+            description: KubeletConfigStatus defines the observed state of a KubeletConfig
+            properties:
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: KubeletConfigCondition defines the state of the KubeletConfig
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the time of the last update
+                        to the current status object.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message provides additional information about the
+                        current condition. This is only to be consumed by humans.
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.  Reasons
+                        are PascalCase
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type specifies the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,380 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1596
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineconfignodes.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfigNode
+    listKind: MachineConfigNodeList
+    plural: machineconfignodes
+    singular: machineconfignode
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.pool.name
+      name: PoolName
+      type: string
+    - jsonPath: .spec.configVersion.desired
+      name: DesiredConfig
+      type: string
+    - jsonPath: .status.configVersion.current
+      name: CurrentConfig
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Updated")].status
+      name: Updated
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
+      name: UpdatePrepared
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdateExecuted")].status
+      name: UpdateExecuted
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdatePostActionComplete")].status
+      name: UpdatePostActionComplete
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdateComplete")].status
+      name: UpdateComplete
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Resumed")].status
+      name: Resumed
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdateCompatible")].status
+      name: UpdateCompatible
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
+      name: UpdatedFilesAndOS
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Cordoned")].status
+      name: CordonedNode
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Drained")].status
+      name: DrainedNode
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="RebootedNode")].status
+      name: RebootedNode
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ReloadedCRIO")].status
+      name: ReloadedCRIO
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Uncordoned")].status
+      name: UncordonedNode
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineConfigNode describes the health of the Machines on the
+          system Compatibility level 4: No compatibility is provided, the API can
+          change at any point for any reason. These capabilities should not be used
+          by applications needing long term support.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of the machine config node.
+            properties:
+              configVersion:
+                description: configVersion holds the desired config version for the
+                  node targeted by this machine config node resource. The desired
+                  version represents the machine config the node will attempt to update
+                  to. This gets set before the machine config operator validates the
+                  new machine config against the current machine config.
+                properties:
+                  desired:
+                    description: desired is the name of the machine config that the
+                      the node should be upgraded to. This value is set when the machine
+                      config pool generates a new version of its rendered configuration.
+                      When this value is changed, the machine config daemon starts
+                      the node upgrade process. This value gets set in the machine
+                      config node spec once the machine config has been targeted for
+                      upgrade and before it is validated. Must be a lowercase RFC-1123
+                      hostname (https://tools.ietf.org/html/rfc1123) It may consist
+                      of only alphanumeric characters, hyphens (-) and periods (.)
+                      and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - desired
+                type: object
+              node:
+                description: node contains a reference to the node for this machine
+                  config node.
+                properties:
+                  name:
+                    description: name is the object name. Must be a lowercase RFC-1123
+                      hostname (https://tools.ietf.org/html/rfc1123) It may consist
+                      of only alphanumeric characters, hyphens (-) and periods (.)
+                      and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+              pinnedImageSets:
+                description: pinnedImageSets holds the desired pinned image sets that
+                  this node should pin and pull.
+                items:
+                  properties:
+                    name:
+                      description: name is the name of the pinned image set. Must
+                        be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        It may consist of only alphanumeric characters, hyphens (-)
+                        and periods (.) and must be at most 253 characters in length.
+                      maxLength: 253
+                      pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 100
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              pool:
+                description: pool contains a reference to the machine config pool
+                  that this machine config node's referenced node belongs to.
+                properties:
+                  name:
+                    description: name is the object name. Must be a lowercase RFC-1123
+                      hostname (https://tools.ietf.org/html/rfc1123) It may consist
+                      of only alphanumeric characters, hyphens (-) and periods (.)
+                      and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - configVersion
+            - node
+            - pool
+            type: object
+          status:
+            description: status describes the last observed state of this machine
+              config node.
+            properties:
+              conditions:
+                description: conditions represent the observations of a machine config
+                  node's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configVersion:
+                description: configVersion describes the current and desired machine
+                  config for this node. The current version represents the current
+                  machine config for the node and is updated after a successful update.
+                  The desired version represents the machine config the node will
+                  attempt to update to. This desired machine config has been compared
+                  to the current machine config and has been validated by the machine
+                  config operator as one that is valid and that exists.
+                properties:
+                  current:
+                    description: current is the name of the machine config currently
+                      in use on the node. This value is updated once the machine config
+                      daemon has completed the update of the configuration for the
+                      node. This value should match the desired version unless an
+                      upgrade is in progress. Must be a lowercase RFC-1123 hostname
+                      (https://tools.ietf.org/html/rfc1123) It may consist of only
+                      alphanumeric characters, hyphens (-) and periods (.) and must
+                      be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                  desired:
+                    description: desired is the MachineConfig the node wants to upgrade
+                      to. This value gets set in the machine config node status once
+                      the machine config has been validated against the current machine
+                      config. Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                      It may consist of only alphanumeric characters, hyphens (-)
+                      and periods (.) and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - desired
+                type: object
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller. This field is updated when the controller observes
+                  a change to the desiredConfig in the configVersion of the machine
+                  config node spec.
+                format: int64
+                type: integer
+              pinnedImageSets:
+                description: pinnedImageSets describes the current and desired pinned
+                  image sets for this node. The current version is the generation
+                  of the pinned image set that has most recently been successfully
+                  pulled and pinned on this node. The desired version is the generation
+                  of the pinned image set that is targeted to be pulled and pinned
+                  on this node.
+                items:
+                  properties:
+                    currentGeneration:
+                      description: currentGeneration is the generation of the pinned
+                        image set that has most recently been successfully pulled
+                        and pinned on this node.
+                      format: int32
+                      type: integer
+                    desiredGeneration:
+                      description: desiredGeneration version is the generation of
+                        the pinned image set that is targeted to be pulled and pinned
+                        on this node.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    lastFailedGeneration:
+                      description: lastFailedGeneration is the generation of the most
+                        recent pinned image set that failed to be pulled and pinned
+                        on this node.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    lastFailedGenerationErrors:
+                      description: lastFailedGenerationErrors is a list of errors
+                        why the lastFailed generation failed to be pulled and pinned.
+                      items:
+                        type: string
+                      maxItems: 10
+                      type: array
+                    name:
+                      description: name is the name of the pinned image set. Must
+                        be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        It may consist of only alphanumeric characters, hyphens (-)
+                        and periods (.) and must be at most 253 characters in length.
+                      maxLength: 253
+                      pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: desired generation must be greater than or equal to the
+                      current generation
+                    rule: 'has(self.desiredGeneration) && has(self.currentGeneration)
+                      ? self.desiredGeneration >= self.currentGeneration : true'
+                  - message: desired generation must be greater than last failed generation
+                    rule: 'has(self.lastFailedGeneration) && has(self.desiredGeneration)
+                      ? self.desiredGeneration >= self.lastFailedGeneration : true'
+                  - message: desired generation must be defined if last failed generation
+                      is defined
+                    rule: 'has(self.lastFailedGeneration) ? has(self.desiredGeneration):
+                      true'
+                maxItems: 100
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - configVersion
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.node.name should match metadata.name
+          rule: self.metadata.name == self.spec.node.name
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-DevPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,380 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1596
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineconfignodes.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfigNode
+    listKind: MachineConfigNodeList
+    plural: machineconfignodes
+    singular: machineconfignode
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.pool.name
+      name: PoolName
+      type: string
+    - jsonPath: .spec.configVersion.desired
+      name: DesiredConfig
+      type: string
+    - jsonPath: .status.configVersion.current
+      name: CurrentConfig
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Updated")].status
+      name: Updated
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
+      name: UpdatePrepared
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdateExecuted")].status
+      name: UpdateExecuted
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdatePostActionComplete")].status
+      name: UpdatePostActionComplete
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdateComplete")].status
+      name: UpdateComplete
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Resumed")].status
+      name: Resumed
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdateCompatible")].status
+      name: UpdateCompatible
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
+      name: UpdatedFilesAndOS
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Cordoned")].status
+      name: CordonedNode
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Drained")].status
+      name: DrainedNode
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="RebootedNode")].status
+      name: RebootedNode
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ReloadedCRIO")].status
+      name: ReloadedCRIO
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Uncordoned")].status
+      name: UncordonedNode
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineConfigNode describes the health of the Machines on the
+          system Compatibility level 4: No compatibility is provided, the API can
+          change at any point for any reason. These capabilities should not be used
+          by applications needing long term support.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of the machine config node.
+            properties:
+              configVersion:
+                description: configVersion holds the desired config version for the
+                  node targeted by this machine config node resource. The desired
+                  version represents the machine config the node will attempt to update
+                  to. This gets set before the machine config operator validates the
+                  new machine config against the current machine config.
+                properties:
+                  desired:
+                    description: desired is the name of the machine config that the
+                      the node should be upgraded to. This value is set when the machine
+                      config pool generates a new version of its rendered configuration.
+                      When this value is changed, the machine config daemon starts
+                      the node upgrade process. This value gets set in the machine
+                      config node spec once the machine config has been targeted for
+                      upgrade and before it is validated. Must be a lowercase RFC-1123
+                      hostname (https://tools.ietf.org/html/rfc1123) It may consist
+                      of only alphanumeric characters, hyphens (-) and periods (.)
+                      and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - desired
+                type: object
+              node:
+                description: node contains a reference to the node for this machine
+                  config node.
+                properties:
+                  name:
+                    description: name is the object name. Must be a lowercase RFC-1123
+                      hostname (https://tools.ietf.org/html/rfc1123) It may consist
+                      of only alphanumeric characters, hyphens (-) and periods (.)
+                      and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+              pinnedImageSets:
+                description: pinnedImageSets holds the desired pinned image sets that
+                  this node should pin and pull.
+                items:
+                  properties:
+                    name:
+                      description: name is the name of the pinned image set. Must
+                        be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        It may consist of only alphanumeric characters, hyphens (-)
+                        and periods (.) and must be at most 253 characters in length.
+                      maxLength: 253
+                      pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 100
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              pool:
+                description: pool contains a reference to the machine config pool
+                  that this machine config node's referenced node belongs to.
+                properties:
+                  name:
+                    description: name is the object name. Must be a lowercase RFC-1123
+                      hostname (https://tools.ietf.org/html/rfc1123) It may consist
+                      of only alphanumeric characters, hyphens (-) and periods (.)
+                      and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - configVersion
+            - node
+            - pool
+            type: object
+          status:
+            description: status describes the last observed state of this machine
+              config node.
+            properties:
+              conditions:
+                description: conditions represent the observations of a machine config
+                  node's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configVersion:
+                description: configVersion describes the current and desired machine
+                  config for this node. The current version represents the current
+                  machine config for the node and is updated after a successful update.
+                  The desired version represents the machine config the node will
+                  attempt to update to. This desired machine config has been compared
+                  to the current machine config and has been validated by the machine
+                  config operator as one that is valid and that exists.
+                properties:
+                  current:
+                    description: current is the name of the machine config currently
+                      in use on the node. This value is updated once the machine config
+                      daemon has completed the update of the configuration for the
+                      node. This value should match the desired version unless an
+                      upgrade is in progress. Must be a lowercase RFC-1123 hostname
+                      (https://tools.ietf.org/html/rfc1123) It may consist of only
+                      alphanumeric characters, hyphens (-) and periods (.) and must
+                      be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                  desired:
+                    description: desired is the MachineConfig the node wants to upgrade
+                      to. This value gets set in the machine config node status once
+                      the machine config has been validated against the current machine
+                      config. Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                      It may consist of only alphanumeric characters, hyphens (-)
+                      and periods (.) and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - desired
+                type: object
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller. This field is updated when the controller observes
+                  a change to the desiredConfig in the configVersion of the machine
+                  config node spec.
+                format: int64
+                type: integer
+              pinnedImageSets:
+                description: pinnedImageSets describes the current and desired pinned
+                  image sets for this node. The current version is the generation
+                  of the pinned image set that has most recently been successfully
+                  pulled and pinned on this node. The desired version is the generation
+                  of the pinned image set that is targeted to be pulled and pinned
+                  on this node.
+                items:
+                  properties:
+                    currentGeneration:
+                      description: currentGeneration is the generation of the pinned
+                        image set that has most recently been successfully pulled
+                        and pinned on this node.
+                      format: int32
+                      type: integer
+                    desiredGeneration:
+                      description: desiredGeneration version is the generation of
+                        the pinned image set that is targeted to be pulled and pinned
+                        on this node.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    lastFailedGeneration:
+                      description: lastFailedGeneration is the generation of the most
+                        recent pinned image set that failed to be pulled and pinned
+                        on this node.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    lastFailedGenerationErrors:
+                      description: lastFailedGenerationErrors is a list of errors
+                        why the lastFailed generation failed to be pulled and pinned.
+                      items:
+                        type: string
+                      maxItems: 10
+                      type: array
+                    name:
+                      description: name is the name of the pinned image set. Must
+                        be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        It may consist of only alphanumeric characters, hyphens (-)
+                        and periods (.) and must be at most 253 characters in length.
+                      maxLength: 253
+                      pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: desired generation must be greater than or equal to the
+                      current generation
+                    rule: 'has(self.desiredGeneration) && has(self.currentGeneration)
+                      ? self.desiredGeneration >= self.currentGeneration : true'
+                  - message: desired generation must be greater than last failed generation
+                    rule: 'has(self.lastFailedGeneration) && has(self.desiredGeneration)
+                      ? self.desiredGeneration >= self.lastFailedGeneration : true'
+                  - message: desired generation must be defined if last failed generation
+                      is defined
+                    rule: 'has(self.lastFailedGeneration) ? has(self.desiredGeneration):
+                      true'
+                maxItems: 100
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - configVersion
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.node.name should match metadata.name
+          rule: self.metadata.name == self.spec.node.name
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,380 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1596
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineconfignodes.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfigNode
+    listKind: MachineConfigNodeList
+    plural: machineconfignodes
+    singular: machineconfignode
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.pool.name
+      name: PoolName
+      type: string
+    - jsonPath: .spec.configVersion.desired
+      name: DesiredConfig
+      type: string
+    - jsonPath: .status.configVersion.current
+      name: CurrentConfig
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Updated")].status
+      name: Updated
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
+      name: UpdatePrepared
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdateExecuted")].status
+      name: UpdateExecuted
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdatePostActionComplete")].status
+      name: UpdatePostActionComplete
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdateComplete")].status
+      name: UpdateComplete
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Resumed")].status
+      name: Resumed
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="UpdateCompatible")].status
+      name: UpdateCompatible
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
+      name: UpdatedFilesAndOS
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Cordoned")].status
+      name: CordonedNode
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Drained")].status
+      name: DrainedNode
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="RebootedNode")].status
+      name: RebootedNode
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ReloadedCRIO")].status
+      name: ReloadedCRIO
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Uncordoned")].status
+      name: UncordonedNode
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineConfigNode describes the health of the Machines on the
+          system Compatibility level 4: No compatibility is provided, the API can
+          change at any point for any reason. These capabilities should not be used
+          by applications needing long term support.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of the machine config node.
+            properties:
+              configVersion:
+                description: configVersion holds the desired config version for the
+                  node targeted by this machine config node resource. The desired
+                  version represents the machine config the node will attempt to update
+                  to. This gets set before the machine config operator validates the
+                  new machine config against the current machine config.
+                properties:
+                  desired:
+                    description: desired is the name of the machine config that the
+                      the node should be upgraded to. This value is set when the machine
+                      config pool generates a new version of its rendered configuration.
+                      When this value is changed, the machine config daemon starts
+                      the node upgrade process. This value gets set in the machine
+                      config node spec once the machine config has been targeted for
+                      upgrade and before it is validated. Must be a lowercase RFC-1123
+                      hostname (https://tools.ietf.org/html/rfc1123) It may consist
+                      of only alphanumeric characters, hyphens (-) and periods (.)
+                      and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - desired
+                type: object
+              node:
+                description: node contains a reference to the node for this machine
+                  config node.
+                properties:
+                  name:
+                    description: name is the object name. Must be a lowercase RFC-1123
+                      hostname (https://tools.ietf.org/html/rfc1123) It may consist
+                      of only alphanumeric characters, hyphens (-) and periods (.)
+                      and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+              pinnedImageSets:
+                description: pinnedImageSets holds the desired pinned image sets that
+                  this node should pin and pull.
+                items:
+                  properties:
+                    name:
+                      description: name is the name of the pinned image set. Must
+                        be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        It may consist of only alphanumeric characters, hyphens (-)
+                        and periods (.) and must be at most 253 characters in length.
+                      maxLength: 253
+                      pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 100
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              pool:
+                description: pool contains a reference to the machine config pool
+                  that this machine config node's referenced node belongs to.
+                properties:
+                  name:
+                    description: name is the object name. Must be a lowercase RFC-1123
+                      hostname (https://tools.ietf.org/html/rfc1123) It may consist
+                      of only alphanumeric characters, hyphens (-) and periods (.)
+                      and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - configVersion
+            - node
+            - pool
+            type: object
+          status:
+            description: status describes the last observed state of this machine
+              config node.
+            properties:
+              conditions:
+                description: conditions represent the observations of a machine config
+                  node's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configVersion:
+                description: configVersion describes the current and desired machine
+                  config for this node. The current version represents the current
+                  machine config for the node and is updated after a successful update.
+                  The desired version represents the machine config the node will
+                  attempt to update to. This desired machine config has been compared
+                  to the current machine config and has been validated by the machine
+                  config operator as one that is valid and that exists.
+                properties:
+                  current:
+                    description: current is the name of the machine config currently
+                      in use on the node. This value is updated once the machine config
+                      daemon has completed the update of the configuration for the
+                      node. This value should match the desired version unless an
+                      upgrade is in progress. Must be a lowercase RFC-1123 hostname
+                      (https://tools.ietf.org/html/rfc1123) It may consist of only
+                      alphanumeric characters, hyphens (-) and periods (.) and must
+                      be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                  desired:
+                    description: desired is the MachineConfig the node wants to upgrade
+                      to. This value gets set in the machine config node status once
+                      the machine config has been validated against the current machine
+                      config. Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                      It may consist of only alphanumeric characters, hyphens (-)
+                      and periods (.) and must be at most 253 characters in length.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - desired
+                type: object
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller. This field is updated when the controller observes
+                  a change to the desiredConfig in the configVersion of the machine
+                  config node spec.
+                format: int64
+                type: integer
+              pinnedImageSets:
+                description: pinnedImageSets describes the current and desired pinned
+                  image sets for this node. The current version is the generation
+                  of the pinned image set that has most recently been successfully
+                  pulled and pinned on this node. The desired version is the generation
+                  of the pinned image set that is targeted to be pulled and pinned
+                  on this node.
+                items:
+                  properties:
+                    currentGeneration:
+                      description: currentGeneration is the generation of the pinned
+                        image set that has most recently been successfully pulled
+                        and pinned on this node.
+                      format: int32
+                      type: integer
+                    desiredGeneration:
+                      description: desiredGeneration version is the generation of
+                        the pinned image set that is targeted to be pulled and pinned
+                        on this node.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    lastFailedGeneration:
+                      description: lastFailedGeneration is the generation of the most
+                        recent pinned image set that failed to be pulled and pinned
+                        on this node.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    lastFailedGenerationErrors:
+                      description: lastFailedGenerationErrors is a list of errors
+                        why the lastFailed generation failed to be pulled and pinned.
+                      items:
+                        type: string
+                      maxItems: 10
+                      type: array
+                    name:
+                      description: name is the name of the pinned image set. Must
+                        be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                        It may consist of only alphanumeric characters, hyphens (-)
+                        and periods (.) and must be at most 253 characters in length.
+                      maxLength: 253
+                      pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                  x-kubernetes-validations:
+                  - message: desired generation must be greater than or equal to the
+                      current generation
+                    rule: 'has(self.desiredGeneration) && has(self.currentGeneration)
+                      ? self.desiredGeneration >= self.currentGeneration : true'
+                  - message: desired generation must be greater than last failed generation
+                    rule: 'has(self.lastFailedGeneration) && has(self.desiredGeneration)
+                      ? self.desiredGeneration >= self.lastFailedGeneration : true'
+                  - message: desired generation must be defined if last failed generation
+                      is defined
+                    rule: 'has(self.lastFailedGeneration) ? has(self.desiredGeneration):
+                      true'
+                maxItems: 100
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - configVersion
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.node.name should match metadata.name
+          rule: self.metadata.name == self.spec.node.name
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,633 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineconfigpools.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfigPool
+    listKind: MachineConfigPoolList
+    plural: machineconfigpools
+    shortNames:
+    - mcp
+    singular: machineconfigpool
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.configuration.name
+      name: Config
+      type: string
+    - description: When all the machines in the pool are updated to the correct machine
+        config.
+      jsonPath: .status.conditions[?(@.type=="Updated")].status
+      name: Updated
+      type: string
+    - description: When at least one of machine is not either not updated or is in
+        the process of updating to the desired machine config.
+      jsonPath: .status.conditions[?(@.type=="Updating")].status
+      name: Updating
+      type: string
+    - description: When progress is blocked on updating one or more nodes or the pool
+        configuration is failing.
+      jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - description: Total number of machines in the machine config pool
+      jsonPath: .status.machineCount
+      name: MachineCount
+      type: number
+    - description: Total number of ready machines targeted by the pool
+      jsonPath: .status.readyMachineCount
+      name: ReadyMachineCount
+      type: number
+    - description: Total number of machines targeted by the pool that have the CurrentMachineConfig
+        as their config
+      jsonPath: .status.updatedMachineCount
+      name: UpdatedMachineCount
+      type: number
+    - description: Total number of machines marked degraded (or unreconcilable)
+      jsonPath: .status.degradedMachineCount
+      name: DegradedMachineCount
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "MachineConfigPool describes a pool of MachineConfigs. \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineConfigPoolSpec is the spec for MachineConfigPool resource.
+            properties:
+              configuration:
+                description: The targeted MachineConfig object for the machine config
+                  pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: "ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs. 1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage. 2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular restrictions like, \"must refer
+                        only to types A and B\" or \"UID not honored\" or \"name must
+                        be restricted\". Those cannot be well described when embedded.
+                        3. Inconsistent validation.  Because the usages are different,
+                        the validation rules are different by usage, which makes it
+                        hard for users to predict what will happen. 4. The fields
+                        are both imprecise and overly precise.  Kind is not a precise
+                        mapping to a URL. This can produce ambiguity during interpretation
+                        and require a REST mapping.  In most cases, the dependency
+                        is on the group,resource tuple and the version of the actual
+                        struct is irrelevant. 5. We cannot easily change it.  Because
+                        this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an
+                        underspecified API type they do not control. \n Instead of
+                        using this type, create a locally provided and used type that
+                        is well-focused on your reference. For example, ServiceReferences
+                        for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        ."
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              machineConfigSelector:
+                description: machineConfigSelector specifies a label selector for
+                  MachineConfigs. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                  on how label and selectors work.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              maxUnavailable:
+                anyOf:
+                - type: integer
+                - type: string
+                description: "maxUnavailable defines either an integer number or percentage
+                  of nodes in the pool that can go Unavailable during an update. This
+                  includes nodes Unavailable for any reason, including user initiated
+                  cordons, failing nodes, etc. The default value is 1. \n A value
+                  larger than 1 will mean multiple nodes going unavailable during
+                  the update, which may affect your workload stress on the remaining
+                  nodes. You cannot set this value to 0 to stop updates (it will default
+                  back to 1); to stop updates, use the 'paused' property instead.
+                  Drain will respect Pod Disruption Budgets (PDBs) such as etcd quorum
+                  guards, even if maxUnavailable is greater than one."
+                x-kubernetes-int-or-string: true
+              nodeSelector:
+                description: nodeSelector specifies a label selector for Machines
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused specifies whether or not changes to this machine
+                  config pool should be stopped. This includes generating new desiredMachineConfig
+                  and update of machines.
+                type: boolean
+              pinnedImageSets:
+                description: "pinnedImageSets specifies a sequence of PinnedImageSetRef
+                  objects for the pool. Nodes within this pool will preload and pin
+                  images defined in the PinnedImageSet. Before pulling images the
+                  MachineConfigDaemon will ensure the total uncompressed size of all
+                  the images does not exceed available resources. If the total size
+                  of the images exceeds the available resources the controller will
+                  report a Degraded status to the MachineConfigPool and not attempt
+                  to pull any images. Also to help ensure the kubelet can mitigate
+                  storage risk, the pinned_image configuration and subsequent service
+                  reload will happen only after all of the images have been pulled
+                  for each set. Images from multiple PinnedImageSets are loaded and
+                  pinned sequentially as listed. Duplicate and existing images will
+                  be skipped. \n Any failure to prefetch or pin images will result
+                  in a Degraded pool. Resolving these failures is the responsibility
+                  of the user. The admin should be proactive in ensuring adequate
+                  storage and proper image authentication exists in advance."
+                items:
+                  properties:
+                    name:
+                      description: name is a reference to the name of a PinnedImageSet.  Must
+                        adhere to RFC-1123 (https://tools.ietf.org/html/rfc1123).
+                        Made up of one of more period-separated (.) segments, where
+                        each segment consists of alphanumeric characters and hyphens
+                        (-), must begin and end with an alphanumeric character, and
+                        is at most 63 characters in length. The total length of the
+                        name must not exceed 253 characters.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 100
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: MachineConfigPoolStatus is the status for MachineConfigPool
+              resource.
+            properties:
+              certExpirys:
+                description: certExpirys keeps track of important certificate expiration
+                  data
+                items:
+                  description: ceryExpiry contains the bundle name and the expiry
+                    date
+                  properties:
+                    bundle:
+                      description: bundle is the name of the bundle in which the subject
+                        certificate resides
+                      type: string
+                    expiry:
+                      description: expiry is the date after which the certificate
+                        will no longer be valid
+                      format: date-time
+                      type: string
+                    subject:
+                      description: subject is the subject of the certificate
+                      type: string
+                  required:
+                  - bundle
+                  - subject
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: MachineConfigPoolCondition contains condition information
+                    for an MachineConfigPool.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                    type:
+                      description: type of the condition, currently ('Done', 'Updating',
+                        'Failed').
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              configuration:
+                description: configuration represents the current MachineConfig object
+                  for the machine config pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: "ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs. 1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage. 2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular restrictions like, \"must refer
+                        only to types A and B\" or \"UID not honored\" or \"name must
+                        be restricted\". Those cannot be well described when embedded.
+                        3. Inconsistent validation.  Because the usages are different,
+                        the validation rules are different by usage, which makes it
+                        hard for users to predict what will happen. 4. The fields
+                        are both imprecise and overly precise.  Kind is not a precise
+                        mapping to a URL. This can produce ambiguity during interpretation
+                        and require a REST mapping.  In most cases, the dependency
+                        is on the group,resource tuple and the version of the actual
+                        struct is irrelevant. 5. We cannot easily change it.  Because
+                        this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an
+                        underspecified API type they do not control. \n Instead of
+                        using this type, create a locally provided and used type that
+                        is well-focused on your reference. For example, ServiceReferences
+                        for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        ."
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              degradedMachineCount:
+                description: degradedMachineCount represents the total number of machines
+                  marked degraded (or unreconcilable). A node is marked degraded if
+                  applying a configuration failed..
+                format: int32
+                type: integer
+              machineCount:
+                description: machineCount represents the total number of machines
+                  in the machine config pool.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              poolSynchronizersStatus:
+                description: poolSynchronizersStatus is the status of the machines
+                  managed by the pool synchronizers.
+                items:
+                  properties:
+                    availableMachineCount:
+                      description: availableMachineCount is the number of machines
+                        managed by the node synchronizer which are available.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    machineCount:
+                      description: machineCount is the number of machines that are
+                        managed by the node synchronizer.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    observedGeneration:
+                      description: observedGeneration is the last generation change
+                        that has been applied.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                      x-kubernetes-validations:
+                      - message: observedGeneration must not move backwards except
+                          to zero
+                        rule: self >= oldSelf || (self == 0 && oldSelf > 0)
+                    poolSynchronizerType:
+                      description: poolSynchronizerType describes the type of the
+                        pool synchronizer.
+                      enum:
+                      - PinnedImageSets
+                      maxLength: 256
+                      type: string
+                    readyMachineCount:
+                      description: readyMachineCount is the number of machines managed
+                        by the node synchronizer that are in a ready state.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    unavailableMachineCount:
+                      description: unavailableMachineCount is the number of machines
+                        managed by the node synchronizer but are unavailable.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    updatedMachineCount:
+                      description: updatedMachineCount is the number of machines that
+                        have been updated by the node synchronizer.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                  required:
+                  - availableMachineCount
+                  - machineCount
+                  - poolSynchronizerType
+                  - readyMachineCount
+                  - unavailableMachineCount
+                  - updatedMachineCount
+                  type: object
+                  x-kubernetes-validations:
+                  - message: machineCount must be greater than or equal to updatedMachineCount
+                    rule: self.machineCount >= self.updatedMachineCount
+                  - message: machineCount must be greater than or equal to availableMachineCount
+                    rule: self.machineCount >= self.availableMachineCount
+                  - message: machineCount must be greater than or equal to unavailableMachineCount
+                    rule: self.machineCount >= self.unavailableMachineCount
+                  - message: machineCount must be greater than or equal to readyMachineCount
+                    rule: self.machineCount >= self.readyMachineCount
+                  - message: availableMachineCount must be greater than or equal to
+                      readyMachineCount
+                    rule: self.availableMachineCount >= self.readyMachineCount
+                type: array
+                x-kubernetes-list-map-keys:
+                - poolSynchronizerType
+                x-kubernetes-list-type: map
+              readyMachineCount:
+                description: readyMachineCount represents the total number of ready
+                  machines targeted by the pool.
+                format: int32
+                type: integer
+              unavailableMachineCount:
+                description: unavailableMachineCount represents the total number of
+                  unavailable (non-ready) machines targeted by the pool. A node is
+                  marked unavailable if it is in updating state or NodeReady condition
+                  is false.
+                format: int32
+                type: integer
+              updatedMachineCount:
+                description: updatedMachineCount represents the total number of machines
+                  targeted by the pool that have the CurrentMachineConfig as their
+                  config.
+                format: int32
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-Default.crd.yaml
@@ -1,0 +1,518 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: Default
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineconfigpools.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfigPool
+    listKind: MachineConfigPoolList
+    plural: machineconfigpools
+    shortNames:
+    - mcp
+    singular: machineconfigpool
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.configuration.name
+      name: Config
+      type: string
+    - description: When all the machines in the pool are updated to the correct machine
+        config.
+      jsonPath: .status.conditions[?(@.type=="Updated")].status
+      name: Updated
+      type: string
+    - description: When at least one of machine is not either not updated or is in
+        the process of updating to the desired machine config.
+      jsonPath: .status.conditions[?(@.type=="Updating")].status
+      name: Updating
+      type: string
+    - description: When progress is blocked on updating one or more nodes or the pool
+        configuration is failing.
+      jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - description: Total number of machines in the machine config pool
+      jsonPath: .status.machineCount
+      name: MachineCount
+      type: number
+    - description: Total number of ready machines targeted by the pool
+      jsonPath: .status.readyMachineCount
+      name: ReadyMachineCount
+      type: number
+    - description: Total number of machines targeted by the pool that have the CurrentMachineConfig
+        as their config
+      jsonPath: .status.updatedMachineCount
+      name: UpdatedMachineCount
+      type: number
+    - description: Total number of machines marked degraded (or unreconcilable)
+      jsonPath: .status.degradedMachineCount
+      name: DegradedMachineCount
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "MachineConfigPool describes a pool of MachineConfigs. \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineConfigPoolSpec is the spec for MachineConfigPool resource.
+            properties:
+              configuration:
+                description: The targeted MachineConfig object for the machine config
+                  pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: "ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs. 1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage. 2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular restrictions like, \"must refer
+                        only to types A and B\" or \"UID not honored\" or \"name must
+                        be restricted\". Those cannot be well described when embedded.
+                        3. Inconsistent validation.  Because the usages are different,
+                        the validation rules are different by usage, which makes it
+                        hard for users to predict what will happen. 4. The fields
+                        are both imprecise and overly precise.  Kind is not a precise
+                        mapping to a URL. This can produce ambiguity during interpretation
+                        and require a REST mapping.  In most cases, the dependency
+                        is on the group,resource tuple and the version of the actual
+                        struct is irrelevant. 5. We cannot easily change it.  Because
+                        this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an
+                        underspecified API type they do not control. \n Instead of
+                        using this type, create a locally provided and used type that
+                        is well-focused on your reference. For example, ServiceReferences
+                        for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        ."
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              machineConfigSelector:
+                description: machineConfigSelector specifies a label selector for
+                  MachineConfigs. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                  on how label and selectors work.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              maxUnavailable:
+                anyOf:
+                - type: integer
+                - type: string
+                description: "maxUnavailable defines either an integer number or percentage
+                  of nodes in the pool that can go Unavailable during an update. This
+                  includes nodes Unavailable for any reason, including user initiated
+                  cordons, failing nodes, etc. The default value is 1. \n A value
+                  larger than 1 will mean multiple nodes going unavailable during
+                  the update, which may affect your workload stress on the remaining
+                  nodes. You cannot set this value to 0 to stop updates (it will default
+                  back to 1); to stop updates, use the 'paused' property instead.
+                  Drain will respect Pod Disruption Budgets (PDBs) such as etcd quorum
+                  guards, even if maxUnavailable is greater than one."
+                x-kubernetes-int-or-string: true
+              nodeSelector:
+                description: nodeSelector specifies a label selector for Machines
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused specifies whether or not changes to this machine
+                  config pool should be stopped. This includes generating new desiredMachineConfig
+                  and update of machines.
+                type: boolean
+            type: object
+          status:
+            description: MachineConfigPoolStatus is the status for MachineConfigPool
+              resource.
+            properties:
+              certExpirys:
+                description: certExpirys keeps track of important certificate expiration
+                  data
+                items:
+                  description: ceryExpiry contains the bundle name and the expiry
+                    date
+                  properties:
+                    bundle:
+                      description: bundle is the name of the bundle in which the subject
+                        certificate resides
+                      type: string
+                    expiry:
+                      description: expiry is the date after which the certificate
+                        will no longer be valid
+                      format: date-time
+                      type: string
+                    subject:
+                      description: subject is the subject of the certificate
+                      type: string
+                  required:
+                  - bundle
+                  - subject
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: MachineConfigPoolCondition contains condition information
+                    for an MachineConfigPool.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                    type:
+                      description: type of the condition, currently ('Done', 'Updating',
+                        'Failed').
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              configuration:
+                description: configuration represents the current MachineConfig object
+                  for the machine config pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: "ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs. 1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage. 2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular restrictions like, \"must refer
+                        only to types A and B\" or \"UID not honored\" or \"name must
+                        be restricted\". Those cannot be well described when embedded.
+                        3. Inconsistent validation.  Because the usages are different,
+                        the validation rules are different by usage, which makes it
+                        hard for users to predict what will happen. 4. The fields
+                        are both imprecise and overly precise.  Kind is not a precise
+                        mapping to a URL. This can produce ambiguity during interpretation
+                        and require a REST mapping.  In most cases, the dependency
+                        is on the group,resource tuple and the version of the actual
+                        struct is irrelevant. 5. We cannot easily change it.  Because
+                        this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an
+                        underspecified API type they do not control. \n Instead of
+                        using this type, create a locally provided and used type that
+                        is well-focused on your reference. For example, ServiceReferences
+                        for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        ."
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              degradedMachineCount:
+                description: degradedMachineCount represents the total number of machines
+                  marked degraded (or unreconcilable). A node is marked degraded if
+                  applying a configuration failed..
+                format: int32
+                type: integer
+              machineCount:
+                description: machineCount represents the total number of machines
+                  in the machine config pool.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              readyMachineCount:
+                description: readyMachineCount represents the total number of ready
+                  machines targeted by the pool.
+                format: int32
+                type: integer
+              unavailableMachineCount:
+                description: unavailableMachineCount represents the total number of
+                  unavailable (non-ready) machines targeted by the pool. A node is
+                  marked unavailable if it is in updating state or NodeReady condition
+                  is false.
+                format: int32
+                type: integer
+              updatedMachineCount:
+                description: updatedMachineCount represents the total number of machines
+                  targeted by the pool that have the CurrentMachineConfig as their
+                  config.
+                format: int32
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-DevPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,633 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineconfigpools.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfigPool
+    listKind: MachineConfigPoolList
+    plural: machineconfigpools
+    shortNames:
+    - mcp
+    singular: machineconfigpool
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.configuration.name
+      name: Config
+      type: string
+    - description: When all the machines in the pool are updated to the correct machine
+        config.
+      jsonPath: .status.conditions[?(@.type=="Updated")].status
+      name: Updated
+      type: string
+    - description: When at least one of machine is not either not updated or is in
+        the process of updating to the desired machine config.
+      jsonPath: .status.conditions[?(@.type=="Updating")].status
+      name: Updating
+      type: string
+    - description: When progress is blocked on updating one or more nodes or the pool
+        configuration is failing.
+      jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - description: Total number of machines in the machine config pool
+      jsonPath: .status.machineCount
+      name: MachineCount
+      type: number
+    - description: Total number of ready machines targeted by the pool
+      jsonPath: .status.readyMachineCount
+      name: ReadyMachineCount
+      type: number
+    - description: Total number of machines targeted by the pool that have the CurrentMachineConfig
+        as their config
+      jsonPath: .status.updatedMachineCount
+      name: UpdatedMachineCount
+      type: number
+    - description: Total number of machines marked degraded (or unreconcilable)
+      jsonPath: .status.degradedMachineCount
+      name: DegradedMachineCount
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "MachineConfigPool describes a pool of MachineConfigs. \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineConfigPoolSpec is the spec for MachineConfigPool resource.
+            properties:
+              configuration:
+                description: The targeted MachineConfig object for the machine config
+                  pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: "ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs. 1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage. 2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular restrictions like, \"must refer
+                        only to types A and B\" or \"UID not honored\" or \"name must
+                        be restricted\". Those cannot be well described when embedded.
+                        3. Inconsistent validation.  Because the usages are different,
+                        the validation rules are different by usage, which makes it
+                        hard for users to predict what will happen. 4. The fields
+                        are both imprecise and overly precise.  Kind is not a precise
+                        mapping to a URL. This can produce ambiguity during interpretation
+                        and require a REST mapping.  In most cases, the dependency
+                        is on the group,resource tuple and the version of the actual
+                        struct is irrelevant. 5. We cannot easily change it.  Because
+                        this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an
+                        underspecified API type they do not control. \n Instead of
+                        using this type, create a locally provided and used type that
+                        is well-focused on your reference. For example, ServiceReferences
+                        for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        ."
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              machineConfigSelector:
+                description: machineConfigSelector specifies a label selector for
+                  MachineConfigs. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                  on how label and selectors work.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              maxUnavailable:
+                anyOf:
+                - type: integer
+                - type: string
+                description: "maxUnavailable defines either an integer number or percentage
+                  of nodes in the pool that can go Unavailable during an update. This
+                  includes nodes Unavailable for any reason, including user initiated
+                  cordons, failing nodes, etc. The default value is 1. \n A value
+                  larger than 1 will mean multiple nodes going unavailable during
+                  the update, which may affect your workload stress on the remaining
+                  nodes. You cannot set this value to 0 to stop updates (it will default
+                  back to 1); to stop updates, use the 'paused' property instead.
+                  Drain will respect Pod Disruption Budgets (PDBs) such as etcd quorum
+                  guards, even if maxUnavailable is greater than one."
+                x-kubernetes-int-or-string: true
+              nodeSelector:
+                description: nodeSelector specifies a label selector for Machines
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused specifies whether or not changes to this machine
+                  config pool should be stopped. This includes generating new desiredMachineConfig
+                  and update of machines.
+                type: boolean
+              pinnedImageSets:
+                description: "pinnedImageSets specifies a sequence of PinnedImageSetRef
+                  objects for the pool. Nodes within this pool will preload and pin
+                  images defined in the PinnedImageSet. Before pulling images the
+                  MachineConfigDaemon will ensure the total uncompressed size of all
+                  the images does not exceed available resources. If the total size
+                  of the images exceeds the available resources the controller will
+                  report a Degraded status to the MachineConfigPool and not attempt
+                  to pull any images. Also to help ensure the kubelet can mitigate
+                  storage risk, the pinned_image configuration and subsequent service
+                  reload will happen only after all of the images have been pulled
+                  for each set. Images from multiple PinnedImageSets are loaded and
+                  pinned sequentially as listed. Duplicate and existing images will
+                  be skipped. \n Any failure to prefetch or pin images will result
+                  in a Degraded pool. Resolving these failures is the responsibility
+                  of the user. The admin should be proactive in ensuring adequate
+                  storage and proper image authentication exists in advance."
+                items:
+                  properties:
+                    name:
+                      description: name is a reference to the name of a PinnedImageSet.  Must
+                        adhere to RFC-1123 (https://tools.ietf.org/html/rfc1123).
+                        Made up of one of more period-separated (.) segments, where
+                        each segment consists of alphanumeric characters and hyphens
+                        (-), must begin and end with an alphanumeric character, and
+                        is at most 63 characters in length. The total length of the
+                        name must not exceed 253 characters.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 100
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: MachineConfigPoolStatus is the status for MachineConfigPool
+              resource.
+            properties:
+              certExpirys:
+                description: certExpirys keeps track of important certificate expiration
+                  data
+                items:
+                  description: ceryExpiry contains the bundle name and the expiry
+                    date
+                  properties:
+                    bundle:
+                      description: bundle is the name of the bundle in which the subject
+                        certificate resides
+                      type: string
+                    expiry:
+                      description: expiry is the date after which the certificate
+                        will no longer be valid
+                      format: date-time
+                      type: string
+                    subject:
+                      description: subject is the subject of the certificate
+                      type: string
+                  required:
+                  - bundle
+                  - subject
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: MachineConfigPoolCondition contains condition information
+                    for an MachineConfigPool.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                    type:
+                      description: type of the condition, currently ('Done', 'Updating',
+                        'Failed').
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              configuration:
+                description: configuration represents the current MachineConfig object
+                  for the machine config pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: "ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs. 1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage. 2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular restrictions like, \"must refer
+                        only to types A and B\" or \"UID not honored\" or \"name must
+                        be restricted\". Those cannot be well described when embedded.
+                        3. Inconsistent validation.  Because the usages are different,
+                        the validation rules are different by usage, which makes it
+                        hard for users to predict what will happen. 4. The fields
+                        are both imprecise and overly precise.  Kind is not a precise
+                        mapping to a URL. This can produce ambiguity during interpretation
+                        and require a REST mapping.  In most cases, the dependency
+                        is on the group,resource tuple and the version of the actual
+                        struct is irrelevant. 5. We cannot easily change it.  Because
+                        this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an
+                        underspecified API type they do not control. \n Instead of
+                        using this type, create a locally provided and used type that
+                        is well-focused on your reference. For example, ServiceReferences
+                        for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        ."
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              degradedMachineCount:
+                description: degradedMachineCount represents the total number of machines
+                  marked degraded (or unreconcilable). A node is marked degraded if
+                  applying a configuration failed..
+                format: int32
+                type: integer
+              machineCount:
+                description: machineCount represents the total number of machines
+                  in the machine config pool.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              poolSynchronizersStatus:
+                description: poolSynchronizersStatus is the status of the machines
+                  managed by the pool synchronizers.
+                items:
+                  properties:
+                    availableMachineCount:
+                      description: availableMachineCount is the number of machines
+                        managed by the node synchronizer which are available.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    machineCount:
+                      description: machineCount is the number of machines that are
+                        managed by the node synchronizer.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    observedGeneration:
+                      description: observedGeneration is the last generation change
+                        that has been applied.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                      x-kubernetes-validations:
+                      - message: observedGeneration must not move backwards except
+                          to zero
+                        rule: self >= oldSelf || (self == 0 && oldSelf > 0)
+                    poolSynchronizerType:
+                      description: poolSynchronizerType describes the type of the
+                        pool synchronizer.
+                      enum:
+                      - PinnedImageSets
+                      maxLength: 256
+                      type: string
+                    readyMachineCount:
+                      description: readyMachineCount is the number of machines managed
+                        by the node synchronizer that are in a ready state.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    unavailableMachineCount:
+                      description: unavailableMachineCount is the number of machines
+                        managed by the node synchronizer but are unavailable.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    updatedMachineCount:
+                      description: updatedMachineCount is the number of machines that
+                        have been updated by the node synchronizer.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                  required:
+                  - availableMachineCount
+                  - machineCount
+                  - poolSynchronizerType
+                  - readyMachineCount
+                  - unavailableMachineCount
+                  - updatedMachineCount
+                  type: object
+                  x-kubernetes-validations:
+                  - message: machineCount must be greater than or equal to updatedMachineCount
+                    rule: self.machineCount >= self.updatedMachineCount
+                  - message: machineCount must be greater than or equal to availableMachineCount
+                    rule: self.machineCount >= self.availableMachineCount
+                  - message: machineCount must be greater than or equal to unavailableMachineCount
+                    rule: self.machineCount >= self.unavailableMachineCount
+                  - message: machineCount must be greater than or equal to readyMachineCount
+                    rule: self.machineCount >= self.readyMachineCount
+                  - message: availableMachineCount must be greater than or equal to
+                      readyMachineCount
+                    rule: self.availableMachineCount >= self.readyMachineCount
+                type: array
+                x-kubernetes-list-map-keys:
+                - poolSynchronizerType
+                x-kubernetes-list-type: map
+              readyMachineCount:
+                description: readyMachineCount represents the total number of ready
+                  machines targeted by the pool.
+                format: int32
+                type: integer
+              unavailableMachineCount:
+                description: unavailableMachineCount represents the total number of
+                  unavailable (non-ready) machines targeted by the pool. A node is
+                  marked unavailable if it is in updating state or NodeReady condition
+                  is false.
+                format: int32
+                type: integer
+              updatedMachineCount:
+                description: updatedMachineCount represents the total number of machines
+                  targeted by the pool that have the CurrentMachineConfig as their
+                  config.
+                format: int32
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfigpools-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,633 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineconfigpools.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfigPool
+    listKind: MachineConfigPoolList
+    plural: machineconfigpools
+    shortNames:
+    - mcp
+    singular: machineconfigpool
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.configuration.name
+      name: Config
+      type: string
+    - description: When all the machines in the pool are updated to the correct machine
+        config.
+      jsonPath: .status.conditions[?(@.type=="Updated")].status
+      name: Updated
+      type: string
+    - description: When at least one of machine is not either not updated or is in
+        the process of updating to the desired machine config.
+      jsonPath: .status.conditions[?(@.type=="Updating")].status
+      name: Updating
+      type: string
+    - description: When progress is blocked on updating one or more nodes or the pool
+        configuration is failing.
+      jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - description: Total number of machines in the machine config pool
+      jsonPath: .status.machineCount
+      name: MachineCount
+      type: number
+    - description: Total number of ready machines targeted by the pool
+      jsonPath: .status.readyMachineCount
+      name: ReadyMachineCount
+      type: number
+    - description: Total number of machines targeted by the pool that have the CurrentMachineConfig
+        as their config
+      jsonPath: .status.updatedMachineCount
+      name: UpdatedMachineCount
+      type: number
+    - description: Total number of machines marked degraded (or unreconcilable)
+      jsonPath: .status.degradedMachineCount
+      name: DegradedMachineCount
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "MachineConfigPool describes a pool of MachineConfigs. \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineConfigPoolSpec is the spec for MachineConfigPool resource.
+            properties:
+              configuration:
+                description: The targeted MachineConfig object for the machine config
+                  pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: "ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs. 1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage. 2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular restrictions like, \"must refer
+                        only to types A and B\" or \"UID not honored\" or \"name must
+                        be restricted\". Those cannot be well described when embedded.
+                        3. Inconsistent validation.  Because the usages are different,
+                        the validation rules are different by usage, which makes it
+                        hard for users to predict what will happen. 4. The fields
+                        are both imprecise and overly precise.  Kind is not a precise
+                        mapping to a URL. This can produce ambiguity during interpretation
+                        and require a REST mapping.  In most cases, the dependency
+                        is on the group,resource tuple and the version of the actual
+                        struct is irrelevant. 5. We cannot easily change it.  Because
+                        this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an
+                        underspecified API type they do not control. \n Instead of
+                        using this type, create a locally provided and used type that
+                        is well-focused on your reference. For example, ServiceReferences
+                        for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        ."
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              machineConfigSelector:
+                description: machineConfigSelector specifies a label selector for
+                  MachineConfigs. Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+                  on how label and selectors work.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              maxUnavailable:
+                anyOf:
+                - type: integer
+                - type: string
+                description: "maxUnavailable defines either an integer number or percentage
+                  of nodes in the pool that can go Unavailable during an update. This
+                  includes nodes Unavailable for any reason, including user initiated
+                  cordons, failing nodes, etc. The default value is 1. \n A value
+                  larger than 1 will mean multiple nodes going unavailable during
+                  the update, which may affect your workload stress on the remaining
+                  nodes. You cannot set this value to 0 to stop updates (it will default
+                  back to 1); to stop updates, use the 'paused' property instead.
+                  Drain will respect Pod Disruption Budgets (PDBs) such as etcd quorum
+                  guards, even if maxUnavailable is greater than one."
+                x-kubernetes-int-or-string: true
+              nodeSelector:
+                description: nodeSelector specifies a label selector for Machines
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused specifies whether or not changes to this machine
+                  config pool should be stopped. This includes generating new desiredMachineConfig
+                  and update of machines.
+                type: boolean
+              pinnedImageSets:
+                description: "pinnedImageSets specifies a sequence of PinnedImageSetRef
+                  objects for the pool. Nodes within this pool will preload and pin
+                  images defined in the PinnedImageSet. Before pulling images the
+                  MachineConfigDaemon will ensure the total uncompressed size of all
+                  the images does not exceed available resources. If the total size
+                  of the images exceeds the available resources the controller will
+                  report a Degraded status to the MachineConfigPool and not attempt
+                  to pull any images. Also to help ensure the kubelet can mitigate
+                  storage risk, the pinned_image configuration and subsequent service
+                  reload will happen only after all of the images have been pulled
+                  for each set. Images from multiple PinnedImageSets are loaded and
+                  pinned sequentially as listed. Duplicate and existing images will
+                  be skipped. \n Any failure to prefetch or pin images will result
+                  in a Degraded pool. Resolving these failures is the responsibility
+                  of the user. The admin should be proactive in ensuring adequate
+                  storage and proper image authentication exists in advance."
+                items:
+                  properties:
+                    name:
+                      description: name is a reference to the name of a PinnedImageSet.  Must
+                        adhere to RFC-1123 (https://tools.ietf.org/html/rfc1123).
+                        Made up of one of more period-separated (.) segments, where
+                        each segment consists of alphanumeric characters and hyphens
+                        (-), must begin and end with an alphanumeric character, and
+                        is at most 63 characters in length. The total length of the
+                        name must not exceed 253 characters.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 100
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+          status:
+            description: MachineConfigPoolStatus is the status for MachineConfigPool
+              resource.
+            properties:
+              certExpirys:
+                description: certExpirys keeps track of important certificate expiration
+                  data
+                items:
+                  description: ceryExpiry contains the bundle name and the expiry
+                    date
+                  properties:
+                    bundle:
+                      description: bundle is the name of the bundle in which the subject
+                        certificate resides
+                      type: string
+                    expiry:
+                      description: expiry is the date after which the certificate
+                        will no longer be valid
+                      format: date-time
+                      type: string
+                    subject:
+                      description: subject is the subject of the certificate
+                      type: string
+                  required:
+                  - bundle
+                  - subject
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: MachineConfigPoolCondition contains condition information
+                    for an MachineConfigPool.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: message is a human readable description of the
+                        details of the last transition, complementing reason.
+                      type: string
+                    reason:
+                      description: reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                    type:
+                      description: type of the condition, currently ('Done', 'Updating',
+                        'Failed').
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              configuration:
+                description: configuration represents the current MachineConfig object
+                  for the machine config pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: "ObjectReference contains enough information to
+                        let you inspect or modify the referred object. --- New uses
+                        of this type are discouraged because of difficulty describing
+                        its usage when embedded in APIs. 1. Ignored fields.  It includes
+                        many fields which are not generally honored.  For instance,
+                        ResourceVersion and FieldPath are both very rarely valid in
+                        actual usage. 2. Invalid usage help.  It is impossible to
+                        add specific help for individual usage.  In most embedded
+                        usages, there are particular restrictions like, \"must refer
+                        only to types A and B\" or \"UID not honored\" or \"name must
+                        be restricted\". Those cannot be well described when embedded.
+                        3. Inconsistent validation.  Because the usages are different,
+                        the validation rules are different by usage, which makes it
+                        hard for users to predict what will happen. 4. The fields
+                        are both imprecise and overly precise.  Kind is not a precise
+                        mapping to a URL. This can produce ambiguity during interpretation
+                        and require a REST mapping.  In most cases, the dependency
+                        is on the group,resource tuple and the version of the actual
+                        struct is irrelevant. 5. We cannot easily change it.  Because
+                        this type is embedded in many locations, updates to this type
+                        will affect numerous schemas.  Don't make new APIs embed an
+                        underspecified API type they do not control. \n Instead of
+                        using this type, create a locally provided and used type that
+                        is well-focused on your reference. For example, ServiceReferences
+                        for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                        ."
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead
+                            of an entire object, this string should contain a valid
+                            JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container
+                            within a pod, this would take on a value like: "spec.containers{name}"
+                            (where "name" refers to the name of the container that
+                            triggered the event) or if no container name is specified
+                            "spec.containers[2]" (container with index 2 in this pod).
+                            This syntax is chosen only to have some well-defined way
+                            of referencing a part of an object. TODO: this design
+                            is not final and this field is subject to change in the
+                            future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference
+                            is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              degradedMachineCount:
+                description: degradedMachineCount represents the total number of machines
+                  marked degraded (or unreconcilable). A node is marked degraded if
+                  applying a configuration failed..
+                format: int32
+                type: integer
+              machineCount:
+                description: machineCount represents the total number of machines
+                  in the machine config pool.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              poolSynchronizersStatus:
+                description: poolSynchronizersStatus is the status of the machines
+                  managed by the pool synchronizers.
+                items:
+                  properties:
+                    availableMachineCount:
+                      description: availableMachineCount is the number of machines
+                        managed by the node synchronizer which are available.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    machineCount:
+                      description: machineCount is the number of machines that are
+                        managed by the node synchronizer.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    observedGeneration:
+                      description: observedGeneration is the last generation change
+                        that has been applied.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                      x-kubernetes-validations:
+                      - message: observedGeneration must not move backwards except
+                          to zero
+                        rule: self >= oldSelf || (self == 0 && oldSelf > 0)
+                    poolSynchronizerType:
+                      description: poolSynchronizerType describes the type of the
+                        pool synchronizer.
+                      enum:
+                      - PinnedImageSets
+                      maxLength: 256
+                      type: string
+                    readyMachineCount:
+                      description: readyMachineCount is the number of machines managed
+                        by the node synchronizer that are in a ready state.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    unavailableMachineCount:
+                      description: unavailableMachineCount is the number of machines
+                        managed by the node synchronizer but are unavailable.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    updatedMachineCount:
+                      description: updatedMachineCount is the number of machines that
+                        have been updated by the node synchronizer.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                  required:
+                  - availableMachineCount
+                  - machineCount
+                  - poolSynchronizerType
+                  - readyMachineCount
+                  - unavailableMachineCount
+                  - updatedMachineCount
+                  type: object
+                  x-kubernetes-validations:
+                  - message: machineCount must be greater than or equal to updatedMachineCount
+                    rule: self.machineCount >= self.updatedMachineCount
+                  - message: machineCount must be greater than or equal to availableMachineCount
+                    rule: self.machineCount >= self.availableMachineCount
+                  - message: machineCount must be greater than or equal to unavailableMachineCount
+                    rule: self.machineCount >= self.unavailableMachineCount
+                  - message: machineCount must be greater than or equal to readyMachineCount
+                    rule: self.machineCount >= self.readyMachineCount
+                  - message: availableMachineCount must be greater than or equal to
+                      readyMachineCount
+                    rule: self.availableMachineCount >= self.readyMachineCount
+                type: array
+                x-kubernetes-list-map-keys:
+                - poolSynchronizerType
+                x-kubernetes-list-type: map
+              readyMachineCount:
+                description: readyMachineCount represents the total number of ready
+                  machines targeted by the pool.
+                format: int32
+                type: integer
+              unavailableMachineCount:
+                description: unavailableMachineCount represents the total number of
+                  unavailable (non-ready) machines targeted by the pool. A node is
+                  marked unavailable if it is in updating state or NodeReady condition
+                  is false.
+                format: int32
+                type: integer
+              updatedMachineCount:
+                description: updatedMachineCount represents the total number of machines
+                  targeted by the pool that have the CurrentMachineConfig as their
+                  config.
+                format: int32
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfigs.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfigs.crd.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineConfig
+    listKind: MachineConfigList
+    plural: machineconfigs
+    shortNames:
+    - mc
+    singular: machineconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Version of the controller that generated the machineconfig. This
+        will be empty if the machineconfig is not managed by a controller.
+      jsonPath: .metadata.annotations.machineconfiguration\.openshift\.io/generated-by-controller-version
+      name: GeneratedByController
+      type: string
+    - description: Version of the Ignition Config defined in the machineconfig.
+      jsonPath: .spec.config.ignition.version
+      name: IgnitionVersion
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "MachineConfig defines the configuration for a machine \n Compatibility
+          level 1: Stable within a major release for a minimum of 12 months or 3 minor
+          releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineConfigSpec is the spec for MachineConfig
+            properties:
+              baseOSExtensionsContainerImage:
+                description: BaseOSExtensionsContainerImage specifies the remote location
+                  that will be used to fetch the extensions container matching a new-format
+                  OS image
+                type: string
+              config:
+                description: Config is a Ignition Config object.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              extensions:
+                description: extensions contains a list of additional features that
+                  can be enabled on host
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              fips:
+                description: fips controls FIPS mode
+                type: boolean
+              kernelArguments:
+                description: kernelArguments contains a list of kernel arguments to
+                  be added
+                items:
+                  type: string
+                nullable: true
+                type: array
+                x-kubernetes-list-type: atomic
+              kernelType:
+                description: kernelType contains which kernel we want to be running
+                  like default (traditional), realtime, 64k-pages (aarch64 only).
+                type: string
+              osImageURL:
+                description: OSImageURL specifies the remote location that will be
+                  used to fetch the OS.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfigurations.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfigurations.crd.yaml
@@ -1,0 +1,1236 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1453
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: machineconfigurations.operator.openshift.io
+spec:
+  group: operator.openshift.io
+  names:
+    kind: MachineConfiguration
+    listKind: MachineConfigurationList
+    plural: machineconfigurations
+    singular: machineconfiguration
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "MachineConfiguration provides information to configure an operator
+          to manage Machine Configuration. \n Compatibility level 1: Stable within
+          a major release for a minimum of 12 months or 3 minor releases (whichever
+          is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              Machine Config Operator
+            properties:
+              failedRevisionLimit:
+                description: failedRevisionLimit is the number of failed static pod
+                  installer revisions to keep on disk and in the api -1 = unlimited,
+                  0 or unset = 5 (default)
+                format: int32
+                type: integer
+              forceRedeploymentReason:
+                description: forceRedeploymentReason can be used to force the redeployment
+                  of the operand by providing a unique string. This provides a mechanism
+                  to kick a previously failed deployment and provide a reason why
+                  you think it will work this time instead of failing again on the
+                  same config.
+                type: string
+              logLevel:
+                default: Normal
+                description: "logLevel is an intent based logging for an overall component.
+                  \ It does not give fine grained control, but it is a simple way
+                  to manage coarse grained logging choices that operators have to
+                  interpret for their operands. \n Valid values are: \"Normal\", \"Debug\",
+                  \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managedBootImages:
+                description: managedBootImages allows configuration for the management
+                  of boot images for machine resources within the cluster. This configuration
+                  allows users to select resources that should be updated to the latest
+                  boot images during cluster upgrades, ensuring that new machines
+                  always boot with the current cluster version's boot image. When
+                  omitted, no boot images will be updated.
+                properties:
+                  machineManagers:
+                    description: machineManagers can be used to register machine management
+                      resources for boot image updates. The Machine Config Operator
+                      will watch for changes to this list. Only one entry is permitted
+                      per type of machine management resource.
+                    items:
+                      description: MachineManager describes a target machine resource
+                        that is registered for boot image updates. It stores identifying
+                        information such as the resource type and the API Group of
+                        the resource. It also provides granular control via the selection
+                        field.
+                      properties:
+                        apiGroup:
+                          description: apiGroup is name of the APIGroup that the machine
+                            management resource belongs to. The only current valid
+                            value is machine.openshift.io. machine.openshift.io means
+                            that the machine manager will only register resources
+                            that belong to OpenShift machine API group.
+                          enum:
+                          - machine.openshift.io
+                          type: string
+                        resource:
+                          description: resource is the machine management resource's
+                            type. The only current valid value is machinesets. machinesets
+                            means that the machine manager will only register resources
+                            of the kind MachineSet.
+                          enum:
+                          - machinesets
+                          type: string
+                        selection:
+                          description: selection allows granular control of the machine
+                            management resources that will be registered for boot
+                            image updates.
+                          properties:
+                            mode:
+                              description: mode determines how machine managers will
+                                be selected for updates. Valid values are All and
+                                Partial. All means that every resource matched by
+                                the machine manager will be updated. Partial requires
+                                specified selector(s) and allows customisation of
+                                which resources matched by the machine manager will
+                                be updated.
+                              enum:
+                              - All
+                              - Partial
+                              type: string
+                            partial:
+                              description: partial provides label selector(s) that
+                                can be used to match machine management resources.
+                                Only permitted when mode is set to "Partial".
+                              properties:
+                                machineResourceSelector:
+                                  description: machineResourceSelector is a label
+                                    selector that can be used to select machine resources
+                                    like MachineSets.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - machineResourceSelector
+                              type: object
+                          required:
+                          - mode
+                          type: object
+                          x-kubernetes-validations:
+                          - message: Partial is required when type is partial, and
+                              forbidden otherwise
+                            rule: 'has(self.mode) && self.mode == ''Partial'' ?  has(self.partial)
+                              : !has(self.partial)'
+                      required:
+                      - apiGroup
+                      - resource
+                      - selection
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - resource
+                    - apiGroup
+                    x-kubernetes-list-type: map
+                type: object
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              nodeDisruptionPolicy:
+                description: nodeDisruptionPolicy allows an admin to set granular
+                  node disruption actions for MachineConfig-based updates, such as
+                  drains, service reloads, etc. Specifying this will allow for less
+                  downtime when doing small configuration updates to the cluster.
+                  This configuration has no effect on cluster upgrades which will
+                  still incur node disruption where required.
+                properties:
+                  files:
+                    description: files is a list of MachineConfig file definitions
+                      and actions to take to changes on those paths This list supports
+                      a maximum of 50 entries.
+                    items:
+                      description: NodeDisruptionPolicySpecFile is a file entry and
+                        corresponding actions to take and is used in the NodeDisruptionPolicyConfig
+                        object
+                      properties:
+                        actions:
+                          description: actions represents the series of commands to
+                            be executed on changes to the file at the corresponding
+                            file path. Actions will be applied in the order that they
+                            are set in this list. If there are other incoming changes
+                            to other MachineConfig entries in the same update that
+                            require a reboot, the reboot will supercede these actions.
+                            Valid actions are Reboot, Drain, Reload, DaemonReload
+                            and None. The Reboot action and the None action cannot
+                            be used in conjunction with any of the other actions.
+                            This list supports a maximum of 10 entries.
+                          items:
+                            properties:
+                              reload:
+                                description: reload specifies the service to reload,
+                                  only valid if type is reload
+                                properties:
+                                  serviceName:
+                                    description: serviceName is the full name (e.g.
+                                      crio.service) of the service to be reloaded
+                                      Service names should be of the format ${NAME}${SERVICETYPE}
+                                      and can up to 255 characters long. ${NAME} must
+                                      be atleast 1 character long and can only consist
+                                      of alphabets, digits, ":", "-", "_", ".", and
+                                      "\". ${SERVICETYPE} must be one of ".service",
+                                      ".socket", ".device", ".mount", ".automount",
+                                      ".swap", ".target", ".path", ".timer", ".snapshot",
+                                      ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              restart:
+                                description: restart specifies the service to restart,
+                                  only valid if type is restart
+                                properties:
+                                  serviceName:
+                                    description: serviceName is the full name (e.g.
+                                      crio.service) of the service to be restarted
+                                      Service names should be of the format ${NAME}${SERVICETYPE}
+                                      and can up to 255 characters long. ${NAME} must
+                                      be atleast 1 character long and can only consist
+                                      of alphabets, digits, ":", "-", "_", ".", and
+                                      "\". ${SERVICETYPE} must be one of ".service",
+                                      ".socket", ".device", ".mount", ".automount",
+                                      ".swap", ".target", ".path", ".timer", ".snapshot",
+                                      ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              type:
+                                description: type represents the commands that will
+                                  be carried out if this NodeDisruptionPolicySpecActionType
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
+                                enum:
+                                - Reboot
+                                - Drain
+                                - Reload
+                                - Restart
+                                - DaemonReload
+                                - None
+                                type: string
+                            required:
+                            - type
+                            type: object
+                            x-kubernetes-validations:
+                            - message: reload is required when type is Reload, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                                : !has(self.reload)'
+                            - message: restart is required when type is Restart, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Restart'' ?
+                                has(self.restart) : !has(self.restart)'
+                          maxItems: 10
+                          type: array
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                          - message: Reboot action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                              == 1 : true'
+                          - message: None action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''None'') ? size(self) ==
+                              1 : true'
+                        path:
+                          description: path is the location of a file being managed
+                            through a MachineConfig. The Actions in the policy will
+                            apply to changes to the file at this path.
+                          type: string
+                      required:
+                      - actions
+                      - path
+                      type: object
+                    maxItems: 50
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - path
+                    x-kubernetes-list-type: map
+                  sshkey:
+                    description: sshkey maps to the ignition.sshkeys field in the
+                      MachineConfig object, definition an action for this will apply
+                      to all sshkey changes in the cluster
+                    properties:
+                      actions:
+                        description: actions represents the series of commands to
+                          be executed on changes to the file at the corresponding
+                          file path. Actions will be applied in the order that they
+                          are set in this list. If there are other incoming changes
+                          to other MachineConfig entries in the same update that require
+                          a reboot, the reboot will supercede these actions. Valid
+                          actions are Reboot, Drain, Reload, DaemonReload and None.
+                          The Reboot action and the None action cannot be used in
+                          conjunction with any of the other actions. This list supports
+                          a maximum of 10 entries.
+                        items:
+                          properties:
+                            reload:
+                              description: reload specifies the service to reload,
+                                only valid if type is reload
+                              properties:
+                                serviceName:
+                                  description: serviceName is the full name (e.g.
+                                    crio.service) of the service to be reloaded Service
+                                    names should be of the format ${NAME}${SERVICETYPE}
+                                    and can up to 255 characters long. ${NAME} must
+                                    be atleast 1 character long and can only consist
+                                    of alphabets, digits, ":", "-", "_", ".", and
+                                    "\". ${SERVICETYPE} must be one of ".service",
+                                    ".socket", ".device", ".mount", ".automount",
+                                    ".swap", ".target", ".path", ".timer", ".snapshot",
+                                    ".slice" or ".scope".
+                                  maxLength: 255
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: Invalid ${SERVICETYPE} in service name.
+                                      Expected format is ${NAME}${SERVICETYPE}, where
+                                      ${SERVICETYPE} must be one of ".service", ".socket",
+                                      ".device", ".mount", ".automount", ".swap",
+                                      ".target", ".path", ".timer",".snapshot", ".slice"
+                                      or ".scope".
+                                    rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                  - message: Invalid ${NAME} in service name. Expected
+                                      format is ${NAME}${SERVICETYPE}, where {NAME}
+                                      must be atleast 1 character long and can only
+                                      consist of alphabets, digits, ":", "-", "_",
+                                      ".", and "\"
+                                    rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                              required:
+                              - serviceName
+                              type: object
+                            restart:
+                              description: restart specifies the service to restart,
+                                only valid if type is restart
+                              properties:
+                                serviceName:
+                                  description: serviceName is the full name (e.g.
+                                    crio.service) of the service to be restarted Service
+                                    names should be of the format ${NAME}${SERVICETYPE}
+                                    and can up to 255 characters long. ${NAME} must
+                                    be atleast 1 character long and can only consist
+                                    of alphabets, digits, ":", "-", "_", ".", and
+                                    "\". ${SERVICETYPE} must be one of ".service",
+                                    ".socket", ".device", ".mount", ".automount",
+                                    ".swap", ".target", ".path", ".timer", ".snapshot",
+                                    ".slice" or ".scope".
+                                  maxLength: 255
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: Invalid ${SERVICETYPE} in service name.
+                                      Expected format is ${NAME}${SERVICETYPE}, where
+                                      ${SERVICETYPE} must be one of ".service", ".socket",
+                                      ".device", ".mount", ".automount", ".swap",
+                                      ".target", ".path", ".timer",".snapshot", ".slice"
+                                      or ".scope".
+                                    rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                  - message: Invalid ${NAME} in service name. Expected
+                                      format is ${NAME}${SERVICETYPE}, where {NAME}
+                                      must be atleast 1 character long and can only
+                                      consist of alphabets, digits, ":", "-", "_",
+                                      ".", and "\"
+                                    rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                              required:
+                              - serviceName
+                              type: object
+                            type:
+                              description: type represents the commands that will
+                                be carried out if this NodeDisruptionPolicySpecActionType
+                                is executed Valid values are Reboot, Drain, Reload,
+                                Restart, DaemonReload and None. reload/restart requires
+                                a corresponding service target specified in the reload/restart
+                                field. Other values require no further configuration
+                              enum:
+                              - Reboot
+                              - Drain
+                              - Reload
+                              - Restart
+                              - DaemonReload
+                              - None
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: reload is required when type is Reload, and forbidden
+                              otherwise
+                            rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                              : !has(self.reload)'
+                          - message: restart is required when type is Restart, and
+                              forbidden otherwise
+                            rule: 'has(self.type) && self.type == ''Restart'' ? has(self.restart)
+                              : !has(self.restart)'
+                        maxItems: 10
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: Reboot action can only be specified standalone,
+                            as it will override any other actions
+                          rule: 'self.exists(x, x.type==''Reboot'') ? size(self) ==
+                            1 : true'
+                        - message: None action can only be specified standalone, as
+                            it will override any other actions
+                          rule: 'self.exists(x, x.type==''None'') ? size(self) ==
+                            1 : true'
+                    required:
+                    - actions
+                    type: object
+                  units:
+                    description: units is a list MachineConfig unit definitions and
+                      actions to take on changes to those services This list supports
+                      a maximum of 50 entries.
+                    items:
+                      description: NodeDisruptionPolicySpecUnit is a systemd unit
+                        name and corresponding actions to take and is used in the
+                        NodeDisruptionPolicyConfig object
+                      properties:
+                        actions:
+                          description: actions represents the series of commands to
+                            be executed on changes to the file at the corresponding
+                            file path. Actions will be applied in the order that they
+                            are set in this list. If there are other incoming changes
+                            to other MachineConfig entries in the same update that
+                            require a reboot, the reboot will supercede these actions.
+                            Valid actions are Reboot, Drain, Reload, DaemonReload
+                            and None. The Reboot action and the None action cannot
+                            be used in conjunction with any of the other actions.
+                            This list supports a maximum of 10 entries.
+                          items:
+                            properties:
+                              reload:
+                                description: reload specifies the service to reload,
+                                  only valid if type is reload
+                                properties:
+                                  serviceName:
+                                    description: serviceName is the full name (e.g.
+                                      crio.service) of the service to be reloaded
+                                      Service names should be of the format ${NAME}${SERVICETYPE}
+                                      and can up to 255 characters long. ${NAME} must
+                                      be atleast 1 character long and can only consist
+                                      of alphabets, digits, ":", "-", "_", ".", and
+                                      "\". ${SERVICETYPE} must be one of ".service",
+                                      ".socket", ".device", ".mount", ".automount",
+                                      ".swap", ".target", ".path", ".timer", ".snapshot",
+                                      ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              restart:
+                                description: restart specifies the service to restart,
+                                  only valid if type is restart
+                                properties:
+                                  serviceName:
+                                    description: serviceName is the full name (e.g.
+                                      crio.service) of the service to be restarted
+                                      Service names should be of the format ${NAME}${SERVICETYPE}
+                                      and can up to 255 characters long. ${NAME} must
+                                      be atleast 1 character long and can only consist
+                                      of alphabets, digits, ":", "-", "_", ".", and
+                                      "\". ${SERVICETYPE} must be one of ".service",
+                                      ".socket", ".device", ".mount", ".automount",
+                                      ".swap", ".target", ".path", ".timer", ".snapshot",
+                                      ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              type:
+                                description: type represents the commands that will
+                                  be carried out if this NodeDisruptionPolicySpecActionType
+                                  is executed Valid values are Reboot, Drain, Reload,
+                                  Restart, DaemonReload and None. reload/restart requires
+                                  a corresponding service target specified in the
+                                  reload/restart field. Other values require no further
+                                  configuration
+                                enum:
+                                - Reboot
+                                - Drain
+                                - Reload
+                                - Restart
+                                - DaemonReload
+                                - None
+                                type: string
+                            required:
+                            - type
+                            type: object
+                            x-kubernetes-validations:
+                            - message: reload is required when type is Reload, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                                : !has(self.reload)'
+                            - message: restart is required when type is Restart, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Restart'' ?
+                                has(self.restart) : !has(self.restart)'
+                          maxItems: 10
+                          type: array
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                          - message: Reboot action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                              == 1 : true'
+                          - message: None action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''None'') ? size(self) ==
+                              1 : true'
+                        name:
+                          description: name represents the service name of a systemd
+                            service managed through a MachineConfig Actions specified
+                            will be applied for changes to the named service. Service
+                            names should be of the format ${NAME}${SERVICETYPE} and
+                            can up to 255 characters long. ${NAME} must be atleast
+                            1 character long and can only consist of alphabets, digits,
+                            ":", "-", "_", ".", and "\". ${SERVICETYPE} must be one
+                            of ".service", ".socket", ".device", ".mount", ".automount",
+                            ".swap", ".target", ".path", ".timer", ".snapshot", ".slice"
+                            or ".scope".
+                          maxLength: 255
+                          type: string
+                          x-kubernetes-validations:
+                          - message: Invalid ${SERVICETYPE} in service name. Expected
+                              format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                              must be one of ".service", ".socket", ".device", ".mount",
+                              ".automount", ".swap", ".target", ".path", ".timer",".snapshot",
+                              ".slice" or ".scope".
+                            rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                          - message: Invalid ${NAME} in service name. Expected format
+                              is ${NAME}${SERVICETYPE}, where {NAME} must be atleast
+                              1 character long and can only consist of alphabets,
+                              digits, ":", "-", "_", ".", and "\"
+                            rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                      required:
+                      - actions
+                      - name
+                      type: object
+                    maxItems: 50
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                type: object
+              observedConfig:
+                description: observedConfig holds a sparse config that controller
+                  has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: "operatorLogLevel is an intent based logging for the
+                  operator itself.  It does not give fine grained control, but it
+                  is a simple way to manage coarse grained logging choices that operators
+                  have to interpret for themselves. \n Valid values are: \"Normal\",
+                  \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              succeededRevisionLimit:
+                description: succeededRevisionLimit is the number of successful static
+                  pod installer revisions to keep on disk and in the api -1 = unlimited,
+                  0 or unset = 5 (default)
+                format: int32
+                type: integer
+              unsupportedConfigOverrides:
+                description: unsupportedConfigOverrides overrides the final configuration
+                  that was computed by the operator. Red Hat does not support the
+                  use of this field. Misuse of this field could lead to unexpected
+                  behavior or conflict with other configuration options. Seek guidance
+                  from the Red Hat support before using this field. Use of this property
+                  blocks cluster upgrades, it must be removed before upgrading your
+                  cluster.
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: status is the most recently observed status of the Machine
+              Config Operator
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              nodeDisruptionPolicyStatus:
+                description: nodeDisruptionPolicyStatus status reflects what the latest
+                  cluster-validated policies are, and will be used by the Machine
+                  Config Daemon during future node updates.
+                properties:
+                  clusterPolicies:
+                    description: clusterPolicies is a merge of cluster default and
+                      user provided node disruption policies.
+                    properties:
+                      files:
+                        description: files is a list of MachineConfig file definitions
+                          and actions to take to changes on those paths
+                        items:
+                          description: NodeDisruptionPolicyStatusFile is a file entry
+                            and corresponding actions to take and is used in the NodeDisruptionPolicyClusterStatus
+                            object
+                          properties:
+                            actions:
+                              description: actions represents the series of commands
+                                to be executed on changes to the file at the corresponding
+                                file path. Actions will be applied in the order that
+                                they are set in this list. If there are other incoming
+                                changes to other MachineConfig entries in the same
+                                update that require a reboot, the reboot will supercede
+                                these actions. Valid actions are Reboot, Drain, Reload,
+                                DaemonReload and None. The Reboot action and the None
+                                action cannot be used in conjunction with any of the
+                                other actions. This list supports a maximum of 10
+                                entries.
+                              items:
+                                properties:
+                                  reload:
+                                    description: reload specifies the service to reload,
+                                      only valid if type is reload
+                                    properties:
+                                      serviceName:
+                                        description: serviceName is the full name
+                                          (e.g. crio.service) of the service to be
+                                          reloaded Service names should be of the
+                                          format ${NAME}${SERVICETYPE} and can up
+                                          to 255 characters long. ${NAME} must be
+                                          atleast 1 character long and can only consist
+                                          of alphabets, digits, ":", "-", "_", ".",
+                                          and "\". ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer", ".snapshot",
+                                          ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  restart:
+                                    description: restart specifies the service to
+                                      restart, only valid if type is restart
+                                    properties:
+                                      serviceName:
+                                        description: serviceName is the full name
+                                          (e.g. crio.service) of the service to be
+                                          restarted Service names should be of the
+                                          format ${NAME}${SERVICETYPE} and can up
+                                          to 255 characters long. ${NAME} must be
+                                          atleast 1 character long and can only consist
+                                          of alphabets, digits, ":", "-", "_", ".",
+                                          and "\". ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer", ".snapshot",
+                                          ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  type:
+                                    description: type represents the commands that
+                                      will be carried out if this NodeDisruptionPolicyStatusActionType
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
+                                    enum:
+                                    - Reboot
+                                    - Drain
+                                    - Reload
+                                    - Restart
+                                    - DaemonReload
+                                    - None
+                                    - Special
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: reload is required when type is Reload,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Reload''
+                                    ? has(self.reload) : !has(self.reload)'
+                                - message: restart is required when type is Restart,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Restart''
+                                    ? has(self.restart) : !has(self.restart)'
+                              maxItems: 10
+                              type: array
+                              x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: Reboot action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                                  == 1 : true'
+                              - message: None action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''None'') ? size(self)
+                                  == 1 : true'
+                            path:
+                              description: path is the location of a file being managed
+                                through a MachineConfig. The Actions in the policy
+                                will apply to changes to the file at this path.
+                              type: string
+                          required:
+                          - actions
+                          - path
+                          type: object
+                        maxItems: 100
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - path
+                        x-kubernetes-list-type: map
+                      sshkey:
+                        description: sshkey is the overall sshkey MachineConfig definition
+                        properties:
+                          actions:
+                            description: actions represents the series of commands
+                              to be executed on changes to the file at the corresponding
+                              file path. Actions will be applied in the order that
+                              they are set in this list. If there are other incoming
+                              changes to other MachineConfig entries in the same update
+                              that require a reboot, the reboot will supercede these
+                              actions. Valid actions are Reboot, Drain, Reload, DaemonReload
+                              and None. The Reboot action and the None action cannot
+                              be used in conjunction with any of the other actions.
+                              This list supports a maximum of 10 entries.
+                            items:
+                              properties:
+                                reload:
+                                  description: reload specifies the service to reload,
+                                    only valid if type is reload
+                                  properties:
+                                    serviceName:
+                                      description: serviceName is the full name (e.g.
+                                        crio.service) of the service to be reloaded
+                                        Service names should be of the format ${NAME}${SERVICETYPE}
+                                        and can up to 255 characters long. ${NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\". ${SERVICETYPE} must be one of
+                                        ".service", ".socket", ".device", ".mount",
+                                        ".automount", ".swap", ".target", ".path",
+                                        ".timer", ".snapshot", ".slice" or ".scope".
+                                      maxLength: 255
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: Invalid ${SERVICETYPE} in service
+                                          name. Expected format is ${NAME}${SERVICETYPE},
+                                          where ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer",".snapshot",
+                                          ".slice" or ".scope".
+                                        rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                      - message: Invalid ${NAME} in service name.
+                                          Expected format is ${NAME}${SERVICETYPE},
+                                          where {NAME} must be atleast 1 character
+                                          long and can only consist of alphabets,
+                                          digits, ":", "-", "_", ".", and "\"
+                                        rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                  required:
+                                  - serviceName
+                                  type: object
+                                restart:
+                                  description: restart specifies the service to restart,
+                                    only valid if type is restart
+                                  properties:
+                                    serviceName:
+                                      description: serviceName is the full name (e.g.
+                                        crio.service) of the service to be restarted
+                                        Service names should be of the format ${NAME}${SERVICETYPE}
+                                        and can up to 255 characters long. ${NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\". ${SERVICETYPE} must be one of
+                                        ".service", ".socket", ".device", ".mount",
+                                        ".automount", ".swap", ".target", ".path",
+                                        ".timer", ".snapshot", ".slice" or ".scope".
+                                      maxLength: 255
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: Invalid ${SERVICETYPE} in service
+                                          name. Expected format is ${NAME}${SERVICETYPE},
+                                          where ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer",".snapshot",
+                                          ".slice" or ".scope".
+                                        rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                      - message: Invalid ${NAME} in service name.
+                                          Expected format is ${NAME}${SERVICETYPE},
+                                          where {NAME} must be atleast 1 character
+                                          long and can only consist of alphabets,
+                                          digits, ":", "-", "_", ".", and "\"
+                                        rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                  required:
+                                  - serviceName
+                                  type: object
+                                type:
+                                  description: type represents the commands that will
+                                    be carried out if this NodeDisruptionPolicyStatusActionType
+                                    is executed Valid values are Reboot, Drain, Reload,
+                                    Restart, DaemonReload, None and Special. reload/restart
+                                    requires a corresponding service target specified
+                                    in the reload/restart field. Other values require
+                                    no further configuration
+                                  enum:
+                                  - Reboot
+                                  - Drain
+                                  - Reload
+                                  - Restart
+                                  - DaemonReload
+                                  - None
+                                  - Special
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: reload is required when type is Reload, and
+                                  forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''Reload'' ?
+                                  has(self.reload) : !has(self.reload)'
+                              - message: restart is required when type is Restart,
+                                  and forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''Restart''
+                                  ? has(self.restart) : !has(self.restart)'
+                            maxItems: 10
+                            type: array
+                            x-kubernetes-list-type: atomic
+                            x-kubernetes-validations:
+                            - message: Reboot action can only be specified standalone,
+                                as it will override any other actions
+                              rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                                == 1 : true'
+                            - message: None action can only be specified standalone,
+                                as it will override any other actions
+                              rule: 'self.exists(x, x.type==''None'') ? size(self)
+                                == 1 : true'
+                        required:
+                        - actions
+                        type: object
+                      units:
+                        description: units is a list MachineConfig unit definitions
+                          and actions to take on changes to those services
+                        items:
+                          description: NodeDisruptionPolicyStatusUnit is a systemd
+                            unit name and corresponding actions to take and is used
+                            in the NodeDisruptionPolicyClusterStatus object
+                          properties:
+                            actions:
+                              description: actions represents the series of commands
+                                to be executed on changes to the file at the corresponding
+                                file path. Actions will be applied in the order that
+                                they are set in this list. If there are other incoming
+                                changes to other MachineConfig entries in the same
+                                update that require a reboot, the reboot will supercede
+                                these actions. Valid actions are Reboot, Drain, Reload,
+                                DaemonReload and None. The Reboot action and the None
+                                action cannot be used in conjunction with any of the
+                                other actions. This list supports a maximum of 10
+                                entries.
+                              items:
+                                properties:
+                                  reload:
+                                    description: reload specifies the service to reload,
+                                      only valid if type is reload
+                                    properties:
+                                      serviceName:
+                                        description: serviceName is the full name
+                                          (e.g. crio.service) of the service to be
+                                          reloaded Service names should be of the
+                                          format ${NAME}${SERVICETYPE} and can up
+                                          to 255 characters long. ${NAME} must be
+                                          atleast 1 character long and can only consist
+                                          of alphabets, digits, ":", "-", "_", ".",
+                                          and "\". ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer", ".snapshot",
+                                          ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  restart:
+                                    description: restart specifies the service to
+                                      restart, only valid if type is restart
+                                    properties:
+                                      serviceName:
+                                        description: serviceName is the full name
+                                          (e.g. crio.service) of the service to be
+                                          restarted Service names should be of the
+                                          format ${NAME}${SERVICETYPE} and can up
+                                          to 255 characters long. ${NAME} must be
+                                          atleast 1 character long and can only consist
+                                          of alphabets, digits, ":", "-", "_", ".",
+                                          and "\". ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer", ".snapshot",
+                                          ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  type:
+                                    description: type represents the commands that
+                                      will be carried out if this NodeDisruptionPolicyStatusActionType
+                                      is executed Valid values are Reboot, Drain,
+                                      Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service
+                                      target specified in the reload/restart field.
+                                      Other values require no further configuration
+                                    enum:
+                                    - Reboot
+                                    - Drain
+                                    - Reload
+                                    - Restart
+                                    - DaemonReload
+                                    - None
+                                    - Special
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: reload is required when type is Reload,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Reload''
+                                    ? has(self.reload) : !has(self.reload)'
+                                - message: restart is required when type is Restart,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Restart''
+                                    ? has(self.restart) : !has(self.restart)'
+                              maxItems: 10
+                              type: array
+                              x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: Reboot action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                                  == 1 : true'
+                              - message: None action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''None'') ? size(self)
+                                  == 1 : true'
+                            name:
+                              description: name represents the service name of a systemd
+                                service managed through a MachineConfig Actions specified
+                                will be applied for changes to the named service.
+                                Service names should be of the format ${NAME}${SERVICETYPE}
+                                and can up to 255 characters long. ${NAME} must be
+                                atleast 1 character long and can only consist of alphabets,
+                                digits, ":", "-", "_", ".", and "\". ${SERVICETYPE}
+                                must be one of ".service", ".socket", ".device", ".mount",
+                                ".automount", ".swap", ".target", ".path", ".timer",
+                                ".snapshot", ".slice" or ".scope".
+                              maxLength: 255
+                              type: string
+                              x-kubernetes-validations:
+                              - message: Invalid ${SERVICETYPE} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                                  must be one of ".service", ".socket", ".device",
+                                  ".mount", ".automount", ".swap", ".target", ".path",
+                                  ".timer",".snapshot", ".slice" or ".scope".
+                                rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                              - message: Invalid ${NAME} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where {NAME} must
+                                  be atleast 1 character long and can only consist
+                                  of alphabets, digits, ":", "-", "_", ".", and "\"
+                                rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                          required:
+                          - actions
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                type: object
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,297 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineosbuilds.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineOSBuild
+    listKind: MachineOSBuildList
+    plural: machineosbuilds
+    singular: machineosbuild
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Prepared")].status
+      name: Prepared
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Building")].status
+      name: Building
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Interrupted")].status
+      name: Interrupted
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Failed")].status
+      name: Failed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineOSBuild describes a build process managed and deployed
+          by the MCO Compatibility level 4: No compatibility is provided, the API
+          can change at any point for any reason. These capabilities should not be
+          used by applications needing long term support.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of the machine os build
+            properties:
+              configGeneration:
+                description: configGeneration tracks which version of MachineOSConfig
+                  this build is based off of
+                format: int64
+                minimum: 1
+                type: integer
+              desiredConfig:
+                description: desiredConfig is the desired config we want to build
+                  an image for.
+                properties:
+                  name:
+                    description: name is the name of the rendered MachineConfig object.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+              machineOSConfig:
+                description: machineOSConfig is the config object which the build
+                  is based off of
+                properties:
+                  name:
+                    description: name of the MachineOSConfig
+                    type: string
+                required:
+                - name
+                type: object
+              renderedImagePushspec:
+                description: 'renderedImagePushspec is set from the MachineOSConfig
+                  The format of the image pullspec is: host[:port][/namespace]/name:<tag>
+                  or svc_name.namespace.svc[:port]/repository/name:<tag>'
+                maxLength: 447
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image reference must end with a valid :<tag>, where
+                    '<digest>' is 64 characters long and '<tag>' is any valid string  Or
+                    it must be a valid .svc followed by a port, repository, image
+                    name, and tag.
+                  rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme. Or it must
+                    be a valid .svc followed by a port, repository, image name, and
+                    tag.
+                  rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+              version:
+                description: version tracks the newest MachineOSBuild for each MachineOSConfig
+                format: int64
+                minimum: 1
+                type: integer
+            required:
+            - configGeneration
+            - desiredConfig
+            - machineOSConfig
+            - renderedImagePushspec
+            - version
+            type: object
+            x-kubernetes-validations:
+            - message: machineOSBuildSpec is immutable once set
+              rule: self == oldSelf
+          status:
+            description: status describes the lst observed state of this machine os
+              build
+            properties:
+              buildEnd:
+                description: buildEnd describes when the build ended.
+                format: date-time
+                type: string
+                x-kubernetes-validations:
+                - message: buildEnd is immutable once set
+                  rule: self == oldSelf
+              buildStart:
+                description: buildStart describes when the build started.
+                format: date-time
+                type: string
+                x-kubernetes-validations:
+                - message: buildStart is immutable once set
+                  rule: self == oldSelf
+              builderReference:
+                description: ImageBuilderType describes the image builder set in the
+                  MachineOSConfig
+                properties:
+                  buildPod:
+                    description: relatedObjects is a list of objects that are related
+                      to the build process.
+                    properties:
+                      group:
+                        description: group of the referent.
+                        type: string
+                      name:
+                        description: name of the referent.
+                        type: string
+                      namespace:
+                        description: namespace of the referent.
+                        type: string
+                      resource:
+                        description: resource of the referent.
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    type: object
+                  imageBuilderType:
+                    description: ImageBuilderType describes the image builder set
+                      in the MachineOSConfig
+                    type: string
+                required:
+                - imageBuilderType
+                type: object
+                x-kubernetes-validations:
+                - message: buildPod is required when imageBuilderType is PodImageBuilder,
+                    and forbidden otherwise
+                  rule: 'has(self.imageBuilderType) && self.imageBuilderType == ''PodImageBuilder''
+                    ?  true : !has(self.buildPod)'
+              conditions:
+                description: 'conditions are state related conditions for the build.
+                  Valid types are: Prepared, Building, Failed, Interrupted, and Succeeded
+                  once a Build is marked as Failed, no future conditions can be set.
+                  This is enforced by the MCO.'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              finalImagePullspec:
+                description: finalImagePushSpec describes the fully qualified pushspec
+                  produced by this build that the final image can be. Must be in sha
+                  format.
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                    suffix, where '<digest>' is 64 characters long
+                  rule: ((self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$')))
+              relatedObjects:
+                description: relatedObjects is a list of objects that are related
+                  to the build process.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    group:
+                      description: group of the referent.
+                      type: string
+                    name:
+                      description: name of the referent.
+                      type: string
+                    namespace:
+                      description: namespace of the referent.
+                      type: string
+                    resource:
+                      description: resource of the referent.
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - resource
+                  type: object
+                type: array
+            required:
+            - buildStart
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-DevPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,297 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineosbuilds.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineOSBuild
+    listKind: MachineOSBuildList
+    plural: machineosbuilds
+    singular: machineosbuild
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Prepared")].status
+      name: Prepared
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Building")].status
+      name: Building
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Interrupted")].status
+      name: Interrupted
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Failed")].status
+      name: Failed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineOSBuild describes a build process managed and deployed
+          by the MCO Compatibility level 4: No compatibility is provided, the API
+          can change at any point for any reason. These capabilities should not be
+          used by applications needing long term support.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of the machine os build
+            properties:
+              configGeneration:
+                description: configGeneration tracks which version of MachineOSConfig
+                  this build is based off of
+                format: int64
+                minimum: 1
+                type: integer
+              desiredConfig:
+                description: desiredConfig is the desired config we want to build
+                  an image for.
+                properties:
+                  name:
+                    description: name is the name of the rendered MachineConfig object.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+              machineOSConfig:
+                description: machineOSConfig is the config object which the build
+                  is based off of
+                properties:
+                  name:
+                    description: name of the MachineOSConfig
+                    type: string
+                required:
+                - name
+                type: object
+              renderedImagePushspec:
+                description: 'renderedImagePushspec is set from the MachineOSConfig
+                  The format of the image pullspec is: host[:port][/namespace]/name:<tag>
+                  or svc_name.namespace.svc[:port]/repository/name:<tag>'
+                maxLength: 447
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image reference must end with a valid :<tag>, where
+                    '<digest>' is 64 characters long and '<tag>' is any valid string  Or
+                    it must be a valid .svc followed by a port, repository, image
+                    name, and tag.
+                  rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme. Or it must
+                    be a valid .svc followed by a port, repository, image name, and
+                    tag.
+                  rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+              version:
+                description: version tracks the newest MachineOSBuild for each MachineOSConfig
+                format: int64
+                minimum: 1
+                type: integer
+            required:
+            - configGeneration
+            - desiredConfig
+            - machineOSConfig
+            - renderedImagePushspec
+            - version
+            type: object
+            x-kubernetes-validations:
+            - message: machineOSBuildSpec is immutable once set
+              rule: self == oldSelf
+          status:
+            description: status describes the lst observed state of this machine os
+              build
+            properties:
+              buildEnd:
+                description: buildEnd describes when the build ended.
+                format: date-time
+                type: string
+                x-kubernetes-validations:
+                - message: buildEnd is immutable once set
+                  rule: self == oldSelf
+              buildStart:
+                description: buildStart describes when the build started.
+                format: date-time
+                type: string
+                x-kubernetes-validations:
+                - message: buildStart is immutable once set
+                  rule: self == oldSelf
+              builderReference:
+                description: ImageBuilderType describes the image builder set in the
+                  MachineOSConfig
+                properties:
+                  buildPod:
+                    description: relatedObjects is a list of objects that are related
+                      to the build process.
+                    properties:
+                      group:
+                        description: group of the referent.
+                        type: string
+                      name:
+                        description: name of the referent.
+                        type: string
+                      namespace:
+                        description: namespace of the referent.
+                        type: string
+                      resource:
+                        description: resource of the referent.
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    type: object
+                  imageBuilderType:
+                    description: ImageBuilderType describes the image builder set
+                      in the MachineOSConfig
+                    type: string
+                required:
+                - imageBuilderType
+                type: object
+                x-kubernetes-validations:
+                - message: buildPod is required when imageBuilderType is PodImageBuilder,
+                    and forbidden otherwise
+                  rule: 'has(self.imageBuilderType) && self.imageBuilderType == ''PodImageBuilder''
+                    ?  true : !has(self.buildPod)'
+              conditions:
+                description: 'conditions are state related conditions for the build.
+                  Valid types are: Prepared, Building, Failed, Interrupted, and Succeeded
+                  once a Build is marked as Failed, no future conditions can be set.
+                  This is enforced by the MCO.'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              finalImagePullspec:
+                description: finalImagePushSpec describes the fully qualified pushspec
+                  produced by this build that the final image can be. Must be in sha
+                  format.
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                    suffix, where '<digest>' is 64 characters long
+                  rule: ((self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$')))
+              relatedObjects:
+                description: relatedObjects is a list of objects that are related
+                  to the build process.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    group:
+                      description: group of the referent.
+                      type: string
+                    name:
+                      description: name of the referent.
+                      type: string
+                    namespace:
+                      description: namespace of the referent.
+                      type: string
+                    resource:
+                      description: resource of the referent.
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - resource
+                  type: object
+                type: array
+            required:
+            - buildStart
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,297 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineosbuilds.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineOSBuild
+    listKind: MachineOSBuildList
+    plural: machineosbuilds
+    singular: machineosbuild
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Prepared")].status
+      name: Prepared
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Building")].status
+      name: Building
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Succeeded")].status
+      name: Succeeded
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Interrupted")].status
+      name: Interrupted
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Failed")].status
+      name: Failed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineOSBuild describes a build process managed and deployed
+          by the MCO Compatibility level 4: No compatibility is provided, the API
+          can change at any point for any reason. These capabilities should not be
+          used by applications needing long term support.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of the machine os build
+            properties:
+              configGeneration:
+                description: configGeneration tracks which version of MachineOSConfig
+                  this build is based off of
+                format: int64
+                minimum: 1
+                type: integer
+              desiredConfig:
+                description: desiredConfig is the desired config we want to build
+                  an image for.
+                properties:
+                  name:
+                    description: name is the name of the rendered MachineConfig object.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+              machineOSConfig:
+                description: machineOSConfig is the config object which the build
+                  is based off of
+                properties:
+                  name:
+                    description: name of the MachineOSConfig
+                    type: string
+                required:
+                - name
+                type: object
+              renderedImagePushspec:
+                description: 'renderedImagePushspec is set from the MachineOSConfig
+                  The format of the image pullspec is: host[:port][/namespace]/name:<tag>
+                  or svc_name.namespace.svc[:port]/repository/name:<tag>'
+                maxLength: 447
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image reference must end with a valid :<tag>, where
+                    '<digest>' is 64 characters long and '<tag>' is any valid string  Or
+                    it must be a valid .svc followed by a port, repository, image
+                    name, and tag.
+                  rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme. Or it must
+                    be a valid .svc followed by a port, repository, image name, and
+                    tag.
+                  rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+              version:
+                description: version tracks the newest MachineOSBuild for each MachineOSConfig
+                format: int64
+                minimum: 1
+                type: integer
+            required:
+            - configGeneration
+            - desiredConfig
+            - machineOSConfig
+            - renderedImagePushspec
+            - version
+            type: object
+            x-kubernetes-validations:
+            - message: machineOSBuildSpec is immutable once set
+              rule: self == oldSelf
+          status:
+            description: status describes the lst observed state of this machine os
+              build
+            properties:
+              buildEnd:
+                description: buildEnd describes when the build ended.
+                format: date-time
+                type: string
+                x-kubernetes-validations:
+                - message: buildEnd is immutable once set
+                  rule: self == oldSelf
+              buildStart:
+                description: buildStart describes when the build started.
+                format: date-time
+                type: string
+                x-kubernetes-validations:
+                - message: buildStart is immutable once set
+                  rule: self == oldSelf
+              builderReference:
+                description: ImageBuilderType describes the image builder set in the
+                  MachineOSConfig
+                properties:
+                  buildPod:
+                    description: relatedObjects is a list of objects that are related
+                      to the build process.
+                    properties:
+                      group:
+                        description: group of the referent.
+                        type: string
+                      name:
+                        description: name of the referent.
+                        type: string
+                      namespace:
+                        description: namespace of the referent.
+                        type: string
+                      resource:
+                        description: resource of the referent.
+                        type: string
+                    required:
+                    - group
+                    - name
+                    - resource
+                    type: object
+                  imageBuilderType:
+                    description: ImageBuilderType describes the image builder set
+                      in the MachineOSConfig
+                    type: string
+                required:
+                - imageBuilderType
+                type: object
+                x-kubernetes-validations:
+                - message: buildPod is required when imageBuilderType is PodImageBuilder,
+                    and forbidden otherwise
+                  rule: 'has(self.imageBuilderType) && self.imageBuilderType == ''PodImageBuilder''
+                    ?  true : !has(self.buildPod)'
+              conditions:
+                description: 'conditions are state related conditions for the build.
+                  Valid types are: Prepared, Building, Failed, Interrupted, and Succeeded
+                  once a Build is marked as Failed, no future conditions can be set.
+                  This is enforced by the MCO.'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              finalImagePullspec:
+                description: finalImagePushSpec describes the fully qualified pushspec
+                  produced by this build that the final image can be. Must be in sha
+                  format.
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                    suffix, where '<digest>' is 64 characters long
+                  rule: ((self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$')))
+              relatedObjects:
+                description: relatedObjects is a list of objects that are related
+                  to the build process.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    group:
+                      description: group of the referent.
+                      type: string
+                    name:
+                      description: name of the referent.
+                      type: string
+                    namespace:
+                      description: namespace of the referent.
+                      type: string
+                    resource:
+                      description: resource of the referent.
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - resource
+                  type: object
+                type: array
+            required:
+            - buildStart
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,352 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineosconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineOSConfig
+    listKind: MachineOSConfigList
+    plural: machineosconfigs
+    singular: machineosconfig
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineOSConfig describes the configuration for a build process
+          managed by the MCO Compatibility level 4: No compatibility is provided,
+          the API can change at any point for any reason. These capabilities should
+          not be used by applications needing long term support.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of the machineosconfig
+            properties:
+              buildInputs:
+                description: buildInputs is where user input options for the build
+                  live
+                properties:
+                  baseImagePullSecret:
+                    description: baseImagePullSecret is the secret used to pull the
+                      base image. must live in the openshift-machine-config-operator
+                      namespace
+                    properties:
+                      name:
+                        description: name is the name of the secret used to push or
+                          pull this MachineOSConfig object. this secret must be in
+                          the openshift-machine-config-operator namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  baseOSExtensionsImagePullspec:
+                    description: 'baseOSExtensionsImagePullspec is the base Extensions
+                      image used in the build process the MachineOSConfig object will
+                      use the in cluster image registry configuration. if you wish
+                      to use a mirror or any other settings specific to registries.conf,
+                      please specify those in the cluster wide registries.conf. The
+                      format of the image pullspec is: host[:port][/namespace]/name@sha256:<digest>'
+                    maxLength: 447
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                        suffix, where '<digest>' is 64 characters long
+                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                    - message: the OCI Image name should follow the host[:port][/namespace]/name
+                        format, resembling a valid URL without the scheme
+                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                  baseOSImagePullspec:
+                    description: 'baseOSImagePullspec is the base OSImage we use to
+                      build our custom image. the MachineOSConfig object will use
+                      the in cluster image registry configuration. if you wish to
+                      use a mirror or any other settings specific to registries.conf,
+                      please specify those in the cluster wide registries.conf. The
+                      format of the image pullspec is: host[:port][/namespace]/name@sha256:<digest>'
+                    maxLength: 447
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                        suffix, where '<digest>' is 64 characters long
+                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                    - message: the OCI Image name should follow the host[:port][/namespace]/name
+                        format, resembling a valid URL without the scheme
+                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                  containerFile:
+                    description: containerFile describes the custom data the user
+                      has specified to build into the image. this is also commonly
+                      called a Dockerfile and you can treat it as such. The content
+                      is the content of your Dockerfile.
+                    items:
+                      description: MachineOSContainerfile contains all custom content
+                        the user wants built into the image
+                      properties:
+                        containerfileArch:
+                          default: noarch
+                          description: 'containerfileArch describes the architecture
+                            this containerfile is to be built for this arch is optional.
+                            If the user does not specify an architecture, it is assumed
+                            that the content can be applied to all architectures,
+                            or in a single arch cluster: the only architecture.'
+                          enum:
+                          - arm64
+                          - amd64
+                          - ppc64le
+                          - s390x
+                          - aarch64
+                          - x86_64
+                          - noarch
+                          type: string
+                        content:
+                          description: content is the custom content to be built
+                          type: string
+                      required:
+                      - content
+                      type: object
+                    maxItems: 7
+                    minItems: 0
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerfileArch
+                    x-kubernetes-list-type: map
+                  imageBuilder:
+                    description: machineOSImageBuilder describes which image builder
+                      will be used in each build triggered by this MachineOSConfig
+                    properties:
+                      imageBuilderType:
+                        default: PodImageBuilder
+                        description: 'imageBuilderType specifies the backend to be
+                          used to build the image. Valid options are: PodImageBuilder'
+                        enum:
+                        - PodImageBuilder
+                        type: string
+                    required:
+                    - imageBuilderType
+                    type: object
+                  releaseVersion:
+                    description: 'releaseVersion is associated with the base OS Image.
+                      This is the version of Openshift that the Base Image is associated
+                      with. This field is populated from the machine-config-osimageurl
+                      configmap in the openshift-machine-config-operator namespace.
+                      It will come in the format: 4.16.0-0.nightly-2024-04-03-065948
+                      or any valid release. The MachineOSBuilder populates this field
+                      and validates that this is a valid stream. This is used as a
+                      label in the dockerfile that builds the OS image.'
+                    type: string
+                  renderedImagePushSecret:
+                    description: renderedImagePushSecret is the secret used to connect
+                      to a user registry. the final image push and pull secrets should
+                      be separate for security concerns. If the final image push secret
+                      is somehow exfiltrated, that gives someone the power to push
+                      images to the image repository. By comparison, if the final
+                      image pull secret gets exfiltrated, that only gives someone
+                      to pull images from the image repository. It's basically the
+                      principle of least permissions. this push secret will be used
+                      only by the MachineConfigController pod to push the image to
+                      the final destination. Not all nodes will need to push this
+                      image, most of them will only need to pull the image in order
+                      to use it.
+                    properties:
+                      name:
+                        description: name is the name of the secret used to push or
+                          pull this MachineOSConfig object. this secret must be in
+                          the openshift-machine-config-operator namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  renderedImagePushspec:
+                    description: 'renderedImagePushspec describes the location of
+                      the final image. the MachineOSConfig object will use the in
+                      cluster image registry configuration. if you wish to use a mirror
+                      or any other settings specific to registries.conf, please specify
+                      those in the cluster wide registries.conf. The format of the
+                      image pushspec is: host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>'
+                    maxLength: 447
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the OCI Image reference must end with a valid :<tag>,
+                        where '<digest>' is 64 characters long and '<tag>' is any
+                        valid string  Or it must be a valid .svc followed by a port,
+                        repository, image name, and tag.
+                      rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
+                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+                    - message: the OCI Image name should follow the host[:port][/namespace]/name
+                        format, resembling a valid URL without the scheme. Or it must
+                        be a valid .svc followed by a port, repository, image name,
+                        and tag.
+                      rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+                required:
+                - baseImagePullSecret
+                - imageBuilder
+                - renderedImagePushSecret
+                - renderedImagePushspec
+                type: object
+              buildOutputs:
+                description: buildOutputs is where user input options for the build
+                  live
+                properties:
+                  currentImagePullSecret:
+                    description: currentImagePullSecret is the secret used to pull
+                      the final produced image. must live in the openshift-machine-config-operator
+                      namespace the final image push and pull secrets should be separate
+                      for security concerns. If the final image push secret is somehow
+                      exfiltrated, that gives someone the power to push images to
+                      the image repository. By comparison, if the final image pull
+                      secret gets exfiltrated, that only gives someone to pull images
+                      from the image repository. It's basically the principle of least
+                      permissions. this pull secret will be used on all nodes in the
+                      pool. These nodes will need to pull the final OS image and boot
+                      into it using rpm-ostree or bootc.
+                    properties:
+                      name:
+                        description: name is the name of the secret used to push or
+                          pull this MachineOSConfig object. this secret must be in
+                          the openshift-machine-config-operator namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              machineConfigPool:
+                description: machineConfigPool is the pool which the build is for
+                properties:
+                  name:
+                    description: name of the MachineConfigPool object.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - buildInputs
+            - machineConfigPool
+            type: object
+          status:
+            description: status describes the status of the machineosconfig
+            properties:
+              conditions:
+                description: conditions are state related conditions for the config.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentImagePullspec:
+                description: currentImagePullspec is the fully qualified image pull
+                  spec used by the MCO to pull down the new OSImage. This must include
+                  sha256.
+                maxLength: 447
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                    suffix, where '<digest>' is 64 characters long
+                  rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme
+                  rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller. this field is updated when the user changes the
+                  configuration in BuildSettings or the MCP this object is associated
+                  with.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,352 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineosconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineOSConfig
+    listKind: MachineOSConfigList
+    plural: machineosconfigs
+    singular: machineosconfig
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineOSConfig describes the configuration for a build process
+          managed by the MCO Compatibility level 4: No compatibility is provided,
+          the API can change at any point for any reason. These capabilities should
+          not be used by applications needing long term support.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of the machineosconfig
+            properties:
+              buildInputs:
+                description: buildInputs is where user input options for the build
+                  live
+                properties:
+                  baseImagePullSecret:
+                    description: baseImagePullSecret is the secret used to pull the
+                      base image. must live in the openshift-machine-config-operator
+                      namespace
+                    properties:
+                      name:
+                        description: name is the name of the secret used to push or
+                          pull this MachineOSConfig object. this secret must be in
+                          the openshift-machine-config-operator namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  baseOSExtensionsImagePullspec:
+                    description: 'baseOSExtensionsImagePullspec is the base Extensions
+                      image used in the build process the MachineOSConfig object will
+                      use the in cluster image registry configuration. if you wish
+                      to use a mirror or any other settings specific to registries.conf,
+                      please specify those in the cluster wide registries.conf. The
+                      format of the image pullspec is: host[:port][/namespace]/name@sha256:<digest>'
+                    maxLength: 447
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                        suffix, where '<digest>' is 64 characters long
+                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                    - message: the OCI Image name should follow the host[:port][/namespace]/name
+                        format, resembling a valid URL without the scheme
+                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                  baseOSImagePullspec:
+                    description: 'baseOSImagePullspec is the base OSImage we use to
+                      build our custom image. the MachineOSConfig object will use
+                      the in cluster image registry configuration. if you wish to
+                      use a mirror or any other settings specific to registries.conf,
+                      please specify those in the cluster wide registries.conf. The
+                      format of the image pullspec is: host[:port][/namespace]/name@sha256:<digest>'
+                    maxLength: 447
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                        suffix, where '<digest>' is 64 characters long
+                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                    - message: the OCI Image name should follow the host[:port][/namespace]/name
+                        format, resembling a valid URL without the scheme
+                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                  containerFile:
+                    description: containerFile describes the custom data the user
+                      has specified to build into the image. this is also commonly
+                      called a Dockerfile and you can treat it as such. The content
+                      is the content of your Dockerfile.
+                    items:
+                      description: MachineOSContainerfile contains all custom content
+                        the user wants built into the image
+                      properties:
+                        containerfileArch:
+                          default: noarch
+                          description: 'containerfileArch describes the architecture
+                            this containerfile is to be built for this arch is optional.
+                            If the user does not specify an architecture, it is assumed
+                            that the content can be applied to all architectures,
+                            or in a single arch cluster: the only architecture.'
+                          enum:
+                          - arm64
+                          - amd64
+                          - ppc64le
+                          - s390x
+                          - aarch64
+                          - x86_64
+                          - noarch
+                          type: string
+                        content:
+                          description: content is the custom content to be built
+                          type: string
+                      required:
+                      - content
+                      type: object
+                    maxItems: 7
+                    minItems: 0
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerfileArch
+                    x-kubernetes-list-type: map
+                  imageBuilder:
+                    description: machineOSImageBuilder describes which image builder
+                      will be used in each build triggered by this MachineOSConfig
+                    properties:
+                      imageBuilderType:
+                        default: PodImageBuilder
+                        description: 'imageBuilderType specifies the backend to be
+                          used to build the image. Valid options are: PodImageBuilder'
+                        enum:
+                        - PodImageBuilder
+                        type: string
+                    required:
+                    - imageBuilderType
+                    type: object
+                  releaseVersion:
+                    description: 'releaseVersion is associated with the base OS Image.
+                      This is the version of Openshift that the Base Image is associated
+                      with. This field is populated from the machine-config-osimageurl
+                      configmap in the openshift-machine-config-operator namespace.
+                      It will come in the format: 4.16.0-0.nightly-2024-04-03-065948
+                      or any valid release. The MachineOSBuilder populates this field
+                      and validates that this is a valid stream. This is used as a
+                      label in the dockerfile that builds the OS image.'
+                    type: string
+                  renderedImagePushSecret:
+                    description: renderedImagePushSecret is the secret used to connect
+                      to a user registry. the final image push and pull secrets should
+                      be separate for security concerns. If the final image push secret
+                      is somehow exfiltrated, that gives someone the power to push
+                      images to the image repository. By comparison, if the final
+                      image pull secret gets exfiltrated, that only gives someone
+                      to pull images from the image repository. It's basically the
+                      principle of least permissions. this push secret will be used
+                      only by the MachineConfigController pod to push the image to
+                      the final destination. Not all nodes will need to push this
+                      image, most of them will only need to pull the image in order
+                      to use it.
+                    properties:
+                      name:
+                        description: name is the name of the secret used to push or
+                          pull this MachineOSConfig object. this secret must be in
+                          the openshift-machine-config-operator namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  renderedImagePushspec:
+                    description: 'renderedImagePushspec describes the location of
+                      the final image. the MachineOSConfig object will use the in
+                      cluster image registry configuration. if you wish to use a mirror
+                      or any other settings specific to registries.conf, please specify
+                      those in the cluster wide registries.conf. The format of the
+                      image pushspec is: host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>'
+                    maxLength: 447
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the OCI Image reference must end with a valid :<tag>,
+                        where '<digest>' is 64 characters long and '<tag>' is any
+                        valid string  Or it must be a valid .svc followed by a port,
+                        repository, image name, and tag.
+                      rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
+                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+                    - message: the OCI Image name should follow the host[:port][/namespace]/name
+                        format, resembling a valid URL without the scheme. Or it must
+                        be a valid .svc followed by a port, repository, image name,
+                        and tag.
+                      rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+                required:
+                - baseImagePullSecret
+                - imageBuilder
+                - renderedImagePushSecret
+                - renderedImagePushspec
+                type: object
+              buildOutputs:
+                description: buildOutputs is where user input options for the build
+                  live
+                properties:
+                  currentImagePullSecret:
+                    description: currentImagePullSecret is the secret used to pull
+                      the final produced image. must live in the openshift-machine-config-operator
+                      namespace the final image push and pull secrets should be separate
+                      for security concerns. If the final image push secret is somehow
+                      exfiltrated, that gives someone the power to push images to
+                      the image repository. By comparison, if the final image pull
+                      secret gets exfiltrated, that only gives someone to pull images
+                      from the image repository. It's basically the principle of least
+                      permissions. this pull secret will be used on all nodes in the
+                      pool. These nodes will need to pull the final OS image and boot
+                      into it using rpm-ostree or bootc.
+                    properties:
+                      name:
+                        description: name is the name of the secret used to push or
+                          pull this MachineOSConfig object. this secret must be in
+                          the openshift-machine-config-operator namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              machineConfigPool:
+                description: machineConfigPool is the pool which the build is for
+                properties:
+                  name:
+                    description: name of the MachineConfigPool object.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - buildInputs
+            - machineConfigPool
+            type: object
+          status:
+            description: status describes the status of the machineosconfig
+            properties:
+              conditions:
+                description: conditions are state related conditions for the config.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentImagePullspec:
+                description: currentImagePullspec is the fully qualified image pull
+                  spec used by the MCO to pull down the new OSImage. This must include
+                  sha256.
+                maxLength: 447
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                    suffix, where '<digest>' is 64 characters long
+                  rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme
+                  rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller. this field is updated when the user changes the
+                  configuration in BuildSettings or the MCP this object is associated
+                  with.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,352 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: machineosconfigs.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: MachineOSConfig
+    listKind: MachineOSConfigList
+    plural: machineosconfigs
+    singular: machineosconfig
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'MachineOSConfig describes the configuration for a build process
+          managed by the MCO Compatibility level 4: No compatibility is provided,
+          the API can change at any point for any reason. These capabilities should
+          not be used by applications needing long term support.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of the machineosconfig
+            properties:
+              buildInputs:
+                description: buildInputs is where user input options for the build
+                  live
+                properties:
+                  baseImagePullSecret:
+                    description: baseImagePullSecret is the secret used to pull the
+                      base image. must live in the openshift-machine-config-operator
+                      namespace
+                    properties:
+                      name:
+                        description: name is the name of the secret used to push or
+                          pull this MachineOSConfig object. this secret must be in
+                          the openshift-machine-config-operator namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  baseOSExtensionsImagePullspec:
+                    description: 'baseOSExtensionsImagePullspec is the base Extensions
+                      image used in the build process the MachineOSConfig object will
+                      use the in cluster image registry configuration. if you wish
+                      to use a mirror or any other settings specific to registries.conf,
+                      please specify those in the cluster wide registries.conf. The
+                      format of the image pullspec is: host[:port][/namespace]/name@sha256:<digest>'
+                    maxLength: 447
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                        suffix, where '<digest>' is 64 characters long
+                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                    - message: the OCI Image name should follow the host[:port][/namespace]/name
+                        format, resembling a valid URL without the scheme
+                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                  baseOSImagePullspec:
+                    description: 'baseOSImagePullspec is the base OSImage we use to
+                      build our custom image. the MachineOSConfig object will use
+                      the in cluster image registry configuration. if you wish to
+                      use a mirror or any other settings specific to registries.conf,
+                      please specify those in the cluster wide registries.conf. The
+                      format of the image pullspec is: host[:port][/namespace]/name@sha256:<digest>'
+                    maxLength: 447
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                        suffix, where '<digest>' is 64 characters long
+                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                    - message: the OCI Image name should follow the host[:port][/namespace]/name
+                        format, resembling a valid URL without the scheme
+                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                  containerFile:
+                    description: containerFile describes the custom data the user
+                      has specified to build into the image. this is also commonly
+                      called a Dockerfile and you can treat it as such. The content
+                      is the content of your Dockerfile.
+                    items:
+                      description: MachineOSContainerfile contains all custom content
+                        the user wants built into the image
+                      properties:
+                        containerfileArch:
+                          default: noarch
+                          description: 'containerfileArch describes the architecture
+                            this containerfile is to be built for this arch is optional.
+                            If the user does not specify an architecture, it is assumed
+                            that the content can be applied to all architectures,
+                            or in a single arch cluster: the only architecture.'
+                          enum:
+                          - arm64
+                          - amd64
+                          - ppc64le
+                          - s390x
+                          - aarch64
+                          - x86_64
+                          - noarch
+                          type: string
+                        content:
+                          description: content is the custom content to be built
+                          type: string
+                      required:
+                      - content
+                      type: object
+                    maxItems: 7
+                    minItems: 0
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - containerfileArch
+                    x-kubernetes-list-type: map
+                  imageBuilder:
+                    description: machineOSImageBuilder describes which image builder
+                      will be used in each build triggered by this MachineOSConfig
+                    properties:
+                      imageBuilderType:
+                        default: PodImageBuilder
+                        description: 'imageBuilderType specifies the backend to be
+                          used to build the image. Valid options are: PodImageBuilder'
+                        enum:
+                        - PodImageBuilder
+                        type: string
+                    required:
+                    - imageBuilderType
+                    type: object
+                  releaseVersion:
+                    description: 'releaseVersion is associated with the base OS Image.
+                      This is the version of Openshift that the Base Image is associated
+                      with. This field is populated from the machine-config-osimageurl
+                      configmap in the openshift-machine-config-operator namespace.
+                      It will come in the format: 4.16.0-0.nightly-2024-04-03-065948
+                      or any valid release. The MachineOSBuilder populates this field
+                      and validates that this is a valid stream. This is used as a
+                      label in the dockerfile that builds the OS image.'
+                    type: string
+                  renderedImagePushSecret:
+                    description: renderedImagePushSecret is the secret used to connect
+                      to a user registry. the final image push and pull secrets should
+                      be separate for security concerns. If the final image push secret
+                      is somehow exfiltrated, that gives someone the power to push
+                      images to the image repository. By comparison, if the final
+                      image pull secret gets exfiltrated, that only gives someone
+                      to pull images from the image repository. It's basically the
+                      principle of least permissions. this push secret will be used
+                      only by the MachineConfigController pod to push the image to
+                      the final destination. Not all nodes will need to push this
+                      image, most of them will only need to pull the image in order
+                      to use it.
+                    properties:
+                      name:
+                        description: name is the name of the secret used to push or
+                          pull this MachineOSConfig object. this secret must be in
+                          the openshift-machine-config-operator namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  renderedImagePushspec:
+                    description: 'renderedImagePushspec describes the location of
+                      the final image. the MachineOSConfig object will use the in
+                      cluster image registry configuration. if you wish to use a mirror
+                      or any other settings specific to registries.conf, please specify
+                      those in the cluster wide registries.conf. The format of the
+                      image pushspec is: host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>'
+                    maxLength: 447
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the OCI Image reference must end with a valid :<tag>,
+                        where '<digest>' is 64 characters long and '<tag>' is any
+                        valid string  Or it must be a valid .svc followed by a port,
+                        repository, image name, and tag.
+                      rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
+                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+                    - message: the OCI Image name should follow the host[:port][/namespace]/name
+                        format, resembling a valid URL without the scheme. Or it must
+                        be a valid .svc followed by a port, repository, image name,
+                        and tag.
+                      rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
+                required:
+                - baseImagePullSecret
+                - imageBuilder
+                - renderedImagePushSecret
+                - renderedImagePushspec
+                type: object
+              buildOutputs:
+                description: buildOutputs is where user input options for the build
+                  live
+                properties:
+                  currentImagePullSecret:
+                    description: currentImagePullSecret is the secret used to pull
+                      the final produced image. must live in the openshift-machine-config-operator
+                      namespace the final image push and pull secrets should be separate
+                      for security concerns. If the final image push secret is somehow
+                      exfiltrated, that gives someone the power to push images to
+                      the image repository. By comparison, if the final image pull
+                      secret gets exfiltrated, that only gives someone to pull images
+                      from the image repository. It's basically the principle of least
+                      permissions. this pull secret will be used on all nodes in the
+                      pool. These nodes will need to pull the final OS image and boot
+                      into it using rpm-ostree or bootc.
+                    properties:
+                      name:
+                        description: name is the name of the secret used to push or
+                          pull this MachineOSConfig object. this secret must be in
+                          the openshift-machine-config-operator namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              machineConfigPool:
+                description: machineConfigPool is the pool which the build is for
+                properties:
+                  name:
+                    description: name of the MachineConfigPool object.
+                    maxLength: 253
+                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - buildInputs
+            - machineConfigPool
+            type: object
+          status:
+            description: status describes the status of the machineosconfig
+            properties:
+              conditions:
+                description: conditions are state related conditions for the config.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentImagePullspec:
+                description: currentImagePullspec is the fully qualified image pull
+                  spec used by the MCO to pull down the new OSImage. This must include
+                  sha256.
+                maxLength: 447
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                    suffix, where '<digest>' is 64 characters long
+                  rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme
+                  rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller. this field is updated when the user changes the
+                  configuration in BuildSettings or the MCP this object is associated
+                  with.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_pinnedimagesets-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_pinnedimagesets-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,165 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1713
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: pinnedimagesets.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: PinnedImageSet
+    listKind: PinnedImageSetList
+    plural: pinnedimagesets
+    singular: pinnedimageset
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "PinnedImageSet describes a set of images that should be pinned
+          by CRI-O and pulled to the nodes which are members of the declared MachineConfigPools.
+          \n Compatibility level 4: No compatibility is provided, the API can change
+          at any point for any reason. These capabilities should not be used by applications
+          needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of this pinned image set.
+            properties:
+              pinnedImages:
+                description: "pinnedImages is a list of OCI Image referenced by digest
+                  that should be pinned and pre-loaded by the nodes of a MachineConfigPool.
+                  Translates into a new file inside the /etc/crio/crio.conf.d directory
+                  with content similar to this: \n pinned_images = [ \"quay.io/openshift-release-dev/ocp-release@sha256:...\",
+                  \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...\", \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...\",
+                  ... ] \n These image references should all be by digest, tags aren't
+                  allowed."
+                items:
+                  properties:
+                    name:
+                      description: "name is an OCI Image referenced by digest. \n
+                        The format of the image ref is: host[:port][/namespace]/name@sha256:<digest>"
+                      maxLength: 447
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                          suffix, where '<digest>' is 64 characters long
+                        rule: self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$')
+                      - message: the OCI Image name should follow the host[:port][/namespace]/name
+                          format, resembling a valid URL without the scheme
+                        rule: self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$')
+                  required:
+                  - name
+                  type: object
+                maxItems: 500
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - pinnedImages
+            type: object
+          status:
+            description: status describes the last observed state of this pinned image
+              set.
+            properties:
+              conditions:
+                description: conditions represent the observations of a pinned image
+                  set's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_pinnedimagesets-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_pinnedimagesets-DevPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,165 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1713
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: pinnedimagesets.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: PinnedImageSet
+    listKind: PinnedImageSetList
+    plural: pinnedimagesets
+    singular: pinnedimageset
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "PinnedImageSet describes a set of images that should be pinned
+          by CRI-O and pulled to the nodes which are members of the declared MachineConfigPools.
+          \n Compatibility level 4: No compatibility is provided, the API can change
+          at any point for any reason. These capabilities should not be used by applications
+          needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of this pinned image set.
+            properties:
+              pinnedImages:
+                description: "pinnedImages is a list of OCI Image referenced by digest
+                  that should be pinned and pre-loaded by the nodes of a MachineConfigPool.
+                  Translates into a new file inside the /etc/crio/crio.conf.d directory
+                  with content similar to this: \n pinned_images = [ \"quay.io/openshift-release-dev/ocp-release@sha256:...\",
+                  \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...\", \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...\",
+                  ... ] \n These image references should all be by digest, tags aren't
+                  allowed."
+                items:
+                  properties:
+                    name:
+                      description: "name is an OCI Image referenced by digest. \n
+                        The format of the image ref is: host[:port][/namespace]/name@sha256:<digest>"
+                      maxLength: 447
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                          suffix, where '<digest>' is 64 characters long
+                        rule: self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$')
+                      - message: the OCI Image name should follow the host[:port][/namespace]/name
+                          format, resembling a valid URL without the scheme
+                        rule: self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$')
+                  required:
+                  - name
+                  type: object
+                maxItems: 500
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - pinnedImages
+            type: object
+          status:
+            description: status describes the last observed state of this pinned image
+              set.
+            properties:
+              conditions:
+                description: conditions represent the observations of a pinned image
+                  set's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_pinnedimagesets-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_pinnedimagesets-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,165 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1713
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: pinnedimagesets.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: PinnedImageSet
+    listKind: PinnedImageSetList
+    plural: pinnedimagesets
+    singular: pinnedimageset
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: "PinnedImageSet describes a set of images that should be pinned
+          by CRI-O and pulled to the nodes which are members of the declared MachineConfigPools.
+          \n Compatibility level 4: No compatibility is provided, the API can change
+          at any point for any reason. These capabilities should not be used by applications
+          needing long term support."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec describes the configuration of this pinned image set.
+            properties:
+              pinnedImages:
+                description: "pinnedImages is a list of OCI Image referenced by digest
+                  that should be pinned and pre-loaded by the nodes of a MachineConfigPool.
+                  Translates into a new file inside the /etc/crio/crio.conf.d directory
+                  with content similar to this: \n pinned_images = [ \"quay.io/openshift-release-dev/ocp-release@sha256:...\",
+                  \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...\", \"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...\",
+                  ... ] \n These image references should all be by digest, tags aren't
+                  allowed."
+                items:
+                  properties:
+                    name:
+                      description: "name is an OCI Image referenced by digest. \n
+                        The format of the image ref is: host[:port][/namespace]/name@sha256:<digest>"
+                      maxLength: 447
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                          suffix, where '<digest>' is 64 characters long
+                        rule: self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$')
+                      - message: the OCI Image name should follow the host[:port][/namespace]/name
+                          format, resembling a valid URL without the scheme
+                        rule: self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$')
+                  required:
+                  - name
+                  type: object
+                maxItems: 500
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            required:
+            - pinnedImages
+            type: object
+          status:
+            description: status describes the last observed state of this pinned image
+              set.
+            properties:
+              conditions:
+                description: conditions represent the observations of a pinned image
+                  set's current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
this makes promotion of featuregates more atomic as the CRD schema for Default changes in the same PR that makes the feature default.

/cc @yuqi-zhang 