### PR TITLE
Temporarily pin feature-gate-analyzer to 4.19

### DIFF
--- a/tools/codegen/cmd/featuregate-test-analyzer.go
+++ b/tools/codegen/cmd/featuregate-test-analyzer.go
@@ -589,12 +589,15 @@ func listTestResultForVariant(featureGate string, jobVariant JobVariant) (*Testi
 			// example: release-4.18, release-4.17
 			release = strings.TrimPrefix(currentRelease, "release-")
 		} else {
+			// Temporary until branching on 2025-04-18, or we find a way to fix sippy to return the dev branch sooner.
+			release = "4.19"
+
 			// means its main branch
-			var err error
-			release, err = getLatestRelease()
-			if err != nil {
-				return nil, fmt.Errorf("couldn't fetch latest release version: %w", err)
-			}
+			// var err error
+			// release, err = getLatestRelease()
+			// if err != nil {
+			// 	return nil, fmt.Errorf("couldn't fetch latest release version: %w", err)
+			// }
 		}
 		queryParams := currURL.Query()
 		queryParams.Add("release", release)


### PR DESCRIPTION
The 4.20 release has been enabled in sippy, which is now being picked up as the latest release branch and is therefore returning incorrect data for 4.19 promotions.

I've requested (https://issues.redhat.com/browse/TRT-2080) a way to determine programatically what the development branch is, but until then, if we can carry this commit until branching (and then revert), we will have accurate feature gate analysis without putting too much pressure on TRT to fix this today.

This is a temporary fix and should be reverted once branching completes on Friday 18th.