### PR TITLE
security: add annotation for validated SCC type

### DIFF
--- a/security/v1/consts.go
+++ b/security/v1/consts.go
@@ -13,4 +13,9 @@ const (
 
 	// MinimallySufficientPodSecurityStandard indicates the PodSecurityStandard that matched the SCCs available to the users of the namespace.
 	MinimallySufficientPodSecurityStandard = "security.openshift.io/MinimallySufficientPodSecurityStandard"
+
+	// ValidatedSCCSubjectTypeAnnotation indicates the subject type that allowed the
+	// SCC admission. This can be used by controllers to detect potential issues
+	// between user-driven SCC usage and the ServiceAccount-driven SCC usage.
+	ValidatedSCCSubjectTypeAnnotation = "security.openshift.io/validated-scc-subject-type"
 )


### PR DESCRIPTION
## What

Add annotation for validated SCC type (User / ServiceAccount).

## Why

An SCC is being assigned to a workload based on the capabilities the ServiceAccount or user has. To distinct, against whom this was validated against, this annotation is being introduced.

This is necessary to identify namespaces that might not be labeled properly by the PSA label syncer as it doesn't watch the user's SCCs and picks the wrong PodSecurityStandard for PodSecurityAdmission labels.

## Reference

- [Pod Security Admission Enforcement Config](https://github.com/openshift/enhancements/pull/1747)