### PR TITLE
RFE-6242: ingress: rename loadBalancerIP to floatingIP

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -52865,9 +52865,9 @@ func schema_openshift_api_operator_v1_OpenStackLoadBalancerParameters(ref common
 				Description: "OpenStackLoadBalancerParameters provides configuration settings that are specific to OpenStack load balancers.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"loadBalancerIP": {
+					"floatingIP": {
 						SchemaProps: spec.SchemaProps{
-							Description: "loadBalancerIP specifies the floating IP address that the load balancer will use. When not specified, an IP address will be assigned randomly by the OpenStack cloud provider. This value must be a valid IPv4 or IPv6 address.",
+							Description: "floatingIP specifies the IP address that the load balancer will use. When not specified, an IP address will be assigned randomly by the OpenStack cloud provider. When specified, the floating IP has to be pre-created.  If the specified value is not a floating IP or is already claimed, the OpenStack cloud provider won't be able to provision the load balancer. This field may only be used if the IngressController has External scope. This value must be a valid IPv4 or IPv6 address.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -30831,8 +30831,8 @@
       "description": "OpenStackLoadBalancerParameters provides configuration settings that are specific to OpenStack load balancers.",
       "type": "object",
       "properties": {
-        "loadBalancerIP": {
-          "description": "loadBalancerIP specifies the floating IP address that the load balancer will use. When not specified, an IP address will be assigned randomly by the OpenStack cloud provider. This value must be a valid IPv4 or IPv6 address.",
+        "floatingIP": {
+          "description": "floatingIP specifies the IP address that the load balancer will use. When not specified, an IP address will be assigned randomly by the OpenStack cloud provider. When specified, the floating IP has to be pre-created.  If the specified value is not a floating IP or is already claimed, the OpenStack cloud provider won't be able to provision the load balancer. This field may only be used if the IngressController has External scope. This value must be a valid IPv4 or IPv6 address.",
           "type": "string"
         }
       }

--- a/operator/v1/tests/ingresscontrollers.operator.openshift.io/IngressControllerLBOpenStack.yaml
+++ b/operator/v1/tests/ingresscontrollers.operator.openshift.io/IngressControllerLBOpenStack.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "Ingress"
+crdName: ingresscontrollers.operator.openshift.io
+tests:
+  onCreate:
+    - name: Should be able to create a minimal ingresscontroller with an internal load balancer on OpenStack.
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        spec:
+          endpointPublishingStrategy:
+            type: LoadBalancerService
+            loadBalancer:
+              scope: Internal
+              providerParameters:
+                type: OpenStack
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        spec:
+          httpEmptyRequestsPolicy: Respond
+          endpointPublishingStrategy:
+            type: LoadBalancerService
+            loadBalancer:
+              dnsManagementPolicy: Managed
+              scope: Internal
+              providerParameters:
+                type: OpenStack
+    - name: Should be able to create a minimal ingresscontroller with an external load balancer on OpenStack.
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        spec:
+          endpointPublishingStrategy:
+            type: LoadBalancerService
+            loadBalancer:
+              scope: External
+              providerParameters:
+                type: OpenStack
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        spec:
+          httpEmptyRequestsPolicy: Respond
+          endpointPublishingStrategy:
+            type: LoadBalancerService
+            loadBalancer:
+              dnsManagementPolicy: Managed
+              scope: External
+              providerParameters:
+                type: OpenStack
+    - name: Should be able to create a minimal ingresscontroller with an external load balancer and a floating IP on OpenStack.
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        spec:
+          endpointPublishingStrategy:
+            type: LoadBalancerService
+            loadBalancer:
+              scope: External
+              providerParameters:
+                type: OpenStack
+                openstack:
+                  floatingIP: "1.2.3.4"
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        spec:
+          httpEmptyRequestsPolicy: Respond
+          endpointPublishingStrategy:
+            type: LoadBalancerService
+            loadBalancer:
+              dnsManagementPolicy: Managed
+              scope: External
+              providerParameters:
+                type: OpenStack
+                openstack:
+                  floatingIP: "1.2.3.4"
+    - name: Should not be able to create ingresscontroller with internal load balancer and a floating IP on OpenStack.
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        spec:
+          endpointPublishingStrategy:
+            type: LoadBalancerService
+            loadBalancer:
+              scope: Internal
+              providerParameters:
+                type: OpenStack
+                openstack:
+                  floatingIP: "1.2.3.4"
+      expectedError: "cannot specify a floating ip when scope is internal"

--- a/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_50_ingress_00_ingresscontrollers.crd.yaml
@@ -639,15 +639,20 @@ spec:
                               If empty, defaults will be applied. See specific openstack fields for
                               details about their defaults.
                             properties:
-                              loadBalancerIP:
+                              floatingIP:
                                 description: |-
-                                  loadBalancerIP specifies the floating IP address that the load balancer will use.
+                                  floatingIP specifies the IP address that the load balancer will use.
                                   When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                                  When specified, the floating IP has to be pre-created.  If the
+                                  specified value is not a floating IP or is already claimed, the
+                                  OpenStack cloud provider won't be able to provision the load
+                                  balancer.
+                                  This field may only be used if the IngressController has External scope.
                                   This value must be a valid IPv4 or IPv6 address.
                                 type: string
                                 x-kubernetes-validations:
-                                - message: loadBalancerIP must be a valid IPv4 or
-                                    IPv6 address
+                                - message: floatingIP must be a valid IPv4 or IPv6
+                                    address
                                   rule: isIP(self)
                             type: object
                           type:
@@ -689,6 +694,10 @@ spec:
                       rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
                         || !has(self.providerParameters.aws) || !has(self.providerParameters.aws.networkLoadBalancer)
                         || !has(self.providerParameters.aws.networkLoadBalancer.eipAllocations)'
+                    - message: cannot specify a floating ip when scope is internal
+                      rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
+                        || !has(self.providerParameters.openstack) || !has(self.providerParameters.openstack.floatingIP)
+                        || self.providerParameters.openstack.floatingIP == ""'
                   nodePort:
                     description: |-
                       nodePort holds parameters for the NodePortService endpoint publishing strategy.
@@ -2815,15 +2824,20 @@ spec:
                               If empty, defaults will be applied. See specific openstack fields for
                               details about their defaults.
                             properties:
-                              loadBalancerIP:
+                              floatingIP:
                                 description: |-
-                                  loadBalancerIP specifies the floating IP address that the load balancer will use.
+                                  floatingIP specifies the IP address that the load balancer will use.
                                   When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                                  When specified, the floating IP has to be pre-created.  If the
+                                  specified value is not a floating IP or is already claimed, the
+                                  OpenStack cloud provider won't be able to provision the load
+                                  balancer.
+                                  This field may only be used if the IngressController has External scope.
                                   This value must be a valid IPv4 or IPv6 address.
                                 type: string
                                 x-kubernetes-validations:
-                                - message: loadBalancerIP must be a valid IPv4 or
-                                    IPv6 address
+                                - message: floatingIP must be a valid IPv4 or IPv6
+                                    address
                                   rule: isIP(self)
                             type: object
                           type:
@@ -2865,6 +2879,10 @@ spec:
                       rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
                         || !has(self.providerParameters.aws) || !has(self.providerParameters.aws.networkLoadBalancer)
                         || !has(self.providerParameters.aws.networkLoadBalancer.eipAllocations)'
+                    - message: cannot specify a floating ip when scope is internal
+                      rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
+                        || !has(self.providerParameters.openstack) || !has(self.providerParameters.openstack.floatingIP)
+                        || self.providerParameters.openstack.floatingIP == ""'
                   nodePort:
                     description: |-
                       nodePort holds parameters for the NodePortService endpoint publishing strategy.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
@@ -437,15 +437,20 @@ spec:
                               If empty, defaults will be applied. See specific openstack fields for
                               details about their defaults.
                             properties:
-                              loadBalancerIP:
+                              floatingIP:
                                 description: |-
-                                  loadBalancerIP specifies the floating IP address that the load balancer will use.
+                                  floatingIP specifies the IP address that the load balancer will use.
                                   When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                                  When specified, the floating IP has to be pre-created.  If the
+                                  specified value is not a floating IP or is already claimed, the
+                                  OpenStack cloud provider won't be able to provision the load
+                                  balancer.
+                                  This field may only be used if the IngressController has External scope.
                                   This value must be a valid IPv4 or IPv6 address.
                                 type: string
                                 x-kubernetes-validations:
-                                - message: loadBalancerIP must be a valid IPv4 or
-                                    IPv6 address
+                                - message: floatingIP must be a valid IPv4 or IPv6
+                                    address
                                   rule: isIP(self)
                             type: object
                           type:
@@ -482,6 +487,11 @@ spec:
                     - dnsManagementPolicy
                     - scope
                     type: object
+                    x-kubernetes-validations:
+                    - message: cannot specify a floating ip when scope is internal
+                      rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
+                        || !has(self.providerParameters.openstack) || !has(self.providerParameters.openstack.floatingIP)
+                        || self.providerParameters.openstack.floatingIP == ""'
                   nodePort:
                     description: |-
                       nodePort holds parameters for the NodePortService endpoint publishing strategy.
@@ -2387,15 +2397,20 @@ spec:
                               If empty, defaults will be applied. See specific openstack fields for
                               details about their defaults.
                             properties:
-                              loadBalancerIP:
+                              floatingIP:
                                 description: |-
-                                  loadBalancerIP specifies the floating IP address that the load balancer will use.
+                                  floatingIP specifies the IP address that the load balancer will use.
                                   When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                                  When specified, the floating IP has to be pre-created.  If the
+                                  specified value is not a floating IP or is already claimed, the
+                                  OpenStack cloud provider won't be able to provision the load
+                                  balancer.
+                                  This field may only be used if the IngressController has External scope.
                                   This value must be a valid IPv4 or IPv6 address.
                                 type: string
                                 x-kubernetes-validations:
-                                - message: loadBalancerIP must be a valid IPv4 or
-                                    IPv6 address
+                                - message: floatingIP must be a valid IPv4 or IPv6
+                                    address
                                   rule: isIP(self)
                             type: object
                           type:
@@ -2432,6 +2447,11 @@ spec:
                     - dnsManagementPolicy
                     - scope
                     type: object
+                    x-kubernetes-validations:
+                    - message: cannot specify a floating ip when scope is internal
+                      rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
+                        || !has(self.providerParameters.openstack) || !has(self.providerParameters.openstack.floatingIP)
+                        || self.providerParameters.openstack.floatingIP == ""'
                   nodePort:
                     description: |-
                       nodePort holds parameters for the NodePortService endpoint publishing strategy.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
@@ -586,15 +586,20 @@ spec:
                               If empty, defaults will be applied. See specific openstack fields for
                               details about their defaults.
                             properties:
-                              loadBalancerIP:
+                              floatingIP:
                                 description: |-
-                                  loadBalancerIP specifies the floating IP address that the load balancer will use.
+                                  floatingIP specifies the IP address that the load balancer will use.
                                   When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                                  When specified, the floating IP has to be pre-created.  If the
+                                  specified value is not a floating IP or is already claimed, the
+                                  OpenStack cloud provider won't be able to provision the load
+                                  balancer.
+                                  This field may only be used if the IngressController has External scope.
                                   This value must be a valid IPv4 or IPv6 address.
                                 type: string
                                 x-kubernetes-validations:
-                                - message: loadBalancerIP must be a valid IPv4 or
-                                    IPv6 address
+                                - message: floatingIP must be a valid IPv4 or IPv6
+                                    address
                                   rule: isIP(self)
                             type: object
                           type:
@@ -631,6 +636,11 @@ spec:
                     - dnsManagementPolicy
                     - scope
                     type: object
+                    x-kubernetes-validations:
+                    - message: cannot specify a floating ip when scope is internal
+                      rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
+                        || !has(self.providerParameters.openstack) || !has(self.providerParameters.openstack.floatingIP)
+                        || self.providerParameters.openstack.floatingIP == ""'
                   nodePort:
                     description: |-
                       nodePort holds parameters for the NodePortService endpoint publishing strategy.
@@ -2685,15 +2695,20 @@ spec:
                               If empty, defaults will be applied. See specific openstack fields for
                               details about their defaults.
                             properties:
-                              loadBalancerIP:
+                              floatingIP:
                                 description: |-
-                                  loadBalancerIP specifies the floating IP address that the load balancer will use.
+                                  floatingIP specifies the IP address that the load balancer will use.
                                   When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                                  When specified, the floating IP has to be pre-created.  If the
+                                  specified value is not a floating IP or is already claimed, the
+                                  OpenStack cloud provider won't be able to provision the load
+                                  balancer.
+                                  This field may only be used if the IngressController has External scope.
                                   This value must be a valid IPv4 or IPv6 address.
                                 type: string
                                 x-kubernetes-validations:
-                                - message: loadBalancerIP must be a valid IPv4 or
-                                    IPv6 address
+                                - message: floatingIP must be a valid IPv4 or IPv6
+                                    address
                                   rule: isIP(self)
                             type: object
                           type:
@@ -2730,6 +2745,11 @@ spec:
                     - dnsManagementPolicy
                     - scope
                     type: object
+                    x-kubernetes-validations:
+                    - message: cannot specify a floating ip when scope is internal
+                      rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
+                        || !has(self.providerParameters.openstack) || !has(self.providerParameters.openstack.floatingIP)
+                        || self.providerParameters.openstack.floatingIP == ""'
                   nodePort:
                     description: |-
                       nodePort holds parameters for the NodePortService endpoint publishing strategy.

--- a/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/SetEIPForNLBIngressController.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/ingresscontrollers.operator.openshift.io/SetEIPForNLBIngressController.yaml
@@ -492,15 +492,20 @@ spec:
                               If empty, defaults will be applied. See specific openstack fields for
                               details about their defaults.
                             properties:
-                              loadBalancerIP:
+                              floatingIP:
                                 description: |-
-                                  loadBalancerIP specifies the floating IP address that the load balancer will use.
+                                  floatingIP specifies the IP address that the load balancer will use.
                                   When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                                  When specified, the floating IP has to be pre-created.  If the
+                                  specified value is not a floating IP or is already claimed, the
+                                  OpenStack cloud provider won't be able to provision the load
+                                  balancer.
+                                  This field may only be used if the IngressController has External scope.
                                   This value must be a valid IPv4 or IPv6 address.
                                 type: string
                                 x-kubernetes-validations:
-                                - message: loadBalancerIP must be a valid IPv4 or
-                                    IPv6 address
+                                - message: floatingIP must be a valid IPv4 or IPv6
+                                    address
                                   rule: isIP(self)
                             type: object
                           type:
@@ -542,6 +547,10 @@ spec:
                       rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
                         || !has(self.providerParameters.aws) || !has(self.providerParameters.aws.networkLoadBalancer)
                         || !has(self.providerParameters.aws.networkLoadBalancer.eipAllocations)'
+                    - message: cannot specify a floating ip when scope is internal
+                      rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
+                        || !has(self.providerParameters.openstack) || !has(self.providerParameters.openstack.floatingIP)
+                        || self.providerParameters.openstack.floatingIP == ""'
                   nodePort:
                     description: |-
                       nodePort holds parameters for the NodePortService endpoint publishing strategy.
@@ -2502,15 +2511,20 @@ spec:
                               If empty, defaults will be applied. See specific openstack fields for
                               details about their defaults.
                             properties:
-                              loadBalancerIP:
+                              floatingIP:
                                 description: |-
-                                  loadBalancerIP specifies the floating IP address that the load balancer will use.
+                                  floatingIP specifies the IP address that the load balancer will use.
                                   When not specified, an IP address will be assigned randomly by the OpenStack cloud provider.
+                                  When specified, the floating IP has to be pre-created.  If the
+                                  specified value is not a floating IP or is already claimed, the
+                                  OpenStack cloud provider won't be able to provision the load
+                                  balancer.
+                                  This field may only be used if the IngressController has External scope.
                                   This value must be a valid IPv4 or IPv6 address.
                                 type: string
                                 x-kubernetes-validations:
-                                - message: loadBalancerIP must be a valid IPv4 or
-                                    IPv6 address
+                                - message: floatingIP must be a valid IPv4 or IPv6
+                                    address
                                   rule: isIP(self)
                             type: object
                           type:
@@ -2552,6 +2566,10 @@ spec:
                       rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
                         || !has(self.providerParameters.aws) || !has(self.providerParameters.aws.networkLoadBalancer)
                         || !has(self.providerParameters.aws.networkLoadBalancer.eipAllocations)'
+                    - message: cannot specify a floating ip when scope is internal
+                      rule: '!has(self.scope) || self.scope != ''Internal'' || !has(self.providerParameters)
+                        || !has(self.providerParameters.openstack) || !has(self.providerParameters.openstack.floatingIP)
+                        || self.providerParameters.openstack.floatingIP == ""'
                   nodePort:
                     description: |-
                       nodePort holds parameters for the NodePortService endpoint publishing strategy.

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1122,8 +1122,8 @@ func (NodePortStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_OpenStackLoadBalancerParameters = map[string]string{
-	"":               "OpenStackLoadBalancerParameters provides configuration settings that are specific to OpenStack load balancers.",
-	"loadBalancerIP": "loadBalancerIP specifies the floating IP address that the load balancer will use. When not specified, an IP address will be assigned randomly by the OpenStack cloud provider. This value must be a valid IPv4 or IPv6 address. ",
+	"":           "OpenStackLoadBalancerParameters provides configuration settings that are specific to OpenStack load balancers.",
+	"floatingIP": "floatingIP specifies the IP address that the load balancer will use. When not specified, an IP address will be assigned randomly by the OpenStack cloud provider. When specified, the floating IP has to be pre-created.  If the specified value is not a floating IP or is already claimed, the OpenStack cloud provider won't be able to provision the load balancer. This field may only be used if the IngressController has External scope. This value must be a valid IPv4 or IPv6 address. ",
 }
 
 func (OpenStackLoadBalancerParameters) SwaggerDoc() map[string]string {


### PR DESCRIPTION
This was poorly named and this hasn't been used anywhere so we can make
the change while it's still time.

Also add CEL validation to make sure the field is only used for external
LB (and add tests).