### PR TITLE
Revert "OCPBUGS-44693: Disable ResilientWatchCacheInitialization"

### DIFF
--- a/features.md
+++ b/features.md
@@ -6,7 +6,6 @@
 | MachineAPIMigration| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
-| ResilientWatchCacheInitialization| | | | | |  |
 | GatewayAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | NewOLM| | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | AWSClusterHostedDNS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -694,11 +694,4 @@ var (
 					enhancementPR("https://github.com/openshift/enhancements/pull/1711").
 					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
-
-	FeatureGateResilientWatchCacheInitialization = newFeatureGate("ResilientWatchCacheInitialization").
-							reportProblemsToJiraComponent("kube-apiserver").
-							contactPerson("p0lyn0mial").
-							productScope(kubernetes).
-							enhancementPR("https://github.com/kubernetes/enhancements/issues/4568").
-							mustRegister()
 )

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -137,9 +137,6 @@
                         "name": "ProcMountType"
                     },
                     {
-                        "name": "ResilientWatchCacheInitialization"
-                    },
-                    {
                         "name": "RouteAdvertisements"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -35,9 +35,6 @@
                     },
                     {
                         "name": "NewOLM"
-                    },
-                    {
-                        "name": "ResilientWatchCacheInitialization"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -38,9 +38,6 @@
                     },
                     {
                         "name": "NewOLM"
-                    },
-                    {
-                        "name": "ResilientWatchCacheInitialization"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -137,9 +137,6 @@
                         "name": "ProcMountType"
                     },
                     {
-                        "name": "ResilientWatchCacheInitialization"
-                    },
-                    {
                         "name": "RouteAdvertisements"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -32,9 +32,6 @@
                     },
                     {
                         "name": "MultiArchInstallAzure"
-                    },
-                    {
-                        "name": "ResilientWatchCacheInitialization"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -35,9 +35,6 @@
                     },
                     {
                         "name": "MultiArchInstallAzure"
-                    },
-                    {
-                        "name": "ResilientWatchCacheInitialization"
                     }
                 ],
                 "enabled": [


### PR DESCRIPTION
This reverts commit 52ecd418ae879ad0872a7a0d98cdc6f827afe73f.

After syncing with @deads2k , the expectation is not to disable the FG but to fix the underlying issue.


