### PR TITLE
Add verify-lint-fix make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,13 @@ lint:
 lint-fix:
 	hack/lint-fix.sh
 
+# Ignore the exit code of the fix lint, it will always error as there are unfixed issues
+# that cannot be fixed from historic commits.
+.PHONY: verify-lint-fix
+verify-lint-fix:
+	make lint-fix 2>/dev/null || true
+	git diff --exit-code
+
 .PHONY: verify-scripts
 verify-scripts:
 	bash -x hack/verify-deepcopy.sh


### PR DESCRIPTION
This adds a new make target, which I'll add to the lint status check, that runs the lint-fixes (output to null for now as it's noisy) and then checks for a diff. Similar to other verify checks.

This means we can enforce that all fixes are applied prior to passing the lint check.

Eg this means we will always convert `kubeuilder:validation:Required` to `required` automatically.