### PR TITLE
WIP: Reject new nodestatus with nonzero revision set

### DIFF
--- a/operator/v1/tests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/tests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -77,3 +77,89 @@ tests:
           nodeStatuses:
           - nodeName: a
       expectedStatusError: "status.nodeStatuses[0].currentRevision: Invalid value: \"object\": cannot be unset once set"
+    - name: Should reject setting new nodeStatus with a non-zero currentRevision
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec: {} # No spec is required for a KubeAPIServer
+        status:
+          nodeStatuses: []
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec: {} # No spec is required for a KubeAPIServer
+        status:
+          nodeStatuses:
+          - nodeName: a
+            currentRevision: 3
+      expectedStatusError: "status.nodeStatuses[0].currentRevision: Invalid value: \"integer\": must be set to 0 on creation"
+    - name: Should reject setting new nodeStatus with a non-zero targetRevision
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec: {} # No spec is required for a KubeAPIServer
+        status:
+          nodeStatuses: []
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec: {} # No spec is required for a KubeAPIServer
+        status:
+          nodeStatuses:
+          - nodeName: a
+            targetRevision: 3
+      expectedStatusError: "status.nodeStatuses[0].targetRevision: Invalid value: \"integer\": must be set to 0 on creation"
+    - name: Should allow adding nodes with name only
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec: {} # No spec is required for a KubeAPIServer
+        status:
+          nodeStatuses:
+          - nodeName: a
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec: {} # No spec is required for a KubeAPIServer
+        status:
+          nodeStatuses:
+          - nodeName: a
+          - nodeName: b
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          nodeStatuses:
+          - nodeName: a
+          - nodeName: b
+    - name: Should allow adding nodes with name only with default currentRevision 0
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec: {} # No spec is required for a KubeAPIServer
+        status:
+          nodeStatuses:
+          - nodeName: a
+      updated: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec: {} # No spec is required for a KubeAPIServer
+        status:
+          nodeStatuses:
+          - nodeName: a
+            currentRevision: 0
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+        status:
+          nodeStatuses:
+          - nodeName: a
+            currentRevision: 0
+  
+      

--- a/operator/v1/types.go
+++ b/operator/v1/types.go
@@ -265,8 +265,10 @@ type NodeStatus struct {
 
 	// currentRevision is the generation of the most recently successful deployment
 	// +kubebuilder:validation:XValidation:rule="self >= oldSelf",message="must only increase"
+	// +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || self == 0",message="must be set to 0 on creation",optionalOldSelf=true
 	CurrentRevision int32 `json:"currentRevision"`
 	// targetRevision is the generation of the deployment we're trying to apply
+	// +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || self == 0",message="must be set to 0 on creation",optionalOldSelf=true
 	TargetRevision int32 `json:"targetRevision,omitempty"`
 
 	// lastFailedRevision is the generation of the deployment we tried and failed to deploy.

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -259,6 +259,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -296,6 +299,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -246,6 +246,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -283,6 +286,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -259,6 +259,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -296,6 +299,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -259,6 +259,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -296,6 +299,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -228,6 +228,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -265,6 +268,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -237,6 +237,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -274,6 +277,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -228,6 +228,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -265,6 +268,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/AAA_ungated.yaml
@@ -233,6 +233,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -270,6 +273,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/EtcdBackendQuota.yaml
@@ -246,6 +246,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -283,6 +286,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/HardwareSpeed.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/etcds.operator.openshift.io/HardwareSpeed.yaml
@@ -246,6 +246,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -283,6 +286,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -229,6 +229,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -266,6 +269,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubecontrollermanagers.operator.openshift.io/AAA_ungated.yaml
@@ -238,6 +238,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -275,6 +278,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeschedulers.operator.openshift.io/AAA_ungated.yaml
@@ -229,6 +229,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -266,6 +269,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-CustomNoUpgrade.crd.yaml
@@ -259,6 +259,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -296,6 +299,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-Default.crd.yaml
@@ -246,6 +246,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -283,6 +286,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-DevPreviewNoUpgrade.crd.yaml
@@ -259,6 +259,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -296,6 +299,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_12_etcd_01_etcds-TechPreviewNoUpgrade.crd.yaml
@@ -259,6 +259,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -296,6 +299,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -228,6 +228,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -265,6 +268,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-controller-manager_01_kubecontrollermanagers.crd.yaml
@@ -237,6 +237,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -274,6 +277,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object

--- a/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
+++ b/payload-manifests/crds/0000_25_kube-scheduler_01_kubeschedulers.crd.yaml
@@ -228,6 +228,9 @@ spec:
                       x-kubernetes-validations:
                       - message: must only increase
                         rule: self >= oldSelf
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                     lastFailedCount:
                       description: lastFailedCount is how often the installer pod
                         of the last failed revision failed.
@@ -265,6 +268,10 @@ spec:
                         we're trying to apply
                       format: int32
                       type: integer
+                      x-kubernetes-validations:
+                      - message: must be set to 0 on creation
+                        optionalOldSelf: true
+                        rule: oldSelf.hasValue() || self == 0
                   required:
                   - nodeName
                   type: object


### PR DESCRIPTION
This is basically same with https://github.com/openshift/api/pull/2208. Differences are;
* No optional field marking of currentRevision, targetRevision
* Additional tests for happy paths
DO NOT MERGE