### PR TITLE
Add the field "MarketType" to "AwsMachineProviderConfig"

### DIFF
--- a/machine/v1beta1/types_awsprovider.go
+++ b/machine/v1beta1/types_awsprovider.go
@@ -95,6 +95,18 @@ type AWSMachineProviderConfig struct {
 	// The field size should be greater than 0 and the field input must start with cr-***
 	// +optional
 	CapacityReservationID string `json:"capacityReservationId"`
+	// marketType specifies the type of market for the EC2 instance.
+	// Valid values are OnDemand, Spot, CapacityBlock and omitted.
+	//
+	// Defaults to OnDemand.
+	// When SpotMarketOptions is provided, the marketType defaults to "Spot".
+	//
+	// When set to OnDemand the instance runs as a standard OnDemand instance.
+	// When set to Spot the instance runs as a Spot instance.
+	// When set to CapacityBlock the instance utilizes pre-purchased compute capacity (capacity blocks) with AWS Capacity Reservations.
+	// If this value is selected, capacityReservationID must be specified to identify the target reservation.
+	// +optional
+	MarketType MarketType `json:"marketType,omitempty"`
 }
 
 // BlockDeviceMappingSpec describes a block device mapping
@@ -320,3 +332,22 @@ type AWSMachineProviderStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
+
+// MarketType describes the market type of an EC2 Instance
+// +kubebuilder:validation:Enum:=OnDemand;Spot;CapacityBlock
+type MarketType string
+
+const (
+
+	// MarketTypeOnDemand is a MarketType enum value
+	// When set to OnDemand the instance runs as a standard OnDemand instance.
+	MarketTypeOnDemand MarketType = "OnDemand"
+
+	// MarketTypeSpot is a MarketType enum value
+	// When set to Spot the instance runs as a Spot instance.
+	MarketTypeSpot MarketType = "Spot"
+
+	// MarketTypeCapacityBlock is a MarketType enum value
+	// When set to CapacityBlock the instance utilizes pre-purchased compute capacity (capacity blocks) with AWS Capacity Reservations.
+	MarketTypeCapacityBlock MarketType = "CapacityBlock"
+)

--- a/machine/v1beta1/zz_generated.swagger_doc_generated.go
+++ b/machine/v1beta1/zz_generated.swagger_doc_generated.go
@@ -33,6 +33,7 @@ var map_AWSMachineProviderConfig = map[string]string{
 	"placementGroupName":      "placementGroupName specifies the name of the placement group in which to launch the instance. The placement group must already be created and may use any placement strategy. When omitted, no placement group is used when creating the EC2 instance.",
 	"placementGroupPartition": "placementGroupPartition is the partition number within the placement group in which to launch the instance. This must be an integer value between 1 and 7. It is only valid if the placement group, referred in `PlacementGroupName` was created with strategy set to partition.",
 	"capacityReservationId":   "capacityReservationId specifies the target Capacity Reservation into which the instance should be launched. The field size should be greater than 0 and the field input must start with cr-***",
+	"marketType":              "marketType specifies the type of market for the EC2 instance. Valid values are OnDemand, Spot, CapacityBlock and omitted.\n\nDefaults to OnDemand. When SpotMarketOptions is provided, the marketType defaults to \"Spot\".\n\nWhen set to OnDemand the instance runs as a standard OnDemand instance. When set to Spot the instance runs as a Spot instance. When set to CapacityBlock the instance utilizes pre-purchased compute capacity (capacity blocks) with AWS Capacity Reservations. If this value is selected, capacityReservationID must be specified to identify the target reservation.",
 }
 
 func (AWSMachineProviderConfig) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -35671,6 +35671,13 @@ func schema_openshift_api_machine_v1beta1_AWSMachineProviderConfig(ref common.Re
 							Format:      "",
 						},
 					},
+					"marketType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "marketType specifies the type of market for the EC2 instance. Valid values are OnDemand, Spot, CapacityBlock and omitted.\n\nDefaults to OnDemand. When SpotMarketOptions is provided, the marketType defaults to \"Spot\".\n\nWhen set to OnDemand the instance runs as a standard OnDemand instance. When set to Spot the instance runs as a Spot instance. When set to CapacityBlock the instance utilizes pre-purchased compute capacity (capacity blocks) with AWS Capacity Reservations. If this value is selected, capacityReservationID must be specified to identify the target reservation.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"ami", "instanceType", "deviceIndex", "subnet", "placement"},
 			},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -20536,6 +20536,10 @@
             "$ref": "#/definitions/com.github.openshift.api.machine.v1beta1.LoadBalancerReference"
           }
         },
+        "marketType": {
+          "description": "marketType specifies the type of market for the EC2 instance. Valid values are OnDemand, Spot, CapacityBlock and omitted.\n\nDefaults to OnDemand. When SpotMarketOptions is provided, the marketType defaults to \"Spot\".\n\nWhen set to OnDemand the instance runs as a standard OnDemand instance. When set to Spot the instance runs as a Spot instance. When set to CapacityBlock the instance utilizes pre-purchased compute capacity (capacity blocks) with AWS Capacity Reservations. If this value is selected, capacityReservationID must be specified to identify the target reservation.",
+          "type": "string"
+        },
         "metadata": {
           "default": {},
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"


### PR DESCRIPTION
This PR adds support market type in AwsMachineProviderConfig. A new field, `MarketType`, is added. This ID is used specify the instance type i.e CapacityBlock, Spot, OnDemand.