### PR TITLE
OCPBUGS-48527: Fix issues if you use operator/v1 types in your own CRDs.

### DIFF
--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -257,7 +257,7 @@ type StaticPodOperatorStatus struct {
 }
 
 // NodeStatus provides information about the current state of a particular node managed by this operator.
-// +kubebuilder:validation:XValidation:rule="has(self.currentRevision) || !has(oldSelf.currentRevision)",message="cannot be unset once set",fieldPath=".currentRevision"
+// +kubebuilder:validation:XValidation:rule="has(self.currentRevision) || !has(oldSelf.currentRevision)",message="cannot be unset once set"
 type NodeStatus struct {
 	// nodeName is the name of the node
 	// +required

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -300,8 +300,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -287,8 +287,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -300,8 +300,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -300,8 +300,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -269,8 +269,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -278,8 +278,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -269,8 +269,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
@@ -274,8 +274,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
@@ -287,8 +287,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/HardwareSpeed.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/HardwareSpeed.yaml
@@ -287,8 +287,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -270,8 +270,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
@@ -279,8 +279,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
@@ -270,8 +270,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -300,8 +300,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -287,8 +287,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -300,8 +300,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -300,8 +300,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -269,8 +269,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -278,8 +278,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:

--- a/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -269,8 +269,7 @@ spec:
                   - nodeName
                   type: object
                   x-kubernetes-validations:
-                  - fieldPath: .currentRevision
-                    message: cannot be unset once set
+                  - message: cannot be unset once set
                     rule: has(self.currentRevision) || !has(oldSelf.currentRevision)
                 type: array
                 x-kubernetes-list-map-keys:


### PR DESCRIPTION
I am able to test this in a vendored version and my CRD works without any errors.

The bug linked was a more detailed explanation of how I saw this bug.