### PR TITLE
machine-api: disallow unsetting authoritativeAPI

### DIFF
--- a/machine/v1beta1/types_machineset.go
+++ b/machine/v1beta1/types_machineset.go
@@ -112,6 +112,7 @@ type MachineTemplateSpec struct {
 
 // MachineSetStatus defines the observed state of MachineSet
 // +openshift:validation:FeatureGateAwareXValidation:featureGate=MachineAPIMigration,rule="!has(oldSelf.synchronizedGeneration) || (has(self.synchronizedGeneration) && self.synchronizedGeneration >= oldSelf.synchronizedGeneration) || (oldSelf.authoritativeAPI == 'Migrating' && self.authoritativeAPI != 'Migrating')",message="synchronizedGeneration must not decrease unless authoritativeAPI is transitioning from Migrating to another value"
+// +openshift:validation:FeatureGateAwareXValidation:featureGate=MachineAPIMigration,rule="self.authoritativeAPI != ” || oldSelf.authoritativeAPI == ”",message="authoritativeAPI cannot be unset once it has been set"
 type MachineSetStatus struct {
 	// Replicas is the most recently observed number of replicas.
 	Replicas int32 `json:"replicas"`

--- a/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-CustomNoUpgrade.crd.yaml
+++ b/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-CustomNoUpgrade.crd.yaml
@@ -692,6 +692,8 @@ spec:
                 && self.synchronizedGeneration >= oldSelf.synchronizedGeneration)
                 || (oldSelf.authoritativeAPI == ''Migrating'' && self.authoritativeAPI
                 != ''Migrating'')'
+            - message: authoritativeAPI cannot be unset once it has been set
+              rule: self.authoritativeAPI != ” || oldSelf.authoritativeAPI == ”
         type: object
     served: true
     storage: true

--- a/machine/v1beta1/zz_generated.featuregated-crd-manifests/machinesets.machine.openshift.io/MachineAPIMigration.yaml
+++ b/machine/v1beta1/zz_generated.featuregated-crd-manifests/machinesets.machine.openshift.io/MachineAPIMigration.yaml
@@ -692,6 +692,8 @@ spec:
                 && self.synchronizedGeneration >= oldSelf.synchronizedGeneration)
                 || (oldSelf.authoritativeAPI == ''Migrating'' && self.authoritativeAPI
                 != ''Migrating'')'
+            - message: authoritativeAPI cannot be unset once it has been set
+              rule: self.authoritativeAPI != ” || oldSelf.authoritativeAPI == ”
         type: object
     served: true
     storage: true


### PR DESCRIPTION
We should disallow unsetting authoritativeAPI once it has been set.