### PR TITLE
Drop feature promotion from main verify check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ verify-scripts:
 	bash -x hack/verify-prerelease-lifecycle-gen.sh
 	hack/verify-payload-crds.sh
 	hack/verify-payload-featuregates.sh
-	hack/verify-promoted-features-pass-tests.sh
 
 .PHONY: verify
 verify: verify-scripts lint verify-crd-schema verify-codegen-crds


### PR DESCRIPTION
This drops the feature gate promotion from the main verify check, as it has now been added as a separate check on its own

/hold Must merge after https://github.com/openshift/api/pull/2173 and https://github.com/openshift/release/pull/61007