### PR TITLE
ClusterOperator Conditions should be a listType=map

### DIFF
--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -53,6 +53,8 @@ type ClusterOperatorStatus struct {
 	// conditions describes the state of the operator's managed and monitored components.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
 	// +optional
 	Conditions []ClusterOperatorStatusCondition `json:"conditions,omitempty"  patchStrategy:"merge" patchMergeKey:"type"`
 

--- a/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusteroperators.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusteroperators.crd.yaml
@@ -108,6 +108,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               extension:
                 description: |-
                   extension contains any additional status information specific to the

--- a/config/v1/zz_generated.featuregated-crd-manifests/clusteroperators.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/clusteroperators.config.openshift.io/AAA_ungated.yaml
@@ -111,6 +111,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               extension:
                 description: |-
                   extension contains any additional status information specific to the

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -10280,6 +10280,10 @@ func schema_openshift_api_config_v1_ClusterOperatorStatus(ref common.ReferenceCa
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"type",
+								},
+								"x-kubernetes-list-type":       "map",
 								"x-kubernetes-patch-merge-key": "type",
 								"x-kubernetes-patch-strategy":  "merge",
 							},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -5181,6 +5181,10 @@
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.config.v1.ClusterOperatorStatusCondition"
           },
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map",
           "x-kubernetes-patch-merge-key": "type",
           "x-kubernetes-patch-strategy": "merge"
         },


### PR DESCRIPTION
We are building a group of controllers, and expected, like most conditions, for this list to be a map with the key as the `type` field. The patch markers suggest this was the intention, but it does not currently have the correct markers.

For anyone already updating this list, it means they must currently supply the entire list when providing the update, the default behaviour is atomic. In the future, providing the whole list will continue to work, but will mean that these updates now own each condition within the list.

But for those trying to use SSA, which is currently not possible, we will be able to set individual conditions within the list with different field managers, allowing multiple controllers to act upon the conditions list without conflict.