### PR TITLE
Add path warning for protobuf updates

### DIFF
--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -10,6 +10,12 @@ To skip protobuf generation, set \$PROTO_OPTIONAL."
   exit 1
 fi
 
+if [[ "${GOPATH}/src/github.com/openshift/api" != "${SCRIPT_ROOT}" ]]; then
+  echo "Generating protobuf requires the repository to be checked out within the GOPATH."
+  echo "The repository must be checked out at ${GOPATH}/src/github.com/openshift/api."
+  exit 1
+fi
+
 if [[ "$(protoc --version)" != "libprotoc 23."* ]]; then
   echo "Generating protobuf requires protoc 23.x. Please download and
 install the platform appropriate Protobuf package for your OS:


### PR DESCRIPTION
Some folks have been having issues recently because the protobuf generator is very, very fussy about where it is located.

You must have `$GOPATH` set, and you must check out the API repo at `$GOPATH/src/github.com/openshift/api`. If you do not, it will just write the resources there anyway, and remove any proto files from your actual checkout location. Resulting in confusion as "it deleted all the proto files".

This PR adds a check in the script, until we can work out a way to get around this weird proto generation issue (perhaps moving to gengo v2 will fix this for us)