### PR TITLE
Update controller-tools to latest

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -32,7 +32,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
-replace sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.0.0-20240809124726-b901265f16d5
+replace sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704
 
 require (
 	cloud.google.com/go v0.115.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -240,8 +240,8 @@ github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA
 github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v1.34.0 h1:eSSPsPNp6ZpsG8X1OVmOTxig+CblTc4AxpPBykhe2Os=
 github.com/onsi/gomega v1.34.0/go.mod h1:MIKI8c+f+QLWk+hxbePD4i0LMJSExPaZOVfkoex4cAo=
-github.com/openshift/controller-tools v0.0.0-20240809124726-b901265f16d5 h1:ImjAJqnPX8ILYw1iaZkToByrUqBHhCmYw+Bk1uEVKRo=
-github.com/openshift/controller-tools v0.0.0-20240809124726-b901265f16d5/go.mod h1:80xsUppuf2iNgiThH2bzDIN5204p5E93z+YtNnAJlHA=
+github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704 h1:sdLkU07gS60g16e0VEHwF+KDX4ROZJS5QgnloWyUG30=
+github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704/go.mod h1:80xsUppuf2iNgiThH2bzDIN5204p5E93z+YtNnAJlHA=
 github.com/openshift/crd-schema-checker v0.0.0-20241014171011-8425fdfe9988 h1:K/URE0cbSqv27EkbpPXGMu1vC78C0WmnHhO1Lx8Hzzk=
 github.com/openshift/crd-schema-checker v0.0.0-20241014171011-8425fdfe9988/go.mod h1:sTxJ4ZFW9r9fEdbW2v0yMRi6NcyTbx0fII4p83IQ+L8=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -1170,7 +1170,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/controller-tools v0.15.0 => github.com/openshift/controller-tools v0.0.0-20240809124726-b901265f16d5
+# sigs.k8s.io/controller-tools v0.15.0 => github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704
 ## explicit; go 1.22.0
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
@@ -1201,4 +1201,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.0.0-20240809124726-b901265f16d5
+# sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704

--- a/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
+++ b/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
@@ -62,7 +62,7 @@ func init() {
 			WithHelp(markers.SimpleHelp("OpenShift", "specifies the FeatureGate that is required to generate this field.")),
 	)
 	ValidationMarkers = append(ValidationMarkers,
-		must(markers.MakeDefinition(OpenShiftFeatureGateAwareXValidationMarkerName, markers.DescribesType, FeatureGateXValidation{})).
+		must(markers.MakeDefinition(OpenShiftFeatureGateAwareXValidationMarkerName, markers.DescribesField, FeatureGateXValidation{})).
 			WithHelp(markers.SimpleHelp("OpenShift", "specifies the FeatureGate that is required to generate this XValidation rule.")),
 	)
 }
@@ -122,12 +122,23 @@ func (m FeatureSetXValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) err
 func (m FeatureSetXValidation) ApplyFirst() {}
 
 type FeatureGateEnum struct {
+	// FeatureGateNames represents the optional feature gates that can enable this field.
+	// If any of the feature gates are enabled, the field will be enabled.
 	FeatureGateNames []string `marker:"featureGate"`
-	EnumValues       []string `marker:"enum"`
+	// RequiredFeatureGateNames represents the required feature gates that must be enabled to enable this field.
+	// If any of the required feature gates are not enabled, the field will not be enabled.
+	RequiredFeatureGateNames []string `marker:"requiredFeatureGate,optional"`
+	EnumValues               []string `marker:"enum"`
 }
 
 func (m FeatureGateEnum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if !FeatureGatesForCurrentFile.HasAny(m.FeatureGateNames...) {
+	if !FeatureGatesForCurrentFile.HasAny(append(m.FeatureGateNames, m.RequiredFeatureGateNames...)...) {
+		// No required or optional feature gates are enabled, so we don't need to apply this marker
+		return nil
+	}
+
+	if !FeatureGatesForCurrentFile.HasAll(m.RequiredFeatureGateNames...) {
+		// Not all required feature gates are enabled, so we don't need to apply this marker
 		return nil
 	}
 
@@ -150,12 +161,23 @@ func (m FeatureGateEnum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 }
 
 type FeatureGateMaxItems struct {
+	// FeatureGateNames represents the optional feature gates that can enable this field.
+	// If any of the feature gates are enabled, the field will be enabled.
 	FeatureGateNames []string `marker:"featureGate"`
-	MaxItems         int      `marker:"maxItems"`
+	// RequiredFeatureGateNames represents the required feature gates that must be enabled to enable this field.
+	// If any of the required feature gates are not enabled, the field will not be enabled.
+	RequiredFeatureGateNames []string `marker:"requiredFeatureGate,optional"`
+	MaxItems                 int      `marker:"maxItems"`
 }
 
 func (m FeatureGateMaxItems) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if !FeatureGatesForCurrentFile.HasAny(m.FeatureGateNames...) {
+	if !FeatureGatesForCurrentFile.HasAny(append(m.FeatureGateNames, m.RequiredFeatureGateNames...)...) {
+		// No required or optional feature gates are enabled, so we don't need to apply this marker
+		return nil
+	}
+
+	if !FeatureGatesForCurrentFile.HasAll(m.RequiredFeatureGateNames...) {
+		// Not all required feature gates are enabled, so we don't need to apply this marker
 		return nil
 	}
 
@@ -168,13 +190,24 @@ func (m FeatureGateMaxItems) ApplyToSchema(schema *apiext.JSONSchemaProps) error
 }
 
 type FeatureGateXValidation struct {
+	// FeatureGateNames represents the optional feature gates that can enable this field.
+	// If any of the feature gates are enabled, the field will be enabled.
 	FeatureGateNames []string `marker:"featureGate"`
-	Rule             string
-	Message          string `marker:",optional"`
+	// RequiredFeatureGateNames represents the required feature gates that must be enabled to enable this field.
+	// If any of the required feature gates are not enabled, the field will not be enabled.
+	RequiredFeatureGateNames []string `marker:"requiredFeatureGate,optional"`
+	Rule                     string
+	Message                  string `marker:",optional"`
 }
 
 func (m FeatureGateXValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if !FeatureGatesForCurrentFile.HasAny(m.FeatureGateNames...) {
+	if !FeatureGatesForCurrentFile.HasAny(append(m.FeatureGateNames, m.RequiredFeatureGateNames...)...) {
+		// No required or optional feature gates are enabled, so we don't need to apply this marker
+		return nil
+	}
+
+	if !FeatureGatesForCurrentFile.HasAll(m.RequiredFeatureGateNames...) {
+		// Not all required feature gates are enabled, so we don't need to apply this marker
 		return nil
 	}
 


### PR DESCRIPTION
Bumping controller tools to include a new option for required feature gates (AND between gates) as well as a fix to apply openshift gated xvalidations to fields, as well as structs.