### PR TITLE
OSASINFRA-3690: Fix typo

### DIFF
--- a/machine/v1alpha1/types_openstack.go
+++ b/machine/v1alpha1/types_openstack.go
@@ -368,7 +368,7 @@ type RootVolume struct {
 	// volumeType specifies a volume type to use when creating the root
 	// volume. If not specified the default volume type will be used.
 	VolumeType string `json:"volumeType,omitempty"`
-	// diskSize specifies the size, in GB, of the created root volume.
+	// diskSize specifies the size, in GiB, of the created root volume.
 	Size int `json:"diskSize,omitempty"`
 	// availabilityZone specifies the Cinder availability where the root volume will be created.
 	Zone string `json:"availabilityZone,omitempty"`

--- a/machine/v1alpha1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1alpha1/zz_generated.swagger_doc_generated.go
@@ -146,7 +146,7 @@ func (PortOpts) SwaggerDoc() map[string]string {
 var map_RootVolume = map[string]string{
 	"sourceUUID":       "sourceUUID specifies the UUID of a glance image used to populate the root volume. Deprecated: set image in the platform spec instead. This will be ignored if image is set in the platform spec.",
 	"volumeType":       "volumeType specifies a volume type to use when creating the root volume. If not specified the default volume type will be used.",
-	"diskSize":         "diskSize specifies the size, in GB, of the created root volume.",
+	"diskSize":         "diskSize specifies the size, in GiB, of the created root volume.",
 	"availabilityZone": "availabilityZone specifies the Cinder availability where the root volume will be created.",
 	"sourceType":       "Deprecated: sourceType will be silently ignored. There is no replacement.",
 	"deviceType":       "Deprecated: deviceType will be silently ignored. There is no replacement.",

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -35098,7 +35098,7 @@ func schema_openshift_api_machine_v1alpha1_RootVolume(ref common.ReferenceCallba
 					},
 					"diskSize": {
 						SchemaProps: spec.SchemaProps{
-							Description: "diskSize specifies the size, in GB, of the created root volume.",
+							Description: "diskSize specifies the size, in GiB, of the created root volume.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -20257,7 +20257,7 @@
           "type": "string"
         },
         "diskSize": {
-          "description": "diskSize specifies the size, in GB, of the created root volume.",
+          "description": "diskSize specifies the size, in GiB, of the created root volume.",
           "type": "integer",
           "format": "int32"
         },


### PR DESCRIPTION
Cinder uses GiB, not GB. This was a source of confusion during the MAPO<->CAPO work.

More discussion here: https://github.com/openshift/cluster-capi-operator/pull/188#discussion_r1927180443
