### PR TITLE
Update KAL with bug fixes for embedded fields

### DIFF
--- a/tools/.custom-gcl.yml
+++ b/tools/.custom-gcl.yml
@@ -3,4 +3,4 @@ name: golangci-kal
 destination: ./bin
 plugins:
 - module: 'github.com/JoelSpeed/kal'
-  version: v0.0.0-20241215115308-238fddd4bda0
+  version: v0.0.0-20241217211810-b52f67ed8ff3

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.0
 
 require (
 	cloud.google.com/go/storage v1.43.0
-	github.com/JoelSpeed/kal v0.0.0-20241215115308-238fddd4bda0
+	github.com/JoelSpeed/kal v0.0.0-20241217211810-b52f67ed8ff3
 	github.com/dave/dst v0.27.3
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.12.0

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -38,8 +38,8 @@ github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rW
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.0 h1:/fTUt5vmbkAcMBt4YQiuC23cV0kEsN1MVMNqeOW43cU=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.0/go.mod h1:ONJg5sxcbsdQQ4pOW8TGdTidT2TMAUy/2Xhr8mrYaao=
-github.com/JoelSpeed/kal v0.0.0-20241215115308-238fddd4bda0 h1:0FiMbmgFHEPTkVHP+3cduDQWMz4s7R5M+UEoOOHcQus=
-github.com/JoelSpeed/kal v0.0.0-20241215115308-238fddd4bda0/go.mod h1:zptAqBcJGHljQfJR7oQXVKS/E6KVUFZDkE7OJDQeKOw=
+github.com/JoelSpeed/kal v0.0.0-20241217211810-b52f67ed8ff3 h1:vQ40rOyUpXw5N18atxAKLyV4LImaLpmxuDxc+3P/DVg=
+github.com/JoelSpeed/kal v0.0.0-20241217211810-b52f67ed8ff3/go.mod h1:zptAqBcJGHljQfJR7oQXVKS/E6KVUFZDkE7OJDQeKOw=
 github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
 github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/commentstart/analyzer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/commentstart/analyzer.go
@@ -56,21 +56,21 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		for _, field := range sTyp.Fields.List {
-			checkField(pass, sTyp, field, jsonTags)
+			checkField(pass, field, jsonTags)
 		}
 	})
 
 	return nil, nil //nolint:nilnil
 }
 
-func checkField(pass *analysis.Pass, sTyp *ast.StructType, field *ast.Field, jsonTags extractjsontags.StructFieldTags) {
+func checkField(pass *analysis.Pass, field *ast.Field, jsonTags extractjsontags.StructFieldTags) {
 	if field == nil || len(field.Names) == 0 {
 		return
 	}
 
 	fieldName := field.Names[0].Name
 
-	tagInfo := jsonTags.FieldTags(sTyp, fieldName)
+	tagInfo := jsonTags.FieldTags(field)
 
 	if tagInfo.Name == "" {
 		return

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/conditions/analyzer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/conditions/analyzer.go
@@ -67,6 +67,7 @@ func (a *analyzer) run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	// Filter to structs so that we can iterate over fields in a struct.
+	// We need a struct here so that we can tell where in the struct the field is.
 	nodeFilter := []ast.Node{
 		(*ast.StructType)(nil),
 	}
@@ -82,12 +83,7 @@ func (a *analyzer) run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		for i, field := range sTyp.Fields.List {
-			if field == nil || len(field.Names) == 0 {
-				continue
-			}
-
-			fieldName := field.Names[0].Name
-			fieldMarkers := markersAccess.StructFieldMarkers(sTyp, fieldName)
+			fieldMarkers := markersAccess.FieldMarkers(field)
 
 			a.checkField(pass, i, field, fieldMarkers)
 		}

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags/analyzer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags/analyzer.go
@@ -21,36 +21,26 @@ var (
 // StructFieldTags is used to find information about
 // json tags on fields within struct.
 type StructFieldTags interface {
-	FieldTags(*ast.StructType, string) FieldTagInfo
+	FieldTags(*ast.Field) FieldTagInfo
 }
 
 type structFieldTags struct {
-	structToFieldTags map[*ast.StructType]map[string]FieldTagInfo
+	fieldTags map[*ast.Field]FieldTagInfo
 }
 
 func newStructFieldTags() StructFieldTags {
 	return &structFieldTags{
-		structToFieldTags: make(map[*ast.StructType]map[string]FieldTagInfo),
+		fieldTags: make(map[*ast.Field]FieldTagInfo),
 	}
 }
 
-func (s *structFieldTags) insertFieldTagInfo(styp *ast.StructType, field string, tagInfo FieldTagInfo) {
-	if s.structToFieldTags[styp] == nil {
-		s.structToFieldTags[styp] = make(map[string]FieldTagInfo)
-	}
-
-	s.structToFieldTags[styp][field] = tagInfo
+func (s *structFieldTags) insertFieldTagInfo(field *ast.Field, tagInfo FieldTagInfo) {
+	s.fieldTags[field] = tagInfo
 }
 
 // FieldTags find the tag information for the named field within the given struct.
-func (s *structFieldTags) FieldTags(styp *ast.StructType, field string) FieldTagInfo {
-	structFields := s.structToFieldTags[styp]
-
-	if structFields != nil {
-		return structFields[field]
-	}
-
-	return FieldTagInfo{}
+func (s *structFieldTags) FieldTags(field *ast.Field) FieldTagInfo {
+	return s.fieldTags[field]
 }
 
 // Analyzer is the analyzer for the jsontags package.
@@ -71,7 +61,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	// Filter to structs so that we can iterate over fields in a struct.
 	nodeFilter := []ast.Node{
-		(*ast.StructType)(nil),
+		(*ast.Field)(nil),
 	}
 
 	results, ok := newStructFieldTags().(*structFieldTags)
@@ -80,24 +70,12 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	inspect.Preorder(nodeFilter, func(n ast.Node) {
-		sTyp, ok := n.(*ast.StructType)
+		field, ok := n.(*ast.Field)
 		if !ok {
 			return
 		}
 
-		if sTyp.Fields == nil {
-			return
-		}
-
-		for i := 0; i < sTyp.Fields.NumFields(); i++ {
-			field := sTyp.Fields.List[i]
-			if len(field.Names) == 0 || field.Names[0] == nil {
-				continue
-			}
-
-			fieldName := field.Names[0].Name
-			results.insertFieldTagInfo(sTyp, fieldName, extractTagInfo(field.Tag))
-		}
+		results.insertFieldTagInfo(field, extractTagInfo(field.Tag))
 	})
 
 	return results, nil

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags/doc.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags/doc.go
@@ -10,26 +10,21 @@ Example:
 	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	jsonTags := pass.ResultOf[extractjsontags.Analyzer].(extractjsontags.StructFieldTags)
 
-	// Filter to structs so that we can iterate over fields in a struct.
+	// Filter to fields so that we can iterate over fields in a struct.
 	nodeFilter := []ast.Node{
-		(*ast.StructType)(nil),
+		(*ast.Field)(nil),
 	}
 
 	inspect.Preorder(nodeFilter, func(n ast.Node) {
-		sTyp, ok := n.(*ast.StructType)
+		field, ok := n.(*ast.Field)
 		if !ok {
 			return
 		}
 
-		if sTyp.Fields == nil {
-			return
-		}
+		tagInfo := jsonTags.FieldTags(field)
 
-		for _, field := range sTyp.Fields.List {
-			tagInfo := jsonTags.FieldTags(sTyp, field.Names[0].Name)
+		...
 
-			...
-		}
 	})
 
 For each field, tag information is returned as a [FieldTagInfo] struct.

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/helpers/markers/doc.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/helpers/markers/doc.go
@@ -30,9 +30,7 @@ Example:
 			}
 
 			structMarkers := markersAccess.StructMarkers(sTyp)
-
-			fieldName := field.Names[0].Name
-			fieldMarkers := markersAccess.StructFieldMarkers(sTyp, fieldName)
+			fieldMarkers := markersAccess.FieldMarkers(field)
 
 			...
 		}
@@ -45,8 +43,7 @@ Additional information about the marker can be found in the [Marker] struct, for
 
 Example:
 
-	fieldName := field.Names[0].Name
-	fieldMarkers := markersAccess.StructFieldMarkers(sTyp, fieldName)
+	fieldMarkers := markersAccess.FieldMarkers(field)
 
 	if fieldMarkers.Has("required") {
 		requiredMarker := fieldMarkers["required"]

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/integers/analyzer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/integers/analyzer.go
@@ -31,7 +31,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, errCouldNotGetInspector
 	}
 
-	// Filter to structs so that we can iterate over fields in a struct.
+	// Filter to fields so that we can look at fields within structs.
 	// Filter typespecs so that we can look at type aliases.
 	nodeFilter := []ast.Node{
 		(*ast.StructType)(nil),

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/nobools/analyzer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/nobools/analyzer.go
@@ -31,7 +31,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, errCouldNotGetInspector
 	}
 
-	// Filter to structs so that we can iterate over fields in a struct.
+	// Filter to fields so that we can look at fields within structs.
 	// Filter typespecs so that we can look at type aliases.
 	nodeFilter := []ast.Node{
 		(*ast.StructType)(nil),

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/nophase/analyzer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/nophase/analyzer.go
@@ -39,9 +39,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		return nil, errCouldNotGetJSONTags
 	}
 
-	// Filter to structs so that we can iterate over fields in a struct.
+	// Filter to fields so that we can iterate over fields in a struct.
 	nodeFilter := []ast.Node{
-		(*ast.StructType)(nil),
+		(*ast.Field)(nil),
 	}
 
 	// Preorder visits all the nodes of the AST in depth-first order. It calls
@@ -49,41 +49,35 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	//
 	// We use the filter defined above, ensuring we only look at struct fields.
 	inspect.Preorder(nodeFilter, func(n ast.Node) {
-		sTyp, ok := n.(*ast.StructType)
+		field, ok := n.(*ast.Field)
 		if !ok {
 			return
 		}
 
-		if sTyp.Fields == nil {
+		if field == nil || len(field.Names) == 0 {
 			return
 		}
 
-		for _, field := range sTyp.Fields.List {
-			if field == nil || len(field.Names) == 0 {
-				continue
-			}
+		fieldName := field.Names[0].Name
 
-			fieldName := field.Names[0].Name
+		// First check if the struct field name contains 'phase'
+		if strings.Contains(strings.ToLower(fieldName), "phase") {
+			pass.Reportf(field.Pos(),
+				"field %s: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields",
+				fieldName,
+			)
 
-			// First check if the struct field name contains 'phase'
-			if strings.Contains(strings.ToLower(fieldName), "phase") {
-				pass.Reportf(field.Pos(),
-					"field %s: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields",
-					fieldName,
-				)
+			return
+		}
 
-				continue
-			}
+		// Then check if the json serialization of the field contains 'phase'
+		tagInfo := jsonTags.FieldTags(field)
 
-			// Then check if the json serialization of the field contains 'phase'
-			tagInfo := jsonTags.FieldTags(sTyp, fieldName)
-
-			if strings.Contains(strings.ToLower(tagInfo.Name), "phase") {
-				pass.Reportf(field.Pos(),
-					"field %s: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields",
-					fieldName,
-				)
-			}
+		if strings.Contains(strings.ToLower(tagInfo.Name), "phase") {
+			pass.Reportf(field.Pos(),
+				"field %s: phase fields are deprecated and conditions should be preferred, avoid phase like enum fields",
+				fieldName,
+			)
 		}
 	})
 

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/requiredfields/analyzer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/requiredfields/analyzer.go
@@ -63,32 +63,21 @@ func (a *analyzer) run(pass *analysis.Pass) (interface{}, error) {
 		return nil, errCouldNotGetJSONTags
 	}
 
-	// Filter to structs so that we can iterate over fields in a struct.
+	// Filter to fields so that we can iterate over fields in a struct.
 	nodeFilter := []ast.Node{
-		(*ast.StructType)(nil),
+		(*ast.Field)(nil),
 	}
 
 	inspect.Preorder(nodeFilter, func(n ast.Node) {
-		sTyp, ok := n.(*ast.StructType)
+		field, ok := n.(*ast.Field)
 		if !ok {
 			return
 		}
 
-		if sTyp.Fields == nil {
-			return
-		}
+		fieldMarkers := markersAccess.FieldMarkers(field)
+		fieldTagInfo := jsonTags.FieldTags(field)
 
-		for _, field := range sTyp.Fields.List {
-			if field == nil || len(field.Names) == 0 {
-				continue
-			}
-
-			fieldName := field.Names[0].Name
-			fieldMarkers := markersAccess.StructFieldMarkers(sTyp, fieldName)
-			fieldTagInfo := jsonTags.FieldTags(sTyp, fieldName)
-
-			a.checkField(pass, field, fieldMarkers, fieldTagInfo)
-		}
+		a.checkField(pass, field, fieldMarkers, fieldTagInfo)
 	})
 
 	return nil, nil //nolint:nilnil

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/utils/type_check.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/utils/type_check.go
@@ -39,6 +39,8 @@ func (t *typeChecker) CheckNode(pass *analysis.Pass, node ast.Node) {
 		for _, field := range n.Fields.List {
 			t.checkField(pass, field)
 		}
+	case *ast.Field:
+		t.checkField(pass, n)
 	case *ast.TypeSpec:
 		t.checkTypeSpec(pass, n, node, "type")
 	}
@@ -74,6 +76,9 @@ func (t *typeChecker) checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node
 		t.checkTypeExpr(pass, typ.X, node, fmt.Sprintf("%s pointer", prefix))
 	case *ast.ArrayType:
 		t.checkTypeExpr(pass, typ.Elt, node, fmt.Sprintf("%s array element", prefix))
+	case *ast.MapType:
+		t.checkTypeExpr(pass, typ.Key, node, fmt.Sprintf("%s map key", prefix))
+		t.checkTypeExpr(pass, typ.Value, node, fmt.Sprintf("%s map value", prefix))
 	}
 }
 

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -81,7 +81,7 @@ github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer
 github.com/GaijinEntertainment/go-exhaustruct/v3/internal/comment
 github.com/GaijinEntertainment/go-exhaustruct/v3/internal/pattern
 github.com/GaijinEntertainment/go-exhaustruct/v3/internal/structure
-# github.com/JoelSpeed/kal v0.0.0-20241215115308-238fddd4bda0
+# github.com/JoelSpeed/kal v0.0.0-20241217211810-b52f67ed8ff3
 ## explicit; go 1.22.1
 github.com/JoelSpeed/kal
 github.com/JoelSpeed/kal/cmd/kal


### PR DESCRIPTION
This includes fixes for the linter not picking up the json tags on embedded fields like objectmeta and typemeta, leading to no reports of missing comments or the optional/required tag on the metadata field