### PR TITLE
NO-JIRA: Add envtest archives for K8s 1.32.1

### DIFF
--- a/envtest-releases.yaml
+++ b/envtest-releases.yaml
@@ -38,3 +38,16 @@ releases:
         envtest-v1.31.2-linux-arm64.tar.gz:
             hash: f6ad42b701537ddfd6873e9700f8e73927763878eaf36a5437d71fb62bffda91ce7f502e13f9ef4b508d37973ccddd3d847eba0d7150f7acb5495fd82558fbad
             selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.31.2-linux-arm64.tar.gz
+    v1.32.1:
+        envtest-v1.32.1-darwin-amd64.tar.gz:
+            hash: e81d0b8e9d58bcefc8e741e298698670a39bf77923623fb8554b1a4b201a033678d2949e18dcf6933722c69f954b0de93c8f7136ff0641f69e5128a5a3fb6b26
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.32.1-darwin-amd64.tar.gz
+        envtest-v1.32.1-darwin-arm64.tar.gz:
+            hash: 57be0af5cbf72b659c14f955205fa9a95da9af9213bc9b6a5a1090394a0cd5f98c57127b3d8a69dc349bc33112f52505a6f030369bb09a27f9fb2c13a66475d1
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.32.1-darwin-arm64.tar.gz
+        envtest-v1.32.1-linux-amd64.tar.gz:
+            hash: 711c6d6d9443dce6b465403149837d636f440091b77ec45753d9c60fea0d6ba7811b0045ebf16f7b74504d1f47fcf1da90d7c810a18be31311c90f068d9fd1fd
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.32.1-linux-amd64.tar.gz
+        envtest-v1.32.1-linux-arm64.tar.gz:
+            hash: 0bc52e6344ae0753715bc39c2878696c72a3129356df484835586165238361c109ad3e1ebd354af8ecdf1026c3a2b98ed225ad0c6dd348cb3ff128a7cfdcc2f8
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.32.1-linux-arm64.tar.gz

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -35,6 +35,8 @@ publish-kubebuilder-tools:
 	@# Make sure to update the `-version` to the full semver (x.y.z) of the Kube version that the release is based on (check o/k).
 	@# The payload should be any CI build (not nightly/EC) published in the CI registry that matches the defined version.
 	@# Pull secret should be the standard pull secret used for spinning up OpenShift clusters, if you do not have one, follow https://docs.google.com/document/d/1ez2jrjiIQJChobfSu2ISJ5uM_-3HGouamL_xIa2_1W4/edit#heading=h.me93l6citmsq
+	@# This also expects you to be already authenticated with the OpenShift GCE devel project on Google Cloud, if you are not,
+	@# follow the 'Create the Service Account and grant permissions' and 'Generate an access key' @# steps at https://docs.google.com/document/d/1qm37EKkjgoPtjW4909UClzvsjQO5VSpPUvFO_hW_PEg
 	go run ./publish-kubebuilder-tools/main.go -version v1.32.1 -output-dir /tmp/kubebuilder-tools -payload=registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2025-01-30-154351 -pull-secret $(PULL_SECRET) -index-file ../envtest-releases.yaml
 
 #############################################

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -35,7 +35,7 @@ publish-kubebuilder-tools:
 	@# Make sure to update the `-version` to the full semver (x.y.z) of the Kube version that the release is based on (check o/k).
 	@# The payload should be any CI build (not nightly/EC) published in the CI registry that matches the defined version.
 	@# Pull secret should be the standard pull secret used for spinning up OpenShift clusters, if you do not have one, follow https://docs.google.com/document/d/1ez2jrjiIQJChobfSu2ISJ5uM_-3HGouamL_xIa2_1W4/edit#heading=h.me93l6citmsq
-	go run ./publish-kubebuilder-tools/main.go -version v1.31.2 -output-dir /tmp/kubebuilder-tools -payload=registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2024-11-26-014609 -pull-secret $(PULL_SECRET) -index-file ../envtest-releases.yaml
+	go run ./publish-kubebuilder-tools/main.go -version v1.32.1 -output-dir /tmp/kubebuilder-tools -payload=registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2025-01-30-154351 -pull-secret $(PULL_SECRET) -index-file ../envtest-releases.yaml
 
 #############################################
 #


### PR DESCRIPTION
They are required for testing purposes on the repositories where we bump k8s dependencies to 1.32.

CC @JoelSpeed @deads2k @bertinatto