### PR TITLE
OPRUN-3588: Add OperatorLifecycleManagerV1 cluster version capability

### DIFF
--- a/config/v1/tests/clusterversions.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/clusterversions.config.openshift.io/AAA_ungated.yaml
@@ -138,6 +138,46 @@ tests:
             baselineCapabilitySet: None
             additionalEnabledCapabilities:
             - baremetal
+    - name: Should be able to create a ClusterVersion with base capability None, and additional capability OperatorLifecycleManagerV1
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - OperatorLifecycleManagerV1
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - OperatorLifecycleManagerV1
+    - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities OperatorLifecycleManager and OperatorLifecycleManagerV1
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - OperatorLifecycleManager
+            - OperatorLifecycleManagerV1
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - OperatorLifecycleManager
+            - OperatorLifecycleManagerV1
     - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities marketplace and OperatorLifecycleManager
       initial: |
         apiVersion: config.openshift.io/v1

--- a/config/v1/tests/clusterversions.config.openshift.io/SignatureStores.yaml
+++ b/config/v1/tests/clusterversions.config.openshift.io/SignatureStores.yaml
@@ -139,6 +139,46 @@ tests:
             baselineCapabilitySet: None
             additionalEnabledCapabilities:
             - baremetal
+    - name: Should be able to create a ClusterVersion with base capability None, and additional capability OperatorLifecycleManagerV1
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - OperatorLifecycleManagerV1
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - OperatorLifecycleManagerV1
+    - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities OperatorLifecycleManager and OperatorLifecycleManagerV1
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - OperatorLifecycleManager
+            - OperatorLifecycleManagerV1
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: ClusterVersion
+        spec:
+          clusterID: foo
+          capabilities:
+            baselineCapabilitySet: None
+            additionalEnabledCapabilities:
+            - OperatorLifecycleManager
+            - OperatorLifecycleManagerV1
     - name: Should be able to create a ClusterVersion with base capability None, and additional capabilities marketplace and OperatorLifecycleManager
       initial: |
         apiVersion: config.openshift.io/v1

--- a/config/v1/types_cluster_version.go
+++ b/config/v1/types_cluster_version.go
@@ -288,7 +288,7 @@ const (
 )
 
 // ClusterVersionCapability enumerates optional, core cluster components.
-// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry;OperatorLifecycleManager;CloudCredential;Ingress;CloudControllerManager
+// +kubebuilder:validation:Enum=openshift-samples;baremetal;marketplace;Console;Insights;Storage;CSISnapshot;NodeTuning;MachineAPI;Build;DeploymentConfig;ImageRegistry;OperatorLifecycleManager;CloudCredential;Ingress;CloudControllerManager;OperatorLifecycleManagerV1
 type ClusterVersionCapability string
 
 const (
@@ -379,9 +379,13 @@ const (
 	// allows to distribute Docker images
 	ClusterVersionCapabilityImageRegistry ClusterVersionCapability = "ImageRegistry"
 
-	// ClusterVersionCapabilityOperatorLifecycleManager manages the Operator Lifecycle Manager
+	// ClusterVersionCapabilityOperatorLifecycleManager manages the Operator Lifecycle Manager (legacy)
 	// which itself manages the lifecycle of operators
 	ClusterVersionCapabilityOperatorLifecycleManager ClusterVersionCapability = "OperatorLifecycleManager"
+
+	// ClusterVersionCapabilityOperatorLifecycleManagerV1 manages the Operator Lifecycle Manager (v1)
+	// which itself manages the lifecycle of operators
+	ClusterVersionCapabilityOperatorLifecycleManagerV1 ClusterVersionCapability = "OperatorLifecycleManagerV1"
 
 	// ClusterVersionCapabilityCloudCredential manages credentials for cloud providers
 	// in openshift cluster
@@ -422,6 +426,7 @@ var KnownClusterVersionCapabilities = []ClusterVersionCapability{
 	ClusterVersionCapabilityDeploymentConfig,
 	ClusterVersionCapabilityImageRegistry,
 	ClusterVersionCapabilityOperatorLifecycleManager,
+	ClusterVersionCapabilityOperatorLifecycleManagerV1,
 	ClusterVersionCapabilityCloudCredential,
 	ClusterVersionCapabilityIngress,
 	ClusterVersionCapabilityCloudControllerManager,
@@ -600,6 +605,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityDeploymentConfig,
 		ClusterVersionCapabilityImageRegistry,
 		ClusterVersionCapabilityOperatorLifecycleManager,
+		ClusterVersionCapabilityOperatorLifecycleManagerV1,
 		ClusterVersionCapabilityCloudCredential,
 		ClusterVersionCapabilityIngress,
 		ClusterVersionCapabilityCloudControllerManager,
@@ -618,6 +624,7 @@ var ClusterVersionCapabilitySets = map[ClusterVersionCapabilitySet][]ClusterVers
 		ClusterVersionCapabilityDeploymentConfig,
 		ClusterVersionCapabilityImageRegistry,
 		ClusterVersionCapabilityOperatorLifecycleManager,
+		ClusterVersionCapabilityOperatorLifecycleManagerV1,
 		ClusterVersionCapabilityCloudCredential,
 		ClusterVersionCapabilityIngress,
 		ClusterVersionCapabilityCloudControllerManager,

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-CustomNoUpgrade.crd.yaml
@@ -94,6 +94,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -378,6 +379,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -404,6 +406,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-Default.crd.yaml
@@ -94,6 +94,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -327,6 +328,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -353,6 +355,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-DevPreviewNoUpgrade.crd.yaml
@@ -94,6 +94,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -378,6 +379,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -404,6 +406,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversions-TechPreviewNoUpgrade.crd.yaml
@@ -94,6 +94,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -378,6 +379,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -404,6 +406,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic

--- a/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/AAA_ungated.yaml
@@ -96,6 +96,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -329,6 +330,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -355,6 +357,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic

--- a/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/SignatureStores.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/clusterversions.config.openshift.io/SignatureStores.yaml
@@ -96,6 +96,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -380,6 +381,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
@@ -406,6 +408,7 @@ spec:
                       - CloudCredential
                       - Ingress
                       - CloudControllerManager
+                      - OperatorLifecycleManagerV1
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic


### PR DESCRIPTION
Preconditions: 
 - [x] #2061 merged

Changes:
 * Adds the 'OperatorLifecycleManagerV1' cluster capability

Next PR: [openshift/cluster-olm-operator#74](https://github.com/openshift/cluster-olm-operator/pull/74)