### PR TITLE
Fix FeatureGateNewOLMCatalogdAPIV1Metas spelling error

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -522,13 +522,13 @@ var (
 				enableForClusterProfile(SelfManaged, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade, configv1.Default).
 				mustRegister()
 
-	FeatureGateNewOLMCatalogdMetas = newFeatureGate("NewOLMCatalogdAPIV1Metas").
-					reportProblemsToJiraComponent("olm").
-					contactPerson("jordank").
-					productScope(ocpSpecific).
-					enhancementPR("https://github.com/openshift/enhancements/pull/1749").
-					enableForClusterProfile(SelfManaged, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
-					mustRegister()
+	FeatureGateNewOLMCatalogdAPIV1Metas = newFeatureGate("NewOLMCatalogdAPIV1Metas").
+						reportProblemsToJiraComponent("olm").
+						contactPerson("jordank").
+						productScope(ocpSpecific).
+						enhancementPR("https://github.com/openshift/enhancements/pull/1749").
+						enableForClusterProfile(SelfManaged, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+						mustRegister()
 
 	FeatureGateInsightsOnDemandDataGather = newFeatureGate("InsightsOnDemandDataGather").
 						reportProblemsToJiraComponent("insights").
@@ -742,7 +742,6 @@ var (
 					enhancementPR("https://github.com/openshift/enhancements/pull/1492").
 					enableIn(configv1.DevPreviewNoUpgrade).
 					mustRegister()
-
 
 	FeatureGateGCPCustomAPIEndpoints = newFeatureGate("GCPCustomAPIEndpoints").
 					reportProblemsToJiraComponent("Installer").


### PR DESCRIPTION
It was missing "APIV1", was named FeatureGateNewOLMCatalogdMetas before.

Signed-off-by: Anik Bhattacharjee <anbhatta@redhat.com>