### PR TITLE
Add the `shortName` value of `cpms` for the `controlplanemachinset` API

### DIFF
--- a/machine/v1/types_controlplanemachineset.go
+++ b/machine/v1/types_controlplanemachineset.go
@@ -10,7 +10,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=controlplanemachinesets,scope=Namespaced
+// +kubebuilder:resource:path=controlplanemachinesets,scope=Namespaced,shortName=cpms
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas",description="Desired Replicas"

--- a/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-CustomNoUpgrade.crd.yaml
+++ b/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-CustomNoUpgrade.crd.yaml
@@ -15,6 +15,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-Default.crd.yaml
+++ b/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-Default.crd.yaml
@@ -15,6 +15,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-DevPreviewNoUpgrade.crd.yaml
+++ b/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-DevPreviewNoUpgrade.crd.yaml
@@ -15,6 +15,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-TechPreviewNoUpgrade.crd.yaml
+++ b/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-TechPreviewNoUpgrade.crd.yaml
@@ -15,6 +15,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/machine/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/machine/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -47,7 +47,8 @@ controlplanemachinesets.machine.openshift.io:
     name: Age
     type: date
   Scope: Namespaced
-  ShortNames: null
+  ShortNames:
+  - cpms
   TopLevelFeatureGates: []
   Version: v1
 

--- a/machine/v1/zz_generated.featuregated-crd-manifests/controlplanemachinesets.machine.openshift.io/AAA_ungated.yaml
+++ b/machine/v1/zz_generated.featuregated-crd-manifests/controlplanemachinesets.machine.openshift.io/AAA_ungated.yaml
@@ -17,6 +17,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/machine/v1/zz_generated.featuregated-crd-manifests/controlplanemachinesets.machine.openshift.io/CPMSMachineNamePrefix.yaml
+++ b/machine/v1/zz_generated.featuregated-crd-manifests/controlplanemachinesets.machine.openshift.io/CPMSMachineNamePrefix.yaml
@@ -17,6 +17,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/machine/v1/zz_generated.featuregated-crd-manifests/controlplanemachinesets.machine.openshift.io/MachineAPIMigration.yaml
+++ b/machine/v1/zz_generated.featuregated-crd-manifests/controlplanemachinesets.machine.openshift.io/MachineAPIMigration.yaml
@@ -17,6 +17,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-CustomNoUpgrade.crd.yaml
@@ -15,6 +15,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-Default.crd.yaml
@@ -15,6 +15,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-DevPreviewNoUpgrade.crd.yaml
@@ -15,6 +15,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:

--- a/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-TechPreviewNoUpgrade.crd.yaml
@@ -15,6 +15,8 @@ spec:
     kind: ControlPlaneMachineSet
     listKind: ControlPlaneMachineSetList
     plural: controlplanemachinesets
+    shortNames:
+    - cpms
     singular: controlplanemachineset
   scope: Namespaced
   versions:


### PR DESCRIPTION
Add the `shortName` value of `cpms` for the `controlplanemachinset` API, making it easier for operators to references these objects.