### PR TITLE
Ensure custom feature gate mainfest path is passed into generator

### DIFF
--- a/tools/codegen/cmd/crd_manifest_merge.go
+++ b/tools/codegen/cmd/crd_manifest_merge.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/openshift/api/tools/codegen/pkg/generation"
 	"github.com/openshift/api/tools/codegen/pkg/manifestmerge"
 	"github.com/spf13/cobra"
@@ -40,6 +41,7 @@ func init() {
 // newSchemaPatchGenerator builds a new schemapatch generator.
 func newCRDManifestMerger() generation.Generator {
 	return manifestmerge.NewGenerator(manifestmerge.Options{
-		Verify: verify,
+		PayloadFeatureGatePath: manifestMergePayloadManifestPath,
+		Verify:                 verify,
 	})
 }


### PR DESCRIPTION
Without passing this field into the new generator options, the flag is redundant. That's ok for o/api but when trying to use this with the feature gate at a different path, it's not presently working.