### PR TITLE
OTA-1489: Do not create the ClusterVersionOperator CRD in Hypershift

### DIFF
--- a/operator/v1alpha1/types_clusterversion.go
+++ b/operator/v1alpha1/types_clusterversion.go
@@ -20,6 +20,8 @@ import (
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/2044
 // +openshift:enable:FeatureGate=ClusterVersionOperatorConfiguration
 // +kubebuilder:validation:XValidation:rule="self.metadata.name == 'cluster'",message="ClusterVersionOperator is a singleton; the .metadata.name field must be 'cluster'"
+// +kubebuilder:metadata:annotations=include.release.openshift.io/ibm-cloud-managed=false
+// +kubebuilder:metadata:annotations=include.release.openshift.io/self-managed-high-availability=true
 type ClusterVersionOperator struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversionoperators-CustomNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversionoperators-CustomNoUpgrade.crd.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/2044
     api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: CustomNoUpgrade
   name: clusterversionoperators.operator.openshift.io

--- a/operator/v1alpha1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversionoperators-DevPreviewNoUpgrade.crd.yaml
+++ b/operator/v1alpha1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusterversionoperators-DevPreviewNoUpgrade.crd.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/2044
     api.openshift.io/merged-by-featuregates: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/feature-set: DevPreviewNoUpgrade
   name: clusterversionoperators.operator.openshift.io

--- a/operator/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
+++ b/operator/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
@@ -1,5 +1,7 @@
 clusterversionoperators.operator.openshift.io:
-  Annotations: {}
+  Annotations:
+    include.release.openshift.io/ibm-cloud-managed: "false"
+    include.release.openshift.io/self-managed-high-availability: "true"
   ApprovedPRNumber: https://github.com/openshift/api/pull/2044
   CRDName: clusterversionoperators.operator.openshift.io
   Capability: ""

--- a/operator/v1alpha1/zz_generated.featuregated-crd-manifests/clusterversionoperators.operator.openshift.io/ClusterVersionOperatorConfiguration.yaml
+++ b/operator/v1alpha1/zz_generated.featuregated-crd-manifests/clusterversionoperators.operator.openshift.io/ClusterVersionOperatorConfiguration.yaml
@@ -7,6 +7,8 @@ metadata:
     api.openshift.io/filename-operator: cluster-version-operator
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/ClusterVersionOperatorConfiguration: "true"
+    include.release.openshift.io/ibm-cloud-managed: "false"
+    include.release.openshift.io/self-managed-high-availability: "true"
   name: clusterversionoperators.operator.openshift.io
 spec:
   group: operator.openshift.io


### PR DESCRIPTION
The CVO in HyperShift will not use the `ClusterVersionOperator` resource in
the hosted cluster. Thus, there is no need to create the CRD in the hosted cluster.

The CVO will still utilize the feature gate in HyperShift, as there will be a
new internal logic to read and parse a configuration file provided by a
HyperShift component. However, the `ClusterVersionOperator` CRD itself
is not needed.

This was proposed in the relevant enhancement https://github.com/openshift/enhancements/blob/master/enhancements/update/cvo-log-level-api.md#hypershift--hosted-control-planes.