### PR TITLE
Fix handling of validations that require multiple feature gates

### DIFF
--- a/example/v1/tests/stableconfigtypes.example.openshift.io/Example+Example2.yaml
+++ b/example/v1/tests/stableconfigtypes.example.openshift.io/Example+Example2.yaml
@@ -1,0 +1,36 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "Example API"
+crdName: stableconfigtypes.example.openshift.io
+featureGates:
+- Example
+- Example2
+tests:
+  onCreate:
+    - name: Should persist stable fields
+      initial: |
+        apiVersion: example.openshift.io/v1
+        kind: StableConfigType
+        spec:
+          stableField: "Allowed"
+          immutableField: foo
+      expected: |
+        apiVersion: example.openshift.io/v1
+        kind: StableConfigType
+        spec:
+          stableField: "Allowed"
+          immutableField: foo
+          nonZeroDefault: 8
+  onUpdate:
+    - name: Should not allow removal of a tech preview field
+      initial: |
+        apiVersion: example.openshift.io/v1
+        kind: StableConfigType
+        spec:
+          stableField: "Invalid"
+          immutableField: foo
+      updated: |
+        apiVersion: example.openshift.io/v1
+        kind: StableConfigType
+        spec:
+          immutableField: foo
+      expectedError: "spec: Invalid value: \"object\": stableField may not be removed once set"

--- a/example/v1/types_stable.go
+++ b/example/v1/types_stable.go
@@ -33,6 +33,7 @@ type StableConfigType struct {
 
 // StableConfigTypeSpec is the desired state
 // +openshift:validation:FeatureGateAwareXValidation:featureGate=Example,rule="has(oldSelf.coolNewField) ? has(self.coolNewField) : true",message="coolNewField may not be removed once set"
+// +openshift:validation:FeatureGateAwareXValidation:requiredFeatureGate=Example;Example2,rule="has(oldSelf.stableField) ? has(self.stableField) : true",message="stableField may not be removed once set (this should only show up with both the Example and Example2 feature gates)"
 type StableConfigTypeSpec struct {
 	// coolNewField is a field that is for tech preview only.  On normal clusters this shouldn't be present
 	//

--- a/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-DevPreviewNoUpgrade.crd.yaml
+++ b/example/v1/zz_generated.crd-manifests/0000_50_my-operator_01_stableconfigtypes-DevPreviewNoUpgrade.crd.yaml
@@ -168,6 +168,9 @@ spec:
             x-kubernetes-validations:
             - message: coolNewField may not be removed once set
               rule: 'has(oldSelf.coolNewField) ? has(self.coolNewField) : true'
+            - message: stableField may not be removed once set (this should only show
+                up with both the Example and Example2 feature gates)
+              rule: 'has(oldSelf.stableField) ? has(self.stableField) : true'
           status:
             description: status is the most recently observed status of the StableConfigType.
             properties:

--- a/example/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/example/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -6,6 +6,7 @@ stableconfigtypes.example.openshift.io:
   Category: ""
   FeatureGates:
   - Example
+  - Example+Example2
   FilenameOperatorName: my-operator
   FilenameOperatorOrdering: "01"
   FilenameRunLevel: "0000_50"

--- a/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/Example+Example2.yaml
+++ b/example/v1/zz_generated.featuregated-crd-manifests/stableconfigtypes.example.openshift.io/Example+Example2.yaml
@@ -3,10 +3,11 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/xxx
-    api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade
+    api.openshift.io/filename-cvo-runlevel: "0000_50"
+    api.openshift.io/filename-operator: my-operator
+    api.openshift.io/filename-ordering: "01"
+    feature-gate.release.openshift.io/Example: "true"
+    feature-gate.release.openshift.io/Example2: "true"
   name: stableconfigtypes.example.openshift.io
 spec:
   group: example.openshift.io

--- a/features.md
+++ b/features.md
@@ -7,6 +7,7 @@
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
 | ClusterVersionOperatorConfiguration| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
+| Example2| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | GatewayAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | NewOLM| | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | AWSClusterHostedDNS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -490,6 +490,14 @@ var (
 				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 				mustRegister()
 
+	FeatureGateExample2 = newFeatureGate("Example2").
+				reportProblemsToJiraComponent("cluster-config").
+				contactPerson("JoelSpeed").
+				productScope(ocpSpecific).
+				enhancementPR(legacyFeatureGateWithoutEnhancement).
+				enableIn(configv1.DevPreviewNoUpgrade).
+				mustRegister()
+
 	FeatureGatePlatformOperators = newFeatureGate("PlatformOperators").
 					reportProblemsToJiraComponent("olm").
 					contactPerson("joe").

--- a/features/legacyfeaturegates.go
+++ b/features/legacyfeaturegates.go
@@ -37,6 +37,8 @@ var legacyFeatureGates = sets.New(
 	// never add to this list, if you think you have an exception ask @deads2k
 	"Example",
 	// never add to this list, if you think you have an exception ask @deads2k
+	"Example2",
+	// never add to this list, if you think you have an exception ask @deads2k
 	"GCPClusterHostedDNS",
 	// never add to this list, if you think you have an exception ask @deads2k
 	"GCPLabelsTags",

--- a/payload-command/render/legacyfeaturegates.go
+++ b/payload-command/render/legacyfeaturegates.go
@@ -39,6 +39,8 @@ var legacyFeatureGates = sets.New(
 	// never add to this list, if you think you have an exception ask @deads2k
 	"Example",
 	// never add to this list, if you think you have an exception ask @deads2k
+	"Example2",
+	// never add to this list, if you think you have an exception ask @deads2k
 	"GCPClusterHostedDNS",
 	// never add to this list, if you think you have an exception ask @deads2k
 	"GCPLabelsTags",

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -56,6 +56,9 @@
                         "name": "Example"
                     },
                     {
+                        "name": "Example2"
+                    },
+                    {
                         "name": "GCPClusterHostedDNS"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -102,6 +102,9 @@
                         "name": "Example"
                     },
                     {
+                        "name": "Example2"
+                    },
+                    {
                         "name": "ExternalOIDC"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -28,6 +28,9 @@
                         "name": "EventedPLEG"
                     },
                     {
+                        "name": "Example2"
+                    },
+                    {
                         "name": "GatewayAPI"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -56,6 +56,9 @@
                         "name": "Example"
                     },
                     {
+                        "name": "Example2"
+                    },
+                    {
                         "name": "ExternalOIDC"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -99,6 +99,9 @@
                         "name": "Example"
                     },
                     {
+                        "name": "Example2"
+                    },
+                    {
                         "name": "ExternalOIDC"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -28,6 +28,9 @@
                         "name": "EventedPLEG"
                     },
                     {
+                        "name": "Example2"
+                    },
+                    {
                         "name": "GatewayAPI"
                     },
                     {

--- a/tools/codegen/pkg/emptypartialschemas/tags.go
+++ b/tools/codegen/pkg/emptypartialschemas/tags.go
@@ -2,10 +2,11 @@ package emptypartialschemas
 
 import (
 	"fmt"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/gengo/types"
 	"strconv"
 	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/gengo/types"
 )
 
 // known tags that are handled by empty partial schema generation.
@@ -80,6 +81,17 @@ func extractFeatureGatesFromValidationMarker(comments []string, tagName string) 
 			if len(featureGate) > 0 {
 				ret = append(ret, featureGate)
 			}
+		}
+	}
+
+	for _, tagVal := range tagVals {
+		requiredFeatureGates := extractNamedValuesFromSingleLine(tagVal)["requiredFeatureGate"]
+
+		// Use + as the separator between required feature gates in file names.
+		requiredFeatureGates = strings.Replace(requiredFeatureGates, ";", "+", -1)
+
+		if len(requiredFeatureGates) > 0 {
+			ret = append(ret, requiredFeatureGates)
 		}
 	}
 

--- a/tools/codegen/pkg/manifestmerge/filters.go
+++ b/tools/codegen/pkg/manifestmerge/filters.go
@@ -2,15 +2,16 @@ package manifestmerge
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
 	"github.com/openshift/api/tools/codegen/pkg/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"os"
-	"path"
-	"path/filepath"
 	kyaml "sigs.k8s.io/yaml"
-	"strings"
 )
 
 func AllKnownFeatureSets(payloadFeatureGatePath string) (sets.String, error) {
@@ -149,7 +150,7 @@ func (f *ForFeatureGates) UseManifest(data []byte) (bool, error) {
 		return true, nil
 	}
 
-	return manifestFeatureGates.HasAny(f.allowedFeatureGates.UnsortedList()...), nil
+	return f.allowedFeatureGates.HasAll(manifestFeatureGates.UnsortedList()...), nil
 }
 
 func (f *ForFeatureGates) String() string {

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -34,7 +34,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
-replace sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704
+replace sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20250108094724-6eb6da5d6efd
 
 // Temporary until we rebase to 1.32.0 or higher deps. To enable the format library early.
 replace k8s.io/apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20241125210059-e3abfef0b992

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -456,8 +456,8 @@ github.com/onsi/ginkgo/v2 v2.20.2 h1:7NVCeyIWROIAheY21RLS+3j2bb52W0W82tkberYytp4
 github.com/onsi/ginkgo/v2 v2.20.2/go.mod h1:K9gyxPIlb+aIvnZ8bd9Ak+YP18w3APlR+5coaZoE2ag=
 github.com/onsi/gomega v1.34.2 h1:pNCwDkzrsv7MS9kpaQvVb1aVLahQXyJ/Tv5oAZMI3i8=
 github.com/onsi/gomega v1.34.2/go.mod h1:v1xfxRgk0KIsG+QOdm7p8UosrOzPYRo60fd3B/1Dukc=
-github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704 h1:sdLkU07gS60g16e0VEHwF+KDX4ROZJS5QgnloWyUG30=
-github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704/go.mod h1:80xsUppuf2iNgiThH2bzDIN5204p5E93z+YtNnAJlHA=
+github.com/openshift/controller-tools v0.12.1-0.20250108094724-6eb6da5d6efd h1:+tHtYnbIIT0NZurG+MpoyHArg27ysMUzViFhbM3/Erw=
+github.com/openshift/controller-tools v0.12.1-0.20250108094724-6eb6da5d6efd/go.mod h1:80xsUppuf2iNgiThH2bzDIN5204p5E93z+YtNnAJlHA=
 github.com/openshift/crd-schema-checker v0.0.0-20241113192003-573763d3107a h1:gBheMF1vVwxfnuGHJ82f/nmUATdtewq60/yhbBqD4+M=
 github.com/openshift/crd-schema-checker v0.0.0-20241113192003-573763d3107a/go.mod h1:sTxJ4ZFW9r9fEdbW2v0yMRi6NcyTbx0fII4p83IQ+L8=
 github.com/openshift/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20241125210059-e3abfef0b992 h1:UHSO67L/pCyCcqZphO4PiX638s6QrpJN8OBYMkFIeYE=

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -2189,7 +2189,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/controller-tools v0.15.0 => github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704
+# sigs.k8s.io/controller-tools v0.15.0 => github.com/openshift/controller-tools v0.12.1-0.20250108094724-6eb6da5d6efd
 ## explicit; go 1.22.0
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
@@ -2220,5 +2220,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20241105174925-ead1ef573704
+# sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20250108094724-6eb6da5d6efd
 # k8s.io/apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/apiserver v0.0.0-20241125210059-e3abfef0b992

--- a/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
+++ b/tools/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/patch_validation.go
@@ -124,7 +124,7 @@ func (m FeatureSetXValidation) ApplyFirst() {}
 type FeatureGateEnum struct {
 	// FeatureGateNames represents the optional feature gates that can enable this field.
 	// If any of the feature gates are enabled, the field will be enabled.
-	FeatureGateNames []string `marker:"featureGate"`
+	FeatureGateNames []string `marker:"featureGate,optional"`
 	// RequiredFeatureGateNames represents the required feature gates that must be enabled to enable this field.
 	// If any of the required feature gates are not enabled, the field will not be enabled.
 	RequiredFeatureGateNames []string `marker:"requiredFeatureGate,optional"`
@@ -132,6 +132,10 @@ type FeatureGateEnum struct {
 }
 
 func (m FeatureGateEnum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+	if len(m.FeatureGateNames)+len(m.RequiredFeatureGateNames) == 0 {
+		return fmt.Errorf("marker %s requires at least one of featureGate or requiredFeatureGate", OpenShiftFeatureGateAwareEnumMarkerName)
+	}
+
 	if !FeatureGatesForCurrentFile.HasAny(append(m.FeatureGateNames, m.RequiredFeatureGateNames...)...) {
 		// No required or optional feature gates are enabled, so we don't need to apply this marker
 		return nil
@@ -163,7 +167,7 @@ func (m FeatureGateEnum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 type FeatureGateMaxItems struct {
 	// FeatureGateNames represents the optional feature gates that can enable this field.
 	// If any of the feature gates are enabled, the field will be enabled.
-	FeatureGateNames []string `marker:"featureGate"`
+	FeatureGateNames []string `marker:"featureGate,optional"`
 	// RequiredFeatureGateNames represents the required feature gates that must be enabled to enable this field.
 	// If any of the required feature gates are not enabled, the field will not be enabled.
 	RequiredFeatureGateNames []string `marker:"requiredFeatureGate,optional"`
@@ -171,6 +175,10 @@ type FeatureGateMaxItems struct {
 }
 
 func (m FeatureGateMaxItems) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+	if len(m.FeatureGateNames)+len(m.RequiredFeatureGateNames) == 0 {
+		return fmt.Errorf("marker %s requires at least one of featureGate or requiredFeatureGate", OpenShiftFeatureGateAwareMaxItemsMarkerName)
+	}
+
 	if !FeatureGatesForCurrentFile.HasAny(append(m.FeatureGateNames, m.RequiredFeatureGateNames...)...) {
 		// No required or optional feature gates are enabled, so we don't need to apply this marker
 		return nil
@@ -192,7 +200,7 @@ func (m FeatureGateMaxItems) ApplyToSchema(schema *apiext.JSONSchemaProps) error
 type FeatureGateXValidation struct {
 	// FeatureGateNames represents the optional feature gates that can enable this field.
 	// If any of the feature gates are enabled, the field will be enabled.
-	FeatureGateNames []string `marker:"featureGate"`
+	FeatureGateNames []string `marker:"featureGate,optional"`
 	// RequiredFeatureGateNames represents the required feature gates that must be enabled to enable this field.
 	// If any of the required feature gates are not enabled, the field will not be enabled.
 	RequiredFeatureGateNames []string `marker:"requiredFeatureGate,optional"`
@@ -201,6 +209,10 @@ type FeatureGateXValidation struct {
 }
 
 func (m FeatureGateXValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+	if len(m.FeatureGateNames)+len(m.RequiredFeatureGateNames) == 0 {
+		return fmt.Errorf("marker %s requires at least one of featureGate or requiredFeatureGate", OpenShiftFeatureGateAwareXValidationMarkerName)
+	}
+
 	if !FeatureGatesForCurrentFile.HasAny(append(m.FeatureGateNames, m.RequiredFeatureGateNames...)...) {
 		// No required or optional feature gates are enabled, so we don't need to apply this marker
 		return nil


### PR DESCRIPTION
We have a couple of examples (for example https://github.com/openshift/api/pull/2131) of validations that end up relying on multiple feature gates. Thus far, this has caused an issue where one gate is promoted, but the other is not, since the validation cannot be automatically handled if the gated validation is promoted prior to the ungated dependent gate.

This PR updates the example API with a second Example2 feature gate, and then adds a validation that is only enabled when both the Example and Example2 feature gates are enabled (as can be seen by the fact that the validation is enabled in Custom and Dev CRDs, but not TPNU where Example2 is disabled.

I need to merge https://github.com/openshift/kubernetes-sigs-controller-tools/pull/25 and update the vendor here before we can merge this

CC @gcs278 @deads2k 