### PR TITLE
Fix race in tests using CRD patches for ratcheting

### DIFF
--- a/tests/generator.go
+++ b/tests/generator.go
@@ -241,7 +241,11 @@ func generateOnUpdateTable(onUpdateTests []OnUpdateTestSpec, crdFileName string)
 			Expect(initialStatus).ToNot(BeNil())
 		}
 
-		Expect(k8sClient.Create(ctx, initialObj)).ToNot(HaveOccurred(), "initial object should create successfully")
+		// Use an eventually here, so that any modification to the CRD
+		// has time to be reflected in the CRD storage.
+		Eventually(func() error {
+			return k8sClient.Create(ctx, initialObj)
+		}).Should(Succeed(), "initial object should create successfully")
 
 		if initialStatus != nil {
 			Expect(unstructured.SetNestedField(initialObj.Object, initialStatus, "status")).To(Succeed(), "should be able to restore initial status")


### PR DESCRIPTION
This should fix a race between the CRD being updated, and being active and served, vs the attempt to create a resource.

Seeking a flake occasionally because the initial object isn't created, because it fails the validation that the previous patch to the CRD schema was removing, as part of our ratcheting tests.

Also moves the CRD schema cleanup earlier to avoid exiting before we do the cleanup