### PR TITLE
MachineOSBuild: make ObjectReference fields optional

### DIFF
--- a/machineconfiguration/v1/types_machineosbuild.go
+++ b/machineconfiguration/v1/types_machineosbuild.go
@@ -177,16 +177,16 @@ type ObjectReference struct {
 	// Example: "", "apps", "build.openshift.io", etc.
 	// +kubebuilder:validation:XValidation:rule="!format.dns1123Subdomain().validate(self).hasValue()",message="a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character."
 	// +kubebuilder:validation:MaxLength:=253
-	// +required
+	// +optional
 	Group string `json:"group"`
 	// resource of the referent.
 	// This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
 	// and should start and end with an alphanumeric character.
 	// Example: "deployments", "deploymentconfigs", "pods", etc.
-	// +required
 	// +kubebuilder:validation:XValidation:rule=`!format.dns1123Label().validate(self).hasValue()`,message="the value must consist of only lowercase alphanumeric characters and hyphens"
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
+	// +optional
 	Resource string `json:"resource"`
 	// namespace of the referent.
 	// This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-CustomNoUpgrade.crd.yaml
@@ -217,9 +217,7 @@ spec:
                             characters and hyphens
                           rule: '!format.dns1123Label().validate(self).hasValue()'
                     required:
-                    - group
                     - name
-                    - resource
                     type: object
                 required:
                 - imageBuilderType
@@ -378,9 +376,7 @@ spec:
                           characters and hyphens
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
-                  - group
                   - name
-                  - resource
                   type: object
                 maxItems: 10
                 type: array

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-DevPreviewNoUpgrade.crd.yaml
@@ -217,9 +217,7 @@ spec:
                             characters and hyphens
                           rule: '!format.dns1123Label().validate(self).hasValue()'
                     required:
-                    - group
                     - name
-                    - resource
                     type: object
                 required:
                 - imageBuilderType
@@ -378,9 +376,7 @@ spec:
                           characters and hyphens
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
-                  - group
                   - name
-                  - resource
                   type: object
                 maxItems: 10
                 type: array

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds-TechPreviewNoUpgrade.crd.yaml
@@ -217,9 +217,7 @@ spec:
                             characters and hyphens
                           rule: '!format.dns1123Label().validate(self).hasValue()'
                     required:
-                    - group
                     - name
-                    - resource
                     type: object
                 required:
                 - imageBuilderType
@@ -378,9 +376,7 @@ spec:
                           characters and hyphens
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
-                  - group
                   - name
-                  - resource
                   type: object
                 maxItems: 10
                 type: array

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-CustomNoUpgrade.crd.yaml
@@ -328,9 +328,7 @@ spec:
                         characters and hyphens
                       rule: '!format.dns1123Label().validate(self).hasValue()'
                 required:
-                - group
                 - name
-                - resource
                 type: object
               observedGeneration:
                 description: observedGeneration represents the generation of the MachineOSConfig

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -328,9 +328,7 @@ spec:
                         characters and hyphens
                       rule: '!format.dns1123Label().validate(self).hasValue()'
                 required:
-                - group
                 - name
-                - resource
                 type: object
               observedGeneration:
                 description: observedGeneration represents the generation of the MachineOSConfig

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -328,9 +328,7 @@ spec:
                         characters and hyphens
                       rule: '!format.dns1123Label().validate(self).hasValue()'
                 required:
-                - group
                 - name
-                - resource
                 type: object
               observedGeneration:
                 description: observedGeneration represents the generation of the MachineOSConfig

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineosbuilds.machineconfiguration.openshift.io/OnClusterBuild.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineosbuilds.machineconfiguration.openshift.io/OnClusterBuild.yaml
@@ -217,9 +217,7 @@ spec:
                             characters and hyphens
                           rule: '!format.dns1123Label().validate(self).hasValue()'
                     required:
-                    - group
                     - name
-                    - resource
                     type: object
                 required:
                 - imageBuilderType
@@ -378,9 +376,7 @@ spec:
                           characters and hyphens
                         rule: '!format.dns1123Label().validate(self).hasValue()'
                   required:
-                  - group
                   - name
-                  - resource
                   type: object
                 maxItems: 10
                 type: array

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineosconfigs.machineconfiguration.openshift.io/OnClusterBuild.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineosconfigs.machineconfiguration.openshift.io/OnClusterBuild.yaml
@@ -328,9 +328,7 @@ spec:
                         characters and hyphens
                       rule: '!format.dns1123Label().validate(self).hasValue()'
                 required:
-                - group
                 - name
-                - resource
                 type: object
               observedGeneration:
                 description: observedGeneration represents the generation of the MachineOSConfig


### PR DESCRIPTION
These seem to have been made required during alpha API as it was copied from an existing reference. These do not need to be required and it helps with testing to set them as optional. This also makes it closer to the corev1 ObjectReference type.

This should be also safe from a compatibility perspective, and even if not, this API has not yet been used, so there isn't any dependency on it.