### PR TITLE
OTA-209: operator/v1alpha1: Add the `ClusterVersionOperator` to scheme

### DIFF
--- a/operator/v1alpha1/register.go
+++ b/operator/v1alpha1/register.go
@@ -39,6 +39,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&OLMList{},
 		&EtcdBackup{},
 		&EtcdBackupList{},
+		&ClusterVersionOperator{},
+		&ClusterVersionOperatorList{},
 	)
 
 	return nil


### PR DESCRIPTION
operator/v1alpha1: Add the `ClusterVersionOperator` to scheme

I forgot to register the new type in the scheme when adding the `ClusterVersionOperator` API in https://github.com/openshift/api/pull/2044.

This pull request references https://issues.redhat.com/browse/OTA-209