### PR TITLE
WIP: Add uid and extra claim mappings for external OIDC configuration

### DIFF
--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -262,6 +262,29 @@ type TokenClaimMappings struct {
 	// groups for the cluster identity.
 	// The referenced claim must use array of strings values.
 	Groups PrefixedClaimMapping `json:"groups,omitempty"`
+
+	// uid is an optional field for configuring the claim mapping
+	// used to construct the uid for the cluster identity.
+	//
+	// When using uid.claim to specify the claim it must be a single string value.
+	// When using uid.expression the expression must result in a single string value.
+	//
+	// When omitted, this means the user has no opinion and the platform
+	// is left to choose a default, which is subject to change over time.
+	// The current default is to use the 'sub' claim.
+	// +optional
+	// +openshift:enable:FeatureGate=ExternalOIDCWithUIDAndExtraMappings
+	UID UIDClaimMapping `json:"uid,omitempty"`
+
+	// extra is an optional field for configuring the mappings
+	// used to construct the extra attribute for the cluster identity.
+	// When omitted, no extra attributes will be present on the cluster identity.
+	// key values for extra mappings must be unique.
+	// +optional
+	// +openshift:enable:FeatureGate=ExternalOIDCWithUIDAndExtraMappings
+	// +listType=map
+	// +listMapKey=key
+	Extra []ExtraMapping `json:"extra,omitempty"`
 }
 
 type TokenClaimMapping struct {
@@ -269,6 +292,98 @@ type TokenClaimMapping struct {
 	//
 	// +required
 	Claim string `json:"claim"`
+}
+
+// +kubebuilder:validation:XValidation:rule='!(has(self.claim) && has(self.expression))',message='both claim and expression must not be set'
+// +kubebuilder:validation:Xvalidation:rule='has(self.claim) || has(self.expression)',message='one of claim or expression must be set'
+type TokenClaimOrExpressionMapping struct {
+	// claim is an optional field for specifying the
+	// JWT token claim that is used in the mapping.
+	// The value of this claim will be assigned to
+	// the field in which this mapping is associated.
+	//
+	// Either claim or expression must be set.
+	// claim must not be specified when expression is set.
+	// claim must not exceed 256 characters in length.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxLength=256
+	Claim string `json:"claim,omitempty"`
+
+	// expression is an optional field for specifying a
+	// CEL expression that produces a string value from
+	// JWT token claims.
+	//
+	// CEL expressions have access to the token claims
+	// through a CEL variable, 'claims'.
+	// 'claims' is a map of claim names to claim values.
+	// For example, the 'sub' claim value can be accessed as 'claims.sub'.
+	// Nested claims can be accessed using dot notation ('claims.foo.bar').
+	//
+	// Either claim or expression must be set.
+	// expression must not be specified when claim is set.
+	// expression must not exceed 1024 characters in length.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxLength=1024
+	Expression string `json:"expression,omitempty"`
+}
+
+type ExtraMapping struct {
+	// key is a required field that specifies the string
+	// to use as the extra attribute key.
+	//
+	// key must be a domain-prefix path (e.g 'example.org/foo').
+	// key must not exceed 318 characters in length.
+	// key must contain the '/' character, separating the domain and path characters.
+	// key must not be empty.
+	//
+	// The domain portion of the key (string of characters prior to the '/') must be a valid RFC1123 subdomain.
+	// It must not exceed 253 characters in length.
+	// It must start and end with an alphanumeric character.
+	// It must only contain lower case alphanumeric characters and '-' or '.'.
+	// It must not use the reserved domains, or be subdomains of, kubernetes.io, k8s.io.
+	//
+	// The path portion of the key (string of characters after the '/') must only contain
+	// alphanumeric characters, percent-encoded octets, '-', '.', '_', '~', '!', '$', '&', ''', '(', ')', '*', '+', ',', ';', '=', and ':'.
+	// It must not exceed 64 characters in length.
+	//
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=318
+	// +kubebuilder:validation:XValidation:rule="self.contains('/')",message="key must contain the '/' character"
+	// +kubebuilder:validation:XValidation:rule="self.split('/', 2).size() == 2",message="key must contain both a domain and path separated by the '/' character"
+	//
+	// +kubebuilder:validation:XValidation:rule="!format.dns1123Subdomain().validate(self.split('/', 2)[0]).hasValue()",message="the domain of the key must consist of only lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
+	// +kubebuilder:validation:XValidation:rule="self.split('/', 2)[0] == 'kubernetes.io'",message="the domain 'kubernetes.io' is reserved for Kubernetes use"
+	// +kubebuilder:validation:XValidation:rule="self.split('/', 2)[0].endsWith('.kubernetes.io')",message="the subdomains '*.kubernetes.io' are reserved for Kubernetes use"
+	// +kubebuilder:validation:XValidation:rule="self.split('/', 2)[0] == 'k8s.io'",message="the domain 'k8s.io' is reserved for Kubernetes use"
+	// +kubebuilder:validation:XValidation:rule="self.split('/', 2)[0].endsWith('.k8s.io')",message="the subdomains '*.k8s.io' are reserved for Kubernetes use"
+	// +kubebuilder:validation:XValidation:rule="self.split('/', 2)[0].size() > 253",message="the domain of the key must not exceed 253 characters in length"
+	//
+	// +kubebuilder:validation:XValidation:rule="self.split('/', 2)[1].matches('[A-Za-z0-9/\-._~%!$&'()*+,;=:]+')",message="the path of the key must consist of only alphanumeric characters, percent-encoded octets, '-', '.', '_', '~', '!', '$', '&', ''', '(', ')', '*', '+', ',', ';', '=', and ':'"
+	// +kubebuilder:validation:XValidation:rule="self.split('/', 2)[1].size > 64",message="the path of the key must not exceed 64 characters in length"
+	Key string `json:"key"`
+
+	// valueExpression is a required field to specify the CEL expression to extract
+	// the extra attribute value from a JWT token's claims.
+	// valueExpression must produce a string or string array value.
+	// "", [], and null are treated as the extra mapping not being present.
+	// Empty string values within an array are filtered out.
+	//
+	// CEL expressions have access to the token claims
+	// through a CEL variable, 'claims'.
+	// 'claims' is a map of claim names to claim values.
+	// For example, the 'sub' claim value can be accessed as 'claims.sub'.
+	// Nested claims can be accessed using dot notation ('claims.foo.bar').
+	//
+	// valueExpression must not exceed 1024 characters in length.
+	// valueExpression must not be empty.
+	//
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=1024
+	ValueExpression string `json:"valueExpression"`
 }
 
 type OIDCClientConfig struct {
@@ -429,6 +544,10 @@ type PrefixedClaimMapping struct {
 	// an array of strings "a", "b" and  "c", the mapping will result in an
 	// array of string "myoidc:a", "myoidc:b" and "myoidc:c".
 	Prefix string `json:"prefix"`
+}
+
+type UIDClaimMapping struct {
+	TokenClaimOrExpressionMapping `json:",inline"`
 }
 
 type TokenValidationRuleType string

--- a/features/features.go
+++ b/features/features.go
@@ -498,6 +498,15 @@ var (
 				enableForClusterProfile(Hypershift, configv1.Default, configv1.TechPreviewNoUpgrade).
 				mustRegister()
 
+	FeatureGateExternalOIDCWithUIDAndExtraMappings = newFeatureGate("ExternalOIDCWithUIDAndExtraMappings").
+				reportProblemsToJiraComponent("authentication").
+				contactPerson("everettraven").
+				productScope(ocpSpecific).
+				enhancementPR("").
+				enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+				enableForClusterProfile(Hypershift, configv1.TechPreviewNoUpgrade).
+				mustRegister()
+
 	FeatureGateExample = newFeatureGate("Example").
 				reportProblemsToJiraComponent("cluster-config").
 				contactPerson("deads").


### PR DESCRIPTION
Adds:
- A new TechPreview feature-gate `ExternalOIDCWithUIDAndExtraMappings` (still needs to be linked to a proper EP for this. Maybe the existing OIDC one is sufficient?)
- Adds `uid` and `extra` fields to the `authentications.config.openshift.io` CRD's external OIDC provider configuration options, gated by the new `ExternalOIDCWithUIDAndExtraMappings` feature-gate