### PR TITLE
OTA-1339: Add `UpdateStatusAPI` FG for DevPreview

### DIFF
--- a/features.md
+++ b/features.md
@@ -13,6 +13,7 @@
 | SELinuxMount| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | ShortCertRotation| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | SigstoreImageVerificationPKI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
+| UpdateStatusAPI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | NewOLM| | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | AWSClusterHostedDNS| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | AutomatedEtcdBackup| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -825,4 +825,16 @@ var (
 									enhancementPR("https://github.com/openshift/enhancements/pull/1748").
 									enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 									mustRegister()
+
+	FeatureGateUpdateStatusAPI = newFeatureGate("UpdateStatusAPI").
+					reportProblemsToJiraComponent("Cluster Version Operator").
+					contactPerson("pmuller").
+					productScope(ocpSpecific).
+		// OTA originally created and used the UpgradeStatus legacy feature gate for the related
+		// functionality, enabled in TechPreview. Moving the functionality into the cluster,
+		// exposed by an API proved to be more complex and experimental than thought, so it was
+		// decided to create and use a new feature gate that is only enabled in DevPreview.
+		enhancementPR("https://github.com/openshift/enhancements/pull/1701").
+		enableIn(configv1.DevPreviewNoUpgrade).
+		mustRegister()
 )

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -185,6 +185,9 @@
                         "name": "TranslateStreamCloseWebsocketRequests"
                     },
                     {
+                        "name": "UpdateStatusAPI"
+                    },
+                    {
                         "name": "UpgradeStatus"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -270,6 +270,9 @@
                         "name": "TranslateStreamCloseWebsocketRequests"
                     },
                     {
+                        "name": "UpdateStatusAPI"
+                    },
+                    {
                         "name": "UpgradeStatus"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -56,6 +56,9 @@
                     },
                     {
                         "name": "SigstoreImageVerificationPKI"
+                    },
+                    {
+                        "name": "UpdateStatusAPI"
                     }
                 ],
                 "enabled": [

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -185,6 +185,9 @@
                         "name": "TranslateStreamCloseWebsocketRequests"
                     },
                     {
+                        "name": "UpdateStatusAPI"
+                    },
+                    {
                         "name": "UpgradeStatus"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -270,6 +270,9 @@
                         "name": "TranslateStreamCloseWebsocketRequests"
                     },
                     {
+                        "name": "UpdateStatusAPI"
+                    },
+                    {
                         "name": "UpgradeStatus"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -50,6 +50,9 @@
                     },
                     {
                         "name": "SigstoreImageVerificationPKI"
+                    },
+                    {
+                        "name": "UpdateStatusAPI"
                     }
                 ],
                 "enabled": [


### PR DESCRIPTION
OTA originally created and used the UpgradeStatus legacy feature gate for the related functionality, enabled in TechPreview. Moving the functionality into the cluster, exposed by an API proved to be more complex and experimental than thought, so it was decided to create and use a new feature gate that is only enabled in DevPreview.

xref: https://github.com/openshift/api/pull/2233
