### PR TITLE
OCPBUGS-54784: [release-4.18] Bump openshift/controller-tools to latest commit

### DIFF
--- a/tools/go.mod
+++ b/tools/go.mod
@@ -32,7 +32,7 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
-replace sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20250220135952-fe24dd6f3a0c
+replace sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20250409115419-a0be4596dbc5
 
 require (
 	cloud.google.com/go v0.115.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -240,8 +240,8 @@ github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA
 github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v1.34.0 h1:eSSPsPNp6ZpsG8X1OVmOTxig+CblTc4AxpPBykhe2Os=
 github.com/onsi/gomega v1.34.0/go.mod h1:MIKI8c+f+QLWk+hxbePD4i0LMJSExPaZOVfkoex4cAo=
-github.com/openshift/controller-tools v0.12.1-0.20250220135952-fe24dd6f3a0c h1:QnwzeKJQr8ziHUU5Bz83EcxZFj8Nkw6sLFRr9LFv40A=
-github.com/openshift/controller-tools v0.12.1-0.20250220135952-fe24dd6f3a0c/go.mod h1:80xsUppuf2iNgiThH2bzDIN5204p5E93z+YtNnAJlHA=
+github.com/openshift/controller-tools v0.12.1-0.20250409115419-a0be4596dbc5 h1:wAbFzvGOZWXe1/jl5waGgzwSOQAdFs7uo9y11FYaCUs=
+github.com/openshift/controller-tools v0.12.1-0.20250409115419-a0be4596dbc5/go.mod h1:80xsUppuf2iNgiThH2bzDIN5204p5E93z+YtNnAJlHA=
 github.com/openshift/crd-schema-checker v0.0.0-20241113192003-573763d3107a h1:gBheMF1vVwxfnuGHJ82f/nmUATdtewq60/yhbBqD4+M=
 github.com/openshift/crd-schema-checker v0.0.0-20241113192003-573763d3107a/go.mod h1:sTxJ4ZFW9r9fEdbW2v0yMRi6NcyTbx0fII4p83IQ+L8=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -1170,7 +1170,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/common/metrics
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/controller-tools v0.15.0 => github.com/openshift/controller-tools v0.12.1-0.20250220135952-fe24dd6f3a0c
+# sigs.k8s.io/controller-tools v0.15.0 => github.com/openshift/controller-tools v0.12.1-0.20250409115419-a0be4596dbc5
 ## explicit; go 1.22.0
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
@@ -1201,4 +1201,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 ## explicit; go 1.12
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
-# sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20250220135952-fe24dd6f3a0c
+# sigs.k8s.io/controller-tools => github.com/openshift/controller-tools v0.12.1-0.20250409115419-a0be4596dbc5


### PR DESCRIPTION
This is part of a series of backports to 4.18 related to the changes in https://github.com/openshift/api/pull/2234 which needs to be backported to 4.18.

This PR specifically is a manual bump of the openshift/controller-tools dependency to pull in https://github.com/openshift/kubernetes-sigs-controller-tools/pull/29