### PR TITLE
Change OCL CRD deployment to v1 from v1alpha1

### DIFF
--- a/hack/update-payload-crds.sh
+++ b/hack/update-payload-crds.sh
@@ -22,12 +22,9 @@ crd_globs="\
     operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers*.crd.yaml
     config/v1/zz_generated.crd-manifests/0000_10_openshift-controller-manager_01_builds*.crd.yaml
     operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers*.crd.yaml
-    machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_containerruntimeconfigs*.crd.yaml
-    machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs*.crd.yaml
-    machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_kubeletconfigs*.crd.yaml
-    machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigpools*.crd.yaml
-    machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigs*.crd.yaml
-    machineconfiguration/v1alpha1/zz_generated.crd-manifests/*.crd.yaml
+    machineconfiguration/v1/zz_generated.crd-manifests/*.crd.yaml
+    machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes*.crd.yaml
+    machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_pinnedimagesets*.crd.yaml
     operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations*.crd.yaml
     config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies*.crd.yaml
     config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagepolicies*.crd.yaml

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-CustomNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2090
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -35,12 +35,15 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Failed")].status
       name: Failed
       type: string
-    name: v1alpha1
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: |-
           MachineOSBuild describes a build process managed and deployed by the MCO
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -60,132 +63,177 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec describes the configuration of the machine os build
+            description: |-
+              spec describes the configuration of the machine os build.
+              It is immutable once set.
             properties:
-              configGeneration:
-                description: configGeneration tracks which version of MachineOSConfig
-                  this build is based off of
-                format: int64
-                minimum: 1
-                type: integer
-              desiredConfig:
-                description: desiredConfig is the desired config we want to build
-                  an image for.
+              machineConfig:
+                description: machineConfig points to the rendered MachineConfig resource
+                  to be included in this image build.
                 properties:
                   name:
-                    description: name is the name of the rendered MachineConfig object.
+                    description: |-
+                      name is the name of the rendered MachineConfig object.
+                      This value should be between 10 and 253 characters, and must contain only lowercase
+                      alphanumeric characters, hyphens and periods, and should start and end with an alphanumeric character.
                     maxLength: 253
-                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    minLength: 10
                     type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                 required:
                 - name
                 type: object
               machineOSConfig:
-                description: machineOSConfig is the config object which the build
-                  is based off of
+                description: machineOSConfig references the MachineOSConfig resource
+                  that this image build extends.
                 properties:
                   name:
-                    description: name of the MachineOSConfig
+                    description: |-
+                      name of the MachineOSConfig.
+                      The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                 required:
                 - name
                 type: object
-              renderedImagePushspec:
+              renderedImagePushSpec:
                 description: |-
-                  renderedImagePushspec is set from the MachineOSConfig
-                  The format of the image pullspec is:
-                  host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>
+                  renderedImagePushSpec is set by the Machine Config Operator from the MachineOSConfig object this build is attached to.
+                  This field describes the location of the final image, which will be pushed by the build once complete.
+                  The format of the image push spec is: host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>.
+                  The length of the push spec must be between 1 to 447 characters.
                 maxLength: 447
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: the OCI Image reference must end with a valid :<tag>, where
-                    '<digest>' is 64 characters long and '<tag>' is any valid string  Or
-                    it must be a valid .svc followed by a port, repository, image
-                    name, and tag.
-                  rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
-                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
                 - message: the OCI Image name should follow the host[:port][/namespace]/name
                     format, resembling a valid URL without the scheme. Or it must
                     be a valid .svc followed by a port, repository, image name, and
                     tag.
-                  rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
-              version:
-                description: version tracks the newest MachineOSBuild for each MachineOSConfig
-                format: int64
-                minimum: 1
-                type: integer
+                  rule: self.matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?(/[a-zA-Z0-9-_]{1,61})*/[a-zA-Z0-9-_.]+:[a-zA-Z0-9._-]+$')
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$')
             required:
-            - configGeneration
-            - desiredConfig
+            - machineConfig
             - machineOSConfig
-            - renderedImagePushspec
-            - version
+            - renderedImagePushSpec
             type: object
             x-kubernetes-validations:
             - message: machineOSBuildSpec is immutable once set
               rule: self == oldSelf
           status:
-            description: status describes the lst observed state of this machine os
-              build
+            description: status describes the last observed state of this machine
+              os build.
             properties:
               buildEnd:
-                description: buildEnd describes when the build ended.
+                description: |-
+                  buildEnd is the timestamp corresponding to completion of the builder backend.
+                  When omitted the build has either not been started, or is in progress.
+                  It will be populated once the build completes, fails or is interrupted.
                 format: date-time
                 type: string
                 x-kubernetes-validations:
                 - message: buildEnd is immutable once set
                   rule: self == oldSelf
               buildStart:
-                description: buildStart describes when the build started.
+                description: buildStart is the timestamp corresponding to the build
+                  controller initiating the build backend for this MachineOSBuild.
                 format: date-time
                 type: string
                 x-kubernetes-validations:
                 - message: buildStart is immutable once set
                   rule: self == oldSelf
-              builderReference:
-                description: ImageBuilderType describes the image builder set in the
-                  MachineOSConfig
+              builder:
+                description: builder describes the image builder backend used for
+                  this build.
                 properties:
-                  buildPod:
-                    description: relatedObjects is a list of objects that are related
-                      to the build process.
+                  imageBuilderType:
+                    description: |-
+                      imageBuilderType describes the type of image builder used to build this image.
+                      Valid values are Job only.
+                      When set to Job, a pod based builder, using buildah, is launched to build the specified image.
+                    type: string
+                  job:
+                    description: |-
+                      job is a reference to the job object that is managing the image build.
+                      This is required if the imageBuilderType is Job, and forbidden otherwise.
                     properties:
                       group:
-                        description: group of the referent.
+                        description: |-
+                          group of the referent.
+                          The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                          Example: "", "apps", "build.openshift.io", etc.
+                        maxLength: 253
                         type: string
+                        x-kubernetes-validations:
+                        - message: a lowercase RFC 1123 subdomain must consist of
+                            lower case alphanumeric characters, '-' or '.', and must
+                            start and end with an alphanumeric character.
+                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                       name:
-                        description: name of the referent.
+                        description: |-
+                          name of the referent.
+                          The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                        maxLength: 253
+                        minLength: 1
                         type: string
+                        x-kubernetes-validations:
+                        - message: a lowercase RFC 1123 subdomain must consist of
+                            lower case alphanumeric characters, '-' or '.', and must
+                            start and end with an alphanumeric character.
+                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                       namespace:
-                        description: namespace of the referent.
+                        description: |-
+                          namespace of the referent.
+                          This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                          and should start and end with an alphanumeric character.
+                        maxLength: 63
+                        minLength: 1
                         type: string
+                        x-kubernetes-validations:
+                        - message: the value must consist of only lowercase alphanumeric
+                            characters and hyphens
+                          rule: '!format.dns1123Label().validate(self).hasValue()'
                       resource:
-                        description: resource of the referent.
+                        description: |-
+                          resource of the referent.
+                          This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                          and should start and end with an alphanumeric character.
+                          Example: "deployments", "deploymentconfigs", "pods", etc.
+                        maxLength: 63
+                        minLength: 1
                         type: string
+                        x-kubernetes-validations:
+                        - message: the value must consist of only lowercase alphanumeric
+                            characters and hyphens
+                          rule: '!format.dns1123Label().validate(self).hasValue()'
                     required:
                     - group
                     - name
                     - resource
                     type: object
-                  imageBuilderType:
-                    description: imageBuilderType describes the image builder set
-                      in the MachineOSConfig
-                    type: string
                 required:
                 - imageBuilderType
                 type: object
                 x-kubernetes-validations:
-                - message: buildPod is required when imageBuilderType is PodImageBuilder,
-                    and forbidden otherwise
-                  rule: 'has(self.imageBuilderType) && self.imageBuilderType == ''PodImageBuilder''
-                    ?  true : !has(self.buildPod)'
+                - message: job is required when imageBuilderType is Job, and forbidden
+                    otherwise
+                  rule: 'has(self.imageBuilderType) && self.imageBuilderType == ''Job''
+                    ?  has(self.job) : !has(self.job)'
               conditions:
                 description: |-
                   conditions are state related conditions for the build. Valid types are:
-                  Prepared, Building, Failed, Interrupted, and Succeeded
-                  once a Build is marked as Failed, no future conditions can be set. This is enforced by the MCO.
+                  Prepared, Building, Failed, Interrupted, and Succeeded.
+                  Once a Build is marked as Failed, Interrupted or Succeeded, no future conditions can be set.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -240,47 +288,111 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              finalImagePullspec:
-                description: finalImagePushSpec describes the fully qualified pushspec
-                  produced by this build that the final image can be. Must be in sha
-                  format.
+                x-kubernetes-validations:
+                - message: once a Failed condition is set, conditions are immutable
+                  rule: 'oldSelf.exists(x, x.type==''Failed'' && x.status==''True'')
+                    ? self==oldSelf : true'
+                - message: once an Interrupted condition is set, conditions are immutable
+                  rule: 'oldSelf.exists(x, x.type==''Interrupted'' && x.status==''True'')
+                    ? self==oldSelf : true'
+                - message: once an Succeeded condition is set, conditions are immutable
+                  rule: 'oldSelf.exists(x, x.type==''Succeeded'' && x.status==''True'')
+                    ? self==oldSelf : true'
+              digestedImagePushSpec:
+                description: |-
+                  digestedImagePushSpec describes the fully qualified push spec produced by this build.
+                  The format of the push spec is: host[:port][/namespace]/name@sha256:<digest>,
+                  where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                  The length of the whole spec must be between 1 to 447 characters.
+                maxLength: 447
+                minLength: 1
                 type: string
                 x-kubernetes-validations:
                 - message: the OCI Image reference must end with a valid '@sha256:<digest>'
                     suffix, where '<digest>' is 64 characters long
-                  rule: ((self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$')))
+                  rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme
+                  rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
               relatedObjects:
-                description: relatedObjects is a list of objects that are related
-                  to the build process.
+                description: |-
+                  relatedObjects is a list of references to ephemeral objects such as ConfigMaps or Secrets that are meant to be consumed while the build process runs.
+                  After a successful build or when this MachineOSBuild is deleted, these ephemeral objects will be removed.
+                  In the event of a failed build, the objects will remain until the build is removed to allow for inspection.
                 items:
                   description: ObjectReference contains enough information to let
                     you inspect or modify the referred object.
                   properties:
                     group:
-                      description: group of the referent.
+                      description: |-
+                        group of the referent.
+                        The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                        Example: "", "apps", "build.openshift.io", etc.
+                      maxLength: 253
                       type: string
+                      x-kubernetes-validations:
+                      - message: a lowercase RFC 1123 subdomain must consist of lower
+                          case alphanumeric characters, '-' or '.', and must start
+                          and end with an alphanumeric character.
+                        rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                     name:
-                      description: name of the referent.
+                      description: |-
+                        name of the referent.
+                        The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                      maxLength: 253
+                      minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: a lowercase RFC 1123 subdomain must consist of lower
+                          case alphanumeric characters, '-' or '.', and must start
+                          and end with an alphanumeric character.
+                        rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                     namespace:
-                      description: namespace of the referent.
+                      description: |-
+                        namespace of the referent.
+                        This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                        and should start and end with an alphanumeric character.
+                      maxLength: 63
+                      minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: the value must consist of only lowercase alphanumeric
+                          characters and hyphens
+                        rule: '!format.dns1123Label().validate(self).hasValue()'
                     resource:
-                      description: resource of the referent.
+                      description: |-
+                        resource of the referent.
+                        This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                        and should start and end with an alphanumeric character.
+                        Example: "deployments", "deploymentconfigs", "pods", etc.
+                      maxLength: 63
+                      minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: the value must consist of only lowercase alphanumeric
+                          characters and hyphens
+                        rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
                   - group
                   - name
                   - resource
                   type: object
+                maxItems: 10
                 type: array
-            required:
-            - buildStart
+                x-kubernetes-list-map-keys:
+                - name
+                - resource
+                x-kubernetes-list-type: map
             type: object
+            x-kubernetes-validations:
+            - message: buildEnd must be after buildStart
+              rule: 'has(self.buildEnd) ? has(self.buildStart) && timestamp(self.buildStart)
+                < timestamp(self.buildEnd) : true'
         required:
         - spec
         type: object

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-DevPreviewNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2090
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -35,12 +35,15 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Failed")].status
       name: Failed
       type: string
-    name: v1alpha1
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: |-
           MachineOSBuild describes a build process managed and deployed by the MCO
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -60,132 +63,177 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec describes the configuration of the machine os build
+            description: |-
+              spec describes the configuration of the machine os build.
+              It is immutable once set.
             properties:
-              configGeneration:
-                description: configGeneration tracks which version of MachineOSConfig
-                  this build is based off of
-                format: int64
-                minimum: 1
-                type: integer
-              desiredConfig:
-                description: desiredConfig is the desired config we want to build
-                  an image for.
+              machineConfig:
+                description: machineConfig points to the rendered MachineConfig resource
+                  to be included in this image build.
                 properties:
                   name:
-                    description: name is the name of the rendered MachineConfig object.
+                    description: |-
+                      name is the name of the rendered MachineConfig object.
+                      This value should be between 10 and 253 characters, and must contain only lowercase
+                      alphanumeric characters, hyphens and periods, and should start and end with an alphanumeric character.
                     maxLength: 253
-                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    minLength: 10
                     type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                 required:
                 - name
                 type: object
               machineOSConfig:
-                description: machineOSConfig is the config object which the build
-                  is based off of
+                description: machineOSConfig references the MachineOSConfig resource
+                  that this image build extends.
                 properties:
                   name:
-                    description: name of the MachineOSConfig
+                    description: |-
+                      name of the MachineOSConfig.
+                      The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                 required:
                 - name
                 type: object
-              renderedImagePushspec:
+              renderedImagePushSpec:
                 description: |-
-                  renderedImagePushspec is set from the MachineOSConfig
-                  The format of the image pullspec is:
-                  host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>
+                  renderedImagePushSpec is set by the Machine Config Operator from the MachineOSConfig object this build is attached to.
+                  This field describes the location of the final image, which will be pushed by the build once complete.
+                  The format of the image push spec is: host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>.
+                  The length of the push spec must be between 1 to 447 characters.
                 maxLength: 447
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: the OCI Image reference must end with a valid :<tag>, where
-                    '<digest>' is 64 characters long and '<tag>' is any valid string  Or
-                    it must be a valid .svc followed by a port, repository, image
-                    name, and tag.
-                  rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
-                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
                 - message: the OCI Image name should follow the host[:port][/namespace]/name
                     format, resembling a valid URL without the scheme. Or it must
                     be a valid .svc followed by a port, repository, image name, and
                     tag.
-                  rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
-              version:
-                description: version tracks the newest MachineOSBuild for each MachineOSConfig
-                format: int64
-                minimum: 1
-                type: integer
+                  rule: self.matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?(/[a-zA-Z0-9-_]{1,61})*/[a-zA-Z0-9-_.]+:[a-zA-Z0-9._-]+$')
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$')
             required:
-            - configGeneration
-            - desiredConfig
+            - machineConfig
             - machineOSConfig
-            - renderedImagePushspec
-            - version
+            - renderedImagePushSpec
             type: object
             x-kubernetes-validations:
             - message: machineOSBuildSpec is immutable once set
               rule: self == oldSelf
           status:
-            description: status describes the lst observed state of this machine os
-              build
+            description: status describes the last observed state of this machine
+              os build.
             properties:
               buildEnd:
-                description: buildEnd describes when the build ended.
+                description: |-
+                  buildEnd is the timestamp corresponding to completion of the builder backend.
+                  When omitted the build has either not been started, or is in progress.
+                  It will be populated once the build completes, fails or is interrupted.
                 format: date-time
                 type: string
                 x-kubernetes-validations:
                 - message: buildEnd is immutable once set
                   rule: self == oldSelf
               buildStart:
-                description: buildStart describes when the build started.
+                description: buildStart is the timestamp corresponding to the build
+                  controller initiating the build backend for this MachineOSBuild.
                 format: date-time
                 type: string
                 x-kubernetes-validations:
                 - message: buildStart is immutable once set
                   rule: self == oldSelf
-              builderReference:
-                description: ImageBuilderType describes the image builder set in the
-                  MachineOSConfig
+              builder:
+                description: builder describes the image builder backend used for
+                  this build.
                 properties:
-                  buildPod:
-                    description: relatedObjects is a list of objects that are related
-                      to the build process.
+                  imageBuilderType:
+                    description: |-
+                      imageBuilderType describes the type of image builder used to build this image.
+                      Valid values are Job only.
+                      When set to Job, a pod based builder, using buildah, is launched to build the specified image.
+                    type: string
+                  job:
+                    description: |-
+                      job is a reference to the job object that is managing the image build.
+                      This is required if the imageBuilderType is Job, and forbidden otherwise.
                     properties:
                       group:
-                        description: group of the referent.
+                        description: |-
+                          group of the referent.
+                          The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                          Example: "", "apps", "build.openshift.io", etc.
+                        maxLength: 253
                         type: string
+                        x-kubernetes-validations:
+                        - message: a lowercase RFC 1123 subdomain must consist of
+                            lower case alphanumeric characters, '-' or '.', and must
+                            start and end with an alphanumeric character.
+                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                       name:
-                        description: name of the referent.
+                        description: |-
+                          name of the referent.
+                          The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                        maxLength: 253
+                        minLength: 1
                         type: string
+                        x-kubernetes-validations:
+                        - message: a lowercase RFC 1123 subdomain must consist of
+                            lower case alphanumeric characters, '-' or '.', and must
+                            start and end with an alphanumeric character.
+                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                       namespace:
-                        description: namespace of the referent.
+                        description: |-
+                          namespace of the referent.
+                          This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                          and should start and end with an alphanumeric character.
+                        maxLength: 63
+                        minLength: 1
                         type: string
+                        x-kubernetes-validations:
+                        - message: the value must consist of only lowercase alphanumeric
+                            characters and hyphens
+                          rule: '!format.dns1123Label().validate(self).hasValue()'
                       resource:
-                        description: resource of the referent.
+                        description: |-
+                          resource of the referent.
+                          This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                          and should start and end with an alphanumeric character.
+                          Example: "deployments", "deploymentconfigs", "pods", etc.
+                        maxLength: 63
+                        minLength: 1
                         type: string
+                        x-kubernetes-validations:
+                        - message: the value must consist of only lowercase alphanumeric
+                            characters and hyphens
+                          rule: '!format.dns1123Label().validate(self).hasValue()'
                     required:
                     - group
                     - name
                     - resource
                     type: object
-                  imageBuilderType:
-                    description: imageBuilderType describes the image builder set
-                      in the MachineOSConfig
-                    type: string
                 required:
                 - imageBuilderType
                 type: object
                 x-kubernetes-validations:
-                - message: buildPod is required when imageBuilderType is PodImageBuilder,
-                    and forbidden otherwise
-                  rule: 'has(self.imageBuilderType) && self.imageBuilderType == ''PodImageBuilder''
-                    ?  true : !has(self.buildPod)'
+                - message: job is required when imageBuilderType is Job, and forbidden
+                    otherwise
+                  rule: 'has(self.imageBuilderType) && self.imageBuilderType == ''Job''
+                    ?  has(self.job) : !has(self.job)'
               conditions:
                 description: |-
                   conditions are state related conditions for the build. Valid types are:
-                  Prepared, Building, Failed, Interrupted, and Succeeded
-                  once a Build is marked as Failed, no future conditions can be set. This is enforced by the MCO.
+                  Prepared, Building, Failed, Interrupted, and Succeeded.
+                  Once a Build is marked as Failed, Interrupted or Succeeded, no future conditions can be set.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -240,47 +288,111 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              finalImagePullspec:
-                description: finalImagePushSpec describes the fully qualified pushspec
-                  produced by this build that the final image can be. Must be in sha
-                  format.
+                x-kubernetes-validations:
+                - message: once a Failed condition is set, conditions are immutable
+                  rule: 'oldSelf.exists(x, x.type==''Failed'' && x.status==''True'')
+                    ? self==oldSelf : true'
+                - message: once an Interrupted condition is set, conditions are immutable
+                  rule: 'oldSelf.exists(x, x.type==''Interrupted'' && x.status==''True'')
+                    ? self==oldSelf : true'
+                - message: once an Succeeded condition is set, conditions are immutable
+                  rule: 'oldSelf.exists(x, x.type==''Succeeded'' && x.status==''True'')
+                    ? self==oldSelf : true'
+              digestedImagePushSpec:
+                description: |-
+                  digestedImagePushSpec describes the fully qualified push spec produced by this build.
+                  The format of the push spec is: host[:port][/namespace]/name@sha256:<digest>,
+                  where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                  The length of the whole spec must be between 1 to 447 characters.
+                maxLength: 447
+                minLength: 1
                 type: string
                 x-kubernetes-validations:
                 - message: the OCI Image reference must end with a valid '@sha256:<digest>'
                     suffix, where '<digest>' is 64 characters long
-                  rule: ((self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$')))
+                  rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme
+                  rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
               relatedObjects:
-                description: relatedObjects is a list of objects that are related
-                  to the build process.
+                description: |-
+                  relatedObjects is a list of references to ephemeral objects such as ConfigMaps or Secrets that are meant to be consumed while the build process runs.
+                  After a successful build or when this MachineOSBuild is deleted, these ephemeral objects will be removed.
+                  In the event of a failed build, the objects will remain until the build is removed to allow for inspection.
                 items:
                   description: ObjectReference contains enough information to let
                     you inspect or modify the referred object.
                   properties:
                     group:
-                      description: group of the referent.
+                      description: |-
+                        group of the referent.
+                        The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                        Example: "", "apps", "build.openshift.io", etc.
+                      maxLength: 253
                       type: string
+                      x-kubernetes-validations:
+                      - message: a lowercase RFC 1123 subdomain must consist of lower
+                          case alphanumeric characters, '-' or '.', and must start
+                          and end with an alphanumeric character.
+                        rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                     name:
-                      description: name of the referent.
+                      description: |-
+                        name of the referent.
+                        The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                      maxLength: 253
+                      minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: a lowercase RFC 1123 subdomain must consist of lower
+                          case alphanumeric characters, '-' or '.', and must start
+                          and end with an alphanumeric character.
+                        rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                     namespace:
-                      description: namespace of the referent.
+                      description: |-
+                        namespace of the referent.
+                        This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                        and should start and end with an alphanumeric character.
+                      maxLength: 63
+                      minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: the value must consist of only lowercase alphanumeric
+                          characters and hyphens
+                        rule: '!format.dns1123Label().validate(self).hasValue()'
                     resource:
-                      description: resource of the referent.
+                      description: |-
+                        resource of the referent.
+                        This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                        and should start and end with an alphanumeric character.
+                        Example: "deployments", "deploymentconfigs", "pods", etc.
+                      maxLength: 63
+                      minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: the value must consist of only lowercase alphanumeric
+                          characters and hyphens
+                        rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
                   - group
                   - name
                   - resource
                   type: object
+                maxItems: 10
                 type: array
-            required:
-            - buildStart
+                x-kubernetes-list-map-keys:
+                - name
+                - resource
+                x-kubernetes-list-type: map
             type: object
+            x-kubernetes-validations:
+            - message: buildEnd must be after buildStart
+              rule: 'has(self.buildEnd) ? has(self.buildStart) && timestamp(self.buildStart)
+                < timestamp(self.buildEnd) : true'
         required:
         - spec
         type: object

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds-TechPreviewNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2090
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -35,12 +35,15 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Failed")].status
       name: Failed
       type: string
-    name: v1alpha1
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: |-
           MachineOSBuild describes a build process managed and deployed by the MCO
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -60,132 +63,177 @@ spec:
           metadata:
             type: object
           spec:
-            description: spec describes the configuration of the machine os build
+            description: |-
+              spec describes the configuration of the machine os build.
+              It is immutable once set.
             properties:
-              configGeneration:
-                description: configGeneration tracks which version of MachineOSConfig
-                  this build is based off of
-                format: int64
-                minimum: 1
-                type: integer
-              desiredConfig:
-                description: desiredConfig is the desired config we want to build
-                  an image for.
+              machineConfig:
+                description: machineConfig points to the rendered MachineConfig resource
+                  to be included in this image build.
                 properties:
                   name:
-                    description: name is the name of the rendered MachineConfig object.
+                    description: |-
+                      name is the name of the rendered MachineConfig object.
+                      This value should be between 10 and 253 characters, and must contain only lowercase
+                      alphanumeric characters, hyphens and periods, and should start and end with an alphanumeric character.
                     maxLength: 253
-                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                    minLength: 10
                     type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                 required:
                 - name
                 type: object
               machineOSConfig:
-                description: machineOSConfig is the config object which the build
-                  is based off of
+                description: machineOSConfig references the MachineOSConfig resource
+                  that this image build extends.
                 properties:
                   name:
-                    description: name of the MachineOSConfig
+                    description: |-
+                      name of the MachineOSConfig.
+                      The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                 required:
                 - name
                 type: object
-              renderedImagePushspec:
+              renderedImagePushSpec:
                 description: |-
-                  renderedImagePushspec is set from the MachineOSConfig
-                  The format of the image pullspec is:
-                  host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>
+                  renderedImagePushSpec is set by the Machine Config Operator from the MachineOSConfig object this build is attached to.
+                  This field describes the location of the final image, which will be pushed by the build once complete.
+                  The format of the image push spec is: host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>.
+                  The length of the push spec must be between 1 to 447 characters.
                 maxLength: 447
                 minLength: 1
                 type: string
                 x-kubernetes-validations:
-                - message: the OCI Image reference must end with a valid :<tag>, where
-                    '<digest>' is 64 characters long and '<tag>' is any valid string  Or
-                    it must be a valid .svc followed by a port, repository, image
-                    name, and tag.
-                  rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
-                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
                 - message: the OCI Image name should follow the host[:port][/namespace]/name
                     format, resembling a valid URL without the scheme. Or it must
                     be a valid .svc followed by a port, repository, image name, and
                     tag.
-                  rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
-              version:
-                description: version tracks the newest MachineOSBuild for each MachineOSConfig
-                format: int64
-                minimum: 1
-                type: integer
+                  rule: self.matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?(/[a-zA-Z0-9-_]{1,61})*/[a-zA-Z0-9-_.]+:[a-zA-Z0-9._-]+$')
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$')
             required:
-            - configGeneration
-            - desiredConfig
+            - machineConfig
             - machineOSConfig
-            - renderedImagePushspec
-            - version
+            - renderedImagePushSpec
             type: object
             x-kubernetes-validations:
             - message: machineOSBuildSpec is immutable once set
               rule: self == oldSelf
           status:
-            description: status describes the lst observed state of this machine os
-              build
+            description: status describes the last observed state of this machine
+              os build.
             properties:
               buildEnd:
-                description: buildEnd describes when the build ended.
+                description: |-
+                  buildEnd is the timestamp corresponding to completion of the builder backend.
+                  When omitted the build has either not been started, or is in progress.
+                  It will be populated once the build completes, fails or is interrupted.
                 format: date-time
                 type: string
                 x-kubernetes-validations:
                 - message: buildEnd is immutable once set
                   rule: self == oldSelf
               buildStart:
-                description: buildStart describes when the build started.
+                description: buildStart is the timestamp corresponding to the build
+                  controller initiating the build backend for this MachineOSBuild.
                 format: date-time
                 type: string
                 x-kubernetes-validations:
                 - message: buildStart is immutable once set
                   rule: self == oldSelf
-              builderReference:
-                description: ImageBuilderType describes the image builder set in the
-                  MachineOSConfig
+              builder:
+                description: builder describes the image builder backend used for
+                  this build.
                 properties:
-                  buildPod:
-                    description: relatedObjects is a list of objects that are related
-                      to the build process.
+                  imageBuilderType:
+                    description: |-
+                      imageBuilderType describes the type of image builder used to build this image.
+                      Valid values are Job only.
+                      When set to Job, a pod based builder, using buildah, is launched to build the specified image.
+                    type: string
+                  job:
+                    description: |-
+                      job is a reference to the job object that is managing the image build.
+                      This is required if the imageBuilderType is Job, and forbidden otherwise.
                     properties:
                       group:
-                        description: group of the referent.
+                        description: |-
+                          group of the referent.
+                          The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                          Example: "", "apps", "build.openshift.io", etc.
+                        maxLength: 253
                         type: string
+                        x-kubernetes-validations:
+                        - message: a lowercase RFC 1123 subdomain must consist of
+                            lower case alphanumeric characters, '-' or '.', and must
+                            start and end with an alphanumeric character.
+                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                       name:
-                        description: name of the referent.
+                        description: |-
+                          name of the referent.
+                          The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                        maxLength: 253
+                        minLength: 1
                         type: string
+                        x-kubernetes-validations:
+                        - message: a lowercase RFC 1123 subdomain must consist of
+                            lower case alphanumeric characters, '-' or '.', and must
+                            start and end with an alphanumeric character.
+                          rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                       namespace:
-                        description: namespace of the referent.
+                        description: |-
+                          namespace of the referent.
+                          This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                          and should start and end with an alphanumeric character.
+                        maxLength: 63
+                        minLength: 1
                         type: string
+                        x-kubernetes-validations:
+                        - message: the value must consist of only lowercase alphanumeric
+                            characters and hyphens
+                          rule: '!format.dns1123Label().validate(self).hasValue()'
                       resource:
-                        description: resource of the referent.
+                        description: |-
+                          resource of the referent.
+                          This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                          and should start and end with an alphanumeric character.
+                          Example: "deployments", "deploymentconfigs", "pods", etc.
+                        maxLength: 63
+                        minLength: 1
                         type: string
+                        x-kubernetes-validations:
+                        - message: the value must consist of only lowercase alphanumeric
+                            characters and hyphens
+                          rule: '!format.dns1123Label().validate(self).hasValue()'
                     required:
                     - group
                     - name
                     - resource
                     type: object
-                  imageBuilderType:
-                    description: imageBuilderType describes the image builder set
-                      in the MachineOSConfig
-                    type: string
                 required:
                 - imageBuilderType
                 type: object
                 x-kubernetes-validations:
-                - message: buildPod is required when imageBuilderType is PodImageBuilder,
-                    and forbidden otherwise
-                  rule: 'has(self.imageBuilderType) && self.imageBuilderType == ''PodImageBuilder''
-                    ?  true : !has(self.buildPod)'
+                - message: job is required when imageBuilderType is Job, and forbidden
+                    otherwise
+                  rule: 'has(self.imageBuilderType) && self.imageBuilderType == ''Job''
+                    ?  has(self.job) : !has(self.job)'
               conditions:
                 description: |-
                   conditions are state related conditions for the build. Valid types are:
-                  Prepared, Building, Failed, Interrupted, and Succeeded
-                  once a Build is marked as Failed, no future conditions can be set. This is enforced by the MCO.
+                  Prepared, Building, Failed, Interrupted, and Succeeded.
+                  Once a Build is marked as Failed, Interrupted or Succeeded, no future conditions can be set.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -240,47 +288,111 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
                 type: array
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              finalImagePullspec:
-                description: finalImagePushSpec describes the fully qualified pushspec
-                  produced by this build that the final image can be. Must be in sha
-                  format.
+                x-kubernetes-validations:
+                - message: once a Failed condition is set, conditions are immutable
+                  rule: 'oldSelf.exists(x, x.type==''Failed'' && x.status==''True'')
+                    ? self==oldSelf : true'
+                - message: once an Interrupted condition is set, conditions are immutable
+                  rule: 'oldSelf.exists(x, x.type==''Interrupted'' && x.status==''True'')
+                    ? self==oldSelf : true'
+                - message: once an Succeeded condition is set, conditions are immutable
+                  rule: 'oldSelf.exists(x, x.type==''Succeeded'' && x.status==''True'')
+                    ? self==oldSelf : true'
+              digestedImagePushSpec:
+                description: |-
+                  digestedImagePushSpec describes the fully qualified push spec produced by this build.
+                  The format of the push spec is: host[:port][/namespace]/name@sha256:<digest>,
+                  where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                  The length of the whole spec must be between 1 to 447 characters.
+                maxLength: 447
+                minLength: 1
                 type: string
                 x-kubernetes-validations:
                 - message: the OCI Image reference must end with a valid '@sha256:<digest>'
                     suffix, where '<digest>' is 64 characters long
-                  rule: ((self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$')))
+                  rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme
+                  rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
               relatedObjects:
-                description: relatedObjects is a list of objects that are related
-                  to the build process.
+                description: |-
+                  relatedObjects is a list of references to ephemeral objects such as ConfigMaps or Secrets that are meant to be consumed while the build process runs.
+                  After a successful build or when this MachineOSBuild is deleted, these ephemeral objects will be removed.
+                  In the event of a failed build, the objects will remain until the build is removed to allow for inspection.
                 items:
                   description: ObjectReference contains enough information to let
                     you inspect or modify the referred object.
                   properties:
                     group:
-                      description: group of the referent.
+                      description: |-
+                        group of the referent.
+                        The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                        Example: "", "apps", "build.openshift.io", etc.
+                      maxLength: 253
                       type: string
+                      x-kubernetes-validations:
+                      - message: a lowercase RFC 1123 subdomain must consist of lower
+                          case alphanumeric characters, '-' or '.', and must start
+                          and end with an alphanumeric character.
+                        rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                     name:
-                      description: name of the referent.
+                      description: |-
+                        name of the referent.
+                        The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                      maxLength: 253
+                      minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: a lowercase RFC 1123 subdomain must consist of lower
+                          case alphanumeric characters, '-' or '.', and must start
+                          and end with an alphanumeric character.
+                        rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                     namespace:
-                      description: namespace of the referent.
+                      description: |-
+                        namespace of the referent.
+                        This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                        and should start and end with an alphanumeric character.
+                      maxLength: 63
+                      minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: the value must consist of only lowercase alphanumeric
+                          characters and hyphens
+                        rule: '!format.dns1123Label().validate(self).hasValue()'
                     resource:
-                      description: resource of the referent.
+                      description: |-
+                        resource of the referent.
+                        This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                        and should start and end with an alphanumeric character.
+                        Example: "deployments", "deploymentconfigs", "pods", etc.
+                      maxLength: 63
+                      minLength: 1
                       type: string
+                      x-kubernetes-validations:
+                      - message: the value must consist of only lowercase alphanumeric
+                          characters and hyphens
+                        rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
                   - group
                   - name
                   - resource
                   type: object
+                maxItems: 10
                 type: array
-            required:
-            - buildStart
+                x-kubernetes-list-map-keys:
+                - name
+                - resource
+                x-kubernetes-list-type: map
             type: object
+            x-kubernetes-validations:
+            - message: buildEnd must be after buildStart
+              rule: 'has(self.buildEnd) ? has(self.buildStart) && timestamp(self.buildStart)
+                < timestamp(self.buildEnd) : true'
         required:
         - spec
         type: object

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-CustomNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2090
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -19,12 +19,12 @@ spec:
     singular: machineosconfig
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: |-
           MachineOSConfig describes the configuration for a build process managed by the MCO
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -46,202 +46,156 @@ spec:
           spec:
             description: spec describes the configuration of the machineosconfig
             properties:
-              buildInputs:
-                description: buildInputs is where user input options for the build
-                  live
-                properties:
-                  baseImagePullSecret:
-                    description: |-
-                      baseImagePullSecret is the secret used to pull the base image.
-                      must live in the openshift-machine-config-operator namespace
-                    properties:
-                      name:
-                        description: |-
-                          name is the name of the secret used to push or pull this MachineOSConfig object.
-                          this secret must be in the openshift-machine-config-operator namespace.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  baseOSExtensionsImagePullspec:
-                    description: |-
-                      baseOSExtensionsImagePullspec is the base Extensions image used in the build process
-                      the MachineOSConfig object will use the in cluster image registry configuration.
-                      if you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf.
-                      The format of the image pullspec is:
-                      host[:port][/namespace]/name@sha256:<digest>
-                    maxLength: 447
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
-                        suffix, where '<digest>' is 64 characters long
-                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
-                    - message: the OCI Image name should follow the host[:port][/namespace]/name
-                        format, resembling a valid URL without the scheme
-                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                  baseOSImagePullspec:
-                    description: |-
-                      baseOSImagePullspec is the base OSImage we use to build our custom image.
-                      the MachineOSConfig object will use the in cluster image registry configuration.
-                      if you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf.
-                      The format of the image pullspec is:
-                      host[:port][/namespace]/name@sha256:<digest>
-                    maxLength: 447
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
-                        suffix, where '<digest>' is 64 characters long
-                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
-                    - message: the OCI Image name should follow the host[:port][/namespace]/name
-                        format, resembling a valid URL without the scheme
-                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                  containerFile:
-                    description: |-
-                      containerFile describes the custom data the user has specified to build into the image.
-                      this is also commonly called a Dockerfile and you can treat it as such. The content is the content of your Dockerfile.
-                    items:
-                      description: MachineOSContainerfile contains all custom content
-                        the user wants built into the image
-                      properties:
-                        containerfileArch:
-                          default: noarch
-                          description: |-
-                            containerfileArch describes the architecture this containerfile is to be built for
-                            this arch is optional. If the user does not specify an architecture, it is assumed
-                            that the content can be applied to all architectures, or in a single arch cluster: the only architecture.
-                          enum:
-                          - arm64
-                          - amd64
-                          - ppc64le
-                          - s390x
-                          - aarch64
-                          - x86_64
-                          - noarch
-                          type: string
-                        content:
-                          description: content is the custom content to be built
-                          type: string
-                      required:
-                      - content
-                      type: object
-                    maxItems: 7
-                    minItems: 0
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - containerfileArch
-                    x-kubernetes-list-type: map
-                  imageBuilder:
-                    description: machineOSImageBuilder describes which image builder
-                      will be used in each build triggered by this MachineOSConfig
-                    properties:
-                      imageBuilderType:
-                        default: PodImageBuilder
-                        description: |-
-                          imageBuilderType specifies the backend to be used to build the image.
-                          Valid options are: PodImageBuilder
-                        enum:
-                        - PodImageBuilder
-                        type: string
-                    required:
-                    - imageBuilderType
-                    type: object
-                  releaseVersion:
-                    description: |-
-                      releaseVersion is associated with the base OS Image. This is the version of Openshift that the Base Image is associated with.
-                      This field is populated from the machine-config-osimageurl configmap in the openshift-machine-config-operator namespace.
-                      It will come in the format: 4.16.0-0.nightly-2024-04-03-065948 or any valid release. The MachineOSBuilder populates this field and validates that this is a valid stream.
-                      This is used as a label in the dockerfile that builds the OS image.
-                    type: string
-                  renderedImagePushSecret:
-                    description: |-
-                      renderedImagePushSecret is the secret used to connect to a user registry.
-                      the final image push and pull secrets should be separate for security concerns. If the final image push secret is somehow exfiltrated,
-                      that gives someone the power to push images to the image repository. By comparison, if the final image pull secret gets exfiltrated,
-                      that only gives someone to pull images from the image repository. It's basically the principle of least permissions.
-                      this push secret will be used only by the MachineConfigController pod to push the image to the final destination. Not all nodes will need to push this image, most of them
-                      will only need to pull the image in order to use it.
-                    properties:
-                      name:
-                        description: |-
-                          name is the name of the secret used to push or pull this MachineOSConfig object.
-                          this secret must be in the openshift-machine-config-operator namespace.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  renderedImagePushspec:
-                    description: |-
-                      renderedImagePushspec describes the location of the final image.
-                      the MachineOSConfig object will use the in cluster image registry configuration.
-                      if you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf.
-                      The format of the image pushspec is:
-                      host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>
-                    maxLength: 447
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: the OCI Image reference must end with a valid :<tag>,
-                        where '<digest>' is 64 characters long and '<tag>' is any
-                        valid string  Or it must be a valid .svc followed by a port,
-                        repository, image name, and tag.
-                      rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
-                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
-                    - message: the OCI Image name should follow the host[:port][/namespace]/name
-                        format, resembling a valid URL without the scheme. Or it must
-                        be a valid .svc followed by a port, repository, image name,
-                        and tag.
-                      rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
-                required:
-                - baseImagePullSecret
-                - imageBuilder
-                - renderedImagePushSecret
-                - renderedImagePushspec
-                type: object
-              buildOutputs:
-                description: buildOutputs is where user input options for the build
-                  live
-                properties:
-                  currentImagePullSecret:
-                    description: |-
-                      currentImagePullSecret is the secret used to pull the final produced image.
-                      must live in the openshift-machine-config-operator namespace
-                      the final image push and pull secrets should be separate for security concerns. If the final image push secret is somehow exfiltrated,
-                      that gives someone the power to push images to the image repository. By comparison, if the final image pull secret gets exfiltrated,
-                      that only gives someone to pull images from the image repository. It's basically the principle of least permissions.
-                      this pull secret will be used on all nodes in the pool. These nodes will need to pull the final OS image and boot into it using rpm-ostree or bootc.
-                    properties:
-                      name:
-                        description: |-
-                          name is the name of the secret used to push or pull this MachineOSConfig object.
-                          this secret must be in the openshift-machine-config-operator namespace.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                type: object
-              machineConfigPool:
-                description: machineConfigPool is the pool which the build is for
+              baseImagePullSecret:
+                description: |-
+                  baseImagePullSecret is the secret used to pull the base image.
+                  Must live in the openshift-machine-config-operator namespace if provided.
+                  Defaults to using the cluster-wide pull secret if not specified. This is provided during install time of the cluster, and lives in the openshift-config namespace as a secret.
                 properties:
                   name:
-                    description: name of the MachineConfigPool object.
+                    description: |-
+                      name is the name of the secret used to push or pull this MachineOSConfig object.
+                      Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                      This secret must be in the openshift-machine-config-operator namespace.
                     maxLength: 253
-                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                 required:
                 - name
                 type: object
+              containerFile:
+                description: |-
+                  containerFile describes the custom data the user has specified to build into the image.
+                  This is also commonly called a Dockerfile and you can treat it as such. The content is the content of your Dockerfile.
+                  See https://github.com/containers/common/blob/main/docs/Containerfile.5.md for the spec reference.
+                  This is a list indexed by architecture name (e.g. AMD64), and allows specifying one containerFile per arch, up to 4.
+                items:
+                  description: MachineOSContainerfile contains all custom content
+                    the user wants built into the image
+                  properties:
+                    containerfileArch:
+                      default: NoArch
+                      description: |-
+                        containerfileArch describes the architecture this containerfile is to be built for.
+                        This arch is optional. If the user does not specify an architecture, it is assumed
+                        that the content can be applied to all architectures, or in a single arch cluster: the only architecture.
+                      enum:
+                      - ARM64
+                      - AMD64
+                      - PPC64LE
+                      - S390X
+                      - NoArch
+                      type: string
+                    content:
+                      description: |-
+                        content is an embedded Containerfile/Dockerfile that defines the contents to be built into your image.
+                        See https://github.com/containers/common/blob/main/docs/Containerfile.5.md for the spec reference.
+                        for example, this would add the tree package to your hosts:
+                          FROM configs AS final
+                          RUN rpm-ostree install tree && \
+                            ostree container commit
+                        This is a required field and can have a maximum length of **4096** characters.
+                      maxLength: 4096
+                      type: string
+                  required:
+                  - content
+                  type: object
+                maxItems: 4
+                minItems: 0
+                type: array
+                x-kubernetes-list-map-keys:
+                - containerfileArch
+                x-kubernetes-list-type: map
+              imageBuilder:
+                description: |-
+                  imageBuilder describes which image builder will be used in each build triggered by this MachineOSConfig.
+                  Currently supported type(s): Job
+                properties:
+                  imageBuilderType:
+                    description: |-
+                      imageBuilderType specifies the backend to be used to build the image.
+                      Valid options are: Job
+                    enum:
+                    - Job
+                    type: string
+                required:
+                - imageBuilderType
+                type: object
+              machineConfigPool:
+                description: |-
+                  machineConfigPool is the pool which the build is for.
+                  The Machine Config Operator will perform the build and roll out the built image to the specified pool.
+                properties:
+                  name:
+                    description: |-
+                      name of the MachineConfigPool object.
+                      This value should be at most 253 characters, and must contain only lowercase
+                      alphanumeric characters, hyphens and periods, and should start and end with an alphanumeric character.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                required:
+                - name
+                type: object
+              renderedImagePushSecret:
+                description: |-
+                  renderedImagePushSecret is the secret used to connect to a user registry.
+                  The final image push and pull secrets should be separate and assume the principal of least privilege.
+                  The push secret with write privilege is only required to be present on the node hosting the MachineConfigController pod.
+                  The pull secret with read only privileges is required on all nodes.
+                  By separating the two secrets, the risk of write credentials becoming compromised is reduced.
+                properties:
+                  name:
+                    description: |-
+                      name is the name of the secret used to push or pull this MachineOSConfig object.
+                      Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                      This secret must be in the openshift-machine-config-operator namespace.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                required:
+                - name
+                type: object
+              renderedImagePushSpec:
+                description: |-
+                  renderedImagePushSpec describes the location of the final image.
+                  The MachineOSConfig object will use the in cluster image registry configuration.
+                  If you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf via the cluster image.config, ImageContentSourcePolicies, ImageDigestMirrorSet, or ImageTagMirrorSet objects.
+                  The format of the image push spec is: host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>.
+                  The length of the push spec must be between 1 to 447 characters.
+                maxLength: 447
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme. Or it must
+                    be a valid .svc followed by a port, repository, image name, and
+                    tag.
+                  rule: self.matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?(/[a-zA-Z0-9-_]{1,61})*/[a-zA-Z0-9-_.]+:[a-zA-Z0-9._-]+$')
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$')
             required:
-            - buildInputs
+            - imageBuilder
             - machineConfigPool
+            - renderedImagePushSecret
+            - renderedImagePushSpec
             type: object
           status:
             description: status describes the status of the machineosconfig
             properties:
               conditions:
-                description: conditions are state related conditions for the config.
+                description: conditions are state related conditions for the object.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -300,10 +254,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              currentImagePullspec:
-                description: currentImagePullspec is the fully qualified image pull
-                  spec used by the MCO to pull down the new OSImage. This must include
-                  sha256.
+              currentImagePullSpec:
+                description: |-
+                  currentImagePullSpec is the fully qualified image pull spec used by the MCO to pull down the new OSImage. This includes the sha256 image digest.
+                  This is generated when the Machine Config Operator's build controller successfully completes the build, and is populated from the corresponding
+                  MachineOSBuild object's FinalImagePushSpec. This may change after completion in reaction to spec changes that would cause a new image build,
+                  but will not be removed.
+                  The format of the image pull spec is: host[:port][/namespace]/name@sha256:<digest>,
+                  where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                  The length of the whole spec must be between 1 to 447 characters.
                 maxLength: 447
                 minLength: 1
                 type: string
@@ -314,14 +273,74 @@ spec:
                 - message: the OCI Image name should follow the host[:port][/namespace]/name
                     format, resembling a valid URL without the scheme
                   rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+              machineOSBuild:
+                description: machineOSBuild is a reference to the MachineOSBuild object
+                  for this MachineOSConfig, which contains the status for the image
+                  build.
+                properties:
+                  group:
+                    description: |-
+                      group of the referent.
+                      The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                      Example: "", "apps", "build.openshift.io", etc.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                  name:
+                    description: |-
+                      name of the referent.
+                      The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                  namespace:
+                    description: |-
+                      namespace of the referent.
+                      This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                      and should start and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the value must consist of only lowercase alphanumeric
+                        characters and hyphens
+                      rule: '!format.dns1123Label().validate(self).hasValue()'
+                  resource:
+                    description: |-
+                      resource of the referent.
+                      This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                      and should start and end with an alphanumeric character.
+                      Example: "deployments", "deploymentconfigs", "pods", etc.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the value must consist of only lowercase alphanumeric
+                        characters and hyphens
+                      rule: '!format.dns1123Label().validate(self).hasValue()'
+                required:
+                - group
+                - name
+                - resource
+                type: object
               observedGeneration:
-                description: |-
-                  observedGeneration represents the generation observed by the controller.
-                  this field is updated when the user changes the configuration in BuildSettings or the MCP this object is associated with.
+                description: observedGeneration represents the generation of the MachineOSConfig
+                  object observed by the Machine Config Operator's build controller.
                 format: int64
+                minimum: 0
                 type: integer
-            required:
-            - observedGeneration
+                x-kubernetes-validations:
+                - message: observedGeneration must not move backwards
+                  rule: self >= oldSelf
             type: object
         required:
         - spec

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2090
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -19,12 +19,12 @@ spec:
     singular: machineosconfig
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: |-
           MachineOSConfig describes the configuration for a build process managed by the MCO
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -46,202 +46,156 @@ spec:
           spec:
             description: spec describes the configuration of the machineosconfig
             properties:
-              buildInputs:
-                description: buildInputs is where user input options for the build
-                  live
-                properties:
-                  baseImagePullSecret:
-                    description: |-
-                      baseImagePullSecret is the secret used to pull the base image.
-                      must live in the openshift-machine-config-operator namespace
-                    properties:
-                      name:
-                        description: |-
-                          name is the name of the secret used to push or pull this MachineOSConfig object.
-                          this secret must be in the openshift-machine-config-operator namespace.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  baseOSExtensionsImagePullspec:
-                    description: |-
-                      baseOSExtensionsImagePullspec is the base Extensions image used in the build process
-                      the MachineOSConfig object will use the in cluster image registry configuration.
-                      if you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf.
-                      The format of the image pullspec is:
-                      host[:port][/namespace]/name@sha256:<digest>
-                    maxLength: 447
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
-                        suffix, where '<digest>' is 64 characters long
-                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
-                    - message: the OCI Image name should follow the host[:port][/namespace]/name
-                        format, resembling a valid URL without the scheme
-                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                  baseOSImagePullspec:
-                    description: |-
-                      baseOSImagePullspec is the base OSImage we use to build our custom image.
-                      the MachineOSConfig object will use the in cluster image registry configuration.
-                      if you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf.
-                      The format of the image pullspec is:
-                      host[:port][/namespace]/name@sha256:<digest>
-                    maxLength: 447
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
-                        suffix, where '<digest>' is 64 characters long
-                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
-                    - message: the OCI Image name should follow the host[:port][/namespace]/name
-                        format, resembling a valid URL without the scheme
-                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                  containerFile:
-                    description: |-
-                      containerFile describes the custom data the user has specified to build into the image.
-                      this is also commonly called a Dockerfile and you can treat it as such. The content is the content of your Dockerfile.
-                    items:
-                      description: MachineOSContainerfile contains all custom content
-                        the user wants built into the image
-                      properties:
-                        containerfileArch:
-                          default: noarch
-                          description: |-
-                            containerfileArch describes the architecture this containerfile is to be built for
-                            this arch is optional. If the user does not specify an architecture, it is assumed
-                            that the content can be applied to all architectures, or in a single arch cluster: the only architecture.
-                          enum:
-                          - arm64
-                          - amd64
-                          - ppc64le
-                          - s390x
-                          - aarch64
-                          - x86_64
-                          - noarch
-                          type: string
-                        content:
-                          description: content is the custom content to be built
-                          type: string
-                      required:
-                      - content
-                      type: object
-                    maxItems: 7
-                    minItems: 0
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - containerfileArch
-                    x-kubernetes-list-type: map
-                  imageBuilder:
-                    description: machineOSImageBuilder describes which image builder
-                      will be used in each build triggered by this MachineOSConfig
-                    properties:
-                      imageBuilderType:
-                        default: PodImageBuilder
-                        description: |-
-                          imageBuilderType specifies the backend to be used to build the image.
-                          Valid options are: PodImageBuilder
-                        enum:
-                        - PodImageBuilder
-                        type: string
-                    required:
-                    - imageBuilderType
-                    type: object
-                  releaseVersion:
-                    description: |-
-                      releaseVersion is associated with the base OS Image. This is the version of Openshift that the Base Image is associated with.
-                      This field is populated from the machine-config-osimageurl configmap in the openshift-machine-config-operator namespace.
-                      It will come in the format: 4.16.0-0.nightly-2024-04-03-065948 or any valid release. The MachineOSBuilder populates this field and validates that this is a valid stream.
-                      This is used as a label in the dockerfile that builds the OS image.
-                    type: string
-                  renderedImagePushSecret:
-                    description: |-
-                      renderedImagePushSecret is the secret used to connect to a user registry.
-                      the final image push and pull secrets should be separate for security concerns. If the final image push secret is somehow exfiltrated,
-                      that gives someone the power to push images to the image repository. By comparison, if the final image pull secret gets exfiltrated,
-                      that only gives someone to pull images from the image repository. It's basically the principle of least permissions.
-                      this push secret will be used only by the MachineConfigController pod to push the image to the final destination. Not all nodes will need to push this image, most of them
-                      will only need to pull the image in order to use it.
-                    properties:
-                      name:
-                        description: |-
-                          name is the name of the secret used to push or pull this MachineOSConfig object.
-                          this secret must be in the openshift-machine-config-operator namespace.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  renderedImagePushspec:
-                    description: |-
-                      renderedImagePushspec describes the location of the final image.
-                      the MachineOSConfig object will use the in cluster image registry configuration.
-                      if you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf.
-                      The format of the image pushspec is:
-                      host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>
-                    maxLength: 447
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: the OCI Image reference must end with a valid :<tag>,
-                        where '<digest>' is 64 characters long and '<tag>' is any
-                        valid string  Or it must be a valid .svc followed by a port,
-                        repository, image name, and tag.
-                      rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
-                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
-                    - message: the OCI Image name should follow the host[:port][/namespace]/name
-                        format, resembling a valid URL without the scheme. Or it must
-                        be a valid .svc followed by a port, repository, image name,
-                        and tag.
-                      rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
-                required:
-                - baseImagePullSecret
-                - imageBuilder
-                - renderedImagePushSecret
-                - renderedImagePushspec
-                type: object
-              buildOutputs:
-                description: buildOutputs is where user input options for the build
-                  live
-                properties:
-                  currentImagePullSecret:
-                    description: |-
-                      currentImagePullSecret is the secret used to pull the final produced image.
-                      must live in the openshift-machine-config-operator namespace
-                      the final image push and pull secrets should be separate for security concerns. If the final image push secret is somehow exfiltrated,
-                      that gives someone the power to push images to the image repository. By comparison, if the final image pull secret gets exfiltrated,
-                      that only gives someone to pull images from the image repository. It's basically the principle of least permissions.
-                      this pull secret will be used on all nodes in the pool. These nodes will need to pull the final OS image and boot into it using rpm-ostree or bootc.
-                    properties:
-                      name:
-                        description: |-
-                          name is the name of the secret used to push or pull this MachineOSConfig object.
-                          this secret must be in the openshift-machine-config-operator namespace.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                type: object
-              machineConfigPool:
-                description: machineConfigPool is the pool which the build is for
+              baseImagePullSecret:
+                description: |-
+                  baseImagePullSecret is the secret used to pull the base image.
+                  Must live in the openshift-machine-config-operator namespace if provided.
+                  Defaults to using the cluster-wide pull secret if not specified. This is provided during install time of the cluster, and lives in the openshift-config namespace as a secret.
                 properties:
                   name:
-                    description: name of the MachineConfigPool object.
+                    description: |-
+                      name is the name of the secret used to push or pull this MachineOSConfig object.
+                      Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                      This secret must be in the openshift-machine-config-operator namespace.
                     maxLength: 253
-                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                 required:
                 - name
                 type: object
+              containerFile:
+                description: |-
+                  containerFile describes the custom data the user has specified to build into the image.
+                  This is also commonly called a Dockerfile and you can treat it as such. The content is the content of your Dockerfile.
+                  See https://github.com/containers/common/blob/main/docs/Containerfile.5.md for the spec reference.
+                  This is a list indexed by architecture name (e.g. AMD64), and allows specifying one containerFile per arch, up to 4.
+                items:
+                  description: MachineOSContainerfile contains all custom content
+                    the user wants built into the image
+                  properties:
+                    containerfileArch:
+                      default: NoArch
+                      description: |-
+                        containerfileArch describes the architecture this containerfile is to be built for.
+                        This arch is optional. If the user does not specify an architecture, it is assumed
+                        that the content can be applied to all architectures, or in a single arch cluster: the only architecture.
+                      enum:
+                      - ARM64
+                      - AMD64
+                      - PPC64LE
+                      - S390X
+                      - NoArch
+                      type: string
+                    content:
+                      description: |-
+                        content is an embedded Containerfile/Dockerfile that defines the contents to be built into your image.
+                        See https://github.com/containers/common/blob/main/docs/Containerfile.5.md for the spec reference.
+                        for example, this would add the tree package to your hosts:
+                          FROM configs AS final
+                          RUN rpm-ostree install tree && \
+                            ostree container commit
+                        This is a required field and can have a maximum length of **4096** characters.
+                      maxLength: 4096
+                      type: string
+                  required:
+                  - content
+                  type: object
+                maxItems: 4
+                minItems: 0
+                type: array
+                x-kubernetes-list-map-keys:
+                - containerfileArch
+                x-kubernetes-list-type: map
+              imageBuilder:
+                description: |-
+                  imageBuilder describes which image builder will be used in each build triggered by this MachineOSConfig.
+                  Currently supported type(s): Job
+                properties:
+                  imageBuilderType:
+                    description: |-
+                      imageBuilderType specifies the backend to be used to build the image.
+                      Valid options are: Job
+                    enum:
+                    - Job
+                    type: string
+                required:
+                - imageBuilderType
+                type: object
+              machineConfigPool:
+                description: |-
+                  machineConfigPool is the pool which the build is for.
+                  The Machine Config Operator will perform the build and roll out the built image to the specified pool.
+                properties:
+                  name:
+                    description: |-
+                      name of the MachineConfigPool object.
+                      This value should be at most 253 characters, and must contain only lowercase
+                      alphanumeric characters, hyphens and periods, and should start and end with an alphanumeric character.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                required:
+                - name
+                type: object
+              renderedImagePushSecret:
+                description: |-
+                  renderedImagePushSecret is the secret used to connect to a user registry.
+                  The final image push and pull secrets should be separate and assume the principal of least privilege.
+                  The push secret with write privilege is only required to be present on the node hosting the MachineConfigController pod.
+                  The pull secret with read only privileges is required on all nodes.
+                  By separating the two secrets, the risk of write credentials becoming compromised is reduced.
+                properties:
+                  name:
+                    description: |-
+                      name is the name of the secret used to push or pull this MachineOSConfig object.
+                      Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                      This secret must be in the openshift-machine-config-operator namespace.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                required:
+                - name
+                type: object
+              renderedImagePushSpec:
+                description: |-
+                  renderedImagePushSpec describes the location of the final image.
+                  The MachineOSConfig object will use the in cluster image registry configuration.
+                  If you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf via the cluster image.config, ImageContentSourcePolicies, ImageDigestMirrorSet, or ImageTagMirrorSet objects.
+                  The format of the image push spec is: host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>.
+                  The length of the push spec must be between 1 to 447 characters.
+                maxLength: 447
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme. Or it must
+                    be a valid .svc followed by a port, repository, image name, and
+                    tag.
+                  rule: self.matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?(/[a-zA-Z0-9-_]{1,61})*/[a-zA-Z0-9-_.]+:[a-zA-Z0-9._-]+$')
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$')
             required:
-            - buildInputs
+            - imageBuilder
             - machineConfigPool
+            - renderedImagePushSecret
+            - renderedImagePushSpec
             type: object
           status:
             description: status describes the status of the machineosconfig
             properties:
               conditions:
-                description: conditions are state related conditions for the config.
+                description: conditions are state related conditions for the object.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -300,10 +254,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              currentImagePullspec:
-                description: currentImagePullspec is the fully qualified image pull
-                  spec used by the MCO to pull down the new OSImage. This must include
-                  sha256.
+              currentImagePullSpec:
+                description: |-
+                  currentImagePullSpec is the fully qualified image pull spec used by the MCO to pull down the new OSImage. This includes the sha256 image digest.
+                  This is generated when the Machine Config Operator's build controller successfully completes the build, and is populated from the corresponding
+                  MachineOSBuild object's FinalImagePushSpec. This may change after completion in reaction to spec changes that would cause a new image build,
+                  but will not be removed.
+                  The format of the image pull spec is: host[:port][/namespace]/name@sha256:<digest>,
+                  where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                  The length of the whole spec must be between 1 to 447 characters.
                 maxLength: 447
                 minLength: 1
                 type: string
@@ -314,14 +273,74 @@ spec:
                 - message: the OCI Image name should follow the host[:port][/namespace]/name
                     format, resembling a valid URL without the scheme
                   rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+              machineOSBuild:
+                description: machineOSBuild is a reference to the MachineOSBuild object
+                  for this MachineOSConfig, which contains the status for the image
+                  build.
+                properties:
+                  group:
+                    description: |-
+                      group of the referent.
+                      The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                      Example: "", "apps", "build.openshift.io", etc.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                  name:
+                    description: |-
+                      name of the referent.
+                      The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                  namespace:
+                    description: |-
+                      namespace of the referent.
+                      This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                      and should start and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the value must consist of only lowercase alphanumeric
+                        characters and hyphens
+                      rule: '!format.dns1123Label().validate(self).hasValue()'
+                  resource:
+                    description: |-
+                      resource of the referent.
+                      This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                      and should start and end with an alphanumeric character.
+                      Example: "deployments", "deploymentconfigs", "pods", etc.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the value must consist of only lowercase alphanumeric
+                        characters and hyphens
+                      rule: '!format.dns1123Label().validate(self).hasValue()'
+                required:
+                - group
+                - name
+                - resource
+                type: object
               observedGeneration:
-                description: |-
-                  observedGeneration represents the generation observed by the controller.
-                  this field is updated when the user changes the configuration in BuildSettings or the MCP this object is associated with.
+                description: observedGeneration represents the generation of the MachineOSConfig
+                  object observed by the Machine Config Operator's build controller.
                 format: int64
+                minimum: 0
                 type: integer
-            required:
-            - observedGeneration
+                x-kubernetes-validations:
+                - message: observedGeneration must not move backwards
+                  rule: self >= oldSelf
             type: object
         required:
         - spec

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1773
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2090
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -19,12 +19,12 @@ spec:
     singular: machineosconfig
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: |-
           MachineOSConfig describes the configuration for a build process managed by the MCO
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -46,202 +46,156 @@ spec:
           spec:
             description: spec describes the configuration of the machineosconfig
             properties:
-              buildInputs:
-                description: buildInputs is where user input options for the build
-                  live
-                properties:
-                  baseImagePullSecret:
-                    description: |-
-                      baseImagePullSecret is the secret used to pull the base image.
-                      must live in the openshift-machine-config-operator namespace
-                    properties:
-                      name:
-                        description: |-
-                          name is the name of the secret used to push or pull this MachineOSConfig object.
-                          this secret must be in the openshift-machine-config-operator namespace.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  baseOSExtensionsImagePullspec:
-                    description: |-
-                      baseOSExtensionsImagePullspec is the base Extensions image used in the build process
-                      the MachineOSConfig object will use the in cluster image registry configuration.
-                      if you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf.
-                      The format of the image pullspec is:
-                      host[:port][/namespace]/name@sha256:<digest>
-                    maxLength: 447
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
-                        suffix, where '<digest>' is 64 characters long
-                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
-                    - message: the OCI Image name should follow the host[:port][/namespace]/name
-                        format, resembling a valid URL without the scheme
-                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                  baseOSImagePullspec:
-                    description: |-
-                      baseOSImagePullspec is the base OSImage we use to build our custom image.
-                      the MachineOSConfig object will use the in cluster image registry configuration.
-                      if you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf.
-                      The format of the image pullspec is:
-                      host[:port][/namespace]/name@sha256:<digest>
-                    maxLength: 447
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: the OCI Image reference must end with a valid '@sha256:<digest>'
-                        suffix, where '<digest>' is 64 characters long
-                      rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
-                    - message: the OCI Image name should follow the host[:port][/namespace]/name
-                        format, resembling a valid URL without the scheme
-                      rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                  containerFile:
-                    description: |-
-                      containerFile describes the custom data the user has specified to build into the image.
-                      this is also commonly called a Dockerfile and you can treat it as such. The content is the content of your Dockerfile.
-                    items:
-                      description: MachineOSContainerfile contains all custom content
-                        the user wants built into the image
-                      properties:
-                        containerfileArch:
-                          default: noarch
-                          description: |-
-                            containerfileArch describes the architecture this containerfile is to be built for
-                            this arch is optional. If the user does not specify an architecture, it is assumed
-                            that the content can be applied to all architectures, or in a single arch cluster: the only architecture.
-                          enum:
-                          - arm64
-                          - amd64
-                          - ppc64le
-                          - s390x
-                          - aarch64
-                          - x86_64
-                          - noarch
-                          type: string
-                        content:
-                          description: content is the custom content to be built
-                          type: string
-                      required:
-                      - content
-                      type: object
-                    maxItems: 7
-                    minItems: 0
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - containerfileArch
-                    x-kubernetes-list-type: map
-                  imageBuilder:
-                    description: machineOSImageBuilder describes which image builder
-                      will be used in each build triggered by this MachineOSConfig
-                    properties:
-                      imageBuilderType:
-                        default: PodImageBuilder
-                        description: |-
-                          imageBuilderType specifies the backend to be used to build the image.
-                          Valid options are: PodImageBuilder
-                        enum:
-                        - PodImageBuilder
-                        type: string
-                    required:
-                    - imageBuilderType
-                    type: object
-                  releaseVersion:
-                    description: |-
-                      releaseVersion is associated with the base OS Image. This is the version of Openshift that the Base Image is associated with.
-                      This field is populated from the machine-config-osimageurl configmap in the openshift-machine-config-operator namespace.
-                      It will come in the format: 4.16.0-0.nightly-2024-04-03-065948 or any valid release. The MachineOSBuilder populates this field and validates that this is a valid stream.
-                      This is used as a label in the dockerfile that builds the OS image.
-                    type: string
-                  renderedImagePushSecret:
-                    description: |-
-                      renderedImagePushSecret is the secret used to connect to a user registry.
-                      the final image push and pull secrets should be separate for security concerns. If the final image push secret is somehow exfiltrated,
-                      that gives someone the power to push images to the image repository. By comparison, if the final image pull secret gets exfiltrated,
-                      that only gives someone to pull images from the image repository. It's basically the principle of least permissions.
-                      this push secret will be used only by the MachineConfigController pod to push the image to the final destination. Not all nodes will need to push this image, most of them
-                      will only need to pull the image in order to use it.
-                    properties:
-                      name:
-                        description: |-
-                          name is the name of the secret used to push or pull this MachineOSConfig object.
-                          this secret must be in the openshift-machine-config-operator namespace.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  renderedImagePushspec:
-                    description: |-
-                      renderedImagePushspec describes the location of the final image.
-                      the MachineOSConfig object will use the in cluster image registry configuration.
-                      if you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf.
-                      The format of the image pushspec is:
-                      host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>
-                    maxLength: 447
-                    minLength: 1
-                    type: string
-                    x-kubernetes-validations:
-                    - message: the OCI Image reference must end with a valid :<tag>,
-                        where '<digest>' is 64 characters long and '<tag>' is any
-                        valid string  Or it must be a valid .svc followed by a port,
-                        repository, image name, and tag.
-                      rule: ((self.split(':').size() == 2 && self.split(':')[1].matches('^([a-zA-Z0-9-./:])+$'))
-                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
-                    - message: the OCI Image name should follow the host[:port][/namespace]/name
-                        format, resembling a valid URL without the scheme. Or it must
-                        be a valid .svc followed by a port, repository, image name,
-                        and tag.
-                      rule: ((self.split(':').size() == 2 && self.split(':')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
-                        || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$'))
-                required:
-                - baseImagePullSecret
-                - imageBuilder
-                - renderedImagePushSecret
-                - renderedImagePushspec
-                type: object
-              buildOutputs:
-                description: buildOutputs is where user input options for the build
-                  live
-                properties:
-                  currentImagePullSecret:
-                    description: |-
-                      currentImagePullSecret is the secret used to pull the final produced image.
-                      must live in the openshift-machine-config-operator namespace
-                      the final image push and pull secrets should be separate for security concerns. If the final image push secret is somehow exfiltrated,
-                      that gives someone the power to push images to the image repository. By comparison, if the final image pull secret gets exfiltrated,
-                      that only gives someone to pull images from the image repository. It's basically the principle of least permissions.
-                      this pull secret will be used on all nodes in the pool. These nodes will need to pull the final OS image and boot into it using rpm-ostree or bootc.
-                    properties:
-                      name:
-                        description: |-
-                          name is the name of the secret used to push or pull this MachineOSConfig object.
-                          this secret must be in the openshift-machine-config-operator namespace.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                type: object
-              machineConfigPool:
-                description: machineConfigPool is the pool which the build is for
+              baseImagePullSecret:
+                description: |-
+                  baseImagePullSecret is the secret used to pull the base image.
+                  Must live in the openshift-machine-config-operator namespace if provided.
+                  Defaults to using the cluster-wide pull secret if not specified. This is provided during install time of the cluster, and lives in the openshift-config namespace as a secret.
                 properties:
                   name:
-                    description: name of the MachineConfigPool object.
+                    description: |-
+                      name is the name of the secret used to push or pull this MachineOSConfig object.
+                      Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                      This secret must be in the openshift-machine-config-operator namespace.
                     maxLength: 253
-                    pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
                     type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
                 required:
                 - name
                 type: object
+              containerFile:
+                description: |-
+                  containerFile describes the custom data the user has specified to build into the image.
+                  This is also commonly called a Dockerfile and you can treat it as such. The content is the content of your Dockerfile.
+                  See https://github.com/containers/common/blob/main/docs/Containerfile.5.md for the spec reference.
+                  This is a list indexed by architecture name (e.g. AMD64), and allows specifying one containerFile per arch, up to 4.
+                items:
+                  description: MachineOSContainerfile contains all custom content
+                    the user wants built into the image
+                  properties:
+                    containerfileArch:
+                      default: NoArch
+                      description: |-
+                        containerfileArch describes the architecture this containerfile is to be built for.
+                        This arch is optional. If the user does not specify an architecture, it is assumed
+                        that the content can be applied to all architectures, or in a single arch cluster: the only architecture.
+                      enum:
+                      - ARM64
+                      - AMD64
+                      - PPC64LE
+                      - S390X
+                      - NoArch
+                      type: string
+                    content:
+                      description: |-
+                        content is an embedded Containerfile/Dockerfile that defines the contents to be built into your image.
+                        See https://github.com/containers/common/blob/main/docs/Containerfile.5.md for the spec reference.
+                        for example, this would add the tree package to your hosts:
+                          FROM configs AS final
+                          RUN rpm-ostree install tree && \
+                            ostree container commit
+                        This is a required field and can have a maximum length of **4096** characters.
+                      maxLength: 4096
+                      type: string
+                  required:
+                  - content
+                  type: object
+                maxItems: 4
+                minItems: 0
+                type: array
+                x-kubernetes-list-map-keys:
+                - containerfileArch
+                x-kubernetes-list-type: map
+              imageBuilder:
+                description: |-
+                  imageBuilder describes which image builder will be used in each build triggered by this MachineOSConfig.
+                  Currently supported type(s): Job
+                properties:
+                  imageBuilderType:
+                    description: |-
+                      imageBuilderType specifies the backend to be used to build the image.
+                      Valid options are: Job
+                    enum:
+                    - Job
+                    type: string
+                required:
+                - imageBuilderType
+                type: object
+              machineConfigPool:
+                description: |-
+                  machineConfigPool is the pool which the build is for.
+                  The Machine Config Operator will perform the build and roll out the built image to the specified pool.
+                properties:
+                  name:
+                    description: |-
+                      name of the MachineConfigPool object.
+                      This value should be at most 253 characters, and must contain only lowercase
+                      alphanumeric characters, hyphens and periods, and should start and end with an alphanumeric character.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                required:
+                - name
+                type: object
+              renderedImagePushSecret:
+                description: |-
+                  renderedImagePushSecret is the secret used to connect to a user registry.
+                  The final image push and pull secrets should be separate and assume the principal of least privilege.
+                  The push secret with write privilege is only required to be present on the node hosting the MachineConfigController pod.
+                  The pull secret with read only privileges is required on all nodes.
+                  By separating the two secrets, the risk of write credentials becoming compromised is reduced.
+                properties:
+                  name:
+                    description: |-
+                      name is the name of the secret used to push or pull this MachineOSConfig object.
+                      Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character.
+                      This secret must be in the openshift-machine-config-operator namespace.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                required:
+                - name
+                type: object
+              renderedImagePushSpec:
+                description: |-
+                  renderedImagePushSpec describes the location of the final image.
+                  The MachineOSConfig object will use the in cluster image registry configuration.
+                  If you wish to use a mirror or any other settings specific to registries.conf, please specify those in the cluster wide registries.conf via the cluster image.config, ImageContentSourcePolicies, ImageDigestMirrorSet, or ImageTagMirrorSet objects.
+                  The format of the image push spec is: host[:port][/namespace]/name:<tag> or svc_name.namespace.svc[:port]/repository/name:<tag>.
+                  The length of the push spec must be between 1 to 447 characters.
+                maxLength: 447
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: the OCI Image name should follow the host[:port][/namespace]/name
+                    format, resembling a valid URL without the scheme. Or it must
+                    be a valid .svc followed by a port, repository, image name, and
+                    tag.
+                  rule: self.matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?(/[a-zA-Z0-9-_]{1,61})*/[a-zA-Z0-9-_.]+:[a-zA-Z0-9._-]+$')
+                    || self.matches('^[^.]+\\.[^.]+\\.svc:\\d+\\/[^\\/]+\\/[^\\/]+:[^\\/]+$')
             required:
-            - buildInputs
+            - imageBuilder
             - machineConfigPool
+            - renderedImagePushSecret
+            - renderedImagePushSpec
             type: object
           status:
             description: status describes the status of the machineosconfig
             properties:
               conditions:
-                description: conditions are state related conditions for the config.
+                description: conditions are state related conditions for the object.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -300,10 +254,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
-              currentImagePullspec:
-                description: currentImagePullspec is the fully qualified image pull
-                  spec used by the MCO to pull down the new OSImage. This must include
-                  sha256.
+              currentImagePullSpec:
+                description: |-
+                  currentImagePullSpec is the fully qualified image pull spec used by the MCO to pull down the new OSImage. This includes the sha256 image digest.
+                  This is generated when the Machine Config Operator's build controller successfully completes the build, and is populated from the corresponding
+                  MachineOSBuild object's FinalImagePushSpec. This may change after completion in reaction to spec changes that would cause a new image build,
+                  but will not be removed.
+                  The format of the image pull spec is: host[:port][/namespace]/name@sha256:<digest>,
+                  where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                  The length of the whole spec must be between 1 to 447 characters.
                 maxLength: 447
                 minLength: 1
                 type: string
@@ -314,14 +273,74 @@ spec:
                 - message: the OCI Image name should follow the host[:port][/namespace]/name
                     format, resembling a valid URL without the scheme
                   rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+              machineOSBuild:
+                description: machineOSBuild is a reference to the MachineOSBuild object
+                  for this MachineOSConfig, which contains the status for the image
+                  build.
+                properties:
+                  group:
+                    description: |-
+                      group of the referent.
+                      The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                      Example: "", "apps", "build.openshift.io", etc.
+                    maxLength: 253
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                  name:
+                    description: |-
+                      name of the referent.
+                      The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: a lowercase RFC 1123 subdomain must consist of lower
+                        case alphanumeric characters, '-' or '.', and must start and
+                        end with an alphanumeric character.
+                      rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                  namespace:
+                    description: |-
+                      namespace of the referent.
+                      This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                      and should start and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the value must consist of only lowercase alphanumeric
+                        characters and hyphens
+                      rule: '!format.dns1123Label().validate(self).hasValue()'
+                  resource:
+                    description: |-
+                      resource of the referent.
+                      This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
+                      and should start and end with an alphanumeric character.
+                      Example: "deployments", "deploymentconfigs", "pods", etc.
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                    x-kubernetes-validations:
+                    - message: the value must consist of only lowercase alphanumeric
+                        characters and hyphens
+                      rule: '!format.dns1123Label().validate(self).hasValue()'
+                required:
+                - group
+                - name
+                - resource
+                type: object
               observedGeneration:
-                description: |-
-                  observedGeneration represents the generation observed by the controller.
-                  this field is updated when the user changes the configuration in BuildSettings or the MCP this object is associated with.
+                description: observedGeneration represents the generation of the MachineOSConfig
+                  object observed by the Machine Config Operator's build controller.
                 format: int64
+                minimum: 0
                 type: integer
-            required:
-            - observedGeneration
+                x-kubernetes-validations:
+                - message: observedGeneration must not move backwards
+                  rule: self >= oldSelf
             type: object
         required:
         - spec


### PR DESCRIPTION
This PR updates the payload `MachineOSConfig`/`MachineOSBuild` CRDs to v1 from v1alpha1. This should be tested along with https://github.com/openshift/machine-config-operator/pull/4756 and will have to be merged alongside the same.