### PR TITLE
Update KAL to introduce statussubresource and maxlength linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,9 @@ linters-settings:
       settings:
         linters:
           enable:
+          - "maxlength"
           - "nobools"
+          - "statussubresource"
         lintersConfig:
           conditions:
             isFirstField: Warn

--- a/tools/.custom-gcl.yml
+++ b/tools/.custom-gcl.yml
@@ -3,4 +3,4 @@ name: golangci-kal
 destination: ./bin
 plugins:
 - module: 'github.com/JoelSpeed/kal'
-  version: v0.0.0-20250106180308-e8da2ea1f7d6
+  version: v0.0.0-20250121143106-304c215e474e

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.0
 
 require (
 	cloud.google.com/go/storage v1.43.0
-	github.com/JoelSpeed/kal v0.0.0-20250106180308-e8da2ea1f7d6
+	github.com/JoelSpeed/kal v0.0.0-20250121143106-304c215e474e
 	github.com/dave/dst v0.27.3
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.12.0

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -38,8 +38,8 @@ github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rW
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.0 h1:/fTUt5vmbkAcMBt4YQiuC23cV0kEsN1MVMNqeOW43cU=
 github.com/GaijinEntertainment/go-exhaustruct/v3 v3.3.0/go.mod h1:ONJg5sxcbsdQQ4pOW8TGdTidT2TMAUy/2Xhr8mrYaao=
-github.com/JoelSpeed/kal v0.0.0-20250106180308-e8da2ea1f7d6 h1:pPsDHlxzk8fMcDtRnoDjOFeOuEwOjRwxyMgjOGN0DNQ=
-github.com/JoelSpeed/kal v0.0.0-20250106180308-e8da2ea1f7d6/go.mod h1:zptAqBcJGHljQfJR7oQXVKS/E6KVUFZDkE7OJDQeKOw=
+github.com/JoelSpeed/kal v0.0.0-20250121143106-304c215e474e h1:H7jNmU1/bzAi4YFVpRPUzE3hzcrOCk1H6qJpLVCAPaI=
+github.com/JoelSpeed/kal v0.0.0-20250121143106-304c215e474e/go.mod h1:zptAqBcJGHljQfJR7oQXVKS/E6KVUFZDkE7OJDQeKOw=
 github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
 github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/maxlength/analyzer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/maxlength/analyzer.go
@@ -1,0 +1,225 @@
+package maxlength
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/helpers/markers"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const (
+	name = "maxlength"
+
+	kubebuilderMaxLength = "kubebuilder:validation:MaxLength"
+	kubebuilderEnum      = "kubebuilder:validation:Enum"
+	kubebuilderFormat    = "kubebuilder:validation:Format"
+
+	kubebuilderItemsMaxLength = "kubebuilder:validation:items:MaxLength"
+	kubebuilderItemsEnum      = "kubebuilder:validation:items:Enum"
+	kubebuilderItemsFormat    = "kubebuilder:validation:items:Format"
+
+	kubebuilderMaxItems = "kubebuilder:validation:MaxItems"
+)
+
+var (
+	errCouldNotGetInspector = errors.New("could not get inspector")
+	errCouldNotGetMarkers   = errors.New("could not get markers")
+)
+
+// Analyzer is the analyzer for the maxlength package.
+// It checks that strings and arrays have maximum lengths and maximum items respectively.
+var Analyzer = &analysis.Analyzer{
+	Name:     name,
+	Doc:      "Checks that all strings formatted fields are marked with a maximum length, and that arrays are marked with max items.",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspect.Analyzer, markers.Analyzer},
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	if !ok {
+		return nil, errCouldNotGetInspector
+	}
+
+	markersAccess, ok := pass.ResultOf[markers.Analyzer].(markers.Markers)
+	if !ok {
+		return nil, errCouldNotGetMarkers
+	}
+
+	// Filter to structs so that we can iterate over the fields in a struct.
+	nodeFilter := []ast.Node{
+		(*ast.StructType)(nil),
+	}
+
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		sTyp, ok := n.(*ast.StructType)
+		if !ok {
+			return
+		}
+
+		if sTyp.Fields == nil {
+			return
+		}
+
+		for _, field := range sTyp.Fields.List {
+			checkField(pass, field, markersAccess)
+		}
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func checkField(pass *analysis.Pass, field *ast.Field, markersAccess markers.Markers) {
+	if len(field.Names) == 0 || field.Names[0] == nil {
+		return
+	}
+
+	fieldName := field.Names[0].Name
+	prefix := fmt.Sprintf("field %s", fieldName)
+
+	checkTypeExpr(pass, field.Type, field, nil, markersAccess, prefix, kubebuilderMaxLength, needsStringMaxLength)
+}
+
+func checkIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+	if ident.Obj == nil { // Built-in type
+		checkString(pass, ident, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+
+		return
+	}
+
+	tSpec, ok := ident.Obj.Decl.(*ast.TypeSpec)
+	if !ok {
+		return
+	}
+
+	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), marker, needsMaxLength)
+}
+
+func checkString(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+	if ident.Name != "string" {
+		return
+	}
+
+	markers := getCombinedMarkers(markersAccess, node, aliases)
+
+	if needsMaxLength(markers) {
+		pass.Reportf(node.Pos(), "%s must have a maximum length, add %s marker", prefix, marker)
+	}
+}
+
+func checkTypeSpec(pass *analysis.Pass, tSpec *ast.TypeSpec, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+	if tSpec.Name == nil {
+		return
+	}
+
+	typeName := tSpec.Name.Name
+	prefix = fmt.Sprintf("%s %s", prefix, typeName)
+
+	checkTypeExpr(pass, tSpec.Type, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+}
+
+func checkTypeExpr(pass *analysis.Pass, typeExpr ast.Expr, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix, marker string, needsMaxLength func(markers.MarkerSet) bool) {
+	switch typ := typeExpr.(type) {
+	case *ast.Ident:
+		checkIdent(pass, typ, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+	case *ast.StarExpr:
+		checkTypeExpr(pass, typ.X, node, aliases, markersAccess, prefix, marker, needsMaxLength)
+	case *ast.ArrayType:
+		checkArrayType(pass, typ, node, aliases, markersAccess, prefix)
+	}
+}
+
+func checkArrayType(pass *analysis.Pass, arrayType *ast.ArrayType, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix string) {
+	if arrayType.Elt != nil {
+		if ident, ok := arrayType.Elt.(*ast.Ident); ok {
+			checkArrayElementIdent(pass, ident, node, aliases, markersAccess, fmt.Sprintf("%s array element", prefix))
+		}
+	}
+
+	markers := getCombinedMarkers(markersAccess, node, aliases)
+
+	if !markers.Has(kubebuilderMaxItems) {
+		pass.Reportf(node.Pos(), "%s must have a maximum items, add %s marker", prefix, kubebuilderMaxItems)
+	}
+}
+
+func checkArrayElementIdent(pass *analysis.Pass, ident *ast.Ident, node ast.Node, aliases []*ast.TypeSpec, markersAccess markers.Markers, prefix string) {
+	if ident.Obj == nil { // Built-in type
+		checkString(pass, ident, node, aliases, markersAccess, prefix, kubebuilderItemsMaxLength, needsItemsMaxLength)
+
+		return
+	}
+
+	tSpec, ok := ident.Obj.Decl.(*ast.TypeSpec)
+	if !ok {
+		return
+	}
+
+	// If the array element wasn't directly a string, allow a string alias to be used
+	// with either the items style markers or the on alias style markers.
+	checkTypeSpec(pass, tSpec, node, append(aliases, tSpec), markersAccess, fmt.Sprintf("%s type", prefix), kubebuilderMaxLength, func(ms markers.MarkerSet) bool {
+		return needsStringMaxLength(ms) && needsItemsMaxLength(ms)
+	})
+}
+
+func getCombinedMarkers(markersAccess markers.Markers, node ast.Node, aliases []*ast.TypeSpec) markers.MarkerSet {
+	base := markers.NewMarkerSet(getMarkers(markersAccess, node).UnsortedList()...)
+
+	for _, a := range aliases {
+		base.Insert(getMarkers(markersAccess, a).UnsortedList()...)
+	}
+
+	return base
+}
+
+func getMarkers(markersAccess markers.Markers, node ast.Node) markers.MarkerSet {
+	switch t := node.(type) {
+	case *ast.Field:
+		return markersAccess.FieldMarkers(t)
+	case *ast.TypeSpec:
+		return markersAccess.TypeMarkers(t)
+	}
+
+	return nil
+}
+
+// needsMaxLength returns true if the field needs a maximum length.
+// Fields do not need a maximum length if they are already marked with a maximum length,
+// or if they are an enum, or if they are a date, date-time or duration.
+func needsStringMaxLength(markerSet markers.MarkerSet) bool {
+	switch {
+	case markerSet.Has(kubebuilderMaxLength),
+		markerSet.Has(kubebuilderEnum),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("date-time")),
+		markerSet.HasWithValue(kubebuilderFormatWithValue("duration")):
+		return false
+	}
+
+	return true
+}
+
+func needsItemsMaxLength(markerSet markers.MarkerSet) bool {
+	switch {
+	case markerSet.Has(kubebuilderItemsMaxLength),
+		markerSet.Has(kubebuilderItemsEnum),
+		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date")),
+		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("date-time")),
+		markerSet.HasWithValue(kubebuilderItemsFormatWithValue("duration")):
+		return false
+	}
+
+	return true
+}
+
+func kubebuilderFormatWithValue(value string) string {
+	return fmt.Sprintf("%s:=%s", kubebuilderFormat, value)
+}
+
+func kubebuilderItemsFormatWithValue(value string) string {
+	return fmt.Sprintf("%s:=%s", kubebuilderItemsFormat, value)
+}

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/maxlength/doc.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/maxlength/doc.go
@@ -1,0 +1,19 @@
+/*
+maxlength is an analyzer that checks that all string fields have a maximum length, and that all array fields have a maximum number of items.
+
+String fields that are not otherwise bound in length, through being an enum or formatted in a certain way, should have a maximum length.
+This ensures that CEL validations on the field are not overly costly in terms of time and memory.
+
+Array fields should have a maximum number of items.
+This ensures that any CEL validations on the field are not overly costly in terms of time and memory.
+Where arrays are used to represent a list of structures, CEL rules may exist within the array.
+Limiting the array length ensures the cardinality of the rules within the array is not unbounded.
+
+For strings, the maximum length can be set using the `kubebuilder:validation:MaxLength` tag.
+For arrays, the maximum number of items can be set using the `kubebuilder:validation:MaxItems` tag.
+
+For arrays of strings, the maximum length of each string can be set using the `kubebuilder:validation:items:MaxLength` tag,
+on the array field itself.
+Or, if the array uses a string type alias, the `kubebuilder:validation:MaxLength` tag can be used on the alias.
+*/
+package maxlength

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/maxlength/initializer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/maxlength/initializer.go
@@ -1,0 +1,30 @@
+package maxlength
+
+import (
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer {
+	return initializer{}
+}
+
+// intializer implements the AnalyzerInitializer interface.
+type initializer struct{}
+
+// Name returns the name of the Analyzer.
+func (initializer) Name() string {
+	return name
+}
+
+// Init returns the intialized Analyzer.
+func (initializer) Init(cfg config.LintersConfig) (*analysis.Analyzer, error) {
+	return Analyzer, nil
+}
+
+// Default determines whether this Analyzer is on by default, or not.
+func (initializer) Default() bool {
+	return false // For now, CRD only, and so not on by default.
+}

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/registry.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/registry.go
@@ -7,10 +7,12 @@ import (
 	"github.com/JoelSpeed/kal/pkg/analysis/conditions"
 	"github.com/JoelSpeed/kal/pkg/analysis/integers"
 	"github.com/JoelSpeed/kal/pkg/analysis/jsontags"
+	"github.com/JoelSpeed/kal/pkg/analysis/maxlength"
 	"github.com/JoelSpeed/kal/pkg/analysis/nobools"
 	"github.com/JoelSpeed/kal/pkg/analysis/nophase"
 	"github.com/JoelSpeed/kal/pkg/analysis/optionalorrequired"
 	"github.com/JoelSpeed/kal/pkg/analysis/requiredfields"
+	"github.com/JoelSpeed/kal/pkg/analysis/statussubresource"
 	"github.com/JoelSpeed/kal/pkg/config"
 	"golang.org/x/tools/go/analysis"
 
@@ -57,10 +59,12 @@ func NewRegistry() Registry {
 			commentstart.Initializer(),
 			integers.Initializer(),
 			jsontags.Initializer(),
+			maxlength.Initializer(),
 			nobools.Initializer(),
 			nophase.Initializer(),
 			optionalorrequired.Initializer(),
 			requiredfields.Initializer(),
+			statussubresource.Initializer(),
 		},
 	}
 }

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/statussubresource/analyzer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/statussubresource/analyzer.go
@@ -1,0 +1,151 @@
+package statussubresource
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/token"
+
+	"github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags"
+	"github.com/JoelSpeed/kal/pkg/analysis/helpers/markers"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const (
+	name = "statussubresource"
+
+	statusJSONTag = "status"
+
+	// kubebuilderRootMarker is the marker that indicates that a struct is the object root for code and CRD generation.
+	kubebuilderRootMarker = "kubebuilder:object:root:=true"
+
+	// kubebuilderStatusSubresourceMarker is the marker that indicates that the CRD generated for a struct should include the /status subresource.
+	kubebuilderStatusSubresourceMarker = "kubebuilder:subresource:status"
+)
+
+var (
+	errCouldNotGetInspector = errors.New("could not get inspector")
+	errCouldNotGetMarkers   = errors.New("could not get markers")
+	errCouldNotGetJSONTags  = errors.New("could not get json tags")
+)
+
+type analyzer struct{}
+
+// newAnalyzer creates a new analyzer with the given configuration.
+func newAnalyzer() *analysis.Analyzer {
+	a := &analyzer{}
+
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      "Checks that a type marked with kubebuilder:object:root:=true and containing a status field is marked with kubebuilder:subresource:status",
+		Run:      a.run,
+		Requires: []*analysis.Analyzer{inspect.Analyzer, markers.Analyzer, extractjsontags.Analyzer},
+	}
+}
+
+func (a *analyzer) run(pass *analysis.Pass) (interface{}, error) {
+	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	if !ok {
+		return nil, errCouldNotGetInspector
+	}
+
+	markersAccess, ok := pass.ResultOf[markers.Analyzer].(markers.Markers)
+	if !ok {
+		return nil, errCouldNotGetMarkers
+	}
+
+	jsonTags, ok := pass.ResultOf[extractjsontags.Analyzer].(extractjsontags.StructFieldTags)
+	if !ok {
+		return nil, errCouldNotGetJSONTags
+	}
+
+	// Filter to type specs so we can get the names of types
+	nodeFilter := []ast.Node{
+		(*ast.TypeSpec)(nil),
+	}
+
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		typeSpec, ok := n.(*ast.TypeSpec)
+		if !ok {
+			return
+		}
+
+		// we only care about struct types
+		sTyp, ok := typeSpec.Type.(*ast.StructType)
+		if !ok {
+			return
+		}
+
+		// no identifier on the type
+		if typeSpec.Name == nil {
+			return
+		}
+
+		structMarkers := markersAccess.StructMarkers(sTyp)
+		a.checkStruct(pass, sTyp, typeSpec.Name.Name, structMarkers, jsonTags)
+	})
+
+	return nil, nil //nolint:nilnil
+}
+
+func (a *analyzer) checkStruct(pass *analysis.Pass, sTyp *ast.StructType, name string, structMarkers markers.MarkerSet, jsonTags extractjsontags.StructFieldTags) {
+	if sTyp == nil {
+		return
+	}
+
+	if !structMarkers.HasWithValue(kubebuilderRootMarker) {
+		return
+	}
+
+	hasStatusSubresourceMarker := structMarkers.Has(kubebuilderStatusSubresourceMarker)
+	hasStatusField := hasStatusField(sTyp, jsonTags)
+
+	switch {
+	case (hasStatusSubresourceMarker && hasStatusField), (!hasStatusSubresourceMarker && !hasStatusField):
+		// acceptable state
+	case hasStatusSubresourceMarker && !hasStatusField:
+		// Might be able to have some suggested fixes here, but it is likely much more complex
+		// so for now leave it with a descriptive failure message.
+		pass.Reportf(sTyp.Pos(), "root object type %q is marked to enable the status subresource with marker %q but has no status field", name, kubebuilderStatusSubresourceMarker)
+	case !hasStatusSubresourceMarker && hasStatusField:
+		// In this case we can suggest the autofix to add the status subresource marker
+		pass.Report(analysis.Diagnostic{
+			Pos:     sTyp.Pos(),
+			Message: fmt.Sprintf("root object type %q has a status field but does not have the marker %q to enable the status subresource", name, kubebuilderStatusSubresourceMarker),
+			SuggestedFixes: []analysis.SuggestedFix{
+				{
+					Message: "should add the kubebuilder:subresource:status marker",
+					TextEdits: []analysis.TextEdit{
+						// go one line above the struct and add the marker
+						{
+							// sTyp.Pos() is the beginning of the 'struct' keyword. Subtract
+							// the length of the struct name + 7 (2 for spaces surrounding type name, 4 for the 'type' keyword,
+							// and 1 for the newline) to position at the end of the line above the struct
+							// definition.
+							Pos: sTyp.Pos() - token.Pos(len(name)+7),
+							// prefix with a newline to ensure we aren't appending to a previous comment
+							NewText: []byte("\n// +kubebuilder:subresource:status"),
+						},
+					},
+				},
+			},
+		})
+	}
+}
+
+func hasStatusField(sTyp *ast.StructType, jsonTags extractjsontags.StructFieldTags) bool {
+	if sTyp == nil || sTyp.Fields == nil || sTyp.Fields.List == nil {
+		return false
+	}
+
+	for _, field := range sTyp.Fields.List {
+		info := jsonTags.FieldTags(field)
+		if info.Name == statusJSONTag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/statussubresource/doc.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/statussubresource/doc.go
@@ -1,0 +1,10 @@
+// statussubresource is a linter to check that the status subresource is configured correctly for
+// structs marked with the 'kubebuilder:object:root:=true' marker. Correct configuration is that
+// when there is a status field the 'kubebuilder:subresource:status' marker is present on the struct
+// OR when the 'kubebuilder:subresource:status' marker is present on the struct there is a status field.
+//
+// In the case where there is a status field present but no 'kubebuilder:subresource:status' marker, the
+// linter will suggest adding the comment '// +kubebuilder:subresource:status' above the struct.
+//
+// This linter is not enabled by default as it is only applicable to CustomResourceDefinitions.
+package statussubresource

--- a/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/statussubresource/initializer.go
+++ b/tools/vendor/github.com/JoelSpeed/kal/pkg/analysis/statussubresource/initializer.go
@@ -1,0 +1,31 @@
+package statussubresource
+
+import (
+	"github.com/JoelSpeed/kal/pkg/config"
+	"golang.org/x/tools/go/analysis"
+)
+
+// Initializer returns the AnalyzerInitializer for this
+// Analyzer so that it can be added to the registry.
+func Initializer() initializer {
+	return initializer{}
+}
+
+// intializer implements the AnalyzerInitializer interface.
+type initializer struct{}
+
+// Name returns the name of the Analyzer.
+func (initializer) Name() string {
+	return name
+}
+
+// Init returns the intialized Analyzer.
+func (initializer) Init(cfg config.LintersConfig) (*analysis.Analyzer, error) {
+	return newAnalyzer(), nil
+}
+
+// Default determines whether this Analyzer is on by default, or not.
+func (initializer) Default() bool {
+	// This check only applies to CRDs so should not be on by default.
+	return false
+}

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -81,7 +81,7 @@ github.com/GaijinEntertainment/go-exhaustruct/v3/analyzer
 github.com/GaijinEntertainment/go-exhaustruct/v3/internal/comment
 github.com/GaijinEntertainment/go-exhaustruct/v3/internal/pattern
 github.com/GaijinEntertainment/go-exhaustruct/v3/internal/structure
-# github.com/JoelSpeed/kal v0.0.0-20250106180308-e8da2ea1f7d6
+# github.com/JoelSpeed/kal v0.0.0-20250121143106-304c215e474e
 ## explicit; go 1.22.1
 github.com/JoelSpeed/kal
 github.com/JoelSpeed/kal/cmd/kal
@@ -92,10 +92,12 @@ github.com/JoelSpeed/kal/pkg/analysis/helpers/extractjsontags
 github.com/JoelSpeed/kal/pkg/analysis/helpers/markers
 github.com/JoelSpeed/kal/pkg/analysis/integers
 github.com/JoelSpeed/kal/pkg/analysis/jsontags
+github.com/JoelSpeed/kal/pkg/analysis/maxlength
 github.com/JoelSpeed/kal/pkg/analysis/nobools
 github.com/JoelSpeed/kal/pkg/analysis/nophase
 github.com/JoelSpeed/kal/pkg/analysis/optionalorrequired
 github.com/JoelSpeed/kal/pkg/analysis/requiredfields
+github.com/JoelSpeed/kal/pkg/analysis/statussubresource
 github.com/JoelSpeed/kal/pkg/analysis/utils
 github.com/JoelSpeed/kal/pkg/config
 github.com/JoelSpeed/kal/pkg/validation


### PR DESCRIPTION
This updates KAL to include two new linter rules.

### StatusSubresource

This linter will check for objects marked as a CRD root, and, if they have a `status` field, will make sure that they have the appropriate subresource status marker.

It will also report when we have objects that have the marker, but do not have a status field, which is true of several of our APIs (I assume we should drop those).

### MaxLength

This linter will check for untyped strings and arrays and ensure that a maximum length/items is configured appropriately.

Setting maximum lengths on fields is good practice to prevent folks from abusing an API (persisting large data in the database, potential DDOS), but also means that as we add CEL validations over time, their computational complexity is bound and their runtime cost is managed, by having sensible limits in place.

All lists must have a maximum items marker. Authors are expected to think about the use case, and choose something sensible, that is larger (or equal to) the maximum that the use case requires.

Likewise, any string that is not an enum, or has a format as date, date-time or duration, should include a maxLength. Ideally this is some small figure (sub 4kb) that is suitable for the worst case, of the use case, for the field.