### PR TITLE
[DNM] (review-only) WIP: OLM v1 API review

### DIFF
--- a/olm/catalogd/v1alpha1/clustercatalog_crd.yaml
+++ b/olm/catalogd/v1alpha1/clustercatalog_crd.yaml
@@ -49,36 +49,65 @@ spec:
           metadata:
             type: object
           spec:
-            description: ClusterCatalogSpec defines the desired state of ClusterCatalog
+            description: |-
+              spec is the desired state of the ClusterCatalog.
+              spec is required.
+              The controller will work to ensure that the desired
+              catalog is unpacked and served over the catalog content HTTP server.
             properties:
-              availability:
-                default: Enabled
+              availabilityMode:
+                default: Available
                 description: |-
-                  Availability is an optional field that allows users to define whether the ClusterCatalog is utilized by the operator-controller.
+                  availabilityMode allows users to define how the ClusterCatalog is made available to clients on the cluster.
+                  availabilityMode is optional.
 
-                  Allowed values are : ["Enabled", "Disabled"].
-                  If set to "Enabled", the catalog will be used for updates, serving contents, and package installations.
+                  Allowed values are "Available" and "Unavailable" and omitted.
 
-                  If set to "Disabled", catalogd will stop serving the catalog and the cached data will be removed.
+                  When omitted, the default value is "Available".
 
-                  If unspecified, the default value is "Enabled"
+                  When set to "Available", the catalog contents will be unpacked and served over the catalog content HTTP server.
+                  Setting the availabilityMode to "Available" tells clients that they should consider this ClusterCatalog
+                  and its contents as usable.
+
+                  When set to "Unavailable", the catalog contents will no longer be served over the catalog content HTTP server.
+                  When set to this availabilityMode it should be interpreted the same as the ClusterCatalog not existing.
+                  Setting the availabilityMode to "Unavailable" can be useful in scenarios where a user may not want
+                  to delete the ClusterCatalog all together, but would still like it to be treated as if it doesn't exist.
                 enum:
-                - Disabled
-                - Enabled
+                - Unavailable
+                - Available
                 type: string
               priority:
                 default: 0
                 description: |-
-                  priority is an optional field that allows the user to define a priority for a ClusterCatalog.
+                  priority allows the user to define a priority for a ClusterCatalog.
+                  priority is optional.
+
                   A ClusterCatalog's priority is used by clients as a tie-breaker between ClusterCatalogs that meet the client's requirements.
+                  It is up to clients to decide how to handle scenarios where multiple ClusterCatalogs with the same priority meet their requirements.
                   For example, in the case where multiple ClusterCatalogs provide the same bundle.
-                  A higher number means higher priority. Negative numbers are also accepted.
-                  When omitted, the default priority is 0.
+                  A higher number means higher priority.
+
+                  When omitted, the default priority is 0 because that is the zero value of integers.
+
+                  Negative numbers can be used to specify a priority lower than the default.
+                  Positive numbers can be used to specify a priority higher than the default.
+
+                  The lowest possible value is -2147483648.
+                  The highest possible value is 214748647.
                 format: int32
                 type: integer
               source:
                 description: |-
-                  source is a required field that allows the user to define the source of a Catalog that contains catalog metadata in the File-Based Catalog (FBC) format.
+                  source allows a user to define the source of a catalog.
+                  A "catalog" contains information on content that can be installed on a cluster.
+                  Providing a catalog source makes the contents of the catalog discoverable and usable by
+                  other on-cluster components.
+                  These on-cluster components may do a variety of things with this information, such as
+                  presenting the content in a GUI dashboard or installing content from the catalog on the cluster.
+                  The catalog source must contain catalog metadata in the File-Based Catalog (FBC) format.
+                  For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs.
+                  source is a required field.
 
                   Below is a minimal example of a ClusterCatalogSpec that sources a catalog from an image:
 
@@ -86,45 +115,88 @@ spec:
                      type: Image
                      image:
                        ref: quay.io/operatorhubio/catalog:latest
-
-                  For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
                 properties:
                   image:
-                    description: image is used to configure how catalog contents are
-                      sourced from an OCI image. This field must be set when type
-                      is set to "Image" and must be the only field defined for this
-                      type.
+                    description: |-
+                      image is used to configure how catalog contents are sourced from an OCI image.
+                      This field is required when type is Image, and forbidden otherwise.
                     properties:
-                      pollInterval:
+                      pollIntervalMinutes:
                         description: |-
-                          pollInterval is an optional field that allows the user to set the interval at which the image source should be polled for new content.
-                          It must be specified as a duration.
-                          It must not be specified for a catalog image referenced by a sha256 digest.
-                          Examples:
-                            pollInterval: 1h # poll the image source every hour
-                            pollInterval: 30m # poll the image source every 30 minutes
-                            pollInterval: 1h30m # poll the image source every 1 hour and 30 minutes
+                          pollIntervalMinutes allows the user to set the interval, in minutes, at which the image source should be polled for new content.
+                          pollIntervalMinutes is optional.
+                          pollIntervalMinutes can not be specified when ref is a digest-based reference.
 
                           When omitted, the image will not be polled for new content.
-                        format: duration
-                        type: string
+                        minimum: 1
+                        type: integer
                       ref:
                         description: |-
-                          ref is a required field that allows the user to define the reference to a container image containing Catalog contents.
-                          Examples:
-                            ref: quay.io/operatorhubio/catalog:latest # image reference
-                            ref: quay.io/operatorhubio/catalog@sha256:c7392b4be033da629f9d665fec30f6901de51ce3adebeff0af579f311ee5cf1b # image reference with sha256 digest
+                          ref allows users to define the reference to a container image containing Catalog contents.
+                          ref is required.
+                          ref can not be more than 1000 characters.
+
+                          A reference can be broken down into 3 parts - the domain, name, and identifier.
+
+                          The domain is typically the registry where an image is located.
+                          It must be alphanumeric characters (lowercase and uppercase) separated by the "." character.
+                          Hyphenation is allowed, but the domain must start and end with alphanumeric characters.
+                          Specifying a port to use is also allowed by adding the ":" character followed by numeric values.
+                          The port must be the last value in the domain.
+                          Some examples of valid domain values are "registry.mydomain.io", "quay.io", "my-registry.io:8080".
+
+                          The name is typically the repository in the registry where an image is located.
+                          It must contain lowercase alphanumeric characters separated only by the ".", "_", "__", "-" characters.
+                          Multiple names can be concatenated with the "/" character.
+                          The domain and name are combined using the "/" character.
+                          Some examples of valid name values are "operatorhubio/catalog", "catalog", "my-catalog.prod".
+                          An example of the domain and name parts of a reference being combined is "quay.io/operatorhubio/catalog".
+
+                          The identifier is typically the tag or digest for an image reference and is present at the end of the reference.
+                          It starts with a separator character used to distinguish the end of the name and beginning of the identifier.
+                          For a digest-based reference, the "@" character is the separator.
+                          For a tag-based reference, the ":" character is the separator.
+                          An identifier is required in the reference.
+
+                          Digest-based references must contain an algorithm reference immediately after the "@" separator.
+                          The algorithm reference must be followed by the ":" character and an encoded string.
+                          The algorithm must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
+                          Some examples of valid algorithm values are "sha256", "sha256+b64u", "multihash+base58".
+                          The encoded string following the algorithm must be hex digits and must be a minimum of 32 characters.
+
+                          Tag-based references must begin with a word character (alphanumeric + "_") followed by word characters or ".", and "-" characters.
+                          The tag must not be longer than 127 characters.
+
+                          An example of a valid digest-based image reference is "quay.io/operatorhubio/catalog@sha256:200d4ddb2a73594b91358fe6397424e975205bfbe44614f5846033cad64b3f05"
+                          An example of a valid tag-based image reference is "quay.io/operatorhubio/catalog:latest"
+                        maxLength: 1000
                         type: string
                     required:
                     - ref
                     type: object
+                    x-kubernetes-validations:
+                    - message: cannot specify pollIntervalMinutes while using digest-based
+                        image
+                      rule: '!has(self.pollIntervalMinutes) || (self.ref.contains(''@''))'
+                    - message: ref is invalid, it must start with a valid domain
+                      rule: self.ref.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                    - message: ref is invalid, a valid name is required
+                      rule: self.ref.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)')
+                        != ""
+                    - message: ref is invalid, must end with a digest or a tag
+                      rule: self.ref.contains('@') || self.ref.find(':[\\w][\\w.-]{0,127}$')
+                        != ""
+                    - message: ref is invalid, tag or digest is invalid
+                      rule: 'self.ref.contains(''@'') ? self.ref.matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9A-Fa-f]{32,})'')
+                        : self.ref.substring(self.ref.lastIndexOf(":")+1).matches(''[\\w][\\w.-]{0,127}'')'
                   type:
                     description: |-
-                      type is a required reference to the type of source the catalog is sourced from.
+                      type is a reference to the type of source the catalog is sourced from.
+                      type is required.
 
-                      Allowed values are ["Image"]
+                      The only allowed value is "Image".
 
-                      When this field is set to "Image", the ClusterCatalog content will be sourced from an OCI image.
+                      When set to "Image", the ClusterCatalog content will be sourced from an OCI image.
                       When using an image source, the image field must be set and must be the only field defined for this type.
                     enum:
                     - Image
@@ -133,39 +205,40 @@ spec:
                 - type
                 type: object
                 x-kubernetes-validations:
-                - message: source type 'Image' requires image field
-                  rule: self.type == 'Image' && has(self.image)
+                - message: image is required when source type is Image, and forbidden
+                    otherwise
+                  rule: 'has(self.type) && self.type == ''Image'' ? has(self.image)
+                    : !has(self.image)'
             required:
             - source
             type: object
-            x-kubernetes-validations:
-            - message: cannot specify PollInterval while using digest-based image
-              rule: '!has(self.source.image.pollInterval) || (self.source.image.ref.find(''@sha256:'')
-                == "")'
           status:
-            description: ClusterCatalogStatus defines the observed state of ClusterCatalog
+            description: |-
+              status contains information about the state of the ClusterCatalog such as:
+                - Whether or not the catalog contents are being served via the catalog content HTTP server
+                - Whether or not the ClusterCatalog is progressing to a new state
+                - A reference to the source from which the catalog contents were retrieved
             properties:
               conditions:
                 description: |-
                   conditions is a representation of the current state for this ClusterCatalog.
-                  The status is represented by a set of "conditions".
 
-                  Each condition is generally structured in the following format:
-                    - Type: a string representation of the condition type. More or less the condition "name".
-                    - Status: a string representation of the state of the condition. Can be one of ["True", "False", "Unknown"].
-                    - Reason: a string representation of the reason for the current state of the condition. Typically useful for building automation around particular Type+Reason combinations.
-                    - Message: a human-readable message that further elaborates on the state of the condition.
+                  The current condition types are Serving and Progressing.
 
-                  The current set of condition types are:
-                    - "Serving", which represents whether or not the contents of the catalog are being served via the HTTP(S) web server.
-                    - "Progressing", which represents whether or not the ClusterCatalog is progressing towards a new state.
+                  The Serving condition is used to represent whether or not the contents of the catalog is being served via the HTTP(S) web server.
+                  When it has a status of True and a reason of Available, the contents of the catalog are being served.
+                  When it has a status of False and a reason of Unavailable, the contents of the catalog are not being served because the contents are not yet available.
+                  When it has a status of False and a reason of MarkedUnavailable, the contents of the catalog are not being served because the catalog has been intentionally marked as unavailable.
 
-                  The current set of reasons are:
-                    - "Succeeded", this reason is set on the "Progressing" condition when progressing to a new state is successful.
-                    - "Blocked", this reason is set on the "Progressing" condition when the ClusterCatalog controller has encountered an error that requires manual intervention for recovery.
-                    - "Retrying", this reason is set on the "Progressing" condition when the ClusterCatalog controller has encountered an error that might be resolvable on subsequent reconciliation attempts.
-                    - "Available", this reason is set on the "Serving" condition when the contents of the ClusterCatalog are being served via an endpoint on the HTTP(S) web server.
-                    - "Unavailable", this reason is set on the "Serving" condition when there is not an endpoint on the HTTP(S) web server that is serving the contents of the ClusterCatalog.
+                  The Progressing condition is used to represent whether or not the ClusterCatalog is progressing towards a new state.
+                  When it has a status of True and a reason of Retrying, there was an error in the progression of the ClusterCatalog that may be resolved on subsequent reconciliation attempts.
+                  When it has a status of False and a reason of Succeeded, the ClusterCatalog has successfully progressed to a new state and is ready to continue progressing.
+                  When it has a status of False and a reason of Blocked, there was an error in the progression of the ClusterCatalog that requires manual intervention for recovery.
+
+                  In the case that the Serving condition is True with reason Available and Progressing is True with reason Retrying, the previously fetched
+                  catalog contents are still being served via the HTTP(S) web server while we are progressing towards serving a new version of the catalog
+                  contents. This could occur when we've initially fetched the latest contents from the source for this catalog and when polling for changes
+                  to the contents we identify that there are updates to the contents.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -221,48 +294,53 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               lastUnpacked:
                 description: |-
-                  lastUnpacked represents the time when the
-                  ClusterCatalog object was last unpacked successfully.
+                  lastUnpacked represents the time when the contents of the
+                  catalog were extracted from their source format. As an example,
+                  when using an Image source, the OCI image will be pulled and the
+                  image layers written to a file-system backed cache. We refer to the
+                  act of this extraction from the source format as "unpacking".
                 format: date-time
                 type: string
               resolvedSource:
-                description: |-
-                  resolvedSource contains information about the resolved source based on the source type.
-
-                  Below is an example of a resolved source for an image source:
-                  resolvedSource:
-
-                   image:
-                     lastSuccessfulPollAttempt: "2024-09-10T12:22:13Z"
-                     ref: quay.io/operatorhubio/catalog@sha256:c7392b4be033da629f9d665fec30f6901de51ce3adebeff0af579f311ee5cf1b
-                   type: Image
+                description: resolvedSource contains information about the resolved
+                  source based on the source type.
                 properties:
                   image:
-                    description: image is a field containing resolution information
-                      for a catalog sourced from an image.
+                    description: |-
+                      image is a field containing resolution information for a catalog sourced from an image.
+                      This field must be set when type is Image, and forbidden otherwise.
                     properties:
-                      lastSuccessfulPollAttempt:
-                        description: lastSuccessfulPollAttempt is the time when the
-                          resolved source was last successfully polled for new content.
-                        format: date-time
-                        type: string
                       ref:
-                        description: ref contains the resolved sha256 image ref containing
-                          Catalog contents.
+                        description: |-
+                          ref contains the resolved image digest-based reference.
+                          The digest format is used so users can use other tooling to fetch the exact
+                          OCI manifests that were used to extract the catalog contents.
+                        maxLength: 1000
                         type: string
                     required:
-                    - lastSuccessfulPollAttempt
                     - ref
                     type: object
+                    x-kubernetes-validations:
+                    - message: ref is invalid, it must start with a valid domain
+                      rule: self.ref.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                    - message: ref is invalid, a valid name is required
+                      rule: self.ref.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)')
+                        != ""
+                    - message: ref is invalid, digest is invalid
+                      rule: self.ref.matches('(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9A-Fa-f]{32,})')
                   type:
                     description: |-
                       type is a reference to the type of source the catalog is sourced from.
+                      type is required.
 
-                      It will be set to one of the following values: ["Image"].
+                      The only allowed value is "Image".
 
-                      When this field is set to "Image", information about the resolved image source will be set in the 'image' field.
+                      When set to "Image", information about the resolved image source will be set in the 'image' field.
                     enum:
                     - Image
                     type: string
@@ -271,21 +349,42 @@ spec:
                 - type
                 type: object
                 x-kubernetes-validations:
-                - message: source type 'Image' requires image field
-                  rule: self.type == 'Image' && has(self.image)
+                - message: image is required when source type is Image, and forbidden
+                    otherwise
+                  rule: 'has(self.type) && self.type == ''Image'' ? has(self.image)
+                    : !has(self.image)'
               urls:
                 description: urls contains the URLs that can be used to access the
                   catalog.
                 properties:
                   base:
                     description: |-
-                      base is a required cluster-internal URL which provides API access for this ClusterCatalog.
-                      A suffix API access path can be added to retrieve catalog data for the ClusterCatalog.
-                      Currently, a 'v1' API access provides complete FBC retrival via the path "/api/v1/all", with the general form `{base}/api/v1/all`.
+                      base is a cluster-internal URL that provides REST API endpoints for
+                      accessing the content of the catalog.
+
+                      It is expected that users append the path for the REST API endpoint they wish
+                      to access. The general format expected for a request to a REST API endpoint is
+                      {base}/api/{version}/{endpoint}
+
+                      Currently, only a single version of the REST API is served and is accessible at the path
+                      /api/v1.
+
+                      The endpoints served for v1 of the REST API are:
+                        - /all - this endpoint returns the entirety of the catalog contents in the FBC format
+
+                      As the needs of users and clients of the REST API evolve, new versions of the
+                      REST API may be added.
+                    maxLength: 525
                     type: string
                 required:
                 - base
                 type: object
+                x-kubernetes-validations:
+                - message: base must be a valid URL
+                  rule: isURL(self.base)
+                - message: base is invalid, scheme must be one of [http, https]
+                  rule: url(self.base).getScheme() == "http" || url(self.base).getScheme
+                    == "https"
             type: object
         required:
         - metadata

--- a/olm/catalogd/v1alpha1/clustercatalog_crd.yaml
+++ b/olm/catalogd/v1alpha1/clustercatalog_crd.yaml
@@ -1,0 +1,297 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: clustercatalogs.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: ClusterCatalog
+    listKind: ClusterCatalogList
+    plural: clustercatalogs
+    singular: clustercatalog
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.lastUnpacked
+      name: LastUnpacked
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Serving")].status
+      name: Serving
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterCatalog enables users to make File-Based Catalog (FBC) catalog data available to the cluster.
+          For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterCatalogSpec defines the desired state of ClusterCatalog
+            properties:
+              availability:
+                default: Enabled
+                description: |-
+                  Availability is an optional field that allows users to define whether the ClusterCatalog is utilized by the operator-controller.
+
+                  Allowed values are : ["Enabled", "Disabled"].
+                  If set to "Enabled", the catalog will be used for updates, serving contents, and package installations.
+
+                  If set to "Disabled", catalogd will stop serving the catalog and the cached data will be removed.
+
+                  If unspecified, the default value is "Enabled"
+                enum:
+                - Disabled
+                - Enabled
+                type: string
+              priority:
+                default: 0
+                description: |-
+                  priority is an optional field that allows the user to define a priority for a ClusterCatalog.
+                  A ClusterCatalog's priority is used by clients as a tie-breaker between ClusterCatalogs that meet the client's requirements.
+                  For example, in the case where multiple ClusterCatalogs provide the same bundle.
+                  A higher number means higher priority. Negative numbers are also accepted.
+                  When omitted, the default priority is 0.
+                format: int32
+                type: integer
+              source:
+                description: |-
+                  source is a required field that allows the user to define the source of a Catalog that contains catalog metadata in the File-Based Catalog (FBC) format.
+
+                  Below is a minimal example of a ClusterCatalogSpec that sources a catalog from an image:
+
+                   source:
+                     type: Image
+                     image:
+                       ref: quay.io/operatorhubio/catalog:latest
+
+                  For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
+                properties:
+                  image:
+                    description: image is used to configure how catalog contents are
+                      sourced from an OCI image. This field must be set when type
+                      is set to "Image" and must be the only field defined for this
+                      type.
+                    properties:
+                      pollInterval:
+                        description: |-
+                          pollInterval is an optional field that allows the user to set the interval at which the image source should be polled for new content.
+                          It must be specified as a duration.
+                          It must not be specified for a catalog image referenced by a sha256 digest.
+                          Examples:
+                            pollInterval: 1h # poll the image source every hour
+                            pollInterval: 30m # poll the image source every 30 minutes
+                            pollInterval: 1h30m # poll the image source every 1 hour and 30 minutes
+
+                          When omitted, the image will not be polled for new content.
+                        format: duration
+                        type: string
+                      ref:
+                        description: |-
+                          ref is a required field that allows the user to define the reference to a container image containing Catalog contents.
+                          Examples:
+                            ref: quay.io/operatorhubio/catalog:latest # image reference
+                            ref: quay.io/operatorhubio/catalog@sha256:c7392b4be033da629f9d665fec30f6901de51ce3adebeff0af579f311ee5cf1b # image reference with sha256 digest
+                        type: string
+                    required:
+                    - ref
+                    type: object
+                  type:
+                    description: |-
+                      type is a required reference to the type of source the catalog is sourced from.
+
+                      Allowed values are ["Image"]
+
+                      When this field is set to "Image", the ClusterCatalog content will be sourced from an OCI image.
+                      When using an image source, the image field must be set and must be the only field defined for this type.
+                    enum:
+                    - Image
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: source type 'Image' requires image field
+                  rule: self.type == 'Image' && has(self.image)
+            required:
+            - source
+            type: object
+            x-kubernetes-validations:
+            - message: cannot specify PollInterval while using digest-based image
+              rule: '!has(self.source.image.pollInterval) || (self.source.image.ref.find(''@sha256:'')
+                == "")'
+          status:
+            description: ClusterCatalogStatus defines the observed state of ClusterCatalog
+            properties:
+              conditions:
+                description: |-
+                  conditions is a representation of the current state for this ClusterCatalog.
+                  The status is represented by a set of "conditions".
+
+                  Each condition is generally structured in the following format:
+                    - Type: a string representation of the condition type. More or less the condition "name".
+                    - Status: a string representation of the state of the condition. Can be one of ["True", "False", "Unknown"].
+                    - Reason: a string representation of the reason for the current state of the condition. Typically useful for building automation around particular Type+Reason combinations.
+                    - Message: a human-readable message that further elaborates on the state of the condition.
+
+                  The current set of condition types are:
+                    - "Serving", which represents whether or not the contents of the catalog are being served via the HTTP(S) web server.
+                    - "Progressing", which represents whether or not the ClusterCatalog is progressing towards a new state.
+
+                  The current set of reasons are:
+                    - "Succeeded", this reason is set on the "Progressing" condition when progressing to a new state is successful.
+                    - "Blocked", this reason is set on the "Progressing" condition when the ClusterCatalog controller has encountered an error that requires manual intervention for recovery.
+                    - "Retrying", this reason is set on the "Progressing" condition when the ClusterCatalog controller has encountered an error that might be resolvable on subsequent reconciliation attempts.
+                    - "Available", this reason is set on the "Serving" condition when the contents of the ClusterCatalog are being served via an endpoint on the HTTP(S) web server.
+                    - "Unavailable", this reason is set on the "Serving" condition when there is not an endpoint on the HTTP(S) web server that is serving the contents of the ClusterCatalog.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastUnpacked:
+                description: |-
+                  lastUnpacked represents the time when the
+                  ClusterCatalog object was last unpacked successfully.
+                format: date-time
+                type: string
+              resolvedSource:
+                description: |-
+                  resolvedSource contains information about the resolved source based on the source type.
+
+                  Below is an example of a resolved source for an image source:
+                  resolvedSource:
+
+                   image:
+                     lastSuccessfulPollAttempt: "2024-09-10T12:22:13Z"
+                     ref: quay.io/operatorhubio/catalog@sha256:c7392b4be033da629f9d665fec30f6901de51ce3adebeff0af579f311ee5cf1b
+                   type: Image
+                properties:
+                  image:
+                    description: image is a field containing resolution information
+                      for a catalog sourced from an image.
+                    properties:
+                      lastSuccessfulPollAttempt:
+                        description: lastSuccessfulPollAttempt is the time when the
+                          resolved source was last successfully polled for new content.
+                        format: date-time
+                        type: string
+                      ref:
+                        description: ref contains the resolved sha256 image ref containing
+                          Catalog contents.
+                        type: string
+                    required:
+                    - lastSuccessfulPollAttempt
+                    - ref
+                    type: object
+                  type:
+                    description: |-
+                      type is a reference to the type of source the catalog is sourced from.
+
+                      It will be set to one of the following values: ["Image"].
+
+                      When this field is set to "Image", information about the resolved image source will be set in the 'image' field.
+                    enum:
+                    - Image
+                    type: string
+                required:
+                - image
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: source type 'Image' requires image field
+                  rule: self.type == 'Image' && has(self.image)
+              urls:
+                description: urls contains the URLs that can be used to access the
+                  catalog.
+                properties:
+                  base:
+                    description: |-
+                      base is a required cluster-internal URL which provides API access for this ClusterCatalog.
+                      A suffix API access path can be added to retrieve catalog data for the ClusterCatalog.
+                      Currently, a 'v1' API access provides complete FBC retrival via the path "/api/v1/all", with the general form `{base}/api/v1/all`.
+                    type: string
+                required:
+                - base
+                type: object
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/olm/catalogd/v1alpha1/clustercatalog_crd.yaml
+++ b/olm/catalogd/v1alpha1/clustercatalog_crd.yaml
@@ -84,9 +84,10 @@ spec:
                   priority is optional.
 
                   A ClusterCatalog's priority is used by clients as a tie-breaker between ClusterCatalogs that meet the client's requirements.
-                  It is up to clients to decide how to handle scenarios where multiple ClusterCatalogs with the same priority meet their requirements.
-                  For example, in the case where multiple ClusterCatalogs provide the same bundle.
                   A higher number means higher priority.
+
+                  It is up to clients to decide how to handle scenarios where multiple ClusterCatalogs with the same priority meet their requirements.
+                  When deciding how to break the tie in this scenario, it is recommended that clients prompt their users for additional input.
 
                   When omitted, the default priority is 0 because that is the zero value of integers.
 
@@ -94,7 +95,7 @@ spec:
                   Positive numbers can be used to specify a priority higher than the default.
 
                   The lowest possible value is -2147483648.
-                  The highest possible value is 214748647.
+                  The highest possible value is 2147483647.
                 format: int32
                 type: integer
               source:
@@ -162,7 +163,7 @@ spec:
                           The algorithm reference must be followed by the ":" character and an encoded string.
                           The algorithm must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
                           Some examples of valid algorithm values are "sha256", "sha256+b64u", "multihash+base58".
-                          The encoded string following the algorithm must be hex digits and must be a minimum of 32 characters.
+                          The encoded string following the algorithm must be hex digits (a-f, A-F, 0-9) and must be a minimum of 32 characters.
 
                           Tag-based references must begin with a word character (alphanumeric + "_") followed by word characters or ".", and "-" characters.
                           The tag must not be longer than 127 characters.
@@ -171,24 +172,52 @@ spec:
                           An example of a valid tag-based image reference is "quay.io/operatorhubio/catalog:latest"
                         maxLength: 1000
                         type: string
+                        x-kubernetes-validations:
+                        - message: must start with a valid domain. valid domains must
+                            be alphanumeric characters (lowercase and uppercase) separated
+                            by the "." character.
+                          rule: self.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                        - message: a valid name is required. valid names must contain
+                            lowercase alphanumeric characters separated only by the
+                            ".", "_", "__", "-" characters.
+                          rule: self.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)')
+                            != ""
+                        - message: must end with a digest or a tag
+                          rule: self.find('(@.*:)') != "" || self.find(':.*$') !=
+                            ""
+                        - message: tag is invalid. the tag must not be more than 127
+                            characters
+                          rule: 'self.find(''(@.*:)'') == "" ? (self.find('':.*$'')
+                            != "" ? self.find('':.*$'').substring(1).size() <= 127
+                            : true) : true'
+                        - message: tag is invalid. valid tags must begin with a word
+                            character (alphanumeric + "_") followed by word characters
+                            or ".", and "-" characters
+                          rule: 'self.find(''(@.*:)'') == "" ? (self.find('':.*$'')
+                            != "" ? self.find('':.*$'').matches('':[\\w][\\w.-]*$'')
+                            : true) : true'
+                        - message: digest algorithm is not valid. valid algorithms
+                            must start with an uppercase or lowercase alpha character
+                            followed by alphanumeric characters and may contain the
+                            "-", "_", "+", and "." characters.
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find(''(@.*:)'').matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:])'')
+                            : true'
+                        - message: digest is not valid. the encoded string must be
+                            at least 32 characters
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').substring(1).size()
+                            >= 32 : true'
+                        - message: digest is not valid. the encoded string must only
+                            contain hex characters (A-F, a-f, 0-9)
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').matches('':[0-9A-Fa-f]*$'')
+                            : true'
                     required:
                     - ref
                     type: object
                     x-kubernetes-validations:
                     - message: cannot specify pollIntervalMinutes while using digest-based
                         image
-                      rule: '!has(self.pollIntervalMinutes) || (self.ref.contains(''@''))'
-                    - message: ref is invalid, it must start with a valid domain
-                      rule: self.ref.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
-                    - message: ref is invalid, a valid name is required
-                      rule: self.ref.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)')
-                        != ""
-                    - message: ref is invalid, must end with a digest or a tag
-                      rule: self.ref.contains('@') || self.ref.find(':[\\w][\\w.-]{0,127}$')
-                        != ""
-                    - message: ref is invalid, tag or digest is invalid
-                      rule: 'self.ref.contains(''@'') ? self.ref.matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9A-Fa-f]{32,})'')
-                        : self.ref.substring(self.ref.lastIndexOf(":")+1).matches(''[\\w][\\w.-]{0,127}'')'
+                      rule: 'self.ref.find(''(@.*:)'') != "" ? !has(self.pollIntervalMinutes)
+                        : true'
                   type:
                     description: |-
                       type is a reference to the type of source the catalog is sourced from.
@@ -228,11 +257,11 @@ spec:
                   The Serving condition is used to represent whether or not the contents of the catalog is being served via the HTTP(S) web server.
                   When it has a status of True and a reason of Available, the contents of the catalog are being served.
                   When it has a status of False and a reason of Unavailable, the contents of the catalog are not being served because the contents are not yet available.
-                  When it has a status of False and a reason of MarkedUnavailable, the contents of the catalog are not being served because the catalog has been intentionally marked as unavailable.
+                  When it has a status of False and a reason of UserSpecifiedUnavailable, the contents of the catalog are not being served because the catalog has been intentionally marked as unavailable.
 
-                  The Progressing condition is used to represent whether or not the ClusterCatalog is progressing towards a new state.
+                  The Progressing condition is used to represent whether or not the ClusterCatalog is progressing or is ready to progress towards a new state.
                   When it has a status of True and a reason of Retrying, there was an error in the progression of the ClusterCatalog that may be resolved on subsequent reconciliation attempts.
-                  When it has a status of False and a reason of Succeeded, the ClusterCatalog has successfully progressed to a new state and is ready to continue progressing.
+                  When it has a status of True and a reason of Succeeded, the ClusterCatalog has successfully progressed to a new state and is ready to continue progressing.
                   When it has a status of False and a reason of Blocked, there was an error in the progression of the ClusterCatalog that requires manual intervention for recovery.
 
                   In the case that the Serving condition is True with reason Available and Progressing is True with reason Retrying, the previously fetched
@@ -299,7 +328,7 @@ spec:
                 x-kubernetes-list-type: map
               lastUnpacked:
                 description: |-
-                  lastUnpacked represents the time when the contents of the
+                  lastUnpacked represents the last time the contents of the
                   catalog were extracted from their source format. As an example,
                   when using an Image source, the OCI image will be pulled and the
                   image layers written to a file-system backed cache. We refer to the
@@ -322,17 +351,35 @@ spec:
                           OCI manifests that were used to extract the catalog contents.
                         maxLength: 1000
                         type: string
+                        x-kubernetes-validations:
+                        - message: must start with a valid domain. valid domains must
+                            be alphanumeric characters (lowercase and uppercase) separated
+                            by the "." character.
+                          rule: self.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
+                        - message: a valid name is required. valid names must contain
+                            lowercase alphanumeric characters separated only by the
+                            ".", "_", "__", "-" characters.
+                          rule: self.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)')
+                            != ""
+                        - message: must end with a digest
+                          rule: self.find('(@.*:)') != ""
+                        - message: digest algorithm is not valid. valid algorithms
+                            must start with an uppercase or lowercase alpha character
+                            followed by alphanumeric characters and may contain the
+                            "-", "_", "+", and "." characters.
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find(''(@.*:)'').matches(''(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:])'')
+                            : true'
+                        - message: digest is not valid. the encoded string must be
+                            at least 32 characters
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').substring(1).size()
+                            >= 32 : true'
+                        - message: digest is not valid. the encoded string must only
+                            contain hex characters (A-F, a-f, 0-9)
+                          rule: 'self.find(''(@.*:)'') != "" ? self.find('':.*$'').matches('':[0-9A-Fa-f]*$'')
+                            : true'
                     required:
                     - ref
                     type: object
-                    x-kubernetes-validations:
-                    - message: ref is invalid, it must start with a valid domain
-                      rule: self.ref.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\b')
-                    - message: ref is invalid, a valid name is required
-                      rule: self.ref.find('(\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)')
-                        != ""
-                    - message: ref is invalid, digest is invalid
-                      rule: self.ref.matches('(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9A-Fa-f]{32,})')
                   type:
                     description: |-
                       type is a reference to the type of source the catalog is sourced from.
@@ -359,32 +406,30 @@ spec:
                 properties:
                   base:
                     description: |-
-                      base is a cluster-internal URL that provides REST API endpoints for
+                      base is a cluster-internal URL that provides endpoints for
                       accessing the content of the catalog.
 
-                      It is expected that users append the path for the REST API endpoint they wish
-                      to access. The general format expected for a request to a REST API endpoint is
-                      {base}/api/{version}/{endpoint}
+                      It is expected that clients append the path for the endpoint they wish
+                      to access.
 
-                      Currently, only a single version of the REST API is served and is accessible at the path
+                      Currently, only a single endpoint is served and is accessible at the path
                       /api/v1.
 
-                      The endpoints served for v1 of the REST API are:
+                      The endpoints served for the v1 API are:
                         - /all - this endpoint returns the entirety of the catalog contents in the FBC format
 
-                      As the needs of users and clients of the REST API evolve, new versions of the
-                      REST API may be added.
+                      As the needs of users and clients of the evolve, new endpoints may be added.
                     maxLength: 525
                     type: string
+                    x-kubernetes-validations:
+                    - message: must be a valid URL
+                      rule: isURL(self)
+                    - message: scheme must be either http or https
+                      rule: 'isURL(self) ? (url(self).getScheme() == "http" || url(self).getScheme()
+                        == "https") : true'
                 required:
                 - base
                 type: object
-                x-kubernetes-validations:
-                - message: base must be a valid URL
-                  rule: isURL(self.base)
-                - message: base is invalid, scheme must be one of [http, https]
-                  rule: url(self.base).getScheme() == "http" || url(self.base).getScheme
-                    == "https"
             type: object
         required:
         - metadata

--- a/olm/catalogd/v1alpha1/clustercatalog_types.go
+++ b/olm/catalogd/v1alpha1/clustercatalog_types.go
@@ -8,6 +8,9 @@ import (
 // +enum
 type SourceType string
 
+// AvailabilityMode defines the availability of the catalog
+type AvailabilityMode string
+
 const (
 	SourceTypeImage SourceType = "Image"
 
@@ -15,9 +18,9 @@ const (
 	TypeServing     = "Serving"
 
 	// Serving reasons
-	ReasonAvailable   = "Available"
-	ReasonUnavailable = "Unavailable"
-	ReasonDisabled    = "Disabled"
+	ReasonAvailable        = "Available"
+	ReasonUnavailable      = "Unavailable"
+	ReasonMarkedUnavailabe = "MarkedUnavailable"
 
 	// Progressing reasons
 	ReasonSucceeded = "Succeeded"
@@ -26,8 +29,8 @@ const (
 
 	MetadataNameLabel = "olm.operatorframework.io/metadata.name"
 
-	AvailabilityEnabled  = "Enabled"
-	AvailabilityDisabled = "Disabled"
+	AvailabilityModeAvailable   AvailabilityMode = "Available"
+	AvailabilityModeUnavailable AvailabilityMode = "Unavailable"
 )
 
 //+kubebuilder:object:root=true
@@ -40,10 +43,24 @@ const (
 // ClusterCatalog enables users to make File-Based Catalog (FBC) catalog data available to the cluster.
 // For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
 type ClusterCatalog struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata"`
 
-	Spec   ClusterCatalogSpec   `json:"spec"`
+	// spec is the desired state of the ClusterCatalog.
+	// spec is required.
+	// The controller will work to ensure that the desired
+	// catalog is unpacked and served over the catalog content HTTP server.
+	// +kubebuilder:validation:Required
+	Spec ClusterCatalogSpec `json:"spec"`
+
+	// status contains information about the state of the ClusterCatalog such as:
+	//   - Whether or not the catalog contents are being served via the catalog content HTTP server
+	//   - Whether or not the ClusterCatalog is progressing to a new state
+	//   - A reference to the source from which the catalog contents were retrieved
+	// +optional
 	Status ClusterCatalogStatus `json:"status,omitempty"`
 }
 
@@ -52,15 +69,28 @@ type ClusterCatalog struct {
 // ClusterCatalogList contains a list of ClusterCatalog
 type ClusterCatalogList struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ListMeta `json:"metadata"`
 
+	// items is a list of ClusterCatalogs.
+	// items is required.
+	// +kubebuilder:validation:Required
 	Items []ClusterCatalog `json:"items"`
 }
 
 // ClusterCatalogSpec defines the desired state of ClusterCatalog
-// +kubebuilder:validation:XValidation:rule="!has(self.source.image.pollInterval) || (self.source.image.ref.find('@sha256:') == \"\")",message="cannot specify PollInterval while using digest-based image"
 type ClusterCatalogSpec struct {
-	// source is a required field that allows the user to define the source of a Catalog that contains catalog metadata in the File-Based Catalog (FBC) format.
+	// source allows a user to define the source of a catalog.
+	// A "catalog" contains information on content that can be installed on a cluster.
+	// Providing a catalog source makes the contents of the catalog discoverable and usable by
+	// other on-cluster components.
+	// These on-cluster components may do a variety of things with this information, such as
+	// presenting the content in a GUI dashboard or installing content from the catalog on the cluster.
+	// The catalog source must contain catalog metadata in the File-Based Catalog (FBC) format.
+	// For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs.
+	// source is a required field.
 	//
 	// Below is a minimal example of a ClusterCatalogSpec that sources a catalog from an image:
 	//
@@ -69,103 +99,137 @@ type ClusterCatalogSpec struct {
 	//    image:
 	//      ref: quay.io/operatorhubio/catalog:latest
 	//
-	// For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
+	// +kubebuilder:validation:Required
 	Source CatalogSource `json:"source"`
 
-	// priority is an optional field that allows the user to define a priority for a ClusterCatalog.
+	// priority allows the user to define a priority for a ClusterCatalog.
+	// priority is optional.
+	//
 	// A ClusterCatalog's priority is used by clients as a tie-breaker between ClusterCatalogs that meet the client's requirements.
+	// It is up to clients to decide how to handle scenarios where multiple ClusterCatalogs with the same priority meet their requirements.
 	// For example, in the case where multiple ClusterCatalogs provide the same bundle.
-	// A higher number means higher priority. Negative numbers are also accepted.
-	// When omitted, the default priority is 0.
+	// A higher number means higher priority.
+	//
+	// When omitted, the default priority is 0 because that is the zero value of integers.
+	//
+	// Negative numbers can be used to specify a priority lower than the default.
+	// Positive numbers can be used to specify a priority higher than the default.
+	//
+	// The lowest possible value is -2147483648.
+	// The highest possible value is 214748647.
+	//
 	// +kubebuilder:default:=0
+	// +kubebuilder:validation:minimum:=-2147483648
+	// +kubebuilder:validation:maximum:=214748647
 	// +optional
 	Priority int32 `json:"priority"`
 
-	// Availability is an optional field that allows users to define whether the ClusterCatalog is utilized by the operator-controller.
+	// availabilityMode allows users to define how the ClusterCatalog is made available to clients on the cluster.
+	// availabilityMode is optional.
 	//
-	// Allowed values are : ["Enabled", "Disabled"].
-	// If set to "Enabled", the catalog will be used for updates, serving contents, and package installations.
+	// Allowed values are "Available" and "Unavailable" and omitted.
 	//
-	// If set to "Disabled", catalogd will stop serving the catalog and the cached data will be removed.
+	// When omitted, the default value is "Available".
 	//
-	// If unspecified, the default value is "Enabled"
+	// When set to "Available", the catalog contents will be unpacked and served over the catalog content HTTP server.
+	// Setting the availabilityMode to "Available" tells clients that they should consider this ClusterCatalog
+	// and its contents as usable.
 	//
-	// +kubebuilder:validation:Enum="Disabled";"Enabled"
-	// +kubebuilder:default="Enabled"
+	// When set to "Unavailable", the catalog contents will no longer be served over the catalog content HTTP server.
+	// When set to this availabilityMode it should be interpreted the same as the ClusterCatalog not existing.
+	// Setting the availabilityMode to "Unavailable" can be useful in scenarios where a user may not want
+	// to delete the ClusterCatalog all together, but would still like it to be treated as if it doesn't exist.
+	//
+	// +kubebuilder:validation:Enum:="Unavailable";"Available"
+	// +kubebuilder:default:="Available"
 	// +optional
-	Availability string `json:"availability,omitempty"`
+	AvailabilityMode AvailabilityMode `json:"availabilityMode,omitempty"`
 }
 
 // ClusterCatalogStatus defines the observed state of ClusterCatalog
 type ClusterCatalogStatus struct {
 	// conditions is a representation of the current state for this ClusterCatalog.
-	// The status is represented by a set of "conditions".
 	//
-	// Each condition is generally structured in the following format:
-	//   - Type: a string representation of the condition type. More or less the condition "name".
-	//   - Status: a string representation of the state of the condition. Can be one of ["True", "False", "Unknown"].
-	//   - Reason: a string representation of the reason for the current state of the condition. Typically useful for building automation around particular Type+Reason combinations.
-	//   - Message: a human-readable message that further elaborates on the state of the condition.
+	// The current condition types are Serving and Progressing.
 	//
-	// The current set of condition types are:
-	//   - "Serving", which represents whether or not the contents of the catalog are being served via the HTTP(S) web server.
-	//   - "Progressing", which represents whether or not the ClusterCatalog is progressing towards a new state.
+	// The Serving condition is used to represent whether or not the contents of the catalog is being served via the HTTP(S) web server.
+	// When it has a status of True and a reason of Available, the contents of the catalog are being served.
+	// When it has a status of False and a reason of Unavailable, the contents of the catalog are not being served because the contents are not yet available.
+	// When it has a status of False and a reason of MarkedUnavailable, the contents of the catalog are not being served because the catalog has been intentionally marked as unavailable.
 	//
-	// The current set of reasons are:
-	//   - "Succeeded", this reason is set on the "Progressing" condition when progressing to a new state is successful.
-	//   - "Blocked", this reason is set on the "Progressing" condition when the ClusterCatalog controller has encountered an error that requires manual intervention for recovery.
-	//   - "Retrying", this reason is set on the "Progressing" condition when the ClusterCatalog controller has encountered an error that might be resolvable on subsequent reconciliation attempts.
-	//   - "Available", this reason is set on the "Serving" condition when the contents of the ClusterCatalog are being served via an endpoint on the HTTP(S) web server.
-	//   - "Unavailable", this reason is set on the "Serving" condition when there is not an endpoint on the HTTP(S) web server that is serving the contents of the ClusterCatalog.
+	// The Progressing condition is used to represent whether or not the ClusterCatalog is progressing towards a new state.
+	// When it has a status of True and a reason of Retrying, there was an error in the progression of the ClusterCatalog that may be resolved on subsequent reconciliation attempts.
+	// When it has a status of False and a reason of Succeeded, the ClusterCatalog has successfully progressed to a new state and is ready to continue progressing.
+	// When it has a status of False and a reason of Blocked, there was an error in the progression of the ClusterCatalog that requires manual intervention for recovery.
 	//
+	// In the case that the Serving condition is True with reason Available and Progressing is True with reason Retrying, the previously fetched
+	// catalog contents are still being served via the HTTP(S) web server while we are progressing towards serving a new version of the catalog
+	// contents. This could occur when we've initially fetched the latest contents from the source for this catalog and when polling for changes
+	// to the contents we identify that there are updates to the contents.
+	//
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 	// resolvedSource contains information about the resolved source based on the source type.
-	//
-	// Below is an example of a resolved source for an image source:
-	// resolvedSource:
-	//
-	//  image:
-	//    lastSuccessfulPollAttempt: "2024-09-10T12:22:13Z"
-	//    ref: quay.io/operatorhubio/catalog@sha256:c7392b4be033da629f9d665fec30f6901de51ce3adebeff0af579f311ee5cf1b
-	//  type: Image
 	// +optional
 	ResolvedSource *ResolvedCatalogSource `json:"resolvedSource,omitempty"`
 	// urls contains the URLs that can be used to access the catalog.
 	// +optional
 	URLs *ClusterCatalogURLs `json:"urls,omitempty"`
-	// lastUnpacked represents the time when the
-	// ClusterCatalog object was last unpacked successfully.
+	// lastUnpacked represents the last time the contents of the
+	// catalog were extracted from their source format. As an example,
+	// when using an Image source, the OCI image will be pulled and the
+	// image layers written to a file-system backed cache. We refer to the
+	// act of this extraction from the source format as "unpacking".
 	// +optional
-	LastUnpacked metav1.Time `json:"lastUnpacked,omitempty"`
+	LastUnpacked *metav1.Time `json:"lastUnpacked,omitempty"`
 }
 
 // ClusterCatalogURLs contains the URLs that can be used to access the catalog.
+// +kubebuilder:validation:XValidation:rule="isURL(self.base)",message="base must be a valid URL"
+// +kubebuilder:validation:XValidation:rule="url(self.base).getScheme() == \"http\" || url(self.base).getScheme == \"https\"",message="base is invalid, scheme must be one of [http, https]"
 type ClusterCatalogURLs struct {
-	// base is a required cluster-internal URL which provides API access for this ClusterCatalog.
-	// A suffix API access path can be added to retrieve catalog data for the ClusterCatalog.
-	// Currently, a 'v1' API access provides complete FBC retrival via the path "/api/v1/all", with the general form `{base}/api/v1/all`.
+	// base is a cluster-internal URL that provides REST API endpoints for
+	// accessing the content of the catalog.
+	//
+	// It is expected that users append the path for the REST API endpoint they wish
+	// to access. The general format expected for a request to a REST API endpoint is
+	// {base}/api/{version}/{endpoint}
+	//
+	// Currently, only a single version of the REST API is served and is accessible at the path
+	// /api/v1.
+	//
+	// The endpoints served for v1 of the REST API are:
+	//   - /all - this endpoint returns the entirety of the catalog contents in the FBC format
+	//
+	// As the needs of users and clients of the REST API evolve, new versions of the
+	// REST API may be added.
+	//
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength:=525
 	Base string `json:"base"`
 }
 
 // CatalogSource is a discriminated union of possible sources for a Catalog.
 // CatalogSource contains the sourcing information for a Catalog
 // +union
-// +kubebuilder:validation:XValidation:rule="self.type == 'Image' && has(self.image)",message="source type 'Image' requires image field"
+// +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'Image' ? has(self.image) : !has(self.image)",message="image is required when source type is Image, and forbidden otherwise"
 type CatalogSource struct {
-	// type is a required reference to the type of source the catalog is sourced from.
+	// type is a reference to the type of source the catalog is sourced from.
+	// type is required.
 	//
-	// Allowed values are ["Image"]
+	// The only allowed value is "Image".
 	//
-	// When this field is set to "Image", the ClusterCatalog content will be sourced from an OCI image.
+	// When set to "Image", the ClusterCatalog content will be sourced from an OCI image.
 	// When using an image source, the image field must be set and must be the only field defined for this type.
 	//
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum:="Image"
 	// +kubebuilder:validation:Required
 	Type SourceType `json:"type"`
-	// image is used to configure how catalog contents are sourced from an OCI image. This field must be set when type is set to "Image" and must be the only field defined for this type.
+	// image is used to configure how catalog contents are sourced from an OCI image.
+	// This field is required when type is Image, and forbidden otherwise.
 	// +optional
 	Image *ImageSource `json:"image,omitempty"`
 }
@@ -173,49 +237,94 @@ type CatalogSource struct {
 // ResolvedCatalogSource is a discriminated union of resolution information for a Catalog.
 // ResolvedCatalogSource contains the information about a sourced Catalog
 // +union
-// +kubebuilder:validation:XValidation:rule="self.type == 'Image' && has(self.image)",message="source type 'Image' requires image field"
+// +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'Image' ? has(self.image) : !has(self.image)",message="image is required when source type is Image, and forbidden otherwise"
 type ResolvedCatalogSource struct {
 	// type is a reference to the type of source the catalog is sourced from.
+	// type is required.
 	//
-	// It will be set to one of the following values: ["Image"].
+	// The only allowed value is "Image".
 	//
-	// When this field is set to "Image", information about the resolved image source will be set in the 'image' field.
+	// When set to "Image", information about the resolved image source will be set in the 'image' field.
 	//
 	// +unionDiscriminator
 	// +kubebuilder:validation:Enum:="Image"
 	// +kubebuilder:validation:Required
 	Type SourceType `json:"type"`
 	// image is a field containing resolution information for a catalog sourced from an image.
+	// This field must be set when type is Image, and forbidden otherwise.
 	Image *ResolvedImageSource `json:"image"`
 }
 
 // ResolvedImageSource provides information about the resolved source of a Catalog sourced from an image.
+// +kubebuilder:validation:XValidation:rule="self.ref.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\\\b')",message="ref is invalid, it must start with a valid domain"
+// +kubebuilder:validation:XValidation:rule="self.ref.find('(\\\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)') != \"\"",message="ref is invalid, a valid name is required"
+// +kubebuilder:validation:XValidation:rule="self.ref.matches('(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9A-Fa-f]{32,})')",message="ref is invalid, digest is invalid"
 type ResolvedImageSource struct {
-	// ref contains the resolved sha256 image ref containing Catalog contents.
+	// ref contains the resolved image digest-based reference.
+	// The digest format is used so users can use other tooling to fetch the exact
+	// OCI manifests that were used to extract the catalog contents.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength:=1000
 	Ref string `json:"ref"`
-	// lastSuccessfulPollAttempt is the time when the resolved source was last successfully polled for new content.
-	LastSuccessfulPollAttempt metav1.Time `json:"lastSuccessfulPollAttempt"`
 }
 
 // ImageSource enables users to define the information required for sourcing a Catalog from an OCI image
+// +kubebuilder:validation:XValidation:rule="!has(self.pollIntervalMinutes) || (self.ref.contains('@'))",message="cannot specify pollIntervalMinutes while using digest-based image"
+// +kubebuilder:validation:XValidation:rule="self.ref.matches('^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])((\\\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(:[0-9]+)?\\\\b')",message="ref is invalid, it must start with a valid domain"
+// +kubebuilder:validation:XValidation:rule="self.ref.find('(\\\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?((\\\\/[a-z0-9]+((([._]|__|[-]*)[a-z0-9]+)+)?)+)?)') != \"\"",message="ref is invalid, a valid name is required"
+// +kubebuilder:validation:XValidation:rule="self.ref.contains('@') || self.ref.find(':[\\\\w][\\\\w.-]{0,127}$') != \"\"",message="ref is invalid, must end with a digest or a tag"
+// +kubebuilder:validation:XValidation:rule="self.ref.contains('@') ? self.ref.matches('(@[A-Za-z][A-Za-z0-9]*([-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9A-Fa-f]{32,})') : self.ref.substring(self.ref.lastIndexOf(\":\")+1).matches('[\\\\w][\\\\w.-]{0,127}')",message="ref is invalid, tag or digest is invalid"
 type ImageSource struct {
-	// ref is a required field that allows the user to define the reference to a container image containing Catalog contents.
-	// Examples:
-	//   ref: quay.io/operatorhubio/catalog:latest # image reference
-	//   ref: quay.io/operatorhubio/catalog@sha256:c7392b4be033da629f9d665fec30f6901de51ce3adebeff0af579f311ee5cf1b # image reference with sha256 digest
+	// ref allows users to define the reference to a container image containing Catalog contents.
+	// ref is required.
+	// ref can not be more than 1000 characters.
+	//
+	// A reference can be broken down into 3 parts - the domain, name, and identifier.
+	//
+	// The domain is typically the registry where an image is located.
+	// It must be alphanumeric characters (lowercase and uppercase) separated by the "." character.
+	// Hyphenation is allowed, but the domain must start and end with alphanumeric characters.
+	// Specifying a port to use is also allowed by adding the ":" character followed by numeric values.
+	// The port must be the last value in the domain.
+	// Some examples of valid domain values are "registry.mydomain.io", "quay.io", "my-registry.io:8080".
+	//
+	// The name is typically the repository in the registry where an image is located.
+	// It must contain lowercase alphanumeric characters separated only by the ".", "_", "__", "-" characters.
+	// Multiple names can be concatenated with the "/" character.
+	// The domain and name are combined using the "/" character.
+	// Some examples of valid name values are "operatorhubio/catalog", "catalog", "my-catalog.prod".
+	// An example of the domain and name parts of a reference being combined is "quay.io/operatorhubio/catalog".
+	//
+	// The identifier is typically the tag or digest for an image reference and is present at the end of the reference.
+	// It starts with a separator character used to distinguish the end of the name and beginning of the identifier.
+	// For a digest-based reference, the "@" character is the separator.
+	// For a tag-based reference, the ":" character is the separator.
+	// An identifier is required in the reference.
+	//
+	// Digest-based references must contain an algorithm reference immediately after the "@" separator.
+	// The algorithm reference must be followed by the ":" character and an encoded string.
+	// The algorithm must start with an uppercase or lowercase alpha character followed by alphanumeric characters and may contain the "-", "_", "+", and "." characters.
+	// Some examples of valid algorithm values are "sha256", "sha256+b64u", "multihash+base58".
+	// The encoded string following the algorithm must be hex digits and must be a minimum of 32 characters.
+	//
+	// Tag-based references must begin with a word character (alphanumeric + "_") followed by word characters or ".", and "-" characters.
+	// The tag must not be longer than 127 characters.
+	//
+	// An example of a valid digest-based image reference is "quay.io/operatorhubio/catalog@sha256:200d4ddb2a73594b91358fe6397424e975205bfbe44614f5846033cad64b3f05"
+	// An example of a valid tag-based image reference is "quay.io/operatorhubio/catalog:latest"
+	//
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength:=1000
 	Ref string `json:"ref"`
-	// pollInterval is an optional field that allows the user to set the interval at which the image source should be polled for new content.
-	// It must be specified as a duration.
-	// It must not be specified for a catalog image referenced by a sha256 digest.
-	// Examples:
-	//   pollInterval: 1h # poll the image source every hour
-	//   pollInterval: 30m # poll the image source every 30 minutes
-	//   pollInterval: 1h30m # poll the image source every 1 hour and 30 minutes
+
+	// pollIntervalMinutes allows the user to set the interval, in minutes, at which the image source should be polled for new content.
+	// pollIntervalMinutes is optional.
+	// pollIntervalMinutes can not be specified when ref is a digest-based reference.
 	//
 	// When omitted, the image will not be polled for new content.
-	// +kubebuilder:validation:Format:=duration
+	// +kubebuilder:validation:Minimum:=1
 	// +optional
-	PollInterval *metav1.Duration `json:"pollInterval,omitempty"`
+	PollIntervalMinutes *int `json:"pollIntervalMinutes,omitempty"`
 }
 
 func init() {

--- a/olm/catalogd/v1alpha1/clustercatalog_types.go
+++ b/olm/catalogd/v1alpha1/clustercatalog_types.go
@@ -1,0 +1,219 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SourceType defines the type of source used for catalogs.
+// +enum
+type SourceType string
+
+const (
+	SourceTypeImage SourceType = "Image"
+
+	TypeProgressing = "Progressing"
+	TypeServing     = "Serving"
+
+	// Serving reasons
+	ReasonAvailable   = "Available"
+	ReasonUnavailable = "Unavailable"
+	ReasonDisabled    = "Disabled"
+
+	// Progressing reasons
+	ReasonSucceeded = "Succeeded"
+	ReasonRetrying  = "Retrying"
+	ReasonBlocked   = "Blocked"
+
+	MetadataNameLabel = "olm.operatorframework.io/metadata.name"
+
+	AvailabilityEnabled  = "Enabled"
+	AvailabilityDisabled = "Disabled"
+)
+
+//+kubebuilder:object:root=true
+//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name=LastUnpacked,type=date,JSONPath=`.status.lastUnpacked`
+//+kubebuilder:printcolumn:name="Serving",type=string,JSONPath=`.status.conditions[?(@.type=="Serving")].status`
+//+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`
+
+// ClusterCatalog enables users to make File-Based Catalog (FBC) catalog data available to the cluster.
+// For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
+type ClusterCatalog struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata"`
+
+	Spec   ClusterCatalogSpec   `json:"spec"`
+	Status ClusterCatalogStatus `json:"status,omitempty"`
+}
+
+//+kubebuilder:object:root=true
+
+// ClusterCatalogList contains a list of ClusterCatalog
+type ClusterCatalogList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []ClusterCatalog `json:"items"`
+}
+
+// ClusterCatalogSpec defines the desired state of ClusterCatalog
+// +kubebuilder:validation:XValidation:rule="!has(self.source.image.pollInterval) || (self.source.image.ref.find('@sha256:') == \"\")",message="cannot specify PollInterval while using digest-based image"
+type ClusterCatalogSpec struct {
+	// source is a required field that allows the user to define the source of a Catalog that contains catalog metadata in the File-Based Catalog (FBC) format.
+	//
+	// Below is a minimal example of a ClusterCatalogSpec that sources a catalog from an image:
+	//
+	//  source:
+	//    type: Image
+	//    image:
+	//      ref: quay.io/operatorhubio/catalog:latest
+	//
+	// For more information on FBC, see https://olm.operatorframework.io/docs/reference/file-based-catalogs/#docs
+	Source CatalogSource `json:"source"`
+
+	// priority is an optional field that allows the user to define a priority for a ClusterCatalog.
+	// A ClusterCatalog's priority is used by clients as a tie-breaker between ClusterCatalogs that meet the client's requirements.
+	// For example, in the case where multiple ClusterCatalogs provide the same bundle.
+	// A higher number means higher priority. Negative numbers are also accepted.
+	// When omitted, the default priority is 0.
+	// +kubebuilder:default:=0
+	// +optional
+	Priority int32 `json:"priority"`
+
+	// Availability is an optional field that allows users to define whether the ClusterCatalog is utilized by the operator-controller.
+	//
+	// Allowed values are : ["Enabled", "Disabled"].
+	// If set to "Enabled", the catalog will be used for updates, serving contents, and package installations.
+	//
+	// If set to "Disabled", catalogd will stop serving the catalog and the cached data will be removed.
+	//
+	// If unspecified, the default value is "Enabled"
+	//
+	// +kubebuilder:validation:Enum="Disabled";"Enabled"
+	// +kubebuilder:default="Enabled"
+	// +optional
+	Availability string `json:"availability,omitempty"`
+}
+
+// ClusterCatalogStatus defines the observed state of ClusterCatalog
+type ClusterCatalogStatus struct {
+	// conditions is a representation of the current state for this ClusterCatalog.
+	// The status is represented by a set of "conditions".
+	//
+	// Each condition is generally structured in the following format:
+	//   - Type: a string representation of the condition type. More or less the condition "name".
+	//   - Status: a string representation of the state of the condition. Can be one of ["True", "False", "Unknown"].
+	//   - Reason: a string representation of the reason for the current state of the condition. Typically useful for building automation around particular Type+Reason combinations.
+	//   - Message: a human-readable message that further elaborates on the state of the condition.
+	//
+	// The current set of condition types are:
+	//   - "Serving", which represents whether or not the contents of the catalog are being served via the HTTP(S) web server.
+	//   - "Progressing", which represents whether or not the ClusterCatalog is progressing towards a new state.
+	//
+	// The current set of reasons are:
+	//   - "Succeeded", this reason is set on the "Progressing" condition when progressing to a new state is successful.
+	//   - "Blocked", this reason is set on the "Progressing" condition when the ClusterCatalog controller has encountered an error that requires manual intervention for recovery.
+	//   - "Retrying", this reason is set on the "Progressing" condition when the ClusterCatalog controller has encountered an error that might be resolvable on subsequent reconciliation attempts.
+	//   - "Available", this reason is set on the "Serving" condition when the contents of the ClusterCatalog are being served via an endpoint on the HTTP(S) web server.
+	//   - "Unavailable", this reason is set on the "Serving" condition when there is not an endpoint on the HTTP(S) web server that is serving the contents of the ClusterCatalog.
+	//
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+	// resolvedSource contains information about the resolved source based on the source type.
+	//
+	// Below is an example of a resolved source for an image source:
+	// resolvedSource:
+	//
+	//  image:
+	//    lastSuccessfulPollAttempt: "2024-09-10T12:22:13Z"
+	//    ref: quay.io/operatorhubio/catalog@sha256:c7392b4be033da629f9d665fec30f6901de51ce3adebeff0af579f311ee5cf1b
+	//  type: Image
+	// +optional
+	ResolvedSource *ResolvedCatalogSource `json:"resolvedSource,omitempty"`
+	// urls contains the URLs that can be used to access the catalog.
+	// +optional
+	URLs *CatalogURLs `json:"urls,omitempty"`
+	// lastUnpacked represents the time when the
+	// ClusterCatalog object was last unpacked successfully.
+	// +optional
+	LastUnpacked metav1.Time `json:"lastUnpacked,omitempty"`
+}
+
+type CatalogURLs struct {
+	// base is a required cluster-internal URL from which on-cluster components can access the API endpoint for this catalog
+	Base string `json:"base"`
+}
+
+// CatalogSource is a discriminated union of possible sources for a Catalog.
+// CatalogSource contains the sourcing information for a Catalog
+// +union
+// +kubebuilder:validation:XValidation:rule="self.type == 'Image' && has(self.image)",message="source type 'Image' requires image field"
+type CatalogSource struct {
+	// type is a required reference to the type of source the catalog is sourced from.
+	//
+	// Allowed values are ["Image"]
+	//
+	// When this field is set to "Image", the ClusterCatalog content will be sourced from an OCI image.
+	// When using an image source, the image field must be set and must be the only field defined for this type.
+	//
+	// +unionDiscriminator
+	// +kubebuilder:validation:Enum:="Image"
+	// +kubebuilder:validation:Required
+	Type SourceType `json:"type"`
+	// image is used to configure how catalog contents are sourced from an OCI image. This field must be set when type is set to "Image" and must be the only field defined for this type.
+	// +optional
+	Image *ImageSource `json:"image,omitempty"`
+}
+
+// ResolvedCatalogSource is a discriminated union of resolution information for a Catalog.
+// ResolvedCatalogSource contains the information about a sourced Catalog
+// +union
+// +kubebuilder:validation:XValidation:rule="self.type == 'Image' && has(self.image)",message="source type 'Image' requires image field"
+type ResolvedCatalogSource struct {
+	// type is a reference to the type of source the catalog is sourced from.
+	//
+	// It will be set to one of the following values: ["Image"].
+	//
+	// When this field is set to "Image", information about the resolved image source will be set in the 'image' field.
+	//
+	// +unionDiscriminator
+	// +kubebuilder:validation:Enum:="Image"
+	// +kubebuilder:validation:Required
+	Type SourceType `json:"type"`
+	// image is a field containing resolution information for a catalog sourced from an image.
+	Image *ResolvedImageSource `json:"image"`
+}
+
+// ResolvedImageSource provides information about the resolved source of a Catalog sourced from an image.
+type ResolvedImageSource struct {
+	// ref contains the resolved sha256 image ref containing Catalog contents.
+	Ref string `json:"ref"`
+	// lastSuccessfulPollAttempt is the time when the resolved source was last successfully polled for new content.
+	LastSuccessfulPollAttempt metav1.Time `json:"lastSuccessfulPollAttempt"`
+}
+
+// ImageSource enables users to define the information required for sourcing a Catalog from an OCI image
+type ImageSource struct {
+	// ref is a required field that allows the user to define the reference to a container image containing Catalog contents.
+	// Examples:
+	//   ref: quay.io/operatorhubio/catalog:latest # image reference
+	//   ref: quay.io/operatorhubio/catalog@sha256:c7392b4be033da629f9d665fec30f6901de51ce3adebeff0af579f311ee5cf1b # image reference with sha256 digest
+	Ref string `json:"ref"`
+	// pollInterval is an optional field that allows the user to set the interval at which the image source should be polled for new content.
+	// It must be specified as a duration.
+	// It must not be specified for a catalog image referenced by a sha256 digest.
+	// Examples:
+	//   pollInterval: 1h # poll the image source every hour
+	//   pollInterval: 30m # poll the image source every 30 minutes
+	//   pollInterval: 1h30m # poll the image source every 1 hour and 30 minutes
+	//
+	// When omitted, the image will not be polled for new content.
+	// +kubebuilder:validation:Format:=duration
+	// +optional
+	PollInterval *metav1.Duration `json:"pollInterval,omitempty"`
+}
+
+func init() {
+	SchemeBuilder.Register(&ClusterCatalog{}, &ClusterCatalogList{})
+}

--- a/olm/catalogd/v1alpha1/clustercatalog_types.go
+++ b/olm/catalogd/v1alpha1/clustercatalog_types.go
@@ -133,15 +133,19 @@ type ClusterCatalogStatus struct {
 	ResolvedSource *ResolvedCatalogSource `json:"resolvedSource,omitempty"`
 	// urls contains the URLs that can be used to access the catalog.
 	// +optional
-	URLs *CatalogURLs `json:"urls,omitempty"`
+	URLs *ClusterCatalogURLs `json:"urls,omitempty"`
 	// lastUnpacked represents the time when the
 	// ClusterCatalog object was last unpacked successfully.
 	// +optional
 	LastUnpacked metav1.Time `json:"lastUnpacked,omitempty"`
 }
 
-type CatalogURLs struct {
-	// base is a required cluster-internal URL from which on-cluster components can access the API endpoint for this catalog
+// ClusterCatalogURLs contains the URLs that can be used to access the catalog.
+type ClusterCatalogURLs struct {
+	// base is a required cluster-internal URL which provides API access for this ClusterCatalog.
+	// A suffix API access path can be added to retrieve catalog data for the ClusterCatalog.
+	// Currently, a 'v1' API access provides complete FBC retrival via the path "/api/v1/all", with the general form `{base}/api/v1/all`.
+	// +kubebuilder:validation:Required
 	Base string `json:"base"`
 }
 

--- a/olm/catalogd/v1alpha1/groupversion_info.go
+++ b/olm/catalogd/v1alpha1/groupversion_info.go
@@ -1,0 +1,20 @@
+// Package v1alpha1 contains API Schema definitions for the olm v1alpha1 API group
+// +kubebuilder:object:generate=true
+// +groupName=olm.operatorframework.io
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+var (
+	// GroupVersion is group version used to register these objects
+	GroupVersion = schema.GroupVersion{Group: "olm.operatorframework.io", Version: "v1alpha1"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)

--- a/olm/operator-controller/v1alpha1/clusterextension_crd.yaml
+++ b/olm/operator-controller/v1alpha1/clusterextension_crd.yaml
@@ -1,0 +1,582 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: clusterextensions.olm.operatorframework.io
+spec:
+  group: olm.operatorframework.io
+  names:
+    kind: ClusterExtension
+    listKind: ClusterExtensionList
+    plural: clusterextensions
+    singular: clusterextension
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterExtension is the Schema for the clusterextensions API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterExtensionSpec defines the desired state of ClusterExtension
+            properties:
+              install:
+                description: |-
+                  install is a required field used to configure the installation options
+                  for the ClusterExtension such as the installation namespace,
+                  the service account and the pre-flight check configuration.
+
+                  Below is a minimal example of an installation definition (in yaml):
+                  install:
+                     namespace: example-namespace
+                     serviceAccount:
+                       name: example-sa
+                properties:
+                  namespace:
+                    description: |-
+                      namespace is a reference to the Namespace in which the bundle of
+                      content for the package referenced in the packageName field will be applied.
+                      The bundle may contain cluster-scoped resources or resources that are
+                      applied to other Namespaces. This Namespace is expected to exist.
+
+                      namespace is required, immutable, and follows the DNS label standard
+                      as defined in [RFC 1123]. This means that valid values:
+                        - Contain no more than 63 characters
+                        - Contain only lowercase alphanumeric characters or '-'
+                        - Start with an alphanumeric character
+                        - End with an alphanumeric character
+
+                      Some examples of valid values are:
+                        - some-namespace
+                        - 123-namespace
+                        - 1-namespace-2
+                        - somenamespace
+
+                      Some examples of invalid values are:
+                        - -some-namespace
+                        - some-namespace-
+                        - thisisareallylongnamespacenamethatisgreaterthanthemaximumlength
+                        - some.namespace
+
+                      [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                    x-kubernetes-validations:
+                    - message: namespace is immutable
+                      rule: self == oldSelf
+                  preflight:
+                    description: |-
+                      preflight is an optional field that can be used to configure the preflight checks run before installation or upgrade of the content for the package specified in the packageName field.
+
+                      When specified, it overrides the default configuration of the preflight checks that are required to execute successfully during an install/upgrade operation.
+
+                      When not specified, the default configuration for each preflight check will be used.
+                    properties:
+                      crdUpgradeSafety:
+                        description: |-
+                          crdUpgradeSafety is used to configure the CRD Upgrade Safety pre-flight
+                          checks that run prior to upgrades of installed content.
+
+                          The CRD Upgrade Safety pre-flight check safeguards from unintended
+                          consequences of upgrading a CRD, such as data loss.
+
+                          This field is required if the spec.install.preflight field is specified.
+                        properties:
+                          policy:
+                            default: Enabled
+                            description: |-
+                              policy is used to configure the state of the CRD Upgrade Safety pre-flight check.
+
+                              This field is required when the spec.install.preflight.crdUpgradeSafety field is
+                              specified.
+
+                              Allowed values are ["Enabled", "Disabled"]. The default value is "Enabled".
+
+                              When set to "Disabled", the CRD Upgrade Safety pre-flight check will be skipped
+                              when performing an upgrade operation. This should be used with caution as
+                              unintended consequences such as data loss can occur.
+
+                              When set to "Enabled", the CRD Upgrade Safety pre-flight check will be run when
+                              performing an upgrade operation.
+                            enum:
+                            - Enabled
+                            - Disabled
+                            type: string
+                        required:
+                        - policy
+                        type: object
+                    required:
+                    - crdUpgradeSafety
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of [crdUpgradeSafety] are required when
+                        preflight is specified
+                      rule: has(self.crdUpgradeSafety)
+                  serviceAccount:
+                    description: |-
+                      serviceAccount is a required reference to a ServiceAccount that exists
+                      in the installNamespace. The provided ServiceAccount is used to install and
+                      manage the content for the package specified in the packageName field.
+
+                      In order to successfully install and manage the content for the package,
+                      the ServiceAccount provided via this field should be configured with the
+                      appropriate permissions to perform the necessary operations on all the
+                      resources that are included in the bundle of content being applied.
+                    properties:
+                      name:
+                        description: |-
+                          name is a required, immutable reference to the name of the ServiceAccount
+                          to be used for installation and management of the content for the package
+                          specified in the packageName field.
+
+                          This ServiceAccount is expected to exist in the installNamespace.
+
+                          This field follows the DNS subdomain name standard as defined in [RFC
+                          1123]. This means that valid values:
+                            - Contain no more than 253 characters
+                            - Contain only lowercase alphanumeric characters, '-', or '.'
+                            - Start with an alphanumeric character
+                            - End with an alphanumeric character
+
+                          Some examples of valid values are:
+                            - some-serviceaccount
+                            - 123-serviceaccount
+                            - 1-serviceaccount-2
+                            - someserviceaccount
+                            - some.serviceaccount
+
+                          Some examples of invalid values are:
+                            - -some-serviceaccount
+                            - some-serviceaccount-
+
+                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                        x-kubernetes-validations:
+                        - message: name is immutable
+                          rule: self == oldSelf
+                    required:
+                    - name
+                    type: object
+                required:
+                - namespace
+                - serviceAccount
+                type: object
+              source:
+                description: |-
+                  source is a required field which selects the installation source of content
+                  for this ClusterExtension. Selection is performed by setting the sourceType.
+
+                  Catalog is currently the only implemented sourceType, and setting the
+                  sourcetype to "Catalog" requires the catalog field to also be defined.
+
+                  Below is a minimal example of a source definition (in yaml):
+
+                  source:
+                    sourceType: Catalog
+                    catalog:
+                      packageName: example-package
+                properties:
+                  catalog:
+                    description: |-
+                      catalog is used to configure how information is sourced from a catalog. This field must be defined when sourceType is set to "Catalog",
+                      and must be the only field defined for this sourceType.
+                    properties:
+                      channels:
+                        description: |-
+                          channels is an optional reference to a set of channels belonging to
+                          the package specified in the packageName field.
+
+                          A "channel" is a package author defined stream of updates for an extension.
+
+                          When specified, it is used to constrain the set of installable bundles and
+                          the automated upgrade path. This constraint is an AND operation with the
+                          version field. For example:
+                            - Given channel is set to "foo"
+                            - Given version is set to ">=1.0.0, <1.5.0"
+                            - Only bundles that exist in channel "foo" AND satisfy the version range comparison will be considered installable
+                            - Automatic upgrades will be constrained to upgrade edges defined by the selected channel
+
+                          When unspecified, upgrade edges across all channels will be used to identify valid automatic upgrade paths.
+
+                          This field follows the DNS subdomain name standard as defined in [RFC
+                          1123]. This means that valid entries:
+                            - Contain no more than 253 characters
+                            - Contain only lowercase alphanumeric characters, '-', or '.'
+                            - Start with an alphanumeric character
+                            - End with an alphanumeric character
+
+                          Some examples of valid values are:
+                            - 1.1.x
+                            - alpha
+                            - stable
+                            - stable-v1
+                            - v1-stable
+                            - dev-preview
+                            - preview
+                            - community
+
+                          Some examples of invalid values are:
+                            - -some-channel
+                            - some-channel-
+                            - thisisareallylongchannelnamethatisgreaterthanthemaximumlength
+                            - original_40
+                            - --default-channel
+
+                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                        items:
+                          maxLength: 253
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        type: array
+                      packageName:
+                        description: |-
+                          packageName is a reference to the name of the package to be installed
+                          and is used to filter the content from catalogs.
+
+                          This field is required, immutable and follows the DNS subdomain name
+                          standard as defined in [RFC 1123]. This means that valid entries:
+                            - Contain no more than 253 characters
+                            - Contain only lowercase alphanumeric characters, '-', or '.'
+                            - Start with an alphanumeric character
+                            - End with an alphanumeric character
+
+                          Some examples of valid values are:
+                            - some-package
+                            - 123-package
+                            - 1-package-2
+                            - somepackage
+
+                          Some examples of invalid values are:
+                            - -some-package
+                            - some-package-
+                            - thisisareallylongpackagenamethatisgreaterthanthemaximumlength
+                            - some.package
+
+                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                        maxLength: 253
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                        x-kubernetes-validations:
+                        - message: packageName is immutable
+                          rule: self == oldSelf
+                      selector:
+                        description: |-
+                          selector is an optional field that can be used
+                          to filter the set of ClusterCatalogs used in the bundle
+                          selection process.
+
+                          When unspecified, all ClusterCatalogs will be used in
+                          the bundle selection process.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      upgradeConstraintPolicy:
+                        default: CatalogProvided
+                        description: |-
+                          upgradeConstraintPolicy is an optional field that controls whether
+                          the upgrade path(s) defined in the catalog are enforced for the package
+                          referenced in the packageName field.
+
+                          Allowed values are: ["CatalogProvided", "SelfCertified"].
+
+                          When this field is set to "CatalogProvided", automatic upgrades will only occur
+                          when upgrade constraints specified by the package author are met.
+
+                          When this field is set to "SelfCertified", the upgrade constraints specified by
+                          the package author are ignored. This allows for upgrades and downgrades to
+                          any version of the package. This is considered a dangerous operation as it
+                          can lead to unknown and potentially disastrous outcomes, such as data
+                          loss. It is assumed that users have independently verified changes when
+                          using this option.
+
+                          If unspecified, the default value is "CatalogProvided".
+                        enum:
+                        - CatalogProvided
+                        - SelfCertified
+                        type: string
+                      version:
+                        description: |-
+                          version is an optional semver constraint (a specific version or range of versions). When unspecified, the latest version available will be installed.
+
+                          Acceptable version ranges are no longer than 64 characters.
+                          Version ranges are composed of comma- or space-delimited values and one or
+                          more comparison operators, known as comparison strings. Additional
+                          comparison strings can be added using the OR operator (||).
+
+                          # Range Comparisons
+
+                          To specify a version range, you can use a comparison string like ">=3.0,
+                          <3.6". When specifying a range, automatic updates will occur within that
+                          range. The example comparison string means "install any version greater than
+                          or equal to 3.0.0 but less than 3.6.0.". It also states intent that if any
+                          upgrades are available within the version range after initial installation,
+                          those upgrades should be automatically performed.
+
+                          # Pinned Versions
+
+                          To specify an exact version to install you can use a version range that
+                          "pins" to a specific version. When pinning to a specific version, no
+                          automatic updates will occur. An example of a pinned version range is
+                          "0.6.0", which means "only install version 0.6.0 and never
+                          upgrade from this version".
+
+                          # Basic Comparison Operators
+
+                          The basic comparison operators and their meanings are:
+                            - "=", equal (not aliased to an operator)
+                            - "!=", not equal
+                            - "<", less than
+                            - ">", greater than
+                            - ">=", greater than OR equal to
+                            - "<=", less than OR equal to
+
+                          # Wildcard Comparisons
+
+                          You can use the "x", "X", and "*" characters as wildcard characters in all
+                          comparison operations. Some examples of using the wildcard characters:
+                            - "1.2.x", "1.2.X", and "1.2.*" is equivalent to ">=1.2.0, < 1.3.0"
+                            - ">= 1.2.x", ">= 1.2.X", and ">= 1.2.*" is equivalent to ">= 1.2.0"
+                            - "<= 2.x", "<= 2.X", and "<= 2.*" is equivalent to "< 3"
+                            - "x", "X", and "*" is equivalent to ">= 0.0.0"
+
+                          # Patch Release Comparisons
+
+                          When you want to specify a minor version up to the next major version you
+                          can use the "~" character to perform patch comparisons. Some examples:
+                            - "~1.2.3" is equivalent to ">=1.2.3, <1.3.0"
+                            - "~1" and "~1.x" is equivalent to ">=1, <2"
+                            - "~2.3" is equivalent to ">=2.3, <2.4"
+                            - "~1.2.x" is equivalent to ">=1.2.0, <1.3.0"
+
+                          # Major Release Comparisons
+
+                          You can use the "^" character to make major release comparisons after a
+                          stable 1.0.0 version is published. If there is no stable version published, // minor versions define the stability level. Some examples:
+                            - "^1.2.3" is equivalent to ">=1.2.3, <2.0.0"
+                            - "^1.2.x" is equivalent to ">=1.2.0, <2.0.0"
+                            - "^2.3" is equivalent to ">=2.3, <3"
+                            - "^2.x" is equivalent to ">=2.0.0, <3"
+                            - "^0.2.3" is equivalent to ">=0.2.3, <0.3.0"
+                            - "^0.2" is equivalent to ">=0.2.0, <0.3.0"
+                            - "^0.0.3" is equvalent to ">=0.0.3, <0.0.4"
+                            - "^0.0" is equivalent to ">=0.0.0, <0.1.0"
+                            - "^0" is equivalent to ">=0.0.0, <1.0.0"
+
+                          # OR Comparisons
+                          You can use the "||" character to represent an OR operation in the version
+                          range. Some examples:
+                            - ">=1.2.3, <2.0.0 || >3.0.0"
+                            - "^0 || ^3 || ^5"
+
+                          For more information on semver, please see https://semver.org/
+                        maxLength: 64
+                        pattern: ^(\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\^)\s*(v?(0|[1-9]\d*|[x|X|\*])(\.(0|[1-9]\d*|x|X|\*]))?(\.(0|[1-9]\d*|x|X|\*))?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?)\s*)((?:\s+|,\s*|\s*\|\|\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\^)\s*(v?(0|[1-9]\d*|x|X|\*])(\.(0|[1-9]\d*|x|X|\*))?(\.(0|[1-9]\d*|x|X|\*]))?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?)\s*)*$
+                        type: string
+                    required:
+                    - packageName
+                    type: object
+                  sourceType:
+                    description: |-
+                      sourceType is a required reference to the type of install source.
+
+                      Allowed values are ["Catalog"]
+
+                      When this field is set to "Catalog", information for determining the appropriate
+                      bundle of content to install will be fetched from ClusterCatalog resources existing
+                      on the cluster. When using the Catalog sourceType, the catalog field must also be set.
+                    enum:
+                    - Catalog
+                    type: string
+                required:
+                - sourceType
+                type: object
+                x-kubernetes-validations:
+                - message: sourceType Catalog requires catalog field
+                  rule: self.sourceType == 'Catalog' && has(self.catalog)
+            required:
+            - install
+            - source
+            type: object
+          status:
+            description: ClusterExtensionStatus defines the observed state of ClusterExtension.
+            properties:
+              conditions:
+                description: |-
+                  conditions is a representation of the current state for this ClusterExtension.
+                  The status is represented by a set of "conditions".
+
+                  Each condition is generally structured in the following format:
+                    - Type: a string representation of the condition type. More or less the condition "name".
+                    - Status: a string representation of the state of the condition. Can be one of ["True", "False", "Unknown"].
+                    - Reason: a string representation of the reason for the current state of the condition. Typically useful for building automation around particular Type+Reason combinations.
+                    - Message: a human readable message that further elaborates on the state of the condition
+
+                  The global set of condition types are:
+                    - "Installed", represents whether or not the a bundle has been installed for this ClusterExtension
+                    - "Progressing", represents whether or not the ClusterExtension is progressing towards a new state
+
+                  When the ClusterExtension is sourced from a catalog, the following conditions are also possible:
+                    - "Deprecated", represents an aggregation of the PackageDeprecated, ChannelDeprecated, and BundleDeprecated condition types
+                    - "PackageDeprecated", represents whether or not the package specified in the spec.source.catalog.packageName field has been deprecated
+                    - "ChannelDeprecated", represents whether or not any channel specified in spec.source.catalog.channels has been deprecated
+                    - "BundleDeprecated", represents whether or not the installed bundle is deprecated
+
+                  The current set of reasons are:
+                    - "Succeeded", this reason is set on the "Installed" and "Progressing" conditions when initial installation and progressing to a new state is successful
+                    - "Failed", this reason is set on the "Installed" condition when an error has occurred while performing the initial installation.
+                    - "Blocked", this reason is set on the "Progressing" condition when the ClusterExtension controller has encountered an error that requires manual intervention for recovery
+                    - "Retrying", this reason is set on the "Progressing" condition when the ClusterExtension controller has encountered an error that could be resolved on subsequent reconciliation attempts
+                    - "Deprecated", this reason is set on the "Deprecated", "PackageDeprecated", "ChannelDeprecated", and "BundleDeprecated" conditions to signal that the installed package has been deprecated at the particular scope
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              install:
+                properties:
+                  bundle:
+                    description: |-
+                      bundle is a representation of the currently installed bundle.
+
+                      A "bundle" is a versioned set of content that represents the resources that
+                      need to be applied to a cluster to install a package.
+                    properties:
+                      name:
+                        description: |-
+                          name is a required field and is a reference
+                          to the name of a bundle
+                        type: string
+                      version:
+                        description: |-
+                          version is a required field and is a reference
+                          to the version that this bundle represents
+                        type: string
+                    required:
+                    - name
+                    - version
+                    type: object
+                required:
+                - bundle
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/olm/operator-controller/v1alpha1/clusterextension_crd.yaml
+++ b/olm/operator-controller/v1alpha1/clusterextension_crd.yaml
@@ -58,36 +58,9 @@ spec:
             properties:
               install:
                 description: |-
-                  install is a required field used to configure the installation options
-                  for the ClusterExtension such as the installation namespace,
-                  the service account and the pre-flight check configuration.
-
-                  Below is a minimal example of an installation definition (in yaml):
-                  install:
-                     namespace: example-namespace
-                     serviceAccount:
-                       name: example-sa
+                  install is an optional field used to configure the installation options
+                  for the ClusterExtension such as the pre-flight check configuration.
                 properties:
-                  namespace:
-                    description: |-
-                      namespace designates the kubernetes Namespace where bundle content
-                      for the 'packageName' package field will be applied and the necessary
-                      service account can be found.
-                      The bundle may contain cluster-scoped resources or resources that are
-                      applied to other Namespaces. This Namespace is expected to exist.
-
-                      namespace is required, immutable, and follows the DNS label standard
-                      as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters or hyphens (-),
-                      start and end with an alphanumeric character, and be no longer than 63 characters
-
-                      [RFC 1123]: https://tools.ietf.org/html/rfc1123
-                    maxLength: 63
-                    type: string
-                    x-kubernetes-validations:
-                    - message: namespace is immutable
-                      rule: self == oldSelf
-                    - message: namespace must be a valid DNS1123 label
-                      rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
                   preflight:
                     description: |-
                       preflight is an optional field that can be used to configure the checks that are
@@ -105,7 +78,6 @@ spec:
                           consequences of upgrading a CRD, such as data loss.
                         properties:
                           enforcement:
-                            default: Strict
                             description: |-
                               enforcement is a required field, used to configure the state of the CRD Upgrade Safety pre-flight check.
 
@@ -131,55 +103,77 @@ spec:
                     - message: at least one of [crdUpgradeSafety] are required when
                         preflight is specified
                       rule: has(self.crdUpgradeSafety)
-                  serviceAccount:
+                type: object
+                x-kubernetes-validations:
+                - message: at least one of [preflight] are required when install is
+                    specified
+                  rule: has(self.preflight)
+              namespace:
+                description: |-
+                  namespace is a reference to a Kubernetes namespace.
+                  This is the namespace in which the provided ServiceAccount must exist.
+                  It also designates the default namespace where namespace-scoped resources
+                  for the extension are applied to the cluster.
+                  Some extensions may contain namespace-scoped resources to be applied in other namespaces.
+                  This namespace must exist.
+
+                  namespace is required, immutable, and follows the DNS label standard
+                  as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters or hyphens (-),
+                  start and end with an alphanumeric character, and be no longer than 63 characters
+
+                  [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                maxLength: 63
+                type: string
+                x-kubernetes-validations:
+                - message: namespace is immutable
+                  rule: self == oldSelf
+                - message: namespace must be a valid DNS1123 label
+                  rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+              serviceAccount:
+                description: |-
+                  serviceAccount is a reference to a ServiceAccount used to perform all interactions
+                  with the cluster that are required to manage the extension.
+                  The ServiceAccount must be configured with the necessary permissions to perform these interactions.
+                  The ServiceAccount must exist in the namespace referenced in the spec.
+                  serviceAccount is required.
+                properties:
+                  name:
                     description: |-
-                      serviceAccount is a required reference to a ServiceAccount that exists
-                      in the installNamespace which is used to install and
-                      manage the content for the package specified in the packageName field.
+                      name is a required, immutable reference to the name of the ServiceAccount
+                      to be used for installation and management of the content for the package
+                      specified in the packageName field.
 
-                      In order to successfully install and manage the content for the package,
-                      the ServiceAccount provided via this field should be configured with the
-                      appropriate permissions to perform the necessary operations on all the
-                      resources that are included in the bundle of content being applied.
-                    properties:
-                      name:
-                        description: |-
-                          name is a required, immutable reference to the name of the ServiceAccount
-                          to be used for installation and management of the content for the package
-                          specified in the packageName field.
+                      This ServiceAccount must exist in the installNamespace.
 
-                          This ServiceAccount must exist in the installNamespace.
+                      name follows the DNS subdomain standard as defined in [RFC 1123].
+                      It must contain only lowercase alphanumeric characters,
+                      hyphens (-) or periods (.), start and end with an alphanumeric character,
+                      and be no longer than 253 characters.
 
-                          name follows the DNS subdomain standard as defined in [RFC 1123].
-                          It must contain only lowercase alphanumeric characters,
-                          hyphens (-) or periods (.), start and end with an alphanumeric character,
-                          and be no longer than 253 characters.
+                      Some examples of valid values are:
+                        - some-serviceaccount
+                        - 123-serviceaccount
+                        - 1-serviceaccount-2
+                        - someserviceaccount
+                        - some.serviceaccount
 
-                          Some examples of valid values are:
-                            - some-serviceaccount
-                            - 123-serviceaccount
-                            - 1-serviceaccount-2
-                            - someserviceaccount
-                            - some.serviceaccount
+                      Some examples of invalid values are:
+                        - -some-serviceaccount
+                        - some-serviceaccount-
 
-                          Some examples of invalid values are:
-                            - -some-serviceaccount
-                            - some-serviceaccount-
-
-                          [RFC 1123]: https://tools.ietf.org/html/rfc1123
-                        maxLength: 253
-                        type: string
-                        x-kubernetes-validations:
-                        - message: name is immutable
-                          rule: self == oldSelf
-                        - message: name must be a valid DNS1123 subdomain
-                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
-                    required:
-                    - name
-                    type: object
+                      [RFC 1123]: https://tools.ietf.org/html/rfc1123
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: name is immutable
+                      rule: self == oldSelf
+                    - message: name must be a valid DNS1123 subdomain. It must contain
+                        only lowercase alphanumeric characters, hyphens (-) or periods
+                        (.), start and end with an alphanumeric character, and be
+                        no longer than 253 characters
+                      rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
                 required:
-                - namespace
-                - serviceAccount
+                - name
                 type: object
               source:
                 description: |-
@@ -211,7 +205,7 @@ spec:
                           Each channel in the list must follow the DNS subdomain standard
                           as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
                           hyphens (-) or periods (.), start and end with an alphanumeric character,
-                          and be no longer than 253 characters.
+                          and be no longer than 253 characters. No more than 256 channels can be specified.
 
                           When specified, it is used to constrain the set of installable bundles and
                           the automated upgrade path. This constraint is an AND operation with the
@@ -277,7 +271,10 @@ spec:
                         x-kubernetes-validations:
                         - message: packageName is immutable
                           rule: self == oldSelf
-                        - message: packageName must be a valid DNS1123 subdomain
+                        - message: packageName must be a valid DNS1123 subdomain.
+                            It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric
+                            character, and be no longer than 253 characters
                           rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
                       selector:
                         description: |-
@@ -460,7 +457,8 @@ spec:
                   rule: 'has(self.sourceType) && self.sourceType == ''Catalog'' ?
                     has(self.catalog) : !has(self.catalog)'
             required:
-            - install
+            - namespace
+            - serviceAccount
             - source
             type: object
           status:
@@ -477,8 +475,8 @@ spec:
 
                   The Progressing condition represents whether or not the ClusterExtension is advancing towards a new state.
                   When Progressing is True and the Reason is Succeeded, the ClusterExtension is making progress towards a new state.
+                  When Progressing is True and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.
                   When Progressing is False and the Reason is Blocked, the ClusterExtension has encountered an error that requires manual intervention for recovery.
-                  When Progressing is False and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.
 
                   When the ClusterExtension is sourced from a catalog, if may also communicate a deprecation condition.
                   These are indications from a package owner to guide users away from a particular package, channel, or bundle.
@@ -563,16 +561,19 @@ spec:
                           and be no longer than 253 characters.
                         type: string
                         x-kubernetes-validations:
-                        - message: packageName must be a valid DNS1123 subdomain
+                        - message: packageName must be a valid DNS1123 subdomain.
+                            It must contain only lowercase alphanumeric characters,
+                            hyphens (-) or periods (.), start and end with an alphanumeric
+                            character, and be no longer than 253 characters
                           rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
                       version:
                         description: |-
                           version is a required field and is a reference to the version that this bundle represents
-                          version follows the semantic versioning standard as defined in https://semver.org/, but permits a leading 'v' character.
+                          version follows the semantic versioning standard as defined in https://semver.org/.
                         type: string
                         x-kubernetes-validations:
-                        - message: version name must foo
-                          rule: self.matches("^v?([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([-0-9A-Za-z]+(\\.[-0-9A-Za-z]+)*))?(\\+([-0-9A-Za-z]+(-\\.[-0-9A-Za-z]+)*))?")
+                        - message: version must be well-formed semver
+                          rule: self.matches("^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([-0-9A-Za-z]+(\\.[-0-9A-Za-z]+)*))?(\\+([-0-9A-Za-z]+(-\\.[-0-9A-Za-z]+)*))?")
                     required:
                     - name
                     - version

--- a/olm/operator-controller/v1alpha1/clusterextension_crd.yaml
+++ b/olm/operator-controller/v1alpha1/clusterextension_crd.yaml
@@ -14,7 +14,23 @@ spec:
     singular: clusterextension
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.install.bundle.name
+      name: Installed Bundle
+      type: string
+    - jsonPath: .status.install.bundle.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Installed')].status
+      name: Installed
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Progressing')].status
+      name: Progressing
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ClusterExtension is the Schema for the clusterextensions API
@@ -37,7 +53,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: ClusterExtensionSpec defines the desired state of ClusterExtension
+            description: spec is an optional field that defines the desired state
+              of the ClusterExtension.
             properties:
               install:
                 description: |-
@@ -53,44 +70,31 @@ spec:
                 properties:
                   namespace:
                     description: |-
-                      namespace is a reference to the Namespace in which the bundle of
-                      content for the package referenced in the packageName field will be applied.
+                      namespace designates the kubernetes Namespace where bundle content
+                      for the 'packageName' package field will be applied and the necessary
+                      service account can be found.
                       The bundle may contain cluster-scoped resources or resources that are
                       applied to other Namespaces. This Namespace is expected to exist.
 
                       namespace is required, immutable, and follows the DNS label standard
-                      as defined in [RFC 1123]. This means that valid values:
-                        - Contain no more than 63 characters
-                        - Contain only lowercase alphanumeric characters or '-'
-                        - Start with an alphanumeric character
-                        - End with an alphanumeric character
-
-                      Some examples of valid values are:
-                        - some-namespace
-                        - 123-namespace
-                        - 1-namespace-2
-                        - somenamespace
-
-                      Some examples of invalid values are:
-                        - -some-namespace
-                        - some-namespace-
-                        - thisisareallylongnamespacenamethatisgreaterthanthemaximumlength
-                        - some.namespace
+                      as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters or hyphens (-),
+                      start and end with an alphanumeric character, and be no longer than 63 characters
 
                       [RFC 1123]: https://tools.ietf.org/html/rfc1123
                     maxLength: 63
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                     x-kubernetes-validations:
                     - message: namespace is immutable
                       rule: self == oldSelf
+                    - message: namespace must be a valid DNS1123 label
+                      rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
                   preflight:
                     description: |-
-                      preflight is an optional field that can be used to configure the preflight checks run before installation or upgrade of the content for the package specified in the packageName field.
+                      preflight is an optional field that can be used to configure the checks that are
+                      run before installation or upgrade of the content for the package specified in the packageName field.
 
-                      When specified, it overrides the default configuration of the preflight checks that are required to execute successfully during an install/upgrade operation.
-
-                      When not specified, the default configuration for each preflight check will be used.
+                      When specified, it replaces the default preflight configuration for install/upgrade actions.
+                      When not specified, the default configuration will be used.
                     properties:
                       crdUpgradeSafety:
                         description: |-
@@ -99,31 +103,26 @@ spec:
 
                           The CRD Upgrade Safety pre-flight check safeguards from unintended
                           consequences of upgrading a CRD, such as data loss.
-
-                          This field is required if the spec.install.preflight field is specified.
                         properties:
-                          policy:
-                            default: Enabled
+                          enforcement:
+                            default: Strict
                             description: |-
-                              policy is used to configure the state of the CRD Upgrade Safety pre-flight check.
+                              enforcement is a required field, used to configure the state of the CRD Upgrade Safety pre-flight check.
 
-                              This field is required when the spec.install.preflight.crdUpgradeSafety field is
-                              specified.
+                              Allowed values are "None" or "Strict". The default value is "Strict".
 
-                              Allowed values are ["Enabled", "Disabled"]. The default value is "Enabled".
-
-                              When set to "Disabled", the CRD Upgrade Safety pre-flight check will be skipped
+                              When set to "None", the CRD Upgrade Safety pre-flight check will be skipped
                               when performing an upgrade operation. This should be used with caution as
                               unintended consequences such as data loss can occur.
 
-                              When set to "Enabled", the CRD Upgrade Safety pre-flight check will be run when
+                              When set to "Strict", the CRD Upgrade Safety pre-flight check will be run when
                               performing an upgrade operation.
                             enum:
-                            - Enabled
-                            - Disabled
+                            - None
+                            - Strict
                             type: string
                         required:
-                        - policy
+                        - enforcement
                         type: object
                     required:
                     - crdUpgradeSafety
@@ -135,7 +134,7 @@ spec:
                   serviceAccount:
                     description: |-
                       serviceAccount is a required reference to a ServiceAccount that exists
-                      in the installNamespace. The provided ServiceAccount is used to install and
+                      in the installNamespace which is used to install and
                       manage the content for the package specified in the packageName field.
 
                       In order to successfully install and manage the content for the package,
@@ -149,14 +148,12 @@ spec:
                           to be used for installation and management of the content for the package
                           specified in the packageName field.
 
-                          This ServiceAccount is expected to exist in the installNamespace.
+                          This ServiceAccount must exist in the installNamespace.
 
-                          This field follows the DNS subdomain name standard as defined in [RFC
-                          1123]. This means that valid values:
-                            - Contain no more than 253 characters
-                            - Contain only lowercase alphanumeric characters, '-', or '.'
-                            - Start with an alphanumeric character
-                            - End with an alphanumeric character
+                          name follows the DNS subdomain standard as defined in [RFC 1123].
+                          It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
 
                           Some examples of valid values are:
                             - some-serviceaccount
@@ -171,11 +168,12 @@ spec:
 
                           [RFC 1123]: https://tools.ietf.org/html/rfc1123
                         maxLength: 253
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                         x-kubernetes-validations:
                         - message: name is immutable
                           rule: self == oldSelf
+                        - message: name must be a valid DNS1123 subdomain
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
                     required:
                     - name
                     type: object
@@ -200,15 +198,20 @@ spec:
                 properties:
                   catalog:
                     description: |-
-                      catalog is used to configure how information is sourced from a catalog. This field must be defined when sourceType is set to "Catalog",
-                      and must be the only field defined for this sourceType.
+                      catalog is used to configure how information is sourced from a catalog.
+                      This field is required when sourceType is "Catalog", and forbidden otherwise.
                     properties:
                       channels:
                         description: |-
                           channels is an optional reference to a set of channels belonging to
                           the package specified in the packageName field.
 
-                          A "channel" is a package author defined stream of updates for an extension.
+                          A "channel" is a package-author-defined stream of updates for an extension.
+
+                          Each channel in the list must follow the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
 
                           When specified, it is used to constrain the set of installable bundles and
                           the automated upgrade path. This constraint is an AND operation with the
@@ -219,13 +222,6 @@ spec:
                             - Automatic upgrades will be constrained to upgrade edges defined by the selected channel
 
                           When unspecified, upgrade edges across all channels will be used to identify valid automatic upgrade paths.
-
-                          This field follows the DNS subdomain name standard as defined in [RFC
-                          1123]. This means that valid entries:
-                            - Contain no more than 253 characters
-                            - Contain only lowercase alphanumeric characters, '-', or '.'
-                            - Start with an alphanumeric character
-                            - End with an alphanumeric character
 
                           Some examples of valid values are:
                             - 1.1.x
@@ -247,20 +243,21 @@ spec:
                           [RFC 1123]: https://tools.ietf.org/html/rfc1123
                         items:
                           maxLength: 253
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                           type: string
+                          x-kubernetes-validations:
+                          - message: channels entries must be valid DNS1123 subdomains
+                            rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+                        maxItems: 256
                         type: array
                       packageName:
                         description: |-
                           packageName is a reference to the name of the package to be installed
                           and is used to filter the content from catalogs.
 
-                          This field is required, immutable and follows the DNS subdomain name
-                          standard as defined in [RFC 1123]. This means that valid entries:
-                            - Contain no more than 253 characters
-                            - Contain only lowercase alphanumeric characters, '-', or '.'
-                            - Start with an alphanumeric character
-                            - End with an alphanumeric character
+                          packageName is required, immutable, and follows the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
 
                           Some examples of valid values are:
                             - some-package
@@ -276,11 +273,12 @@ spec:
 
                           [RFC 1123]: https://tools.ietf.org/html/rfc1123
                         maxLength: 253
-                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
                         x-kubernetes-validations:
                         - message: packageName is immutable
                           rule: self == oldSelf
+                        - message: packageName must be a valid DNS1123 subdomain
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
                       selector:
                         description: |-
                           selector is an optional field that can be used
@@ -340,7 +338,7 @@ spec:
                           the upgrade path(s) defined in the catalog are enforced for the package
                           referenced in the packageName field.
 
-                          Allowed values are: ["CatalogProvided", "SelfCertified"].
+                          Allowed values are: "CatalogProvided" or "SelfCertified", or omitted.
 
                           When this field is set to "CatalogProvided", automatic upgrades will only occur
                           when upgrade constraints specified by the package author are met.
@@ -352,7 +350,7 @@ spec:
                           loss. It is assumed that users have independently verified changes when
                           using this option.
 
-                          If unspecified, the default value is "CatalogProvided".
+                          When this field is omitted, the default value is "CatalogProvided".
                         enum:
                         - CatalogProvided
                         - SelfCertified
@@ -433,8 +431,10 @@ spec:
 
                           For more information on semver, please see https://semver.org/
                         maxLength: 64
-                        pattern: ^(\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\^)\s*(v?(0|[1-9]\d*|[x|X|\*])(\.(0|[1-9]\d*|x|X|\*]))?(\.(0|[1-9]\d*|x|X|\*))?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?)\s*)((?:\s+|,\s*|\s*\|\|\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\^)\s*(v?(0|[1-9]\d*|x|X|\*])(\.(0|[1-9]\d*|x|X|\*))?(\.(0|[1-9]\d*|x|X|\*]))?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?)\s*)*$
                         type: string
+                        x-kubernetes-validations:
+                        - message: invalid version expression
+                          rule: self.matches("^(\\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|[x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*]))?(\\.(0|[1-9]\\d*|x|X|\\*))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)((?:\\s+|,\\s*|\\s*\\|\\|\\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\\^)\\s*(v?(0|[1-9]\\d*|x|X|\\*])(\\.(0|[1-9]\\d*|x|X|\\*))?(\\.(0|[1-9]\\d*|x|X|\\*]))?(-([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?(\\+([0-9A-Za-z\\-]+(\\.[0-9A-Za-z\\-]+)*))?)\\s*)*$")
                     required:
                     - packageName
                     type: object
@@ -442,11 +442,12 @@ spec:
                     description: |-
                       sourceType is a required reference to the type of install source.
 
-                      Allowed values are ["Catalog"]
+                      Allowed values are "Catalog"
 
-                      When this field is set to "Catalog", information for determining the appropriate
-                      bundle of content to install will be fetched from ClusterCatalog resources existing
-                      on the cluster. When using the Catalog sourceType, the catalog field must also be set.
+                      When this field is set to "Catalog", information for determining the
+                      appropriate bundle of content to install will be fetched from
+                      ClusterCatalog resources existing on the cluster.
+                      When using the Catalog sourceType, the catalog field must also be set.
                     enum:
                     - Catalog
                     type: string
@@ -454,42 +455,37 @@ spec:
                 - sourceType
                 type: object
                 x-kubernetes-validations:
-                - message: sourceType Catalog requires catalog field
-                  rule: self.sourceType == 'Catalog' && has(self.catalog)
+                - message: catalog is required when sourceType is Catalog, and forbidden
+                    otherwise
+                  rule: 'has(self.sourceType) && self.sourceType == ''Catalog'' ?
+                    has(self.catalog) : !has(self.catalog)'
             required:
             - install
             - source
             type: object
           status:
-            description: ClusterExtensionStatus defines the observed state of ClusterExtension.
+            description: status is an optional field that defines the observed state
+              of the ClusterExtension.
             properties:
               conditions:
                 description: |-
-                  conditions is a representation of the current state for this ClusterExtension.
-                  The status is represented by a set of "conditions".
+                  The set of condition types which apply to all spec.source variations are Installed and Progressing.
 
-                  Each condition is generally structured in the following format:
-                    - Type: a string representation of the condition type. More or less the condition "name".
-                    - Status: a string representation of the state of the condition. Can be one of ["True", "False", "Unknown"].
-                    - Reason: a string representation of the reason for the current state of the condition. Typically useful for building automation around particular Type+Reason combinations.
-                    - Message: a human readable message that further elaborates on the state of the condition
+                  The Installed condition represents whether or not the bundle has been installed for this ClusterExtension.
+                  When Installed is True and the Reason is Succeeded, the bundle has been successfully installed.
+                  When Installed is False and the Reason is Failed, the bundle has failed to install.
 
-                  The global set of condition types are:
-                    - "Installed", represents whether or not the a bundle has been installed for this ClusterExtension
-                    - "Progressing", represents whether or not the ClusterExtension is progressing towards a new state
+                  The Progressing condition represents whether or not the ClusterExtension is advancing towards a new state.
+                  When Progressing is True and the Reason is Succeeded, the ClusterExtension is making progress towards a new state.
+                  When Progressing is False and the Reason is Blocked, the ClusterExtension has encountered an error that requires manual intervention for recovery.
+                  When Progressing is False and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.
 
-                  When the ClusterExtension is sourced from a catalog, the following conditions are also possible:
-                    - "Deprecated", represents an aggregation of the PackageDeprecated, ChannelDeprecated, and BundleDeprecated condition types
-                    - "PackageDeprecated", represents whether or not the package specified in the spec.source.catalog.packageName field has been deprecated
-                    - "ChannelDeprecated", represents whether or not any channel specified in spec.source.catalog.channels has been deprecated
-                    - "BundleDeprecated", represents whether or not the installed bundle is deprecated
-
-                  The current set of reasons are:
-                    - "Succeeded", this reason is set on the "Installed" and "Progressing" conditions when initial installation and progressing to a new state is successful
-                    - "Failed", this reason is set on the "Installed" condition when an error has occurred while performing the initial installation.
-                    - "Blocked", this reason is set on the "Progressing" condition when the ClusterExtension controller has encountered an error that requires manual intervention for recovery
-                    - "Retrying", this reason is set on the "Progressing" condition when the ClusterExtension controller has encountered an error that could be resolved on subsequent reconciliation attempts
-                    - "Deprecated", this reason is set on the "Deprecated", "PackageDeprecated", "ChannelDeprecated", and "BundleDeprecated" conditions to signal that the installed package has been deprecated at the particular scope
+                  When the ClusterExtension is sourced from a catalog, if may also communicate a deprecation condition.
+                  These are indications from a package owner to guide users away from a particular package, channel, or bundle.
+                  BundleDeprecated is set if the requested bundle version is marked deprecated in the catalog.
+                  ChannelDeprecated is set if the requested channel is marked deprecated in the catalog.
+                  PackageDeprecated is set if the requested package is marked deprecated in the catalog.
+                  Deprecated is a rollup condition that is present when any of the deprecated conditions are present.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -549,24 +545,34 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               install:
+                description: install is a representation of the current installation
+                  status for this ClusterExtension.
                 properties:
                   bundle:
                     description: |-
-                      bundle is a representation of the currently installed bundle.
+                      bundle is a required field which represents the identifying attributes of a bundle.
 
                       A "bundle" is a versioned set of content that represents the resources that
                       need to be applied to a cluster to install a package.
                     properties:
                       name:
                         description: |-
-                          name is a required field and is a reference
-                          to the name of a bundle
+                          name is required and follows the DNS subdomain standard
+                          as defined in [RFC 1123]. It must contain only lowercase alphanumeric characters,
+                          hyphens (-) or periods (.), start and end with an alphanumeric character,
+                          and be no longer than 253 characters.
                         type: string
+                        x-kubernetes-validations:
+                        - message: packageName must be a valid DNS1123 subdomain
+                          rule: self.matches("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
                       version:
                         description: |-
-                          version is a required field and is a reference
-                          to the version that this bundle represents
+                          version is a required field and is a reference to the version that this bundle represents
+                          version follows the semantic versioning standard as defined in https://semver.org/, but permits a leading 'v' character.
                         type: string
+                        x-kubernetes-validations:
+                        - message: version name must foo
+                          rule: self.matches("^v?([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?(-([-0-9A-Za-z]+(\\.[-0-9A-Za-z]+)*))?(\\+([-0-9A-Za-z]+(-\\.[-0-9A-Za-z]+)*))?")
                     required:
                     - name
                     - version

--- a/olm/operator-controller/v1alpha1/clusterextension_types.go
+++ b/olm/operator-controller/v1alpha1/clusterextension_types.go
@@ -1,0 +1,518 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/operator-framework/operator-controller/internal/conditionsets"
+)
+
+var ClusterExtensionKind = "ClusterExtension"
+
+type (
+	UpgradeConstraintPolicy string
+	CRDUpgradeSafetyPolicy  string
+)
+
+const (
+	// The extension will only upgrade if the new version satisfies
+	// the upgrade constraints set by the package author.
+	UpgradeConstraintPolicyCatalogProvided UpgradeConstraintPolicy = "CatalogProvided"
+
+	// Unsafe option which allows an extension to be
+	// upgraded or downgraded to any available version of the package and
+	// ignore the upgrade path designed by package authors.
+	// This assumes that users independently verify the outcome of the changes.
+	// Use with caution as this can lead to unknown and potentially
+	// disastrous results such as data loss.
+	UpgradeConstraintPolicySelfCertified UpgradeConstraintPolicy = "SelfCertified"
+)
+
+// ClusterExtensionSpec defines the desired state of ClusterExtension
+type ClusterExtensionSpec struct {
+	// source is a required field which selects the installation source of content
+	// for this ClusterExtension. Selection is performed by setting the sourceType.
+	//
+	// Catalog is currently the only implemented sourceType, and setting the
+	// sourcetype to "Catalog" requires the catalog field to also be defined.
+	//
+	// Below is a minimal example of a source definition (in yaml):
+	//
+	// source:
+	//   sourceType: Catalog
+	//   catalog:
+	//     packageName: example-package
+	//
+	Source SourceConfig `json:"source"`
+
+	// install is a required field used to configure the installation options
+	// for the ClusterExtension such as the installation namespace,
+	// the service account and the pre-flight check configuration.
+	//
+	// Below is a minimal example of an installation definition (in yaml):
+	// install:
+	//    namespace: example-namespace
+	//    serviceAccount:
+	//      name: example-sa
+	Install ClusterExtensionInstallConfig `json:"install"`
+}
+
+const SourceTypeCatalog = "Catalog"
+
+// SourceConfig is a discriminated union which selects the installation source.
+// +union
+// +kubebuilder:validation:XValidation:rule="self.sourceType == 'Catalog' && has(self.catalog)",message="sourceType Catalog requires catalog field"
+type SourceConfig struct {
+	// sourceType is a required reference to the type of install source.
+	//
+	// Allowed values are ["Catalog"]
+	//
+	// When this field is set to "Catalog", information for determining the appropriate
+	// bundle of content to install will be fetched from ClusterCatalog resources existing
+	// on the cluster. When using the Catalog sourceType, the catalog field must also be set.
+	//
+	// +unionDiscriminator
+	// +kubebuilder:validation:Enum:="Catalog"
+	SourceType string `json:"sourceType"`
+
+	// catalog is used to configure how information is sourced from a catalog. This field must be defined when sourceType is set to "Catalog",
+	// and must be the only field defined for this sourceType.
+	//
+	// +optional.
+	Catalog *CatalogSource `json:"catalog,omitempty"`
+}
+
+// ClusterExtensionInstallConfig is a union which selects the clusterExtension installation config.
+// ClusterExtensionInstallConfig requires the namespace and serviceAccount which should be used for the installation of packages.
+// +union
+type ClusterExtensionInstallConfig struct {
+	// namespace is a reference to the Namespace in which the bundle of
+	// content for the package referenced in the packageName field will be applied.
+	// The bundle may contain cluster-scoped resources or resources that are
+	// applied to other Namespaces. This Namespace is expected to exist.
+	//
+	// namespace is required, immutable, and follows the DNS label standard
+	// as defined in [RFC 1123]. This means that valid values:
+	//   - Contain no more than 63 characters
+	//   - Contain only lowercase alphanumeric characters or '-'
+	//   - Start with an alphanumeric character
+	//   - End with an alphanumeric character
+	//
+	// Some examples of valid values are:
+	//   - some-namespace
+	//   - 123-namespace
+	//   - 1-namespace-2
+	//   - somenamespace
+	//
+	// Some examples of invalid values are:
+	//   - -some-namespace
+	//   - some-namespace-
+	//   - thisisareallylongnamespacenamethatisgreaterthanthemaximumlength
+	//   - some.namespace
+	//
+	// [RFC 1123]: https://tools.ietf.org/html/rfc1123
+	//
+	//+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	//+kubebuilder:validation:MaxLength:=63
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="namespace is immutable"
+	Namespace string `json:"namespace"`
+
+	// serviceAccount is a required reference to a ServiceAccount that exists
+	// in the installNamespace. The provided ServiceAccount is used to install and
+	// manage the content for the package specified in the packageName field.
+	//
+	// In order to successfully install and manage the content for the package,
+	// the ServiceAccount provided via this field should be configured with the
+	// appropriate permissions to perform the necessary operations on all the
+	// resources that are included in the bundle of content being applied.
+	ServiceAccount ServiceAccountReference `json:"serviceAccount"`
+
+	// preflight is an optional field that can be used to configure the preflight checks run before installation or upgrade of the content for the package specified in the packageName field.
+	//
+	// When specified, it overrides the default configuration of the preflight checks that are required to execute successfully during an install/upgrade operation.
+	//
+	// When not specified, the default configuration for each preflight check will be used.
+	//
+	//+optional
+	Preflight *PreflightConfig `json:"preflight,omitempty"`
+}
+
+// CatalogSource defines the required fields for catalog source.
+type CatalogSource struct {
+	// packageName is a reference to the name of the package to be installed
+	// and is used to filter the content from catalogs.
+	//
+	// This field is required, immutable and follows the DNS subdomain name
+	// standard as defined in [RFC 1123]. This means that valid entries:
+	//   - Contain no more than 253 characters
+	//   - Contain only lowercase alphanumeric characters, '-', or '.'
+	//   - Start with an alphanumeric character
+	//   - End with an alphanumeric character
+	//
+	// Some examples of valid values are:
+	//   - some-package
+	//   - 123-package
+	//   - 1-package-2
+	//   - somepackage
+	//
+	// Some examples of invalid values are:
+	//   - -some-package
+	//   - some-package-
+	//   - thisisareallylongpackagenamethatisgreaterthanthemaximumlength
+	//   - some.package
+	//
+	// [RFC 1123]: https://tools.ietf.org/html/rfc1123
+	//
+	//+kubebuilder:validation:MaxLength:=253
+	//+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="packageName is immutable"
+	PackageName string `json:"packageName"`
+
+	// version is an optional semver constraint (a specific version or range of versions). When unspecified, the latest version available will be installed.
+	//
+	// Acceptable version ranges are no longer than 64 characters.
+	// Version ranges are composed of comma- or space-delimited values and one or
+	// more comparison operators, known as comparison strings. Additional
+	// comparison strings can be added using the OR operator (||).
+	//
+	// # Range Comparisons
+	//
+	// To specify a version range, you can use a comparison string like ">=3.0,
+	// <3.6". When specifying a range, automatic updates will occur within that
+	// range. The example comparison string means "install any version greater than
+	// or equal to 3.0.0 but less than 3.6.0.". It also states intent that if any
+	// upgrades are available within the version range after initial installation,
+	// those upgrades should be automatically performed.
+	//
+	// # Pinned Versions
+	//
+	// To specify an exact version to install you can use a version range that
+	// "pins" to a specific version. When pinning to a specific version, no
+	// automatic updates will occur. An example of a pinned version range is
+	// "0.6.0", which means "only install version 0.6.0 and never
+	// upgrade from this version".
+	//
+	// # Basic Comparison Operators
+	//
+	// The basic comparison operators and their meanings are:
+	//   - "=", equal (not aliased to an operator)
+	//   - "!=", not equal
+	//   - "<", less than
+	//   - ">", greater than
+	//   - ">=", greater than OR equal to
+	//   - "<=", less than OR equal to
+	//
+	// # Wildcard Comparisons
+	//
+	// You can use the "x", "X", and "*" characters as wildcard characters in all
+	// comparison operations. Some examples of using the wildcard characters:
+	//   - "1.2.x", "1.2.X", and "1.2.*" is equivalent to ">=1.2.0, < 1.3.0"
+	//   - ">= 1.2.x", ">= 1.2.X", and ">= 1.2.*" is equivalent to ">= 1.2.0"
+	//   - "<= 2.x", "<= 2.X", and "<= 2.*" is equivalent to "< 3"
+	//   - "x", "X", and "*" is equivalent to ">= 0.0.0"
+	//
+	// # Patch Release Comparisons
+	//
+	// When you want to specify a minor version up to the next major version you
+	// can use the "~" character to perform patch comparisons. Some examples:
+	//   - "~1.2.3" is equivalent to ">=1.2.3, <1.3.0"
+	//   - "~1" and "~1.x" is equivalent to ">=1, <2"
+	//   - "~2.3" is equivalent to ">=2.3, <2.4"
+	//   - "~1.2.x" is equivalent to ">=1.2.0, <1.3.0"
+	//
+	// # Major Release Comparisons
+	//
+	// You can use the "^" character to make major release comparisons after a
+	// stable 1.0.0 version is published. If there is no stable version published, // minor versions define the stability level. Some examples:
+	//   - "^1.2.3" is equivalent to ">=1.2.3, <2.0.0"
+	//   - "^1.2.x" is equivalent to ">=1.2.0, <2.0.0"
+	//   - "^2.3" is equivalent to ">=2.3, <3"
+	//   - "^2.x" is equivalent to ">=2.0.0, <3"
+	//   - "^0.2.3" is equivalent to ">=0.2.3, <0.3.0"
+	//   - "^0.2" is equivalent to ">=0.2.0, <0.3.0"
+	//   - "^0.0.3" is equvalent to ">=0.0.3, <0.0.4"
+	//   - "^0.0" is equivalent to ">=0.0.0, <0.1.0"
+	//   - "^0" is equivalent to ">=0.0.0, <1.0.0"
+	//
+	// # OR Comparisons
+	// You can use the "||" character to represent an OR operation in the version
+	// range. Some examples:
+	//   - ">=1.2.3, <2.0.0 || >3.0.0"
+	//   - "^0 || ^3 || ^5"
+	//
+	// For more information on semver, please see https://semver.org/
+	//
+	//+kubebuilder:validation:MaxLength:=64
+	//+kubebuilder:validation:Pattern=`^(\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\^)\s*(v?(0|[1-9]\d*|[x|X|\*])(\.(0|[1-9]\d*|x|X|\*]))?(\.(0|[1-9]\d*|x|X|\*))?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?)\s*)((?:\s+|,\s*|\s*\|\|\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\^)\s*(v?(0|[1-9]\d*|x|X|\*])(\.(0|[1-9]\d*|x|X|\*))?(\.(0|[1-9]\d*|x|X|\*]))?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?)\s*)*$`
+	//+optional
+	Version string `json:"version,omitempty"`
+
+	// channels is an optional reference to a set of channels belonging to
+	// the package specified in the packageName field.
+	//
+	// A "channel" is a package author defined stream of updates for an extension.
+	//
+	// When specified, it is used to constrain the set of installable bundles and
+	// the automated upgrade path. This constraint is an AND operation with the
+	// version field. For example:
+	//   - Given channel is set to "foo"
+	//   - Given version is set to ">=1.0.0, <1.5.0"
+	//   - Only bundles that exist in channel "foo" AND satisfy the version range comparison will be considered installable
+	//   - Automatic upgrades will be constrained to upgrade edges defined by the selected channel
+	//
+	// When unspecified, upgrade edges across all channels will be used to identify valid automatic upgrade paths.
+	//
+	// This field follows the DNS subdomain name standard as defined in [RFC
+	// 1123]. This means that valid entries:
+	//   - Contain no more than 253 characters
+	//   - Contain only lowercase alphanumeric characters, '-', or '.'
+	//   - Start with an alphanumeric character
+	//   - End with an alphanumeric character
+	//
+	// Some examples of valid values are:
+	//   - 1.1.x
+	//   - alpha
+	//   - stable
+	//   - stable-v1
+	//   - v1-stable
+	//   - dev-preview
+	//   - preview
+	//   - community
+	//
+	// Some examples of invalid values are:
+	//   - -some-channel
+	//   - some-channel-
+	//   - thisisareallylongchannelnamethatisgreaterthanthemaximumlength
+	//   - original_40
+	//   - --default-channel
+	//
+	// [RFC 1123]: https://tools.ietf.org/html/rfc1123
+	//
+	//+kubebuilder:validation:items:MaxLength:=253
+	//+kubebuilder:validation:items:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	//+optional
+	Channels []string `json:"channels,omitempty"`
+
+	// selector is an optional field that can be used
+	// to filter the set of ClusterCatalogs used in the bundle
+	// selection process.
+	//
+	// When unspecified, all ClusterCatalogs will be used in
+	// the bundle selection process.
+	//
+	//+optional
+	Selector metav1.LabelSelector `json:"selector,omitempty"`
+
+	// upgradeConstraintPolicy is an optional field that controls whether
+	// the upgrade path(s) defined in the catalog are enforced for the package
+	// referenced in the packageName field.
+	//
+	// Allowed values are: ["CatalogProvided", "SelfCertified"].
+	//
+	// When this field is set to "CatalogProvided", automatic upgrades will only occur
+	// when upgrade constraints specified by the package author are met.
+	//
+	// When this field is set to "SelfCertified", the upgrade constraints specified by
+	// the package author are ignored. This allows for upgrades and downgrades to
+	// any version of the package. This is considered a dangerous operation as it
+	// can lead to unknown and potentially disastrous outcomes, such as data
+	// loss. It is assumed that users have independently verified changes when
+	// using this option.
+	//
+	// If unspecified, the default value is "CatalogProvided".
+	//
+	//+kubebuilder:validation:Enum:=CatalogProvided;SelfCertified
+	//+kubebuilder:default:=CatalogProvided
+	//+optional
+	UpgradeConstraintPolicy UpgradeConstraintPolicy `json:"upgradeConstraintPolicy,omitempty"`
+}
+
+// ServiceAccountReference references a serviceAccount.
+type ServiceAccountReference struct {
+	// name is a required, immutable reference to the name of the ServiceAccount
+	// to be used for installation and management of the content for the package
+	// specified in the packageName field.
+	//
+	// This ServiceAccount is expected to exist in the installNamespace.
+	//
+	// This field follows the DNS subdomain name standard as defined in [RFC
+	// 1123]. This means that valid values:
+	//   - Contain no more than 253 characters
+	//   - Contain only lowercase alphanumeric characters, '-', or '.'
+	//   - Start with an alphanumeric character
+	//   - End with an alphanumeric character
+	//
+	// Some examples of valid values are:
+	//   - some-serviceaccount
+	//   - 123-serviceaccount
+	//   - 1-serviceaccount-2
+	//   - someserviceaccount
+	//   - some.serviceaccount
+	//
+	// Some examples of invalid values are:
+	//   - -some-serviceaccount
+	//   - some-serviceaccount-
+	//
+	// [RFC 1123]: https://tools.ietf.org/html/rfc1123
+	//
+	//+kubebuilder:validation:MaxLength:=253
+	//+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="name is immutable"
+	Name string `json:"name"`
+}
+
+// PreflightConfig holds the configuration for the preflight checks.  If used, at least one preflight check must be non-nil.
+// +kubebuilder:validation:XValidation:rule="has(self.crdUpgradeSafety)",message="at least one of [crdUpgradeSafety] are required when preflight is specified"
+type PreflightConfig struct {
+	// crdUpgradeSafety is used to configure the CRD Upgrade Safety pre-flight
+	// checks that run prior to upgrades of installed content.
+	//
+	// The CRD Upgrade Safety pre-flight check safeguards from unintended
+	// consequences of upgrading a CRD, such as data loss.
+	//
+	// This field is required if the spec.install.preflight field is specified.
+	CRDUpgradeSafety *CRDUpgradeSafetyPreflightConfig `json:"crdUpgradeSafety"`
+}
+
+// CRDUpgradeSafetyPreflightConfig is the configuration for CRD upgrade safety preflight check.
+type CRDUpgradeSafetyPreflightConfig struct {
+	// policy is used to configure the state of the CRD Upgrade Safety pre-flight check.
+	//
+	// This field is required when the spec.install.preflight.crdUpgradeSafety field is
+	// specified.
+	//
+	// Allowed values are ["Enabled", "Disabled"]. The default value is "Enabled".
+	//
+	// When set to "Disabled", the CRD Upgrade Safety pre-flight check will be skipped
+	// when performing an upgrade operation. This should be used with caution as
+	// unintended consequences such as data loss can occur.
+	//
+	// When set to "Enabled", the CRD Upgrade Safety pre-flight check will be run when
+	// performing an upgrade operation.
+	//
+	//+kubebuilder:validation:Enum:="Enabled";"Disabled"
+	//+kubebuilder:default:=Enabled
+	Policy CRDUpgradeSafetyPolicy `json:"policy"`
+}
+
+const (
+	// TODO(user): add more Types, here and into init()
+	TypeInstalled   = "Installed"
+	TypeProgressing = "Progressing"
+
+	// TypeDeprecated is a rollup condition that is present when
+	// any of the deprecated conditions are present.
+	TypeDeprecated        = "Deprecated"
+	TypePackageDeprecated = "PackageDeprecated"
+	TypeChannelDeprecated = "ChannelDeprecated"
+	TypeBundleDeprecated  = "BundleDeprecated"
+
+	ReasonSucceeded  = "Succeeded"
+	ReasonDeprecated = "Deprecated"
+	ReasonFailed     = "Failed"
+	ReasonBlocked    = "Blocked"
+	ReasonRetrying   = "Retrying"
+
+	CRDUpgradeSafetyPolicyEnabled  CRDUpgradeSafetyPolicy = "Enabled"
+	CRDUpgradeSafetyPolicyDisabled CRDUpgradeSafetyPolicy = "Disabled"
+)
+
+func init() {
+	// TODO(user): add Types from above
+	conditionsets.ConditionTypes = append(conditionsets.ConditionTypes,
+		TypeInstalled,
+		TypeDeprecated,
+		TypePackageDeprecated,
+		TypeChannelDeprecated,
+		TypeBundleDeprecated,
+		TypeProgressing,
+	)
+	// TODO(user): add Reasons from above
+	conditionsets.ConditionReasons = append(conditionsets.ConditionReasons,
+		ReasonSucceeded,
+		ReasonDeprecated,
+		ReasonFailed,
+		ReasonBlocked,
+		ReasonRetrying,
+	)
+}
+
+type BundleMetadata struct {
+	// name is a required field and is a reference
+	// to the name of a bundle
+	Name string `json:"name"`
+	// version is a required field and is a reference
+	// to the version that this bundle represents
+	Version string `json:"version"`
+}
+
+// ClusterExtensionStatus defines the observed state of ClusterExtension.
+type ClusterExtensionStatus struct {
+	Install *ClusterExtensionInstallStatus `json:"install,omitempty"`
+
+	// conditions is a representation of the current state for this ClusterExtension.
+	// The status is represented by a set of "conditions".
+	//
+	// Each condition is generally structured in the following format:
+	//   - Type: a string representation of the condition type. More or less the condition "name".
+	//   - Status: a string representation of the state of the condition. Can be one of ["True", "False", "Unknown"].
+	//   - Reason: a string representation of the reason for the current state of the condition. Typically useful for building automation around particular Type+Reason combinations.
+	//   - Message: a human readable message that further elaborates on the state of the condition
+	//
+	// The global set of condition types are:
+	//   - "Installed", represents whether or not the a bundle has been installed for this ClusterExtension
+	//   - "Progressing", represents whether or not the ClusterExtension is progressing towards a new state
+	//
+	// When the ClusterExtension is sourced from a catalog, the following conditions are also possible:
+	//   - "Deprecated", represents an aggregation of the PackageDeprecated, ChannelDeprecated, and BundleDeprecated condition types
+	//   - "PackageDeprecated", represents whether or not the package specified in the spec.source.catalog.packageName field has been deprecated
+	//   - "ChannelDeprecated", represents whether or not any channel specified in spec.source.catalog.channels has been deprecated
+	//   - "BundleDeprecated", represents whether or not the installed bundle is deprecated
+	//
+	// The current set of reasons are:
+	//   - "Succeeded", this reason is set on the "Installed" and "Progressing" conditions when initial installation and progressing to a new state is successful
+	//   - "Failed", this reason is set on the "Installed" condition when an error has occurred while performing the initial installation.
+	//   - "Blocked", this reason is set on the "Progressing" condition when the ClusterExtension controller has encountered an error that requires manual intervention for recovery
+	//   - "Retrying", this reason is set on the "Progressing" condition when the ClusterExtension controller has encountered an error that could be resolved on subsequent reconciliation attempts
+	//   - "Deprecated", this reason is set on the "Deprecated", "PackageDeprecated", "ChannelDeprecated", and "BundleDeprecated" conditions to signal that the installed package has been deprecated at the particular scope
+	//
+	//
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+}
+
+type ClusterExtensionInstallStatus struct {
+	// bundle is a representation of the currently installed bundle.
+	//
+	// A "bundle" is a versioned set of content that represents the resources that
+	// need to be applied to a cluster to install a package.
+	Bundle BundleMetadata `json:"bundle"`
+}
+
+//+kubebuilder:object:root=true
+//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:subresource:status
+
+// ClusterExtension is the Schema for the clusterextensions API
+type ClusterExtension struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   ClusterExtensionSpec   `json:"spec,omitempty"`
+	Status ClusterExtensionStatus `json:"status,omitempty"`
+}
+
+//+kubebuilder:object:root=true
+
+// ClusterExtensionList contains a list of ClusterExtension
+type ClusterExtensionList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []ClusterExtension `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&ClusterExtension{}, &ClusterExtensionList{})
+}

--- a/olm/operator-controller/v1alpha1/groupversion_info.go
+++ b/olm/operator-controller/v1alpha1/groupversion_info.go
@@ -1,0 +1,20 @@
+// Package v1alpha1 contains API Schema definitions for the olm v1alpha1 API group
+// +kubebuilder:object:generate=true
+// +groupName=olm.operatorframework.io
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+var (
+	// GroupVersion is group version used to register these objects
+	GroupVersion = schema.GroupVersion{Group: "olm.operatorframework.io", Version: "v1alpha1"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+
+	// AddToScheme adds the types in this group-version to the given scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)


### PR DESCRIPTION
The Operator Framework group has been working on a re-vamp of the Operator Lifecycle Manager project that we have dubbed "OLM v1". Our upstream project has adopted the OpenShift API conventions and since we intend for it to go GA in OpenShift 4.18 we wanted to get the APIs reviewed before GA.

This PR adds a new `olm` directory containing the Go types for the two APIs that would be introduced:
- `ClusterExtension`
- `ClusterCatalog`

Each API is under a separate sub-directory in this PR because while they are fairly coupled, the APIs live in separate upstream projects:
- The `ClusterExtension` API lives in the upstream project https://github.com/operator-framework/operator-controller (which has a downstream equivalent at https://github.com/openshift/operator-framework-operator-controller) and as such I named the subdirectory `operator-controller`
- The `ClusterCatalog` API lives in the upstream project https://github.com/operator-framework/catalogd (which has a downstream equivalent at https://github.com/openshift/operator-framework-catalogd) and as such I named the subdirectory `catalogd`

~Also of note for reviewers, there is a portion of the `ClusterCatalog` API that is still a work-in-progress, but was included in this PR with what we anticipate it to look like. I will leave PR comments on the exact locations with references to the design document we have in place for the API change and functionality intended.~