### PR TITLE
OCPBUGS-44199: Allow spaces in AWS tags

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
+featureGates:
+- -AWSClusterHostedDNS
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure
@@ -1675,3 +1677,163 @@ tests:
               serviceEndpoints:
               - name: DNSServices
                 url: https://abc
+    - name: Should be able to create an aws resourcetag with spaces
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key with space
+                value: value with space
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key with space
+                value: value with space
+            type: AWS
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key with space
+                value: value with space
+            type: AWS
+    - name: Should be able to create an aws resourcetag with characters '_', '.', '/', '=', '+', '-', ':', '@'
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key:_./=+-@
+                value: value:_./=+-@
+            type: AWS
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key:_./=+-@
+                value: value:_./=+-@
+            type: AWS
+    - name: Should not be able to create an aws resourcetag with character * in key
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key:_./=+-@*
+                value: value
+            type: AWS
+      expectedStatusError: "invalid AWS resource tag key. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
+    - name: Should not be able to create an aws resourcetag with character * in value
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key
+                value: value*
+            type: AWS
+      expectedStatusError: "invalid AWS resource tag value. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -528,18 +528,22 @@ type AWSPlatformStatus struct {
 
 // AWSResourceTag is a tag to apply to AWS resources created for the cluster.
 type AWSResourceTag struct {
-	// key is the key of the tag
+	// key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+	// Key should consist of between 1 and 128 characters, and may
+	// contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.:/=+-@]+$`
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')`,message="invalid AWS resource tag key. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
 	// +required
 	Key string `json:"key"`
-	// value is the value of the tag.
+	// value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+	// Value should consist of between 1 and 256 characters, and may
+	// contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
 	// Some AWS service do not support empty values. Since tags are added to resources in many services, the
 	// length of the tag value must meet the requirements of all services.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.:/=+-@]+$`
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')`,message="invalid AWS resource tag value. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
 	// +required
 	Value string `json:"value"`
 }

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1185,20 +1185,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1158,20 +1158,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
@@ -1255,20 +1255,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
@@ -1151,20 +1151,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
@@ -1151,20 +1151,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
@@ -1151,20 +1151,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/HighlyAvailableArbiter.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/HighlyAvailableArbiter.yaml
@@ -1156,20 +1156,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
@@ -1156,20 +1156,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1166,20 +1166,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
@@ -1162,20 +1162,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
@@ -1152,20 +1152,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
@@ -1152,20 +1152,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1198,8 +1198,8 @@ func (AWSPlatformStatus) SwaggerDoc() map[string]string {
 
 var map_AWSResourceTag = map[string]string{
 	"":      "AWSResourceTag is a tag to apply to AWS resources created for the cluster.",
-	"key":   "key is the key of the tag",
-	"value": "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+	"key":   "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
+	"value": "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
 }
 
 func (AWSResourceTag) SwaggerDoc() map[string]string {

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1467,20 +1467,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
@@ -1452,20 +1452,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
@@ -1549,20 +1549,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
@@ -1445,20 +1445,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
@@ -1445,20 +1445,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
@@ -1445,20 +1445,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter.yaml
@@ -1450,20 +1450,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
@@ -1451,20 +1451,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1460,20 +1460,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
@@ -1446,20 +1446,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
@@ -1446,20 +1446,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -8647,7 +8647,7 @@ func schema_openshift_api_config_v1_AWSResourceTag(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"key": {
 						SchemaProps: spec.SchemaProps{
-							Description: "key is the key of the tag",
+							Description: "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -8655,7 +8655,7 @@ func schema_openshift_api_config_v1_AWSResourceTag(ref common.ReferenceCallback)
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+							Description: "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4232,12 +4232,12 @@
       ],
       "properties": {
         "key": {
-          "description": "key is the key of the tag",
+          "description": "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
           "type": "string",
           "default": ""
         },
         "value": {
-          "description": "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+          "description": "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
           "type": "string",
           "default": ""
         }

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1185,20 +1185,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1467,20 +1467,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value


### PR DESCRIPTION
An incorrect regex validation prevents users from specifying AWS tag keys or values that include spaces, which are
allowed by AWS's official regex:

https://docs.aws.amazon.com/directoryservice/latest/devguide/API_Tag.html

This bug is affecting users, so it would be good to backport to at least 4.17.