### PR TITLE
cpumanager: add featuregate for cpumanager alpha policy options

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -694,4 +694,12 @@ var (
 					enhancementPR("https://github.com/openshift/enhancements/pull/1711").
 					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
+
+	CPUManagerPolicyAlphaOptions = newFeatureGate("CPUManagerPolicyAlphaOptions").
+					reportProblemsToJiraComponent("node").
+					contactPerson("ffromani").
+					productScope(kubernetes).
+					enhancementPR("https://github.com/openshift/enhancements/pull/1724").
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
 )


### PR DESCRIPTION
add feature gate to enable selected users to consume cpumanager policy options of alfpha maturtiy.
Needs to be merged alongside https://github.com/openshift/kubernetes/pull/2136 which enables per-option granularity

for more details: https://github.com/openshift/enhancements/pull/1724