### PR TITLE
OCPBUGS-48542: Remove Never option from IPsec Encapsulation

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -48530,7 +48530,7 @@ func schema_openshift_api_operator_v1_IPsecFullModeConfig(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"encapsulation": {
 						SchemaProps: spec.SchemaProps{
-							Description: "encapsulation option to configure libreswan on how inter-pod traffic across nodes are encapsulated to handle NAT traversal. When configured it uses UDP port 4500 for the encapsulation. Valid values are Always, Never, Auto and omitted. Always means enable UDP encapsulation regardless of whether NAT is detected. Disable means never enable UDP encapsulation even if NAT is present. Auto means enable UDP encapsulation based on the detection of NAT. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is Auto.",
+							Description: "encapsulation option to configure libreswan on how inter-pod traffic across nodes are encapsulated to handle NAT traversal. When configured it uses UDP port 4500 for the encapsulation. Valid values are Always, Auto and omitted. Always means enable UDP encapsulation regardless of whether NAT is detected. Auto means enable UDP encapsulation based on the detection of NAT. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is Auto.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -28282,7 +28282,7 @@
       "type": "object",
       "properties": {
         "encapsulation": {
-          "description": "encapsulation option to configure libreswan on how inter-pod traffic across nodes are encapsulated to handle NAT traversal. When configured it uses UDP port 4500 for the encapsulation. Valid values are Always, Never, Auto and omitted. Always means enable UDP encapsulation regardless of whether NAT is detected. Disable means never enable UDP encapsulation even if NAT is present. Auto means enable UDP encapsulation based on the detection of NAT. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is Auto.",
+          "description": "encapsulation option to configure libreswan on how inter-pod traffic across nodes are encapsulated to handle NAT traversal. When configured it uses UDP port 4500 for the encapsulation. Valid values are Always, Auto and omitted. Always means enable UDP encapsulation regardless of whether NAT is detected. Auto means enable UDP encapsulation based on the detection of NAT. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is Auto.",
           "type": "string"
         }
       }

--- a/operator/v1/types_network.go
+++ b/operator/v1/types_network.go
@@ -580,8 +580,6 @@ type Encapsulation string
 const (
 	// EncapsulationAlways always enable UDP encapsulation regardless of whether NAT is detected.
 	EncapsulationAlways = "Always"
-	// EncapsulationNever never enable UDP encapsulation even if NAT is present.
-	EncapsulationNever = "Never"
 	// EncapsulationAuto enable UDP encapsulation based on the detection of NAT.
 	EncapsulationAuto = "Auto"
 )
@@ -592,13 +590,12 @@ type IPsecFullModeConfig struct {
 	// encapsulation option to configure libreswan on how inter-pod traffic across nodes
 	// are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
 	// for the encapsulation.
-	// Valid values are Always, Never, Auto and omitted.
+	// Valid values are Always, Auto and omitted.
 	// Always means enable UDP encapsulation regardless of whether NAT is detected.
-	// Disable means never enable UDP encapsulation even if NAT is present.
 	// Auto means enable UDP encapsulation based on the detection of NAT.
 	// When omitted, this means no opinion and the platform is left to choose a reasonable
 	// default, which is subject to change over time. The current default is Auto.
-	// +kubebuilder:validation:Enum:=Always;Never;Auto
+	// +kubebuilder:validation:Enum:=Always;Auto
 	// +optional
 	Encapsulation Encapsulation `json:"encapsulation,omitempty"`
 }

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-CustomNoUpgrade.crd.yaml
@@ -424,15 +424,13 @@ spec:
                                   encapsulation option to configure libreswan on how inter-pod traffic across nodes
                                   are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
                                   for the encapsulation.
-                                  Valid values are Always, Never, Auto and omitted.
+                                  Valid values are Always, Auto and omitted.
                                   Always means enable UDP encapsulation regardless of whether NAT is detected.
-                                  Disable means never enable UDP encapsulation even if NAT is present.
                                   Auto means enable UDP encapsulation based on the detection of NAT.
                                   When omitted, this means no opinion and the platform is left to choose a reasonable
                                   default, which is subject to change over time. The current default is Auto.
                                 enum:
                                 - Always
-                                - Never
                                 - Auto
                                 type: string
                             type: object

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-Default.crd.yaml
@@ -424,15 +424,13 @@ spec:
                                   encapsulation option to configure libreswan on how inter-pod traffic across nodes
                                   are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
                                   for the encapsulation.
-                                  Valid values are Always, Never, Auto and omitted.
+                                  Valid values are Always, Auto and omitted.
                                   Always means enable UDP encapsulation regardless of whether NAT is detected.
-                                  Disable means never enable UDP encapsulation even if NAT is present.
                                   Auto means enable UDP encapsulation based on the detection of NAT.
                                   When omitted, this means no opinion and the platform is left to choose a reasonable
                                   default, which is subject to change over time. The current default is Auto.
                                 enum:
                                 - Always
-                                - Never
                                 - Auto
                                 type: string
                             type: object

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-DevPreviewNoUpgrade.crd.yaml
@@ -424,15 +424,13 @@ spec:
                                   encapsulation option to configure libreswan on how inter-pod traffic across nodes
                                   are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
                                   for the encapsulation.
-                                  Valid values are Always, Never, Auto and omitted.
+                                  Valid values are Always, Auto and omitted.
                                   Always means enable UDP encapsulation regardless of whether NAT is detected.
-                                  Disable means never enable UDP encapsulation even if NAT is present.
                                   Auto means enable UDP encapsulation based on the detection of NAT.
                                   When omitted, this means no opinion and the platform is left to choose a reasonable
                                   default, which is subject to change over time. The current default is Auto.
                                 enum:
                                 - Always
-                                - Never
                                 - Auto
                                 type: string
                             type: object

--- a/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_network_01_networks-TechPreviewNoUpgrade.crd.yaml
@@ -424,15 +424,13 @@ spec:
                                   encapsulation option to configure libreswan on how inter-pod traffic across nodes
                                   are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
                                   for the encapsulation.
-                                  Valid values are Always, Never, Auto and omitted.
+                                  Valid values are Always, Auto and omitted.
                                   Always means enable UDP encapsulation regardless of whether NAT is detected.
-                                  Disable means never enable UDP encapsulation even if NAT is present.
                                   Auto means enable UDP encapsulation based on the detection of NAT.
                                   When omitted, this means no opinion and the platform is left to choose a reasonable
                                   default, which is subject to change over time. The current default is Auto.
                                 enum:
                                 - Always
-                                - Never
                                 - Auto
                                 type: string
                             type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AAA_ungated.yaml
@@ -391,15 +391,13 @@ spec:
                                   encapsulation option to configure libreswan on how inter-pod traffic across nodes
                                   are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
                                   for the encapsulation.
-                                  Valid values are Always, Never, Auto and omitted.
+                                  Valid values are Always, Auto and omitted.
                                   Always means enable UDP encapsulation regardless of whether NAT is detected.
-                                  Disable means never enable UDP encapsulation even if NAT is present.
                                   Auto means enable UDP encapsulation based on the detection of NAT.
                                   When omitted, this means no opinion and the platform is left to choose a reasonable
                                   default, which is subject to change over time. The current default is Auto.
                                 enum:
                                 - Always
-                                - Never
                                 - Auto
                                 type: string
                             type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/AdditionalRoutingCapabilities.yaml
@@ -424,15 +424,13 @@ spec:
                                   encapsulation option to configure libreswan on how inter-pod traffic across nodes
                                   are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
                                   for the encapsulation.
-                                  Valid values are Always, Never, Auto and omitted.
+                                  Valid values are Always, Auto and omitted.
                                   Always means enable UDP encapsulation regardless of whether NAT is detected.
-                                  Disable means never enable UDP encapsulation even if NAT is present.
                                   Auto means enable UDP encapsulation based on the detection of NAT.
                                   When omitted, this means no opinion and the platform is left to choose a reasonable
                                   default, which is subject to change over time. The current default is Auto.
                                 enum:
                                 - Always
-                                - Never
                                 - Auto
                                 type: string
                             type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/NetworkLiveMigration.yaml
@@ -391,15 +391,13 @@ spec:
                                   encapsulation option to configure libreswan on how inter-pod traffic across nodes
                                   are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
                                   for the encapsulation.
-                                  Valid values are Always, Never, Auto and omitted.
+                                  Valid values are Always, Auto and omitted.
                                   Always means enable UDP encapsulation regardless of whether NAT is detected.
-                                  Disable means never enable UDP encapsulation even if NAT is present.
                                   Auto means enable UDP encapsulation based on the detection of NAT.
                                   When omitted, this means no opinion and the platform is left to choose a reasonable
                                   default, which is subject to change over time. The current default is Auto.
                                 enum:
                                 - Always
-                                - Never
                                 - Auto
                                 type: string
                             type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/RouteAdvertisements.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/networks.operator.openshift.io/RouteAdvertisements.yaml
@@ -391,15 +391,13 @@ spec:
                                   encapsulation option to configure libreswan on how inter-pod traffic across nodes
                                   are encapsulated to handle NAT traversal. When configured it uses UDP port 4500
                                   for the encapsulation.
-                                  Valid values are Always, Never, Auto and omitted.
+                                  Valid values are Always, Auto and omitted.
                                   Always means enable UDP encapsulation regardless of whether NAT is detected.
-                                  Disable means never enable UDP encapsulation even if NAT is present.
                                   Auto means enable UDP encapsulation based on the detection of NAT.
                                   When omitted, this means no opinion and the platform is left to choose a reasonable
                                   default, which is subject to change over time. The current default is Auto.
                                 enum:
                                 - Always
-                                - Never
                                 - Auto
                                 type: string
                             type: object

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1660,7 +1660,7 @@ func (IPsecConfig) SwaggerDoc() map[string]string {
 
 var map_IPsecFullModeConfig = map[string]string{
 	"":              "IPsecFullModeConfig defines configuration parameters for the IPsec `Full` mode.",
-	"encapsulation": "encapsulation option to configure libreswan on how inter-pod traffic across nodes are encapsulated to handle NAT traversal. When configured it uses UDP port 4500 for the encapsulation. Valid values are Always, Never, Auto and omitted. Always means enable UDP encapsulation regardless of whether NAT is detected. Disable means never enable UDP encapsulation even if NAT is present. Auto means enable UDP encapsulation based on the detection of NAT. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is Auto.",
+	"encapsulation": "encapsulation option to configure libreswan on how inter-pod traffic across nodes are encapsulated to handle NAT traversal. When configured it uses UDP port 4500 for the encapsulation. Valid values are Always, Auto and omitted. Always means enable UDP encapsulation regardless of whether NAT is detected. Auto means enable UDP encapsulation based on the detection of NAT. When omitted, this means no opinion and the platform is left to choose a reasonable default, which is subject to change over time. The current default is Auto.",
 }
 
 func (IPsecFullModeConfig) SwaggerDoc() map[string]string {


### PR DESCRIPTION
The OVN doesn't support encapsulation=no option, so it is not appropriate to have this option in API anymore as it is not supported with underlying system. So removing it from encapsualtion option.