### PR TITLE
WRKLDS-1449: add status subresource to networks.operator.openshift.io

### DIFF
--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -9,6 +9,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=networks,scope=Cluster
+// +kubebuilder:subresource:status
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/475
 // +openshift:file-pattern=cvoRunLevel=0000_70,operatorName=network,operatorOrdering=01
 

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-CustomNoUpgrade.crd.yaml
@@ -999,3 +999,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-Default.crd.yaml
@@ -944,3 +944,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-DevPreviewNoUpgrade.crd.yaml
@@ -999,3 +999,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-TechPreviewNoUpgrade.crd.yaml
@@ -999,3 +999,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/operator/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -336,7 +336,7 @@ networks.operator.openshift.io:
   FilenameOperatorOrdering: "01"
   FilenameRunLevel: "0000_70"
   GroupName: operator.openshift.io
-  HasStatus: false
+  HasStatus: true
   KindName: Network
   Labels: {}
   PluralName: networks

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
@@ -939,3 +939,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
@@ -978,3 +978,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
@@ -944,3 +944,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/RouteAdvertisements.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/RouteAdvertisements.yaml
@@ -955,3 +955,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
-fixes MustHaveStatus error