### PR TITLE
OPRUN-3402: operator/v1: add OLM to scheme

### DIFF
--- a/operator/v1/register.go
+++ b/operator/v1/register.go
@@ -62,6 +62,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&OpenShiftAPIServerList{},
 		&OpenShiftControllerManager{},
 		&OpenShiftControllerManagerList{},
+		&OLM{},
+		&OLMList{},
 		&ServiceCA{},
 		&ServiceCAList{},
 		&ServiceCatalogAPIServer{},


### PR DESCRIPTION
When we added the new v1 type, we forgot to register it in the scheme.