### PR TITLE
SPLAT-1743: Add VMGroup to VSphere Provider workspace

### DIFF
--- a/machine/v1beta1/types_vsphereprovider.go
+++ b/machine/v1beta1/types_vsphereprovider.go
@@ -190,6 +190,10 @@ type Workspace struct {
 	// ResourcePool is the resource pool in which VMs are created/located.
 	// +optional
 	ResourcePool string `gcfg:"resourcepool-path,omitempty" json:"resourcePool,omitempty"`
+	// vmGroup is the cluster vm group in which virtual machines will be added for vm host group based zonal.
+	// +openshift:validation:featureGate=VSphereHostVMGroupZonal
+	// +optional
+	VMGroup string `gcfg:"vmGroup,omitempty" json:"vmGroup,omitempty"`
 }
 
 // VSphereMachineProviderStatus is the type that will be embedded in a Machine.Status.ProviderStatus field.

--- a/machine/v1beta1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1beta1/zz_generated.swagger_doc_generated.go
@@ -822,6 +822,7 @@ var map_Workspace = map[string]string{
 	"folder":       "Folder is the folder in which VMs are created/located.",
 	"datastore":    "Datastore is the datastore in which VMs are created/located.",
 	"resourcePool": "ResourcePool is the resource pool in which VMs are created/located.",
+	"vmGroup":      "vmGroup is the cluster vm group in which virtual machines will be added for vm host group based zonal.",
 }
 
 func (Workspace) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -38843,6 +38843,13 @@ func schema_openshift_api_machine_v1beta1_Workspace(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"vmGroup": {
+						SchemaProps: spec.SchemaProps{
+							Description: "vmGroup is the cluster vm group in which virtual machines will be added for vm host group based zonal.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -22430,6 +22430,10 @@
         "server": {
           "description": "Server is the IP address or FQDN of the vSphere endpoint.",
           "type": "string"
+        },
+        "vmGroup": {
+          "description": "vmGroup is the cluster vm group in which virtual machines will be added for vm host group based zonal.",
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
### Changes

For the machine api operator to support
vm-host based zonal a single new field of
`vmGroup` needs to be added that will indicate
the vCenter cluster group to add a newly created
virtual machine into.

### Additional PRs



- https://github.com/openshift/enhancements/pull/1677
- https://github.com/openshift/installer/pull/8873
- https://github.com/openshift/client-go/pull/294
- https://github.com/openshift/library-go/pull/1782
- https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/325
- https://github.com/openshift/machine-api-operator/pull/1285
- https://github.com/openshift/api/pull/1999