### PR TITLE
no-jira: Validate AWS resource tag keys with aws: prefix

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1527,3 +1527,31 @@ tests:
                 value: value*
             type: AWS
       expectedStatusError: "invalid AWS resource tag value. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
+    - name: Should not be able to create an aws resourcetag with aws prefix in key
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: aws:key
+                value: value with space
+            type: AWS
+      expectedStatusError: "the prefix 'aws:' is reserved for AWS system usage and cannot be used at the beginning of a key"

--- a/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
+featureGates:
+- -AWSClusterHostedDNS
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure
@@ -1365,3 +1367,163 @@ tests:
               - name: BadService
                 url: https://bad-service.com
       expectedStatusError: "platformStatus.ibmcloud.serviceEndpoints[1].name: Unsupported value: \"BadService\": supported values: \"CIS\", \"COS\", \"COSConfig\", \"DNSServices\", \"GlobalCatalog\", \"GlobalSearch\", \"GlobalTagging\", \"HyperProtect\", \"IAM\", \"KeyProtect\", \"ResourceController\", \"ResourceManager\", \"VPC\""
+    - name: Should be able to create an aws resourcetag with spaces
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:          
+              region: us-east-1
+              resourceTags:
+              - key: key with space
+                value: value with space
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key with space
+                value: value with space
+            type: AWS
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key with space
+                value: value with space
+            type: AWS
+    - name: Should be able to create an aws resourcetag with characters '_', '.', '/', '=', '+', '-', ':', '@'
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key:_./=+-@
+                value: value:_./=+-@
+            type: AWS
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key:_./=+-@
+                value: value:_./=+-@
+            type: AWS
+    - name: Should not be able to create an aws resourcetag with character * in key
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key:_./=+-@*
+                value: value
+            type: AWS
+      expectedStatusError: "invalid AWS resource tag key. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
+    - name: Should not be able to create an aws resourcetag with character * in value
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:              
+              region: us-east-1
+              resourceTags:
+              - key: key
+                value: value*
+            type: AWS
+      expectedStatusError: "invalid AWS resource tag value. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -528,18 +528,22 @@ type AWSPlatformStatus struct {
 
 // AWSResourceTag is a tag to apply to AWS resources created for the cluster.
 type AWSResourceTag struct {
-	// key is the key of the tag
+	// key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+	// Key should consist of between 1 and 128 characters, and may
+	// contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.:/=+-@]+$`
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')`,message="invalid AWS resource tag key. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
 	// +required
 	Key string `json:"key"`
-	// value is the value of the tag.
+	// value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+	// Value should consist of between 1 and 256 characters, and may
+	// contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
 	// Some AWS service do not support empty values. Since tags are added to resources in many services, the
 	// length of the tag value must meet the requirements of all services.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.:/=+-@]+$`
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')`,message="invalid AWS resource tag value. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
 	// +required
 	Value string `json:"value"`
 }

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -531,9 +531,11 @@ type AWSResourceTag struct {
 	// key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
 	// Key should consist of between 1 and 128 characters, and may
 	// contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+	// Key must not be start with 'aws:'.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
 	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')`,message="invalid AWS resource tag key. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
+	// +kubebuilder:validation:XValidation:rule=`!self.startsWith('aws:')`,message="the prefix 'aws:' is reserved for AWS system usage and cannot be used at the beginning of a key"
 	// +required
 	Key string `json:"key"`
 	// value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1309,6 +1309,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1318,6 +1319,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1185,20 +1185,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1189,6 +1189,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1198,6 +1199,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1309,6 +1309,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1318,6 +1319,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1309,6 +1309,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1318,6 +1319,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1158,20 +1158,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1162,6 +1162,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1171,6 +1172,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
@@ -1255,20 +1255,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
@@ -1259,6 +1259,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1268,6 +1269,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
@@ -1151,20 +1151,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
@@ -1155,6 +1155,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1164,6 +1165,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
@@ -1151,20 +1151,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
@@ -1155,6 +1155,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1164,6 +1165,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
@@ -1151,20 +1151,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
@@ -1155,6 +1155,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1164,6 +1165,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/HighlyAvailableArbiter.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/HighlyAvailableArbiter.yaml
@@ -1156,20 +1156,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/HighlyAvailableArbiter.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/HighlyAvailableArbiter.yaml
@@ -1160,6 +1160,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1169,6 +1170,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
@@ -1156,20 +1156,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
@@ -1160,6 +1160,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1169,6 +1170,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1166,20 +1166,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1170,6 +1170,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1179,6 +1180,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
@@ -1162,20 +1162,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereHostVMGroupZonal.yaml
@@ -1166,6 +1166,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1175,6 +1176,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
@@ -1152,20 +1152,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
@@ -1156,6 +1156,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1165,6 +1166,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
@@ -1152,20 +1152,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
@@ -1156,6 +1156,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1165,6 +1166,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1245,8 +1245,8 @@ func (AWSPlatformStatus) SwaggerDoc() map[string]string {
 
 var map_AWSResourceTag = map[string]string{
 	"":      "AWSResourceTag is a tag to apply to AWS resources created for the cluster.",
-	"key":   "key is the key of the tag",
-	"value": "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+	"key":   "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
+	"value": "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
 }
 
 func (AWSResourceTag) SwaggerDoc() map[string]string {

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1245,7 +1245,7 @@ func (AWSPlatformStatus) SwaggerDoc() map[string]string {
 
 var map_AWSResourceTag = map[string]string{
 	"":      "AWSResourceTag is a tag to apply to AWS resources created for the cluster.",
-	"key":   "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
+	"key":   "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Key must not be start with 'aws:'.",
 	"value": "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
 }
 

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -1581,6 +1581,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1590,6 +1591,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1467,20 +1467,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1471,6 +1471,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1480,6 +1481,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1581,6 +1581,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1590,6 +1591,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1581,6 +1581,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1590,6 +1591,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
@@ -1452,20 +1452,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
@@ -1456,6 +1456,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1465,6 +1466,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
@@ -1549,20 +1549,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
@@ -1553,6 +1553,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1562,6 +1563,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
@@ -1445,20 +1445,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
@@ -1449,6 +1449,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1458,6 +1459,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
@@ -1445,20 +1445,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
@@ -1449,6 +1449,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1458,6 +1459,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
@@ -1445,20 +1445,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
@@ -1449,6 +1449,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1458,6 +1459,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter.yaml
@@ -1450,20 +1450,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter.yaml
@@ -1454,6 +1454,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1463,6 +1464,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
@@ -1451,20 +1451,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
@@ -1455,6 +1455,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1464,6 +1465,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1460,20 +1460,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1464,6 +1464,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1473,6 +1474,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
@@ -1446,20 +1446,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
@@ -1450,6 +1450,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1459,6 +1460,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
@@ -1446,20 +1446,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
@@ -1450,6 +1450,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1459,6 +1460,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -8647,7 +8647,7 @@ func schema_openshift_api_config_v1_AWSResourceTag(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"key": {
 						SchemaProps: spec.SchemaProps{
-							Description: "key is the key of the tag",
+							Description: "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -8655,7 +8655,7 @@ func schema_openshift_api_config_v1_AWSResourceTag(ref common.ReferenceCallback)
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+							Description: "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -8647,7 +8647,7 @@ func schema_openshift_api_config_v1_AWSResourceTag(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"key": {
 						SchemaProps: spec.SchemaProps{
-							Description: "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
+							Description: "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Key must not be start with 'aws:'.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4232,12 +4232,12 @@
       ],
       "properties": {
         "key": {
-          "description": "key is the key of the tag",
+          "description": "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
           "type": "string",
           "default": ""
         },
         "value": {
-          "description": "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+          "description": "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
           "type": "string",
           "default": ""
         }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4232,7 +4232,7 @@
       ],
       "properties": {
         "key": {
-          "description": "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
+          "description": "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Key must not be start with 'aws:'.",
           "type": "string",
           "default": ""
         },

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1309,6 +1309,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1318,6 +1319,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1185,20 +1185,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1189,6 +1189,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1198,6 +1199,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1309,6 +1309,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1318,6 +1319,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1305,20 +1305,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1309,6 +1309,7 @@ spec:
                                 key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                 Key should consist of between 1 and 128 characters, and may
                                 contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                Key must not be start with 'aws:'.
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -1318,6 +1319,9 @@ spec:
                                   space (' '), '_', '.', '/', '=', '+', '-', ':',
                                   '@'
                                 rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                              - message: the prefix 'aws:' is reserved for AWS system
+                                  usage and cannot be used at the beginning of a key
+                                rule: '!self.startsWith(''aws:'')'
                             value:
                               description: |-
                                 value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -1581,6 +1581,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1590,6 +1591,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1467,20 +1467,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1471,6 +1471,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1480,6 +1481,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1581,6 +1581,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1590,6 +1591,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1577,20 +1577,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1581,6 +1581,7 @@ spec:
                                         key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
                                         Key should consist of between 1 and 128 characters, and may
                                         contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
+                                        Key must not be start with 'aws:'.
                                       maxLength: 128
                                       minLength: 1
                                       type: string
@@ -1590,6 +1591,10 @@ spec:
                                           characters, space (' '), '_', '.', '/',
                                           '=', '+', '-', ':', '@'
                                         rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
+                                      - message: the prefix 'aws:' is reserved for
+                                          AWS system usage and cannot be used at the
+                                          beginning of a key
+                                        rule: '!self.startsWith(''aws:'')'
                                     value:
                                       description: |-
                                         value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.


### PR DESCRIPTION
AWS docs indicate that tag keys cannot be prefix with aws:. See:
https://docs.aws.amazon.com/directoryservice/latest/devguide/API_Tag.html

Using this key prefix leads to an AWS API error indicating the prefix
is reserved for AWS system usage. This commit adds API validation
and ratecheting tests, as the key was previously allowed.

This was originally included in #2124 but cannot land due to a bug addressed by https://github.com/openshift/kubernetes/pull/2167, so 

Depends on #2124 
Depends on https://github.com/openshift/kubernetes/pull/2167