### PR TITLE
Ignore partial manifests when running schemacheck

### DIFF
--- a/tools/codegen/pkg/schemacheck/generator.go
+++ b/tools/codegen/pkg/schemacheck/generator.go
@@ -20,6 +20,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	// featureGatedCRDManifests is the folder name we use to generate
+	// partial CRD manifests.
+	featureGatedCRDManifests = "zz_generated.featuregated-crd-manifests"
+)
+
 // Options contains the configuration required for the schemacheck generator.
 type Options struct {
 	// Disabled indicates whether the schemacheck generator is disabled or not.
@@ -230,6 +236,12 @@ func loadSchemaCheckGenerationContextsForVersionFromDir(version generation.APIVe
 
 	for _, fileInfo := range dirEntries {
 		if fileInfo.IsDir() {
+			if fileInfo.Name() == featureGatedCRDManifests {
+				// We don't want to check the feature gated manifests.
+				// All changes will appear in the merged CRD manifests so checking the partial manifests just duplicates errors.
+				continue
+			}
+
 			subContexts, err := loadSchemaCheckGenerationContextsForVersionFromDir(version, baseCommit, repoBaseDir, filepath.Join(searchPath, fileInfo.Name()), gitBaseSHA)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("could not load schema check generation contexts from dir %q: %v", filepath.Join(searchPath, fileInfo.Name()), err))


### PR DESCRIPTION
All partial manifests end up being generated to at least one (CustomNoUpgrade) of the merged manifests. This means that they often just duplicate errors that are otherwise represented in the merged manifests.

Also, whenever we add a new feature gated field, it forks the entire resource. Because this is a new file according to the schema checker, it determines that all of the pre-existing, non-fixable issues are new and reports them, leading to false positives.

This PR stops the schema check from inspecting the partial manifests to prevent the noise and false positives.

