### PR TITLE
OCPNODE-2877: Remove support to configure cgroupsv1 in OCP

### DIFF
--- a/config/v1/tests/nodes.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/nodes.config.openshift.io/AAA_ungated.yaml
@@ -12,3 +12,111 @@ tests:
         apiVersion: config.openshift.io/v1
         kind: Node
         spec: {}
+    - name: Should be able to create a Node object with cgroupMode set to "v2"
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v2"
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v2"
+    - name: Should not allow to create a Node object with the cgroupMode set to "v1"
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v1"
+      expectedError: "spec.cgroupMode: Unsupported value: \"v1\""
+    - name: Should not allow to create a Node object with the cgroupMode set to unknown value
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "unknown"
+      expectedError: "spec.cgroupMode: Unsupported value: \"unknown\""
+  onUpdate:
+    - name: Should be able to update a Node object with cgroupMode set to "v2"
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec: {}
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v2"
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v2"
+    - name: Should not allow update of cgroupMode from "v2" to "v1"
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v2"
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v1"
+      expectedError: "spec.cgroupMode: Unsupported value: \"v1\""
+    - name: Should allow changing fields other than cgroupMode when a persisted value "v1" is no longer valid
+      initialCRDPatches:
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/cgroupMode
+          value:
+            enum:
+              - v1
+              - v2
+              - ""
+            type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v1"
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v1"
+          workerLatencyProfile: "MediumUpdateAverageReaction"
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v1"
+          workerLatencyProfile: "MediumUpdateAverageReaction"
+    - name: Should allow updating a persisted value of cgroupMode that is no longer valid "v1" to a valid value "v2"
+      initialCRDPatches:
+        - op: replace
+          path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/cgroupMode
+          value:
+            enum:
+              - v1
+              - v2
+              - ""
+            type: string
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v1"
+          workerLatencyProfile: "MediumUpdateAverageReaction"
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v2"
+          workerLatencyProfile: "MediumUpdateAverageReaction"
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Node
+        spec:
+          cgroupMode: "v2"
+          workerLatencyProfile: "MediumUpdateAverageReaction"

--- a/config/v1/types_node.go
+++ b/config/v1/types_node.go
@@ -76,14 +76,14 @@ type NodeStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
-// +kubebuilder:validation:Enum=v1;v2;""
+// +kubebuilder:validation:Enum=v2;""
 type CgroupMode string
 
 const (
 	CgroupModeEmpty   CgroupMode = "" // Empty string indicates to honor user set value on the system that should not be overridden by OpenShift
 	CgroupModeV1      CgroupMode = "v1"
 	CgroupModeV2      CgroupMode = "v2"
-	CgroupModeDefault CgroupMode = CgroupModeV1
+	CgroupModeDefault CgroupMode = CgroupModeV2
 )
 
 // +kubebuilder:validation:Enum=Default;MediumUpdateAverageReaction;LowUpdateSlowReaction

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes-CustomNoUpgrade.crd.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes-Default.crd.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes-DevPreviewNoUpgrade.crd.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes-TechPreviewNoUpgrade.crd.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string

--- a/config/v1/zz_generated.featuregated-crd-manifests/nodes.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/nodes.config.openshift.io/AAA_ungated.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string

--- a/config/v1/zz_generated.featuregated-crd-manifests/nodes.config.openshift.io/MinimumKubeletVersion.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/nodes.config.openshift.io/MinimumKubeletVersion.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string

--- a/payload-manifests/crds/0000_10_config-operator_01_nodes-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_nodes-CustomNoUpgrade.crd.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string

--- a/payload-manifests/crds/0000_10_config-operator_01_nodes-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_nodes-Default.crd.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string

--- a/payload-manifests/crds/0000_10_config-operator_01_nodes-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_nodes-DevPreviewNoUpgrade.crd.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string

--- a/payload-manifests/crds/0000_10_config-operator_01_nodes-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_nodes-TechPreviewNoUpgrade.crd.yaml
@@ -49,7 +49,6 @@ spec:
               cgroupMode:
                 description: cgroupMode determines the cgroups version on the node
                 enum:
-                - v1
                 - v2
                 - ""
                 type: string


### PR DESCRIPTION
- Removing support to configure cgroupsv1 in the OCP clusters.
- Removed the enum validation of "v1" for the `cgroupMode` field of the `nodes.config.openshift.io` object.
- Also added integration tests to validate the enum removal on the `cgroupMode` field

Enhancement Proposal Ref: https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/mco-cgroupsv2-support.md

Summary:
- This PR allows to block the user from setting `cgroupMode v1`
- A change would be added for 4.18 in MCO to set machine-config cluster operator's `Upgradeable=False` when the `cgroupMode` is found to be `v1` and request users to update to `v2`
- All the clusters upgrading to 4.19 have to update to the minimum version of 4.18.z containing the above changes. This can be achieved through the cincinnati-graph-data repo