### PR TITLE
Add separate Make target for feature promotion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ verify-codegen-crds:
 verify-crd-schema:
 	bash -x hack/verify-crd-schema-checker.sh
 
+.PHONY: verify-feature-promotion
+verify-feature-promotion:
+	hack/verify-promoted-features-pass-tests.sh
+
 .PHONY: verify-%
 verify-%:
 	make $*


### PR DESCRIPTION
This adds a separate make target to run the feature promotion checks. This is intended to be used to add a separate check for feature promotion checks aside from the main verify run