### PR TITLE
API-1835: move latestAvailableRevision ot operatorStatus

### DIFF
--- a/imageregistry/v1/zz_generated.crd-manifests/00_configs.crd.yaml
+++ b/imageregistry/v1/zz_generated.crd-manifests/00_configs.crd.yaml
@@ -2000,6 +2000,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/imageregistry/v1/zz_generated.featuregated-crd-manifests/configs.imageregistry.operator.openshift.io/AAA_ungated.yaml
+++ b/imageregistry/v1/zz_generated.featuregated-crd-manifests/configs.imageregistry.operator.openshift.io/AAA_ungated.yaml
@@ -1971,6 +1971,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/imageregistry/v1/zz_generated.featuregated-crd-manifests/configs.imageregistry.operator.openshift.io/ChunkSizeMiB.yaml
+++ b/imageregistry/v1/zz_generated.featuregated-crd-manifests/configs.imageregistry.operator.openshift.io/ChunkSizeMiB.yaml
@@ -1984,6 +1984,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -44567,6 +44567,13 @@ func schema_openshift_api_operator_v1_AuthenticationStatus(ref common.ReferenceC
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -44934,6 +44941,13 @@ func schema_openshift_api_operator_v1_CSISnapshotControllerStatus(ref common.Ref
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -45291,6 +45305,13 @@ func schema_openshift_api_operator_v1_CloudCredentialStatus(ref common.Reference
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -45539,6 +45560,13 @@ func schema_openshift_api_operator_v1_ClusterCSIDriverStatus(ref common.Referenc
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -45803,6 +45831,13 @@ func schema_openshift_api_operator_v1_ConfigStatus(ref common.ReferenceCallback)
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -46248,6 +46283,13 @@ func schema_openshift_api_operator_v1_ConsoleStatus(ref common.ReferenceCallback
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -47247,6 +47289,13 @@ func schema_openshift_api_operator_v1_EtcdStatus(ref common.ReferenceCallback) c
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -47270,13 +47319,6 @@ func schema_openshift_api_operator_v1_EtcdStatus(ref common.ReferenceCallback) c
 									},
 								},
 							},
-						},
-					},
-					"latestAvailableRevision": {
-						SchemaProps: spec.SchemaProps{
-							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
-							Type:        []string{"integer"},
-							Format:      "int32",
 						},
 					},
 					"latestAvailableRevisionReason": {
@@ -49202,6 +49244,13 @@ func schema_openshift_api_operator_v1_InsightsOperatorStatus(ref common.Referenc
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -49516,6 +49565,13 @@ func schema_openshift_api_operator_v1_KubeAPIServerStatus(ref common.ReferenceCa
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -49539,13 +49595,6 @@ func schema_openshift_api_operator_v1_KubeAPIServerStatus(ref common.ReferenceCa
 									},
 								},
 							},
-						},
-					},
-					"latestAvailableRevision": {
-						SchemaProps: spec.SchemaProps{
-							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
-							Type:        []string{"integer"},
-							Format:      "int32",
 						},
 					},
 					"latestAvailableRevisionReason": {
@@ -49833,6 +49882,13 @@ func schema_openshift_api_operator_v1_KubeControllerManagerStatus(ref common.Ref
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -49856,13 +49912,6 @@ func schema_openshift_api_operator_v1_KubeControllerManagerStatus(ref common.Ref
 									},
 								},
 							},
-						},
-					},
-					"latestAvailableRevision": {
-						SchemaProps: spec.SchemaProps{
-							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
-							Type:        []string{"integer"},
-							Format:      "int32",
 						},
 					},
 					"latestAvailableRevisionReason": {
@@ -50128,6 +50177,13 @@ func schema_openshift_api_operator_v1_KubeSchedulerStatus(ref common.ReferenceCa
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -50151,13 +50207,6 @@ func schema_openshift_api_operator_v1_KubeSchedulerStatus(ref common.ReferenceCa
 									},
 								},
 							},
-						},
-					},
-					"latestAvailableRevision": {
-						SchemaProps: spec.SchemaProps{
-							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
-							Type:        []string{"integer"},
-							Format:      "int32",
 						},
 					},
 					"latestAvailableRevisionReason": {
@@ -50395,6 +50444,13 @@ func schema_openshift_api_operator_v1_KubeStorageVersionMigratorStatus(ref commo
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -51103,6 +51159,13 @@ func schema_openshift_api_operator_v1_MyOperatorResourceStatus(ref common.Refere
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -51528,6 +51591,13 @@ func schema_openshift_api_operator_v1_NetworkStatus(ref common.ReferenceCallback
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -52526,6 +52596,13 @@ func schema_openshift_api_operator_v1_OpenShiftAPIServerStatus(ref common.Refere
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -52549,13 +52626,6 @@ func schema_openshift_api_operator_v1_OpenShiftAPIServerStatus(ref common.Refere
 									},
 								},
 							},
-						},
-					},
-					"latestAvailableRevision": {
-						SchemaProps: spec.SchemaProps{
-							Description: "latestAvailableRevision is the latest revision used as suffix of revisioned secrets like encryption-config. A new revision causes a new deployment of pods.",
-							Type:        []string{"integer"},
-							Format:      "int32",
 						},
 					},
 				},
@@ -52764,6 +52834,13 @@ func schema_openshift_api_operator_v1_OpenShiftControllerManagerStatus(ref commo
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -52998,6 +53075,13 @@ func schema_openshift_api_operator_v1_OperatorStatus(ref common.ReferenceCallbac
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -53835,6 +53919,13 @@ func schema_openshift_api_operator_v1_ServiceCAStatus(ref common.ReferenceCallba
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -54070,6 +54161,13 @@ func schema_openshift_api_operator_v1_ServiceCatalogAPIServerStatus(ref common.R
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -54301,6 +54399,13 @@ func schema_openshift_api_operator_v1_ServiceCatalogControllerManagerStatus(ref 
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -54682,6 +54787,13 @@ func schema_openshift_api_operator_v1_StaticPodOperatorStatus(ref common.Referen
 							Format:      "int32",
 						},
 					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"generations": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -54705,13 +54817,6 @@ func schema_openshift_api_operator_v1_StaticPodOperatorStatus(ref common.Referen
 									},
 								},
 							},
-						},
-					},
-					"latestAvailableRevision": {
-						SchemaProps: spec.SchemaProps{
-							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
-							Type:        []string{"integer"},
-							Format:      "int32",
 						},
 					},
 					"latestAvailableRevisionReason": {
@@ -54982,6 +55087,13 @@ func schema_openshift_api_operator_v1_StorageStatus(ref common.ReferenceCallback
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -55963,6 +56075,13 @@ func schema_openshift_api_operator_v1alpha1_OLMStatus(ref common.ReferenceCallba
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -61664,6 +61783,13 @@ func schema_openshift_api_servicecertsigner_v1alpha1_ServiceCertSignerOperatorCo
 						SchemaProps: spec.SchemaProps{
 							Description: "readyReplicas indicates how many replicas are ready and at the desired state",
 							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"latestAvailableRevision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "latestAvailableRevision is the deploymentID of the most recent deployment",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -25897,6 +25897,11 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
+        },
         "oauthAPIServer": {
           "description": "OAuthAPIServer holds status specific only to oauth-apiserver",
           "default": {},
@@ -26128,6 +26133,11 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
+        },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
           "type": "integer",
@@ -26344,6 +26354,11 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
+        },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
           "type": "integer",
@@ -26496,6 +26511,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -26658,6 +26678,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -26923,6 +26948,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -28670,6 +28700,11 @@
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.operator.v1.InsightsReport"
         },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
+        },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
           "type": "integer",
@@ -29393,6 +29428,11 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
+        },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
           "type": "integer",
@@ -29821,6 +29861,11 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
+        },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
           "type": "integer",
@@ -30066,6 +30111,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -30642,7 +30692,7 @@
           "x-kubernetes-list-type": "map"
         },
         "latestAvailableRevision": {
-          "description": "latestAvailableRevision is the latest revision used as suffix of revisioned secrets like encryption-config. A new revision causes a new deployment of pods.",
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
           "type": "integer",
           "format": "int32"
         },
@@ -30789,6 +30839,11 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
+        },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
           "type": "integer",
@@ -30930,6 +30985,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -31417,6 +31477,11 @@
           ],
           "x-kubernetes-list-type": "map"
         },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
+        },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
           "type": "integer",
@@ -31558,6 +31623,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -31701,6 +31771,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -32096,6 +32171,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -32697,6 +32777,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",
@@ -36129,6 +36214,11 @@
             "name"
           ],
           "x-kubernetes-list-type": "map"
+        },
+        "latestAvailableRevision": {
+          "description": "latestAvailableRevision is the deploymentID of the most recent deployment",
+          "type": "integer",
+          "format": "int32"
         },
         "observedGeneration": {
           "description": "observedGeneration is the last generation change you've dealt with",

--- a/operator/v1/tests/authentications.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/tests/authentications.operator.openshift.io/AAA_ungated.yaml
@@ -14,3 +14,117 @@ tests:
         spec:
           logLevel: Normal
           operatorLogLevel: Normal
+  onUpdate:
+    - name: Can add latest revision after creation
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+          name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+         name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 0
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+         name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 0
+    - name: Can update latestRevision to the same value
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+          name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 6
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+         name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 6
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+         name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 6
+    - name: Can increase latestRevision
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+          name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 6
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+         name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 16
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+         name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 16
+    - name: Cannot decrease latestRevision
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+          name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 6
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: Authentication
+        metadata:
+         name: cluster
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          latestAvailableRevision: 5
+      expectedStatusError: must only increase

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -127,6 +127,11 @@ type OperatorStatus struct {
 	// readyReplicas indicates how many replicas are ready and at the desired state
 	ReadyReplicas int32 `json:"readyReplicas"`
 
+	// latestAvailableRevision is the deploymentID of the most recent deployment
+	// +optional
+	// +kubebuilder:validation:XValidation:rule="self >= oldSelf",message="must only increase"
+	LatestAvailableRevision int32 `json:"latestAvailableRevision,omitempty"`
+
 	// generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.
 	// +listType=map
 	// +listMapKey=group
@@ -210,10 +215,6 @@ type StaticPodOperatorSpec struct {
 // node status must be tracked.
 type StaticPodOperatorStatus struct {
 	OperatorStatus `json:",inline"`
-
-	// latestAvailableRevision is the deploymentID of the most recent deployment
-	// +optional
-	LatestAvailableRevision int32 `json:"latestAvailableRevision,omitempty"`
 
 	// latestAvailableRevisionReason describe the detailed reason for the most recent deployment
 	// +optional

--- a/operator/v1/types_openshiftapiserver.go
+++ b/operator/v1/types_openshiftapiserver.go
@@ -40,13 +40,6 @@ type OpenShiftAPIServerSpec struct {
 
 type OpenShiftAPIServerStatus struct {
 	OperatorStatus `json:",inline"`
-
-	// latestAvailableRevision is the latest revision used as suffix of revisioned
-	// secrets like encryption-config. A new revision causes a new deployment of
-	// pods.
-	// +optional
-	// +kubebuilder:validation:Minimum=0
-	LatestAvailableRevision int32 `json:"latestAvailableRevision,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/operator/v1/zz_generated.crd-manifests/0000_10_config-operator_01_configs.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_10_config-operator_01_configs.crd.yaml
@@ -165,6 +165,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -216,6 +216,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -204,6 +204,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -216,6 +216,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -216,6 +216,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -187,6 +187,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -197,6 +197,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -187,6 +187,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.crd-manifests/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
@@ -164,12 +164,13 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               latestAvailableRevision:
-                description: latestAvailableRevision is the latest revision used as
-                  suffix of revisioned secrets like encryption-config. A new revision
-                  causes a new deployment of pods.
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
                 format: int32
-                minimum: 0
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_40_cloud-credential_00_cloudcredentials.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_40_cloud-credential_00_cloudcredentials.crd.yaml
@@ -178,6 +178,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_40_kube-storage-version-migrator_00_kubestorageversionmigrators.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_40_kube-storage-version-migrator_00_kubestorageversionmigrators.crd.yaml
@@ -158,6 +158,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_50_authentication_01_authentications.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_authentication_01_authentications.crd.yaml
@@ -156,6 +156,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               oauthAPIServer:
                 description: OAuthAPIServer holds status specific only to oauth-apiserver
                 properties:

--- a/operator/v1/zz_generated.crd-manifests/0000_50_console_01_consoles.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_console_01_consoles.crd.yaml
@@ -710,6 +710,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_50_insights_00_insightsoperators.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_insights_00_insightsoperators.crd.yaml
@@ -339,6 +339,14 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
@@ -160,6 +160,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_50_service-ca_02_servicecas.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_service-ca_02_servicecas.crd.yaml
@@ -160,6 +160,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_50_storage_01_storages.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_storage_01_storages.crd.yaml
@@ -176,6 +176,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-CustomNoUpgrade.crd.yaml
@@ -982,6 +982,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-Default.crd.yaml
@@ -927,6 +927,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-DevPreviewNoUpgrade.crd.yaml
@@ -982,6 +982,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-TechPreviewNoUpgrade.crd.yaml
@@ -982,6 +982,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_80_csi-snapshot-controller_01_csisnapshotcontrollers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_csi-snapshot-controller_01_csisnapshotcontrollers.crd.yaml
@@ -161,6 +161,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_90_csi-driver_01_clustercsidrivers.crd.yaml
@@ -444,6 +444,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/authentications.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/authentications.operator.openshift.io/AAA_ungated.yaml
@@ -159,6 +159,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               oauthAPIServer:
                 description: OAuthAPIServer holds status specific only to oauth-apiserver
                 properties:

--- a/operator/v1/zz_generated.featuregated-crd-manifests/cloudcredentials.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/cloudcredentials.operator.openshift.io/AAA_ungated.yaml
@@ -179,6 +179,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AAA_ungated.yaml
@@ -342,6 +342,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AWSEFSDriverVolumeMetrics.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/AWSEFSDriverVolumeMetrics.yaml
@@ -391,6 +391,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/VSphereDriverConfiguration.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/clustercsidrivers.operator.openshift.io/VSphereDriverConfiguration.yaml
@@ -375,6 +375,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/configs.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/configs.operator.openshift.io/AAA_ungated.yaml
@@ -166,6 +166,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/consoles.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/consoles.operator.openshift.io/AAA_ungated.yaml
@@ -711,6 +711,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/csisnapshotcontrollers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/csisnapshotcontrollers.operator.openshift.io/AAA_ungated.yaml
@@ -162,6 +162,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
@@ -192,6 +192,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
@@ -204,6 +204,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/HardwareSpeed.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/HardwareSpeed.yaml
@@ -204,6 +204,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/insightsoperators.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/insightsoperators.operator.openshift.io/AAA_ungated.yaml
@@ -340,6 +340,14 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                 type: object
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -188,6 +188,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
@@ -198,6 +198,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
@@ -188,6 +188,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubestorageversionmigrators.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubestorageversionmigrators.operator.openshift.io/AAA_ungated.yaml
@@ -159,6 +159,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
@@ -922,6 +922,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
@@ -961,6 +961,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
@@ -927,6 +927,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/RouteAdvertisements.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/RouteAdvertisements.yaml
@@ -938,6 +938,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/openshiftapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/openshiftapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -165,12 +165,13 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               latestAvailableRevision:
-                description: latestAvailableRevision is the latest revision used as
-                  suffix of revisioned secrets like encryption-config. A new revision
-                  causes a new deployment of pods.
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
                 format: int32
-                minimum: 0
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/openshiftcontrollermanagers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/openshiftcontrollermanagers.operator.openshift.io/AAA_ungated.yaml
@@ -161,6 +161,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/servicecas.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/servicecas.operator.openshift.io/AAA_ungated.yaml
@@ -161,6 +161,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.featuregated-crd-manifests/storages.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/storages.operator.openshift.io/AAA_ungated.yaml
@@ -177,6 +177,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -73,11 +73,12 @@ func (OperatorSpec) SwaggerDoc() map[string]string {
 }
 
 var map_OperatorStatus = map[string]string{
-	"observedGeneration": "observedGeneration is the last generation change you've dealt with",
-	"conditions":         "conditions is a list of conditions and their status",
-	"version":            "version is the level this availability applies to",
-	"readyReplicas":      "readyReplicas indicates how many replicas are ready and at the desired state",
-	"generations":        "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
+	"observedGeneration":      "observedGeneration is the last generation change you've dealt with",
+	"conditions":              "conditions is a list of conditions and their status",
+	"version":                 "version is the level this availability applies to",
+	"readyReplicas":           "readyReplicas indicates how many replicas are ready and at the desired state",
+	"latestAvailableRevision": "latestAvailableRevision is the deploymentID of the most recent deployment",
+	"generations":             "generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.",
 }
 
 func (OperatorStatus) SwaggerDoc() map[string]string {
@@ -97,7 +98,6 @@ func (StaticPodOperatorSpec) SwaggerDoc() map[string]string {
 
 var map_StaticPodOperatorStatus = map[string]string{
 	"":                              "StaticPodOperatorStatus is status for controllers that manage static pods.  There are different needs because individual node status must be tracked.",
-	"latestAvailableRevision":       "latestAvailableRevision is the deploymentID of the most recent deployment",
 	"latestAvailableRevisionReason": "latestAvailableRevisionReason describe the detailed reason for the most recent deployment",
 	"nodeStatuses":                  "nodeStatuses track the deployment values and errors across individual nodes",
 }
@@ -1902,14 +1902,6 @@ var map_OpenShiftAPIServerList = map[string]string{
 
 func (OpenShiftAPIServerList) SwaggerDoc() map[string]string {
 	return map_OpenShiftAPIServerList
-}
-
-var map_OpenShiftAPIServerStatus = map[string]string{
-	"latestAvailableRevision": "latestAvailableRevision is the latest revision used as suffix of revisioned secrets like encryption-config. A new revision causes a new deployment of pods.",
-}
-
-func (OpenShiftAPIServerStatus) SwaggerDoc() map[string]string {
-	return map_OpenShiftAPIServerStatus
 }
 
 var map_OpenShiftControllerManager = map[string]string{

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-CustomNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-CustomNoUpgrade.crd.yaml
@@ -162,6 +162,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-DevPreviewNoUpgrade.crd.yaml
@@ -162,6 +162,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_10_operator-lifecycle-manager_01_olms-TechPreviewNoUpgrade.crd.yaml
@@ -162,6 +162,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/operator/v1alpha1/zz_generated.featuregated-crd-manifests/olms.operator.openshift.io/NewOLM.yaml
+++ b/operator/v1alpha1/zz_generated.featuregated-crd-manifests/olms.operator.openshift.io/NewOLM.yaml
@@ -162,6 +162,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/payload-manifests/crds/0000_10_config-operator_01_configs.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_configs.crd.yaml
@@ -165,6 +165,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -216,6 +216,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -204,6 +204,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -216,6 +216,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -216,6 +216,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -187,6 +187,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -197,6 +197,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -187,6 +187,9 @@ spec:
                   recent deployment
                 format: int32
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               latestAvailableRevisionReason:
                 description: latestAvailableRevisionReason describe the detailed reason
                   for the most recent deployment

--- a/payload-manifests/crds/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
+++ b/payload-manifests/crds/0000_30_openshift-apiserver_01_openshiftapiservers.crd.yaml
@@ -164,12 +164,13 @@ spec:
                 - name
                 x-kubernetes-list-type: map
               latestAvailableRevision:
-                description: latestAvailableRevision is the latest revision used as
-                  suffix of revisioned secrets like encryption-config. A new revision
-                  causes a new deployment of pods.
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
                 format: int32
-                minimum: 0
                 type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/payload-manifests/crds/0000_50_authentication_01_authentications.crd.yaml
+++ b/payload-manifests/crds/0000_50_authentication_01_authentications.crd.yaml
@@ -156,6 +156,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               oauthAPIServer:
                 description: OAuthAPIServer holds status specific only to oauth-apiserver
                 properties:

--- a/payload-manifests/crds/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
+++ b/payload-manifests/crds/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers.crd.yaml
@@ -160,6 +160,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/payload-manifests/crds/0000_50_storage_01_storages.crd.yaml
+++ b/payload-manifests/crds/0000_50_storage_01_storages.crd.yaml
@@ -176,6 +176,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with

--- a/payload-manifests/crds/0000_90_csi-driver_01_clustercsidrivers.crd.yaml
+++ b/payload-manifests/crds/0000_90_csi-driver_01_clustercsidrivers.crd.yaml
@@ -444,6 +444,14 @@ spec:
                 - namespace
                 - name
                 x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
               observedGeneration:
                 description: observedGeneration is the last generation change you've
                   dealt with


### PR DESCRIPTION
This field was used in a couple operators deploying apiservers.  My guess is that it is necessary for KMS.

Also add validation to prevent moving revisions backwards, which would do really bad things.

/assign @bertinatto @p0lyn0mial 