### PR TITLE
NO-JIRA: upkeep: update component name for arbiter feature

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -720,7 +720,7 @@ var (
 						mustRegister()
 
 	FeatureGateHighlyAvailableArbiter = newFeatureGate("HighlyAvailableArbiter").
-						reportProblemsToJiraComponent("TwoNode / Arbiter").
+						reportProblemsToJiraComponent("Two Node with Arbiter").
 						contactPerson("eggfoobar").
 						productScope(ocpSpecific).
 						enhancementPR("https://github.com/openshift/enhancements/pull/1674").


### PR DESCRIPTION
Component name for arbiter changed in jira, updating reference.