### PR TITLE
Add example format validation

### DIFF
--- a/example/v1/tests/stableconfigtypes.example.openshift.io/Example.yaml
+++ b/example/v1/tests/stableconfigtypes.example.openshift.io/Example.yaml
@@ -81,6 +81,28 @@ tests:
             type: TechPreviewOnlyValue
           immutableField: foo
           nonZeroDefault: 8
+    - name: Should persist a valid DNS 1123 subdomain
+      initial: |
+        apiVersion: example.openshift.io/v1
+        kind: StableConfigType
+        spec:
+          immutableField: foo
+          subdomainNameField: foo.bar-baz.qux
+      expected: |
+        apiVersion: example.openshift.io/v1
+        kind: StableConfigType
+        spec:
+          immutableField: foo
+          subdomainNameField: foo.bar-baz.qux
+          nonZeroDefault: 8
+    - name: Should not allow an invalid DNS 1123 subdomain
+      initial: |
+        apiVersion: example.openshift.io/v1
+        kind: StableConfigType
+        spec:
+          immutableField: foo
+          subdomainNameField: foo.-bar.baz
+      expectedError: "spec.subdomainNameField: Invalid value: \"string\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character."
   onUpdate:
     - name: Should not allow removal of a tech preview field
       initial: |

--- a/example/v1/types_stable.go
+++ b/example/v1/types_stable.go
@@ -88,6 +88,14 @@ type StableConfigTypeSpec struct {
 	// set demonstrates how to define and validate set of strings
 	// +optional
 	Set StringSet `json:"set,omitempty"`
+
+	// subdomainNameField represents a kubenetes name field.
+	// The intention is that it validates the name in the same way metadata.Name is validated.
+	// That is, it is a DNS-1123 subdomain.
+	// +kubebuilder:validation:XValidation:rule="!format.dns1123Subdomain().validate(self).hasValue()",message="a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character."
+	// +kubebuilder:validation:MaxLength:=253
+	// +optional
+	SubdomainNameField string `json:"subdomainNameField,omitempty"`
 }
 
 // SetValue defines the types allowed in string set type

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-CustomNoUpgrade.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-CustomNoUpgrade.crd.yaml
@@ -150,6 +150,18 @@ spec:
 
                   If empty, the platform will choose a good default, which may change over time without notice.
                 type: string
+              subdomainNameField:
+                description: |-
+                  subdomainNameField represents a kubenetes name field.
+                  The intention is that it validates the name in the same way metadata.Name is validated.
+                  That is, it is a DNS-1123 subdomain.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: a lowercase RFC 1123 subdomain must consist of lower case
+                    alphanumeric characters, '-' or '.', and must start and end with
+                    an alphanumeric character.
+                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
             required:
             - immutableField
             type: object

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-Default.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-Default.crd.yaml
@@ -145,6 +145,18 @@ spec:
 
                   If empty, the platform will choose a good default, which may change over time without notice.
                 type: string
+              subdomainNameField:
+                description: |-
+                  subdomainNameField represents a kubenetes name field.
+                  The intention is that it validates the name in the same way metadata.Name is validated.
+                  That is, it is a DNS-1123 subdomain.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: a lowercase RFC 1123 subdomain must consist of lower case
+                    alphanumeric characters, '-' or '.', and must start and end with
+                    an alphanumeric character.
+                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
             required:
             - immutableField
             type: object

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-DevPreviewNoUpgrade.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-DevPreviewNoUpgrade.crd.yaml
@@ -150,6 +150,18 @@ spec:
 
                   If empty, the platform will choose a good default, which may change over time without notice.
                 type: string
+              subdomainNameField:
+                description: |-
+                  subdomainNameField represents a kubenetes name field.
+                  The intention is that it validates the name in the same way metadata.Name is validated.
+                  That is, it is a DNS-1123 subdomain.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: a lowercase RFC 1123 subdomain must consist of lower case
+                    alphanumeric characters, '-' or '.', and must start and end with
+                    an alphanumeric character.
+                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
             required:
             - immutableField
             type: object

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-TechPreviewNoUpgrade.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-TechPreviewNoUpgrade.crd.yaml
@@ -150,6 +150,18 @@ spec:
 
                   If empty, the platform will choose a good default, which may change over time without notice.
                 type: string
+              subdomainNameField:
+                description: |-
+                  subdomainNameField represents a kubenetes name field.
+                  The intention is that it validates the name in the same way metadata.Name is validated.
+                  That is, it is a DNS-1123 subdomain.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: a lowercase RFC 1123 subdomain must consist of lower case
+                    alphanumeric characters, '-' or '.', and must start and end with
+                    an alphanumeric character.
+                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
             required:
             - immutableField
             type: object

--- a/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/AAA_ungated.yaml
+++ b/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/AAA_ungated.yaml
@@ -145,6 +145,18 @@ spec:
 
                   If empty, the platform will choose a good default, which may change over time without notice.
                 type: string
+              subdomainNameField:
+                description: |-
+                  subdomainNameField represents a kubenetes name field.
+                  The intention is that it validates the name in the same way metadata.Name is validated.
+                  That is, it is a DNS-1123 subdomain.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: a lowercase RFC 1123 subdomain must consist of lower case
+                    alphanumeric characters, '-' or '.', and must start and end with
+                    an alphanumeric character.
+                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
             required:
             - immutableField
             type: object

--- a/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/Example.yaml
+++ b/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/Example.yaml
@@ -150,6 +150,18 @@ spec:
 
                   If empty, the platform will choose a good default, which may change over time without notice.
                 type: string
+              subdomainNameField:
+                description: |-
+                  subdomainNameField represents a kubenetes name field.
+                  The intention is that it validates the name in the same way metadata.Name is validated.
+                  That is, it is a DNS-1123 subdomain.
+                maxLength: 253
+                type: string
+                x-kubernetes-validations:
+                - message: a lowercase RFC 1123 subdomain must consist of lower case
+                    alphanumeric characters, '-' or '.', and must start and end with
+                    an alphanumeric character.
+                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
             required:
             - immutableField
             type: object

--- a/example/v1/zz_generated.swagger_doc_generated.go
+++ b/example/v1/zz_generated.swagger_doc_generated.go
@@ -61,6 +61,7 @@ var map_StableConfigTypeSpec = map[string]string{
 	"nonZeroDefault":         "nonZeroDefault is a demonstration of creating an integer field that has a non zero default. It required two default tags (one for CRD generation, one for client generation) and must have `omitempty` and be optional. A minimum value is added to demonstrate that a zero value would not be accepted.",
 	"evolvingCollection":     "evolvingCollection demonstrates how to have a collection where the maximum number of items varies on cluster type. For default clusters, this will be \"1\" but on TechPreview clusters, this value will be \"3\".",
 	"set":                    "set demonstrates how to define and validate set of strings",
+	"subdomainNameField":     "subdomainNameField represents a kubenetes name field. The intention is that it validates the name in the same way metadata.Name is validated. That is, it is a DNS-1123 subdomain.",
 }
 
 func (StableConfigTypeSpec) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -23312,6 +23312,13 @@ func schema_openshift_api_example_v1_StableConfigTypeSpec(ref common.ReferenceCa
 							},
 						},
 					},
+					"subdomainNameField": {
+						SchemaProps: spec.SchemaProps{
+							Description: "subdomainNameField represents a kubenetes name field. The intention is that it validates the name in the same way metadata.Name is validated. That is, it is a DNS-1123 subdomain.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"immutableField"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -12891,6 +12891,10 @@
           "description": "stableField is a field that is present on default clusters and on tech preview clusters\n\nIf empty, the platform will choose a good default, which may change over time without notice.",
           "type": "string",
           "default": ""
+        },
+        "subdomainNameField": {
+          "description": "subdomainNameField represents a kubenetes name field. The intention is that it validates the name in the same way metadata.Name is validated. That is, it is a DNS-1123 subdomain.",
+          "type": "string"
         }
       }
     },

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@
 # DO NOT UPDATE THIS until you have published downstream builds for the kubebuilder tools, and checked
 # that there is an equivalent upstream version as well. Check upstream at https://storage.googleapis.com/kubebuilder-tools.
 # Publish downstream with `make -C tools publish-kubebuilder-tools`, see help text there for updating flags before publshing.
-ENVTEST_K8S_VERSION = 1.31.1
+ENVTEST_K8S_VERSION = 1.31.2
 
 # In case of emergency, use these to provide separate upstream/downstream K8s versions for testing.
 ENVTEST_K8S_DOWNSTREAM_VERSION = ${ENVTEST_K8S_VERSION}


### PR DESCRIPTION
This adds an example of the new format library for validating DNS 1123 subdomains to the example API. Will be leveraging this few a through APIs so providing an example hopefully helps some folks.