### PR TITLE
OCPBUGS-44693: Disable ResilientWatchCacheInitialization

### DIFF
--- a/features.md
+++ b/features.md
@@ -6,6 +6,7 @@
 | MachineAPIMigration| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
+| ResilientWatchCacheInitialization| | | | | |  |
 | GatewayAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | NewOLM| | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | AWSClusterHostedDNS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -686,4 +686,11 @@ var (
 					enhancementPR("https://github.com/openshift/enhancements/pull/1711").
 					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
+
+	FeatureGateResilientWatchCacheInitialization = newFeatureGate("ResilientWatchCacheInitialization").
+							reportProblemsToJiraComponent("kube-apiserver").
+							contactPerson("p0lyn0mial").
+							productScope(kubernetes).
+							enhancementPR("https://github.com/kubernetes/enhancements/issues/4568").
+							mustRegister()
 )

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -137,6 +137,9 @@
                         "name": "ProcMountType"
                     },
                     {
+                        "name": "ResilientWatchCacheInitialization"
+                    },
+                    {
                         "name": "RouteAdvertisements"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -35,6 +35,9 @@
                     },
                     {
                         "name": "NewOLM"
+                    },
+                    {
+                        "name": "ResilientWatchCacheInitialization"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -38,6 +38,9 @@
                     },
                     {
                         "name": "NewOLM"
+                    },
+                    {
+                        "name": "ResilientWatchCacheInitialization"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -137,6 +137,9 @@
                         "name": "ProcMountType"
                     },
                     {
+                        "name": "ResilientWatchCacheInitialization"
+                    },
+                    {
                         "name": "RouteAdvertisements"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -32,6 +32,9 @@
                     },
                     {
                         "name": "MultiArchInstallAzure"
+                    },
+                    {
+                        "name": "ResilientWatchCacheInitialization"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -35,6 +35,9 @@
                     },
                     {
                         "name": "MultiArchInstallAzure"
+                    },
+                    {
+                        "name": "ResilientWatchCacheInitialization"
                     }
                 ],
                 "enabled": [


### PR DESCRIPTION
`ResilientWatchCacheInitialization` should be disabled for all API servers. At the moment [we carry a patch ](https://github.com/openshift/kubernetes/blob/master/pkg/features/kube_features.go#L1287-L1288)for kas (which will be replaced by this PR)

The FG will be disabled temporarily until cause of storage error triggering cache reinitialization during bootstrap is fixed in https://issues.redhat.com/browse/OCPBUGS-45126.


There's a separate pre-existing issue causing storage layer errors and watch cache re-initialization during cluster bootstrap. 

With ResilientWatchCacheInitialization enabled, clients (reflectors in particular) are turned away with 429 responses while the watch cache is being repopulated and retry repeatedly. Without this feature, requests hang (consuming priority and fairness "seats") until the watch cache is initialized or they time out. We fail tests when the total number of watch requests during a job exceeds a threshold based on recent historical totals. The systemic 429/retry behavior causes this threshold to be breached. We are temporarily disabling it to reduce noise as it's a symptom and not the cause of the underlying storage errors.