### PR TITLE
Allow multiple FeatureGates in integration test config

### DIFF
--- a/config/v1/tests/authentications.config.openshift.io/ExternalOIDC.yaml
+++ b/config/v1/tests/authentications.config.openshift.io/ExternalOIDC.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Authentication"
 crdName: authentications.config.openshift.io
-featureGate: ExternalOIDC
+featureGates:
+- ExternalOIDC
 tests:
   onCreate:
     - name: Should be able to create a minimal Authentication

--- a/config/v1/tests/clusterversions.config.openshift.io/ImageStreamImportMode.yaml
+++ b/config/v1/tests/clusterversions.config.openshift.io/ImageStreamImportMode.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ClusterVersion"
 crdName: clusterversions.config.openshift.io
-featureGate: ImageStreamImportMode
+featureGates:
+- ImageStreamImportMode
 tests:
   onCreate:
     - name: Should be able to create a minimal ClusterVersion

--- a/config/v1/tests/clusterversions.config.openshift.io/SignatureStores.yaml
+++ b/config/v1/tests/clusterversions.config.openshift.io/SignatureStores.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ClusterVersion"
 crdName: clusterversions.config.openshift.io
-featureGate: SignatureStores
+featureGates:
+- SignatureStores
 tests:
   onCreate:
     - name: Should be able to create a minimal ClusterVersion

--- a/config/v1/tests/images.config.openshift.io/ImageStreamImportMode.yaml
+++ b/config/v1/tests/images.config.openshift.io/ImageStreamImportMode.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Image"
 crdName: images.config.openshift.io
-featureGate: ImageStreamImportMode
+featureGates:
+- ImageStreamImportMode
 tests:
   onCreate:
     - name: Should be able to create a minimal Image config

--- a/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
-featureGate: -VSphereMultiVCenters
+featureGates:
+- -VSphereMultiVCenters
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure

--- a/config/v1/tests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
-featureGate: AWSClusterHostedDNS
+featureGates:
+- AWSClusterHostedDNS
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure

--- a/config/v1/tests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
-featureGate: BareMetalLoadBalancer
+featureGates:
+- BareMetalLoadBalancer
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure

--- a/config/v1/tests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
-featureGate: GCPClusterHostedDNS
+featureGates:
+- GCPClusterHostedDNS
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure

--- a/config/v1/tests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
-featureGate: GCPLabelsTags
+featureGates:
+- GCPLabelsTags
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure

--- a/config/v1/tests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
-featureGate: NutanixMultiSubnets
+featureGates:
+- NutanixMultiSubnets
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure

--- a/config/v1/tests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
-featureGate: VSphereControlPlaneMachineSet
+featureGates:
+- VSphereControlPlaneMachineSet
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure

--- a/config/v1/tests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
-featureGate: VSphereMultiNetworks
+featureGates:
+- VSphereMultiNetworks
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure

--- a/config/v1/tests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
-featureGate: VSphereMultiVCenters
+featureGates:
+- VSphereMultiVCenters
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure

--- a/config/v1/tests/networks.config.openshift.io/NetworkDiagnosticsConfig.yaml
+++ b/config/v1/tests/networks.config.openshift.io/NetworkDiagnosticsConfig.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Network"
 crdName: networks.config.openshift.io
-featureGate: NetworkDiagnosticsConfig
+featureGates:
+- NetworkDiagnosticsConfig
 tests:
   onCreate:
     - name: Should be able to set network diagnostics sourcePlacement and targetPlacement when mode is not set

--- a/config/v1/tests/networks.config.openshift.io/NetworkLiveMigration.yaml
+++ b/config/v1/tests/networks.config.openshift.io/NetworkLiveMigration.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Network"
 crdName: networks.config.openshift.io
-featureGate: NetworkLiveMigration
+featureGates:
+- NetworkLiveMigration
 tests:
   onCreate:
     - name: Should be able to set status conditions

--- a/config/v1/tests/nodes.config.openshift.io/MinimumKubeletVersion.yaml
+++ b/config/v1/tests/nodes.config.openshift.io/MinimumKubeletVersion.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Node"
 crdName: nodes.config.openshift.io
-featureGate: MinimumKubeletVersion
+featureGates:
+- MinimumKubeletVersion
 tests:
   onCreate:
     - name: Should be able to create a minimal Node

--- a/config/v1/tests/schedulers.config.openshift.io/DynamicResourceAllocation.yaml
+++ b/config/v1/tests/schedulers.config.openshift.io/DynamicResourceAllocation.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Scheduler"
 crdName: schedulers.config.openshift.io
-featureGate: DynamicResourceAllocation
+featureGates:
+- DynamicResourceAllocation
 tests:
   onCreate:
     - name: Should be able to create a minimal Scheduler

--- a/config/v1alpha1/tests/backups.config.openshift.io/AutomatedEtcdBackup.yaml
+++ b/config/v1alpha1/tests/backups.config.openshift.io/AutomatedEtcdBackup.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[TechPreview] Backup"
 crdName: backups.config.openshift.io
-featureGate: AutomatedEtcdBackup
+featureGates:
+- AutomatedEtcdBackup
 tests:
   onCreate:
     - name: Should be able to create a Backup with a valid spec

--- a/config/v1alpha1/tests/clusterimagepolicies.config.openshift.io/SigstoreImageVerification.yaml
+++ b/config/v1alpha1/tests/clusterimagepolicies.config.openshift.io/SigstoreImageVerification.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ClusterImagePolicy"
 crdName: clusterimagepolicies.config.openshift.io
-featureGate: SigstoreImageVerification
+featureGates:
+- SigstoreImageVerification
 tests:
   onCreate:
     - name: Should be able to create a minimal ImagePolicy with policyType PublicKey

--- a/config/v1alpha1/tests/imagepolicies.config.openshift.io/SigstoreImageVerification.yaml
+++ b/config/v1alpha1/tests/imagepolicies.config.openshift.io/SigstoreImageVerification.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ImagePolicy"
 crdName: imagepolicies.config.openshift.io
-featureGate: SigstoreImageVerification
+featureGates:
+- SigstoreImageVerification
 tests:
   onCreate:
     - name: Should be able to create a minimal ImagePolicy with policyType PublicKey

--- a/config/v1alpha1/tests/insightsdatagathers.config.openshift.io/InsightsConfig.yaml
+++ b/config/v1alpha1/tests/insightsdatagathers.config.openshift.io/InsightsConfig.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[TechPreview] InsightsDataGather"
 crdName: insightsdatagathers.config.openshift.io
-featureGate: InsightsConfig
+featureGates:
+- InsightsConfig
 tests:
   onCreate:
     - name: Should be able to create a minimal InsightsDataGather

--- a/console/v1/tests/consoleplugins.console.openshift.io/ConsolePluginContentSecurityPolicy.yaml
+++ b/console/v1/tests/consoleplugins.console.openshift.io/ConsolePluginContentSecurityPolicy.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ConsolePlugin"
 crdName: consoleplugins.console.openshift.io
-featureGate: ConsolePluginContentSecurityPolicy
+featureGates:
+- ConsolePluginContentSecurityPolicy
 version: v1
 tests:
   onCreate:

--- a/example/v1/tests/stableconfigtypes.example.openshift.io/-Example.yaml
+++ b/example/v1/tests/stableconfigtypes.example.openshift.io/-Example.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Example API"
 crdName: stableconfigtypes.example.openshift.io
-featureGate: -Example
+featureGates:
+- -Example
 tests:
   onCreate:
     - name: Should not persist a tech preview field

--- a/example/v1/tests/stableconfigtypes.example.openshift.io/Example.yaml
+++ b/example/v1/tests/stableconfigtypes.example.openshift.io/Example.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Example API"
 crdName: stableconfigtypes.example.openshift.io
-featureGate: Example
+featureGates:
+- Example
 tests:
   onCreate:
     - name: Should persist stable fields

--- a/example/v1alpha1/tests/notstableconfigtypes.example.openshift.io/Example.yaml
+++ b/example/v1alpha1/tests/notstableconfigtypes.example.openshift.io/Example.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "NotStableConfigType"
 crdName: notstableconfigtypes.example.openshift.io
-featureGate: Example
+featureGates:
+- Example
 tests:
   onCreate:
     - name: Should be able to create a minimal NotStableConfigType

--- a/imageregistry/v1/tests/configs.imageregistry.operator.openshift.io/ChunkSizeMiB.yaml
+++ b/imageregistry/v1/tests/configs.imageregistry.operator.openshift.io/ChunkSizeMiB.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Config"
 crdName: configs.imageregistry.operator.openshift.io
-featureGate: ChunkSizeMiB
+featureGates:
+- ChunkSizeMiB
 tests:
   onCreate:
     - name: Should be able to create a minimal Config

--- a/insights/v1alpha1/tests/datagathers.insights.openshift.io/InsightsOnDemandDataGather.yaml
+++ b/insights/v1alpha1/tests/datagathers.insights.openshift.io/InsightsOnDemandDataGather.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[TechPreview] DataGather"
 crdName: datagathers.insights.openshift.io
-featureGate: InsightsOnDemandDataGather
+featureGates:
+- InsightsOnDemandDataGather
 tests:
   onCreate:
     - name: Should be able to create a minimal DataGather

--- a/machine/v1/tests/controlplanemachinesets.machine.openshift.io/AAA_ungated.yaml
+++ b/machine/v1/tests/controlplanemachinesets.machine.openshift.io/AAA_ungated.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ControlPlaneMachineSet (-MachineAPIMigration)"
 crdName: controlplanemachinesets.machine.openshift.io
-featureGate: -MachineAPIMigration
+featureGates:
+- -MachineAPIMigration
 tests:
   onCreate:
     - name: Should reject an VSphere platform failure domain without any VSphere config

--- a/machine/v1/tests/controlplanemachinesets.machine.openshift.io/MachineAPIMigration.yaml
+++ b/machine/v1/tests/controlplanemachinesets.machine.openshift.io/MachineAPIMigration.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ControlPlaneMachineSet (+MachineAPIMigration)"
 crdName: controlplanemachinesets.machine.openshift.io
-featureGate: MachineAPIMigration
+featureGates:
+- MachineAPIMigration
 tests:
   onCreate:
     - name: Should reject an VSphere platform failure domain without any VSphere config

--- a/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.aws.machineapimigration.testsuite.yaml
+++ b/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.aws.machineapimigration.testsuite.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ControlPlaneMachineSet (AWS+MachineAPIMigration)"
 crdName: controlplanemachinesets.machine.openshift.io
-featureGate: MachineAPIMigration
+featureGates:
+- MachineAPIMigration
 tests:
   onCreate:
   - name: Should accept an AWS failure domain with the subnet type ID and an ID provided (+MachineAPIMigration)

--- a/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.aws.nomachineapimigration.testsuite.yaml
+++ b/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.aws.nomachineapimigration.testsuite.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ControlPlaneMachineSet (AWS-MachineAPIMigration)"
 crdName: controlplanemachinesets.machine.openshift.io
-featureGate: -MachineAPIMigration
+featureGates:
+- -MachineAPIMigration
 tests:
   onCreate:
   - name: Should accept an AWS failure domain with the subnet type ID and an ID provided (-MachineAPIMigration)

--- a/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.openstack.machineapimigration.testsuite.yaml
+++ b/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.openstack.machineapimigration.testsuite.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ControlPlaneMachineSet (OpenStack+MachineAPIMigration)"
 crdName: controlplanemachinesets.machine.openshift.io
-featureGate: MachineAPIMigration
+featureGates:
+- MachineAPIMigration
 tests:
   onCreate:
   - name: Should accept no failureDomains (+MachineAPIMigration)

--- a/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.openstack.nomachineapimigration.testsuite.yaml
+++ b/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.openstack.nomachineapimigration.testsuite.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ControlPlaneMachineSet (OpenStack-MachineAPIMigration)"
 crdName: controlplanemachinesets.machine.openshift.io
-featureGate: -MachineAPIMigration
+featureGates:
+- -MachineAPIMigration
 tests:
   onCreate:
   - name: Should accept no failureDomains (-MachineAPIMigration)

--- a/machine/v1beta1/tests/machines.machine.openshift.io/AAA_ungated.yaml
+++ b/machine/v1beta1/tests/machines.machine.openshift.io/AAA_ungated.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Machine (-MachineAPIMigration)"
 crdName: machines.machine.openshift.io
-featureGate: -MachineAPIMigration
+featureGates:
+- -MachineAPIMigration
 tests:
   onCreate:
     - name: Should be able to create a minimal Machine

--- a/machine/v1beta1/tests/machines.machine.openshift.io/MachineAPIMigration.yaml
+++ b/machine/v1beta1/tests/machines.machine.openshift.io/MachineAPIMigration.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Machine (+MachineAPIMigration)"
 crdName: machines.machine.openshift.io
-featureGate: MachineAPIMigration
+featureGates:
+- MachineAPIMigration
 tests:
   onCreate:
   - name: Should be able to create a minimal Machine

--- a/machine/v1beta1/tests/machinesets.machine.openshift.io/AAA_ungated.yaml
+++ b/machine/v1beta1/tests/machinesets.machine.openshift.io/AAA_ungated.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "MachineSet (-MachineAPIMigration)"
 crdName: machinesets.machine.openshift.io
-featureGate: -MachineAPIMigration
+featureGates:
+- -MachineAPIMigration
 tests:
   onCreate:
     - name: Should be able to create a minimal MachineSet

--- a/machine/v1beta1/tests/machinesets.machine.openshift.io/MachineAPIMigration.yaml
+++ b/machine/v1beta1/tests/machinesets.machine.openshift.io/MachineAPIMigration.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "MachineSet (+MachineAPIMigration)"
 crdName: machinesets.machine.openshift.io
-featureGate: MachineAPIMigration
+featureGates:
+- MachineAPIMigration
 tests:
   onCreate:
   - name: Should be able to create a minimal MachineSet

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Shamefully missing"
 crdName: controllerconfigs.machineconfiguration.openshift.io
-featureGate: AWSClusterHostedDNS
+featureGates:
+- AWSClusterHostedDNS
 tests:
   onCreate:
     - name: Should be able to create a minimal ControllerConfig

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Shamefully missing"
 crdName: controllerconfigs.machineconfiguration.openshift.io
-featureGate: GCPClusterHostedDNS
+featureGates:
+- GCPClusterHostedDNS
 tests:
   onCreate:
     - name: Should be able to create a minimal ControllerConfig

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Shamefully missing"
 crdName: controllerconfigs.machineconfiguration.openshift.io
-featureGate: GCPLabelsTags
+featureGates:
+- GCPLabelsTags
 tests:
   onCreate:
     - name: Should be able to create a minimal ControllerConfig

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ControllerConfig"
 crdName: controllerconfigs.machineconfiguration.openshift.io
-featureGate: NutanixMultiSubnets
+featureGates:
+- NutanixMultiSubnets
 tests:
   onCreate:
     - name: Should be able to create a minimal ControllerConfig

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Shamefully missing"
 crdName: controllerconfigs.machineconfiguration.openshift.io
-featureGate: VSphereControlPlaneMachineSet
+featureGates:
+- VSphereControlPlaneMachineSet
 tests:
   onCreate:
     - name: Should be able to create a minimal ControllerConfig

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ControllerConfig"
 crdName: controllerconfigs.machineconfiguration.openshift.io
-featureGate: VSphereMultiNetworks
+featureGates:
+- VSphereMultiNetworks
 tests:
   onCreate:
     - name: Should be able to create a minimal ControllerConfig

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ControllerConfig"
 crdName: controllerconfigs.machineconfiguration.openshift.io
-featureGate: VSphereMultiVCenters
+featureGates:
+- VSphereMultiVCenters
 tests:
   onCreate:
     - name: Should be able to create a minimal ControllerConfig

--- a/machineconfiguration/v1/tests/machineconfigpools.machineconfiguration.openshift.io/PinnedImages.yaml
+++ b/machineconfiguration/v1/tests/machineconfigpools.machineconfiguration.openshift.io/PinnedImages.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[TechPreview] MachineConfigPool"
 crdName: machineconfigpools.machineconfiguration.openshift.io
-featureGate: PinnedImages
+featureGates:
+- PinnedImages
 tests:
   onCreate:
     - name: Should be able to create a minimal MachineConfigPool

--- a/machineconfiguration/v1alpha1/tests/machineconfignodes.machineconfiguration.openshift.io/MachineConfigNodes.yaml
+++ b/machineconfiguration/v1alpha1/tests/machineconfignodes.machineconfiguration.openshift.io/MachineConfigNodes.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[TechPreview] MachineConfigNode"
 crdName: machineconfignodes.machineconfiguration.openshift.io
-featureGate: MachineConfigNodes
+featureGates:
+- MachineConfigNodes
 tests:
   onCreate:
     - name: Should be able to create a minimal MachineConfigNode

--- a/machineconfiguration/v1alpha1/tests/machineosbuilds.machineconfiguration.openshift.io/OnClusterBuild.yaml
+++ b/machineconfiguration/v1alpha1/tests/machineosbuilds.machineconfiguration.openshift.io/OnClusterBuild.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[TechPreview] MachineOSBuild"
 crdName: machineosbuilds.machineconfiguration.openshift.io
-featureGate: OnClusterBuild
+featureGates:
+- OnClusterBuild
 tests:
   onCreate:
   - name: Should be able to create a minimal MachineOSBuild

--- a/machineconfiguration/v1alpha1/tests/machineosconfigs.machineconfiguration.openshift.io/OnClusterBuild.yaml
+++ b/machineconfiguration/v1alpha1/tests/machineosconfigs.machineconfiguration.openshift.io/OnClusterBuild.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[TechPreview] MachineOSConfig"
 crdName: machineosconfigs.machineconfiguration.openshift.io
-featureGate: OnClusterBuild
+featureGates:
+- OnClusterBuild
 tests:
   onCreate:
   - name: Should be able to create a minimal MachineOSConfig

--- a/machineconfiguration/v1alpha1/tests/pinnedimagesets.machineconfiguration.openshift.io/PinnedImages.yaml
+++ b/machineconfiguration/v1alpha1/tests/pinnedimagesets.machineconfiguration.openshift.io/PinnedImages.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "[TechPreview] PinnedImageSet"
 crdName: pinnedimagesets.machineconfiguration.openshift.io
-featureGate: PinnedImages
+featureGates:
+- PinnedImages
 tests:
   onCreate:
     - name: Should be able to create a minimal PinnedImageSet

--- a/network/v1alpha1/tests/dnsnameresolvers.network.openshift.io/DNSNameResolver.yaml
+++ b/network/v1alpha1/tests/dnsnameresolvers.network.openshift.io/DNSNameResolver.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "DNSNameResolver"
 crdName: dnsnameresolvers.network.openshift.io
-featureGate: DNSNameResolver
+featureGates:
+- DNSNameResolver
 tests:
   onCreate:
     - name: Should be able to create a minimal DNSNameResolver

--- a/operator/v1/tests/clustercsidrivers.operator.openshift.io/AWSEFSDriverVolumeMetrics.yaml
+++ b/operator/v1/tests/clustercsidrivers.operator.openshift.io/AWSEFSDriverVolumeMetrics.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ClusterCSIDriver"
 crdName: clustercsidrivers.operator.openshift.io
-featureGate: AWSEFSDriverVolumeMetrics
+featureGates:
+- AWSEFSDriverVolumeMetrics
 tests:
   onCreate:
   - name: Should be able to create a minimal ClusterCSIDriver

--- a/operator/v1/tests/clustercsidrivers.operator.openshift.io/VSphereDriverConfiguration.yaml
+++ b/operator/v1/tests/clustercsidrivers.operator.openshift.io/VSphereDriverConfiguration.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ClusterCSIDriver"
 crdName: clustercsidrivers.operator.openshift.io
-featureGate: VSphereDriverConfiguration
+featureGates:
+- VSphereDriverConfiguration
 tests:
   onCreate:
   - name: Should be able to create ClusterCSIDriver with snapshot options

--- a/operator/v1/tests/etcds.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/tests/etcds.operator.openshift.io/AAA_ungated.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Etcd"
 crdName: etcds.operator.openshift.io
-featureGate: -EtcdBackendQuota
+featureGates:
+- -EtcdBackendQuota
 tests:
   onCreate:
     - name: Should be able to create a minimal Etcd

--- a/operator/v1/tests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
+++ b/operator/v1/tests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Etcd"
 crdName: etcds.operator.openshift.io
-featureGate: EtcdBackendQuota
+featureGates:
+- EtcdBackendQuota
 tests:
   onCreate:
     - name: Should be able to create with 8 BackendQuotaGiB

--- a/operator/v1/tests/etcds.operator.openshift.io/HardwareSpeed.yaml
+++ b/operator/v1/tests/etcds.operator.openshift.io/HardwareSpeed.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Etcd"
 crdName: etcds.operator.openshift.io
-featureGate: -EtcdBackendQuota
+featureGates:
+- -EtcdBackendQuota
 tests:
   onCreate:
     - name: Should be able to create with Standard hardware speed

--- a/operator/v1/tests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/tests/ingresscontrollers.operator.openshift.io/AAA_ungated.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "IngressController"
 crdName: ingresscontrollers.operator.openshift.io
-featureGate: SetEIPForNLBIngressController
+featureGates:
+- SetEIPForNLBIngressController
 tests:
   onCreate:
     - name: Should be able to create a minimal IngressController

--- a/operator/v1/tests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
+++ b/operator/v1/tests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Ingress"
 crdName: ingresscontrollers.operator.openshift.io
-featureGate: IngressControllerLBSubnetsAWS
+featureGates:
+- IngressControllerLBSubnetsAWS
 tests:
   onCreate:
     - name: Should be able to create a minimal ingresscontroller with an CLB with subnets using IDs and names.

--- a/operator/v1/tests/ingresscontrollers.operator.openshift.io/SetEIPForNLBIngressController.yaml
+++ b/operator/v1/tests/ingresscontrollers.operator.openshift.io/SetEIPForNLBIngressController.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "IngressController"
 crdName: ingresscontrollers.operator.openshift.io
-featureGate: SetEIPForNLBIngressController
+featureGates:
+- SetEIPForNLBIngressController
 tests:
   onCreate:
     - name: Should be able to create a minimal IngressController

--- a/operator/v1/tests/machineconfigurations.operator.openshift.io/ManagedBootImages.yaml
+++ b/operator/v1/tests/machineconfigurations.operator.openshift.io/ManagedBootImages.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "MachineConfiguration"
 crdName: machineconfigurations.operator.openshift.io
-featureGate: ManagedBootImages
+featureGates:
+- ManagedBootImages
 tests:
   onCreate:
     - name: Should be able to create a minimal MachineConfiguration

--- a/operator/v1/tests/machineconfigurations.operator.openshift.io/NodeDisruptionPolicy.yaml
+++ b/operator/v1/tests/machineconfigurations.operator.openshift.io/NodeDisruptionPolicy.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "MachineConfiguration"
 crdName: machineconfigurations.operator.openshift.io
-featureGate: NodeDisruptionPolicy
+featureGates:
+- NodeDisruptionPolicy
 tests:
   onCreate:
     - name: Should be able to create a minimal MachineConfiguration

--- a/operator/v1/tests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
+++ b/operator/v1/tests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Network"
 crdName: networks.operator.openshift.io
-featureGate: AdditionalRoutingCapabilities
+featureGates:
+- AdditionalRoutingCapabilities
 tests:
   onCreate:
   - name: Should be able to create a minimal Network

--- a/operator/v1/tests/networks.operator.openshift.io/NetworkLiveMigration.yaml
+++ b/operator/v1/tests/networks.operator.openshift.io/NetworkLiveMigration.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Network"
 crdName: networks.operator.openshift.io
-featureGate: NetworkLiveMigration
+featureGates:
+- NetworkLiveMigration
 tests:
   onCreate:
     - name: Should be able to create migration mode

--- a/operator/v1/tests/networks.operator.openshift.io/RouteAdvertisements.yaml
+++ b/operator/v1/tests/networks.operator.openshift.io/RouteAdvertisements.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Network"
 crdName: networks.operator.openshift.io
-featureGate: RouteAdvertisements
+featureGates:
+- RouteAdvertisements
 tests:
   onCreate:
   - name: Should be able to create a minimal Network

--- a/operator/v1alpha1/tests/etcdbackups.operator.openshift.io/AutomatedEtcdBackup.yaml
+++ b/operator/v1alpha1/tests/etcdbackups.operator.openshift.io/AutomatedEtcdBackup.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "EtcdBackup"
 crdName: etcdbackups.operator.openshift.io
-featureGate: AutomatedEtcdBackup
+featureGates:
+- AutomatedEtcdBackup
 tests:
   onCreate:
     - name: Should be able to create an EtcdBackup with a valid spec

--- a/operator/v1alpha1/tests/olms.operator.openshift.io/NewOLM.yaml
+++ b/operator/v1alpha1/tests/olms.operator.openshift.io/NewOLM.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "OLM"
 crdName: olms.operator.openshift.io
-featureGate: NewOLM
+featureGates:
+- NewOLM
 tests:
   onCreate:
     - name: Should be able to create a minimal OLM

--- a/platform/v1alpha1/tests/platformoperators.platform.openshift.io/PlatformOperators.yaml
+++ b/platform/v1alpha1/tests/platformoperators.platform.openshift.io/PlatformOperators.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "PlatformOperator"
 crdName: platformoperators.platform.openshift.io
-featureGate: PlatformOperators
+featureGates:
+- PlatformOperators
 tests:
   onCreate:
     - name: Should be able to create a minimal PlatformOperator

--- a/route/v1/tests/routes.route.openshift.io/RouteExternalCertificate.yaml
+++ b/route/v1/tests/routes.route.openshift.io/RouteExternalCertificate.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Route"
 crdName: routes.route.openshift.io
-featureGate: RouteExternalCertificate
+featureGates:
+- RouteExternalCertificate
 tests:
   onCreate:
     - name: Should be able to create a minimal Route

--- a/security/v1/tests/securitycontextconstraints.security.openshift.io/AAA_ungated.yaml
+++ b/security/v1/tests/securitycontextconstraints.security.openshift.io/AAA_ungated.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "SecurityContextConstraints"
 crdName: securitycontextconstraints.security.openshift.io
-featureGate: -UserNamespacesPodSecurityStandards
+featureGates:
+- -UserNamespacesPodSecurityStandards
 tests:
   onCreate:
     - name: Should be able to create a minimal SecurityContextConstraints

--- a/security/v1/tests/securitycontextconstraints.security.openshift.io/UserNamespacesPodSecurityStandards.yaml
+++ b/security/v1/tests/securitycontextconstraints.security.openshift.io/UserNamespacesPodSecurityStandards.yaml
@@ -1,7 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "SecurityContextConstraints"
 crdName: securitycontextconstraints.security.openshift.io
-featureGate: UserNamespacesPodSecurityStandards
+featureGates:
+- UserNamespacesPodSecurityStandards
 tests:
   onCreate:
     - name: Should be able to create a minimal SecurityContextConstraints with featuregate enabled

--- a/tests/generator.go
+++ b/tests/generator.go
@@ -71,7 +71,7 @@ func loadSuiteFile(path string) (SuiteSpec, error) {
 		return SuiteSpec{}, fmt.Errorf("test suite spec %q is invalid: missing required field `crdName`", path)
 	}
 
-	s.PerTestRuntimeInfo, err = perTestRuntimeInfo(filepath.Dir(path), s.CRDName, s.FeatureGate)
+	s.PerTestRuntimeInfo, err = perTestRuntimeInfo(filepath.Dir(path), s.CRDName, s.FeatureGates)
 	if err != nil {
 		return SuiteSpec{}, fmt.Errorf("unable to determine which CRD files to use: %w", err)
 	}
@@ -421,7 +421,7 @@ func generateSuiteName(suiteSpec SuiteSpec, crdFilename string) (string, error) 
 		gvr.String(),
 		strings.Join(clusterProfiles.List(), ","),
 		featureSet,
-		suiteSpec.FeatureGate,
+		strings.Join(suiteSpec.FeatureGates, ","),
 		filename,
 		suiteSpec.Name,
 	), nil

--- a/tests/types.go
+++ b/tests/types.go
@@ -7,10 +7,11 @@ type SuiteSpec struct {
 
 	CRDName string `json:"crdName"`
 
-	// featureGate is the featureGate that must be enabled for this test to be run.
+	// featureGates is the list of featureGates that must be enabled/disabled for this test to be run.
+	// Disabled feature gates can use a "-" prefix.
 	// As the gate progresses from DevPreview to TechPreview to Default, this won't need changing.
 	// When it eventually goes unconditional, this should to be removed.
-	FeatureGate string `json:"featureGate"`
+	FeatureGates []string `json:"featureGates"`
 
 	// Version is the version of the CRD under test in this file.
 	// When omitted, if there is a single version in the CRD, this is assumed to be the correct version.


### PR DESCRIPTION
Using a comma separated string containing multiple feature gates in a single string in `SuiteSpec` (integration test config).