### PR TITLE
OCPBUGS-53221: Allow spaces in AWS resource tags

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "Infrastructure"
 crdName: infrastructures.config.openshift.io
+featureGates:
+- -AWSClusterHostedDNS
 tests:
   onCreate:
     - name: Should be able to create a minimal Infrastructure
@@ -1365,3 +1367,163 @@ tests:
               - name: BadService
                 url: https://bad-service.com
       expectedStatusError: "platformStatus.ibmcloud.serviceEndpoints[1].name: Unsupported value: \"BadService\": supported values: \"CIS\", \"COS\", \"COSConfig\", \"DNSServices\", \"GlobalCatalog\", \"GlobalSearch\", \"GlobalTagging\", \"HyperProtect\", \"IAM\", \"KeyProtect\", \"ResourceController\", \"ResourceManager\", \"VPC\""
+    - name: Should be able to create an aws resourcetag with spaces
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key with space
+                value: value with space
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key with space
+                value: value with space
+            type: AWS
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key with space
+                value: value with space
+            type: AWS
+    - name: Should be able to create an aws resourcetag with characters '_', '.', '/', '=', '+', '-', ':', '@'
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key:_./=+-@
+                value: value:_./=+-@
+            type: AWS
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key:_./=+-@
+                value: value:_./=+-@
+            type: AWS
+    - name: Should not be able to create an aws resourcetag with character * in key
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key:_./=+-@*
+                value: value
+            type: AWS
+      expectedStatusError: "invalid AWS resource tag key. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
+    - name: Should not be able to create an aws resourcetag with character * in value
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              region: us-east-1
+              resourceTags:
+              - key: key
+                value: value*
+            type: AWS
+      expectedStatusError: "invalid AWS resource tag value. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -525,20 +525,24 @@ type AWSPlatformStatus struct {
 
 // AWSResourceTag is a tag to apply to AWS resources created for the cluster.
 type AWSResourceTag struct {
-	// key is the key of the tag
+	// key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+	// Key should consist of between 1 and 128 characters, and may
+	// contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
-	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.:/=+-@]+$`
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')`,message="invalid AWS resource tag key. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
 	// +required
 	Key string `json:"key"`
-	// value is the value of the tag.
+	// value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+	// Value should consist of between 1 and 256 characters, and may
+	// contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
 	// Some AWS service do not support empty values. Since tags are added to resources in many services, the
 	// length of the tag value must meet the requirements of all services.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.:/=+-@]+$`
+	// +kubebuilder:validation:XValidation:rule=`self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')`,message="invalid AWS resource tag value. The string can contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', '@'"
 	// +required
 	Value string `json:"value"`
 }

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1213,20 +1213,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1105,20 +1105,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1213,20 +1213,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1213,20 +1213,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AAA_ungated.yaml
@@ -1078,20 +1078,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/AWSClusterHostedDNS.yaml
@@ -1179,20 +1179,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/BareMetalLoadBalancer.yaml
@@ -1075,20 +1075,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPClusterHostedDNS.yaml
@@ -1075,20 +1075,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPLabelsTags.yaml
@@ -1075,20 +1075,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/NutanixMultiSubnets.yaml
@@ -1080,20 +1080,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1090,20 +1090,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiNetworks.yaml
@@ -1076,20 +1076,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/VSphereMultiVCenters.yaml
@@ -1076,20 +1076,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1198,8 +1198,8 @@ func (AWSPlatformStatus) SwaggerDoc() map[string]string {
 
 var map_AWSResourceTag = map[string]string{
 	"":      "AWSResourceTag is a tag to apply to AWS resources created for the cluster.",
-	"key":   "key is the key of the tag",
-	"value": "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+	"key":   "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
+	"value": "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
 }
 
 func (AWSResourceTag) SwaggerDoc() map[string]string {

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -1496,20 +1496,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1387,20 +1387,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1496,20 +1496,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1496,20 +1496,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AAA_ungated.yaml
@@ -1372,20 +1372,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/AWSClusterHostedDNS.yaml
@@ -1473,20 +1473,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/BareMetalLoadBalancer.yaml
@@ -1369,20 +1369,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPClusterHostedDNS.yaml
@@ -1369,20 +1369,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPLabelsTags.yaml
@@ -1369,20 +1369,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/NutanixMultiSubnets.yaml
@@ -1375,20 +1375,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereControlPlaneMachineSet.yaml
@@ -1384,20 +1384,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiNetworks.yaml
@@ -1370,20 +1370,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/VSphereMultiVCenters.yaml
@@ -1370,20 +1370,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -8632,7 +8632,7 @@ func schema_openshift_api_config_v1_AWSResourceTag(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"key": {
 						SchemaProps: spec.SchemaProps{
-							Description: "key is the key of the tag",
+							Description: "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -8640,7 +8640,7 @@ func schema_openshift_api_config_v1_AWSResourceTag(ref common.ReferenceCallback)
 					},
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Description: "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+							Description: "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4229,12 +4229,12 @@
       ],
       "properties": {
         "key": {
-          "description": "key is the key of the tag",
+          "description": "key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag. Key should consist of between 1 and 128 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.",
           "type": "string",
           "default": ""
         },
         "value": {
-          "description": "value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
+          "description": "value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag. Value should consist of between 1 and 256 characters, and may contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.",
           "type": "string",
           "default": ""
         }

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1213,20 +1213,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
@@ -1105,20 +1105,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1213,20 +1213,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1213,20 +1213,35 @@ spec:
                             created for the cluster.
                           properties:
                             key:
-                              description: key is the key of the tag
+                              description: |-
+                                key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                Key should consist of between 1 and 128 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                               maxLength: 128
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag key. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                             value:
                               description: |-
-                                value is the value of the tag.
+                                value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                Value should consist of between 1 and 256 characters, and may
+                                contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                 Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                 length of the tag value must meet the requirements of all services.
                               maxLength: 256
                               minLength: 1
-                              pattern: ^[0-9A-Za-z_.:/=+-@]+$
                               type: string
+                              x-kubernetes-validations:
+                              - message: invalid AWS resource tag value. The string
+                                  can contain only the set of alphanumeric characters,
+                                  space (' '), '_', '.', '/', '=', '+', '-', ':',
+                                  '@'
+                                rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                           required:
                           - key
                           - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -1496,20 +1496,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-Default.crd.yaml
@@ -1387,20 +1387,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -1496,20 +1496,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1496,20 +1496,35 @@ spec:
                                     AWS resources created for the cluster.
                                   properties:
                                     key:
-                                      description: key is the key of the tag
+                                      description: |-
+                                        key sets the key of the AWS resource tag key-value pair. Key is required when defining an AWS resource tag.
+                                        Key should consist of between 1 and 128 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                       maxLength: 128
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag key. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                     value:
                                       description: |-
-                                        value is the value of the tag.
+                                        value sets the value of the AWS resource tag key-value pair. Value is required when defining an AWS resource tag.
+                                        Value should consist of between 1 and 256 characters, and may
+                                        contain only the set of alphanumeric characters, space (' '), '_', '.', '/', '=', '+', '-', ':', and '@'.
                                         Some AWS service do not support empty values. Since tags are added to resources in many services, the
                                         length of the tag value must meet the requirements of all services.
                                       maxLength: 256
                                       minLength: 1
-                                      pattern: ^[0-9A-Za-z_.:/=+-@]+$
                                       type: string
+                                      x-kubernetes-validations:
+                                      - message: invalid AWS resource tag value. The
+                                          string can contain only the set of alphanumeric
+                                          characters, space (' '), '_', '.', '/',
+                                          '=', '+', '-', ':', '@'
+                                        rule: self.matches('^[0-9A-Za-z_.:/=+-@ ]+$')
                                   required:
                                   - key
                                   - value


### PR DESCRIPTION
Manual cherry-pick of #2124

---
An incorrect regex validation prevents users from specifying AWS tag keys or values that include spaces, which are allowed by AWS's official regex:

https://docs.aws.amazon.com/directoryservice/latest/devguide/API_Tag.html

Also includes some API cleanup.