### PR TITLE
OCPBUGS-48078: Add ratcheting tests for PowerVS service endpoints

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1365,3 +1365,313 @@ tests:
               - name: BadService
                 url: https://bad-service.com
       expectedStatusError: "platformStatus.ibmcloud.serviceEndpoints[1].name: Unsupported value: \"BadService\": supported values: \"CIS\", \"COS\", \"COSConfig\", \"DNSServices\", \"GlobalCatalog\", \"GlobalSearch\", \"GlobalTagging\", \"HyperProtect\", \"IAM\", \"KeyProtect\", \"ResourceController\", \"ResourceManager\", \"VPC\""
+    - name: Should allow updating other fields with an invalid persisted PowerVS service endpoint name in spec
+      initialCRDPatches:
+      - op: replace
+        path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
+        value:
+          pattern: "^[a-z0-9-]+$"
+          type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          cloudConfig: {}
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          cloudConfig: {}
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+    - name: Should allow updating adding another slice entry with an invalid persisted PowerVS service endpoint name in spec
+      initialCRDPatches:
+      - op: replace
+        path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
+        value:
+          pattern: "^[a-z0-9-]+$"
+          type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+              - name: DNSServices
+                url: https://abc
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+              - name: DNSServices
+                url: https://abc
+    - name: Should not allow updating adding an invalid value to a still invalid value for a PowerVS service endpoint name in spec
+      initialCRDPatches:
+      - op: replace
+        path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
+        value:
+          pattern: "^[a-z0-9-]+$"
+          type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices2
+                url: https://abc
+      expectedError: 'spec.platformSpec.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC"'
+    - name: Should allow updating adding updating an invalid value to a valid value for PowerVS service endpoint name in spec
+      initialCRDPatches:
+      - op: replace
+        path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/platformSpec/properties/powervs/properties/serviceEndpoints/items/properties/name
+        value:
+          pattern: "^[a-z0-9-]+$"
+          type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: DNSServices
+                url: https://abc
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: DNSServices
+                url: https://abc
+    - name: Should allow updating other fields with an invalid persisted PowerVS service endpoint name in status
+      initialCRDPatches:
+      - op: replace
+        path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
+        value:
+          pattern: "^[a-z0-9-]+$"
+          type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platformStatus:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platformStatus:
+            type: PowerVS
+            powervs:
+              region: Foo
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platformStatus:
+            type: PowerVS
+            powervs:
+              region: Foo
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+    - name: Should allow updating adding another slice entry with an invalid persisted PowerVS service endpoint name in status
+      initialCRDPatches:
+      - op: replace
+        path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
+        value:
+          pattern: "^[a-z0-9-]+$"
+          type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platformStatus:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platformStatus:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+              - name: DNSServices
+                url: https://abc
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platformStatus:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+              - name: DNSServices
+                url: https://abc
+    - name: Should not allow updating adding an invalid value to a still invalid value for a PowerVS service endpoint name in status
+      initialCRDPatches:
+      - op: replace
+        path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
+        value:
+          pattern: "^[a-z0-9-]+$"
+          type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platformStatus:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platformStatus:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices2
+                url: https://abc
+      expectedStatusError: 'status.platformStatus.powervs.serviceEndpoints[0].name: Unsupported value: "dnsservices2": supported values: "CIS", "COS", "COSConfig", "DNSServices", "GlobalCatalog", "GlobalSearch", "GlobalTagging", "HyperProtect", "IAM", "KeyProtect", "Power", "ResourceController", "ResourceManager", "VPC"'
+    - name: Should allow updating adding updating an invalid value to a valid value for PowerVS service endpoint name in status
+      initialCRDPatches:
+      - op: replace
+        path: /spec/versions/0/schema/openAPIV3Schema/properties/status/properties/platformStatus/properties/powervs/properties/serviceEndpoints/items/properties/name
+        value:
+          pattern: "^[a-z0-9-]+$"
+          type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platformStatus:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: dnsservices
+                url: https://abc
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          platformStatus:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: DNSServices
+                url: https://abc
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platformStatus:
+            type: PowerVS
+            powervs:
+              serviceEndpoints:
+              - name: DNSServices
+                url: https://abc

--- a/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -408,7 +408,7 @@ tests:
           platformStatus:
             powervs:
               resourceGroup: resource-group-should-not-accept-the-string-that-exceeds-max-length-set
-      expectedStatusError: "platformStatus.powervs.resourceGroup: Too long: may not be longer than 40"
+      expectedStatusError: "platformStatus.powervs.resourceGroup: Too long: may not be more than 40 bytes"
     - name: PowerVS platform status's resourceGroup should match the regex configured
       initial: |
         apiVersion: config.openshift.io/v1

--- a/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.openstack.testsuite.yaml
+++ b/machine/v1/tests/controlplanemachinesets.machine.openshift.io/stable.controlplanemachineset.openstack.testsuite.yaml
@@ -170,7 +170,7 @@ tests:
               - availabilityZone: foo
                 rootVolume:
                   volumeType: a123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345
-    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.openstack[0].rootVolume.volumeType: Too long: may not be longer than 255"
+    expectedError: "spec.template.machines_v1beta1_machine_openshift_io.failureDomains.openstack[0].rootVolume.volumeType: Too long: may not be more than 255 bytes"
   - name: Should reject an OpenStack failure domain with both availabilityZone and root volume provided but with missing root volume availabilityZone
     initial: |
       apiVersion: machine.openshift.io/v1

--- a/operator/v1/tests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
+++ b/operator/v1/tests/ingresscontrollers.operator.openshift.io/IngressControllerLBSubnetsAWS.yaml
@@ -391,7 +391,7 @@ tests:
                     subnets:
                       ids:
                       - subnet-000000000000000010
-      expectedError: "spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.classicLoadBalancer.subnets.ids[0]: Too long: may not be longer than 24"
+      expectedError: "spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.classicLoadBalancer.subnets.ids[0]: Too long: may not be more than 24 bytes"
     - name: Should not be able to create ingresscontroller with subnet id that doesn't start with subnet-.
       initial: |
         apiVersion: operator.openshift.io/v1

--- a/operator/v1/tests/ingresscontrollers.operator.openshift.io/SetEIPForNLBIngressController.yaml
+++ b/operator/v1/tests/ingresscontrollers.operator.openshift.io/SetEIPForNLBIngressController.yaml
@@ -119,7 +119,7 @@ tests:
                     - eipalloc-1234533333333333333333333
                     - eipalloc-1234644444444444444444444
             type: LoadBalancerService
-      expectedError: "[spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.networkLoadBalancer.eipAllocations[0]: Too long: may not be longer than 26, spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.networkLoadBalancer.eipAllocations[1]: Too long: may not be longer than 26,"
+      expectedError: "[spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.networkLoadBalancer.eipAllocations[0]: Too long: may not be more than 26 bytes, spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.networkLoadBalancer.eipAllocations[1]: Too long: may not be more than 26 bytes,"
     - name: Should not be able to create ingresscontroller if the number of eipAllocations is more than 10.
       initial: |
         apiVersion: operator.openshift.io/v1
@@ -250,7 +250,7 @@ tests:
                     eipAllocations:
                     - eipalloc-0123456789abcdef0-0123456
             type: LoadBalancerService
-      expectedError: "IngressController.operator.openshift.io \"default-eip\" is invalid: [spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.networkLoadBalancer.eipAllocations[0]: Too long: may not be longer than 26"
+      expectedError: "IngressController.operator.openshift.io \"default-eip\" is invalid: [spec.endpointPublishingStrategy.loadBalancer.providerParameters.aws.networkLoadBalancer.eipAllocations[0]: Too long: may not be more than 26 bytes"
     - name: Should not be able to create an ingress controller in which the value of eipAllocations has a short hexadecimal part followed by an extra hexadecimal part.
       initial: |
         apiVersion: operator.openshift.io/v1

--- a/samples/v1/tests/configs.samples.operator.openshift.io/AAA_ungated.yaml
+++ b/samples/v1/tests/configs.samples.operator.openshift.io/AAA_ungated.yaml
@@ -56,4 +56,4 @@ tests:
         spec: 
           skippedHelmCharts:
           - foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar
-      expectedError: "Too long: may not be longer than 253"
+      expectedError: "Too long: may not be more than 253 bytes"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@
 # DO NOT UPDATE THIS until you have published downstream builds for the kubebuilder tools, and checked
 # that there is an equivalent upstream version as well. Check upstream at https://storage.googleapis.com/kubebuilder-tools.
 # Publish downstream with `make -C tools publish-kubebuilder-tools`, see help text there for updating flags before publshing.
-ENVTEST_K8S_VERSION = 1.31.2
+ENVTEST_K8S_VERSION = 1.32.1
 
 # In case of emergency, use these to provide separate upstream/downstream K8s versions for testing.
 ENVTEST_K8S_DOWNSTREAM_VERSION = ${ENVTEST_K8S_VERSION}


### PR DESCRIPTION
If we had the ability to add these tests when the PR for these changes was merged, we would have caught this earlier.

This adds tests for both spec and status to show that the ratcheting validation we added for 4.18 is working.

Currently blocked on waiting for https://github.com/openshift/kubernetes/pull/2167 to merge, and then publishing a new set of kubebuilder binaries from that.