### PR TITLE
OCPCLOUD-2914: Add MAPI to CAPI migration to TechPreview

### DIFF
--- a/features.md
+++ b/features.md
@@ -2,7 +2,6 @@
 | ------ | --- | --- | --- | --- | --- | ---  |
 | ClusterAPIInstall| | | | | |  |
 | EventedPLEG| | | | | |  |
-| MachineAPIMigration| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
 | ClusterVersionOperatorConfiguration| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
@@ -39,6 +38,7 @@
 | InsightsOnDemandDataGather| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | InsightsRuntimeExtractor| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | KMSEncryptionProvider| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| MachineAPIMigration| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | MachineAPIProviderOpenStack| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | MachineConfigNodes| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | MaxUnavailableStatefulSet| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -599,6 +599,7 @@ var (
 					contactPerson("jspeed").
 					productScope(ocpSpecific).
 					enhancementPR(legacyFeatureGateWithoutEnhancement).
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureGatePersistentIPsForVirtualization = newFeatureGate("PersistentIPsForVirtualization").

--- a/machine/v1/tests/controlplanemachinesets.machine.openshift.io/CPMSMachineNamePrefix.yaml
+++ b/machine/v1/tests/controlplanemachinesets.machine.openshift.io/CPMSMachineNamePrefix.yaml
@@ -3,7 +3,6 @@ name: "ControlPlaneMachineSet (+CPMSMachineNamePrefix)"
 crdName: controlplanemachinesets.machine.openshift.io
 featureGates:
   - CPMSMachineNamePrefix
-  - -MachineAPIMigration
 tests:
   onCreate:
     - name: Should be able to create a minimal ControlPlaneMachineSet
@@ -24,6 +23,7 @@ tests:
                   machine.openshift.io/cluster-api-machine-type: master
                   machine.openshift.io/cluster-api-cluster: cluster
               spec:
+                authoritativeAPI: MachineAPI
                 providerSpec: {}
       expected: |
         apiVersion: machine.openshift.io/v1
@@ -46,6 +46,7 @@ tests:
                   machine.openshift.io/cluster-api-machine-type: master
                   machine.openshift.io/cluster-api-cluster: cluster
               spec:
+                authoritativeAPI: MachineAPI
                 providerSpec: {}
     - name: Should be able to create ControlPlaneMachineSet with machineNamePrefix
       initial: |
@@ -66,6 +67,7 @@ tests:
                   machine.openshift.io/cluster-api-machine-type: master
                   machine.openshift.io/cluster-api-cluster: cluster
               spec:
+                authoritativeAPI: MachineAPI
                 providerSpec: {}
       expected: |
         apiVersion: machine.openshift.io/v1
@@ -89,6 +91,7 @@ tests:
                   machine.openshift.io/cluster-api-machine-type: master
                   machine.openshift.io/cluster-api-cluster: cluster
               spec:
+                authoritativeAPI: MachineAPI
                 providerSpec: {}
     - name: Should reject to create ControlPlaneMachineSet with empty machineNamePrefix
       initial: |
@@ -109,6 +112,7 @@ tests:
                   machine.openshift.io/cluster-api-machine-type: master
                   machine.openshift.io/cluster-api-cluster: cluster
               spec:
+                authoritativeAPI: MachineAPI
                 providerSpec: {}
       expectedError: 'Invalid value: "": spec.machineNamePrefix in body should be at least 1 chars long'
     - name: Should reject to create ControlPlaneMachineSet with invalid machineNamePrefix
@@ -130,6 +134,7 @@ tests:
                   machine.openshift.io/cluster-api-machine-type: master
                   machine.openshift.io/cluster-api-cluster: cluster
               spec:
+                authoritativeAPI: MachineAPI
                 providerSpec: {}
       expectedError: 'Invalid value: "string": a lowercase RFC 1123 subdomain must consist of lowercase alphanumeric characters, hyphens (''-''), and periods (''.''). Each block, separated by periods, must start and end with an alphanumeric character. Hyphens are not allowed at the start or end of a block, and consecutive periods are not permitted.'
     - name: Should reject to create ControlPlaneMachineSet with invalid machineNamePrefix - Consecutive periods are not permitted
@@ -151,5 +156,6 @@ tests:
                   machine.openshift.io/cluster-api-machine-type: master
                   machine.openshift.io/cluster-api-cluster: cluster
               spec:
+                authoritativeAPI: MachineAPI
                 providerSpec: {}
       expectedError: 'Invalid value: "string": a lowercase RFC 1123 subdomain must consist of lowercase alphanumeric characters, hyphens (''-''), and periods (''.''). Each block, separated by periods, must start and end with an alphanumeric character. Hyphens are not allowed at the start or end of a block, and consecutive periods are not permitted.'

--- a/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-DevPreviewNoUpgrade.crd.yaml
+++ b/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-DevPreviewNoUpgrade.crd.yaml
@@ -553,6 +553,20 @@ spec:
                           failure domain field. This will be overriden when the Machines
                           are created based on the FailureDomains field.
                         properties:
+                          authoritativeAPI:
+                            default: MachineAPI
+                            description: |-
+                              authoritativeAPI is the API that is authoritative for this resource.
+                              Valid values are MachineAPI and ClusterAPI.
+                              When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                              When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                              Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                              Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                              To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                            enum:
+                            - MachineAPI
+                            - ClusterAPI
+                            type: string
                           lifecycleHooks:
                             description: |-
                               lifecycleHooks allow users to pause operations on the machine at

--- a/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-TechPreviewNoUpgrade.crd.yaml
+++ b/machine/v1/zz_generated.crd-manifests/0000_10_control-plane-machine-set_01_controlplanemachinesets-TechPreviewNoUpgrade.crd.yaml
@@ -553,6 +553,20 @@ spec:
                           failure domain field. This will be overriden when the Machines
                           are created based on the FailureDomains field.
                         properties:
+                          authoritativeAPI:
+                            default: MachineAPI
+                            description: |-
+                              authoritativeAPI is the API that is authoritative for this resource.
+                              Valid values are MachineAPI and ClusterAPI.
+                              When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                              When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                              Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                              Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                              To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                            enum:
+                            - MachineAPI
+                            - ClusterAPI
+                            type: string
                           lifecycleHooks:
                             description: |-
                               lifecycleHooks allow users to pause operations on the machine at

--- a/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machines-DevPreviewNoUpgrade.crd.yaml
+++ b/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machines-DevPreviewNoUpgrade.crd.yaml
@@ -81,6 +81,20 @@ spec:
           spec:
             description: MachineSpec defines the desired state of Machine
             properties:
+              authoritativeAPI:
+                default: MachineAPI
+                description: |-
+                  authoritativeAPI is the API that is authoritative for this resource.
+                  Valid values are MachineAPI and ClusterAPI.
+                  When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                  When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                  Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                  Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                  To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                enum:
+                - MachineAPI
+                - ClusterAPI
+                type: string
               lifecycleHooks:
                 description: |-
                   lifecycleHooks allow users to pause operations on the machine at
@@ -364,6 +378,23 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              authoritativeAPI:
+                description: |-
+                  authoritativeAPI is the API that is authoritative for this resource.
+                  Valid values are MachineAPI, ClusterAPI and Migrating.
+                  This value is updated by the migration controller to reflect the authoritative API.
+                  Machine API and Cluster API controllers use this value to determine whether or not to reconcile the resource.
+                  When set to Migrating, the migration controller is currently performing the handover of authority from one API to the other.
+                enum:
+                - MachineAPI
+                - ClusterAPI
+                - Migrating
+                type: string
+                x-kubernetes-validations:
+                - message: The authoritativeAPI field must not transition directly
+                    from MachineAPI to ClusterAPI or vice versa. It must transition
+                    through Migrating.
+                  rule: self == 'Migrating' || self == oldSelf || oldSelf == 'Migrating'
               conditions:
                 description: conditions defines the current state of the Machine
                 items:
@@ -537,7 +568,23 @@ spec:
                   serialized/deserialized from this field.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              synchronizedGeneration:
+                description: |-
+                  synchronizedGeneration is the generation of the authoritative resource that the non-authoritative resource is synchronised with.
+                  This field is set when the authoritative resource is updated and the sync controller has updated the non-authoritative resource to match.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .synchronizedGeneration
+              message: synchronizedGeneration must not decrease unless authoritativeAPI
+                is transitioning from Migrating to another value
+              reason: FieldValueInvalid
+              rule: '!has(oldSelf.synchronizedGeneration) || (has(self.synchronizedGeneration)
+                && self.synchronizedGeneration >= oldSelf.synchronizedGeneration)
+                || (oldSelf.authoritativeAPI == ''Migrating'' && self.authoritativeAPI
+                != ''Migrating'')'
         type: object
     served: true
     storage: true

--- a/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machines-TechPreviewNoUpgrade.crd.yaml
+++ b/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machines-TechPreviewNoUpgrade.crd.yaml
@@ -81,6 +81,20 @@ spec:
           spec:
             description: MachineSpec defines the desired state of Machine
             properties:
+              authoritativeAPI:
+                default: MachineAPI
+                description: |-
+                  authoritativeAPI is the API that is authoritative for this resource.
+                  Valid values are MachineAPI and ClusterAPI.
+                  When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                  When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                  Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                  Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                  To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                enum:
+                - MachineAPI
+                - ClusterAPI
+                type: string
               lifecycleHooks:
                 description: |-
                   lifecycleHooks allow users to pause operations on the machine at
@@ -364,6 +378,23 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              authoritativeAPI:
+                description: |-
+                  authoritativeAPI is the API that is authoritative for this resource.
+                  Valid values are MachineAPI, ClusterAPI and Migrating.
+                  This value is updated by the migration controller to reflect the authoritative API.
+                  Machine API and Cluster API controllers use this value to determine whether or not to reconcile the resource.
+                  When set to Migrating, the migration controller is currently performing the handover of authority from one API to the other.
+                enum:
+                - MachineAPI
+                - ClusterAPI
+                - Migrating
+                type: string
+                x-kubernetes-validations:
+                - message: The authoritativeAPI field must not transition directly
+                    from MachineAPI to ClusterAPI or vice versa. It must transition
+                    through Migrating.
+                  rule: self == 'Migrating' || self == oldSelf || oldSelf == 'Migrating'
               conditions:
                 description: conditions defines the current state of the Machine
                 items:
@@ -537,7 +568,23 @@ spec:
                   serialized/deserialized from this field.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              synchronizedGeneration:
+                description: |-
+                  synchronizedGeneration is the generation of the authoritative resource that the non-authoritative resource is synchronised with.
+                  This field is set when the authoritative resource is updated and the sync controller has updated the non-authoritative resource to match.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .synchronizedGeneration
+              message: synchronizedGeneration must not decrease unless authoritativeAPI
+                is transitioning from Migrating to another value
+              reason: FieldValueInvalid
+              rule: '!has(oldSelf.synchronizedGeneration) || (has(self.synchronizedGeneration)
+                && self.synchronizedGeneration >= oldSelf.synchronizedGeneration)
+                || (oldSelf.authoritativeAPI == ''Migrating'' && self.authoritativeAPI
+                != ''Migrating'')'
         type: object
     served: true
     storage: true

--- a/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-DevPreviewNoUpgrade.crd.yaml
+++ b/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-DevPreviewNoUpgrade.crd.yaml
@@ -66,6 +66,20 @@ spec:
           spec:
             description: MachineSetSpec defines the desired state of MachineSet
             properties:
+              authoritativeAPI:
+                default: MachineAPI
+                description: |-
+                  authoritativeAPI is the API that is authoritative for this resource.
+                  Valid values are MachineAPI and ClusterAPI.
+                  When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                  When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                  Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                  Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                  To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                enum:
+                - MachineAPI
+                - ClusterAPI
+                type: string
               deletePolicy:
                 description: |-
                   deletePolicy defines the policy used to identify nodes to delete when downscaling.
@@ -267,6 +281,20 @@ spec:
                       Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
+                      authoritativeAPI:
+                        default: MachineAPI
+                        description: |-
+                          authoritativeAPI is the API that is authoritative for this resource.
+                          Valid values are MachineAPI and ClusterAPI.
+                          When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                          When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                          Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                          Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                          To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                        enum:
+                        - MachineAPI
+                        - ClusterAPI
+                        type: string
                       lifecycleHooks:
                         description: |-
                           lifecycleHooks allow users to pause operations on the machine at
@@ -535,6 +563,23 @@ spec:
           status:
             description: MachineSetStatus defines the observed state of MachineSet
             properties:
+              authoritativeAPI:
+                description: |-
+                  authoritativeAPI is the API that is authoritative for this resource.
+                  Valid values are MachineAPI, ClusterAPI and Migrating.
+                  This value is updated by the migration controller to reflect the authoritative API.
+                  Machine API and Cluster API controllers use this value to determine whether or not to reconcile the resource.
+                  When set to Migrating, the migration controller is currently performing the handover of authority from one API to the other.
+                enum:
+                - MachineAPI
+                - ClusterAPI
+                - Migrating
+                type: string
+                x-kubernetes-validations:
+                - message: The authoritativeAPI field must not transition directly
+                    from MachineAPI to ClusterAPI or vice versa. It must transition
+                    through Migrating.
+                  rule: self == 'Migrating' || self == oldSelf || oldSelf == 'Migrating'
               availableReplicas:
                 description: The number of available replicas (ready for at least
                   minReadySeconds) for this MachineSet.
@@ -630,7 +675,23 @@ spec:
                 description: replicas is the most recently observed number of replicas.
                 format: int32
                 type: integer
+              synchronizedGeneration:
+                description: |-
+                  synchronizedGeneration is the generation of the authoritative resource that the non-authoritative resource is synchronised with.
+                  This field is set when the authoritative resource is updated and the sync controller has updated the non-authoritative resource to match.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .synchronizedGeneration
+              message: synchronizedGeneration must not decrease unless authoritativeAPI
+                is transitioning from Migrating to another value
+              reason: FieldValueInvalid
+              rule: '!has(oldSelf.synchronizedGeneration) || (has(self.synchronizedGeneration)
+                && self.synchronizedGeneration >= oldSelf.synchronizedGeneration)
+                || (oldSelf.authoritativeAPI == ''Migrating'' && self.authoritativeAPI
+                != ''Migrating'')'
         type: object
     served: true
     storage: true

--- a/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-TechPreviewNoUpgrade.crd.yaml
+++ b/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-TechPreviewNoUpgrade.crd.yaml
@@ -66,6 +66,20 @@ spec:
           spec:
             description: MachineSetSpec defines the desired state of MachineSet
             properties:
+              authoritativeAPI:
+                default: MachineAPI
+                description: |-
+                  authoritativeAPI is the API that is authoritative for this resource.
+                  Valid values are MachineAPI and ClusterAPI.
+                  When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                  When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                  Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                  Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                  To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                enum:
+                - MachineAPI
+                - ClusterAPI
+                type: string
               deletePolicy:
                 description: |-
                   deletePolicy defines the policy used to identify nodes to delete when downscaling.
@@ -267,6 +281,20 @@ spec:
                       Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
+                      authoritativeAPI:
+                        default: MachineAPI
+                        description: |-
+                          authoritativeAPI is the API that is authoritative for this resource.
+                          Valid values are MachineAPI and ClusterAPI.
+                          When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                          When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                          Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                          Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                          To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                        enum:
+                        - MachineAPI
+                        - ClusterAPI
+                        type: string
                       lifecycleHooks:
                         description: |-
                           lifecycleHooks allow users to pause operations on the machine at
@@ -535,6 +563,23 @@ spec:
           status:
             description: MachineSetStatus defines the observed state of MachineSet
             properties:
+              authoritativeAPI:
+                description: |-
+                  authoritativeAPI is the API that is authoritative for this resource.
+                  Valid values are MachineAPI, ClusterAPI and Migrating.
+                  This value is updated by the migration controller to reflect the authoritative API.
+                  Machine API and Cluster API controllers use this value to determine whether or not to reconcile the resource.
+                  When set to Migrating, the migration controller is currently performing the handover of authority from one API to the other.
+                enum:
+                - MachineAPI
+                - ClusterAPI
+                - Migrating
+                type: string
+                x-kubernetes-validations:
+                - message: The authoritativeAPI field must not transition directly
+                    from MachineAPI to ClusterAPI or vice versa. It must transition
+                    through Migrating.
+                  rule: self == 'Migrating' || self == oldSelf || oldSelf == 'Migrating'
               availableReplicas:
                 description: The number of available replicas (ready for at least
                   minReadySeconds) for this MachineSet.
@@ -630,7 +675,23 @@ spec:
                 description: replicas is the most recently observed number of replicas.
                 format: int32
                 type: integer
+              synchronizedGeneration:
+                description: |-
+                  synchronizedGeneration is the generation of the authoritative resource that the non-authoritative resource is synchronised with.
+                  This field is set when the authoritative resource is updated and the sync controller has updated the non-authoritative resource to match.
+                format: int64
+                minimum: 0
+                type: integer
             type: object
+            x-kubernetes-validations:
+            - fieldPath: .synchronizedGeneration
+              message: synchronizedGeneration must not decrease unless authoritativeAPI
+                is transitioning from Migrating to another value
+              reason: FieldValueInvalid
+              rule: '!has(oldSelf.synchronizedGeneration) || (has(self.synchronizedGeneration)
+                && self.synchronizedGeneration >= oldSelf.synchronizedGeneration)
+                || (oldSelf.authoritativeAPI == ''Migrating'' && self.authoritativeAPI
+                != ''Migrating'')'
         type: object
     served: true
     storage: true

--- a/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-DevPreviewNoUpgrade.crd.yaml
@@ -553,6 +553,20 @@ spec:
                           failure domain field. This will be overriden when the Machines
                           are created based on the FailureDomains field.
                         properties:
+                          authoritativeAPI:
+                            default: MachineAPI
+                            description: |-
+                              authoritativeAPI is the API that is authoritative for this resource.
+                              Valid values are MachineAPI and ClusterAPI.
+                              When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                              When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                              Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                              Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                              To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                            enum:
+                            - MachineAPI
+                            - ClusterAPI
+                            type: string
                           lifecycleHooks:
                             description: |-
                               lifecycleHooks allow users to pause operations on the machine at

--- a/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_control-plane-machine-set_01_controlplanemachinesets-TechPreviewNoUpgrade.crd.yaml
@@ -553,6 +553,20 @@ spec:
                           failure domain field. This will be overriden when the Machines
                           are created based on the FailureDomains field.
                         properties:
+                          authoritativeAPI:
+                            default: MachineAPI
+                            description: |-
+                              authoritativeAPI is the API that is authoritative for this resource.
+                              Valid values are MachineAPI and ClusterAPI.
+                              When set to MachineAPI, writes to the spec of the machine.openshift.io copy of this resource will be reflected into the cluster.x-k8s.io copy.
+                              When set to ClusterAPI, writes to the spec of the cluster.x-k8s.io copy of this resource will be reflected into the machine.openshift.io copy.
+                              Updates to the status will be reflected in both copies of the resource, based on the controller implementing the functionality of the API.
+                              Currently the authoritative API determines which controller will manage the resource, this will change in a future release.
+                              To ensure the change has been accepted, please verify that the `status.authoritativeAPI` field has been updated to the desired value and that the `Synchronized` condition is present and set to `True`.
+                            enum:
+                            - MachineAPI
+                            - ClusterAPI
+                            type: string
                           lifecycleHooks:
                             description: |-
                               lifecycleHooks allow users to pause operations on the machine at

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -22,9 +22,6 @@
                         "name": "EventedPLEG"
                     },
                     {
-                        "name": "MachineAPIMigration"
-                    },
-                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {
@@ -166,6 +163,9 @@
                     },
                     {
                         "name": "KMSv1"
+                    },
+                    {
+                        "name": "MachineAPIMigration"
                     },
                     {
                         "name": "MachineAPIProviderOpenStack"

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -28,9 +28,6 @@
                         "name": "Example2"
                     },
                     {
-                        "name": "MachineAPIMigration"
-                    },
-                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {
@@ -178,6 +175,9 @@
                     },
                     {
                         "name": "KMSv1"
+                    },
+                    {
+                        "name": "MachineAPIMigration"
                     },
                     {
                         "name": "MachineAPIProviderOpenStack"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -22,9 +22,6 @@
                         "name": "EventedPLEG"
                     },
                     {
-                        "name": "MachineAPIMigration"
-                    },
-                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {
@@ -157,6 +154,9 @@
                     },
                     {
                         "name": "KMSv1"
+                    },
+                    {
+                        "name": "MachineAPIMigration"
                     },
                     {
                         "name": "MachineAPIProviderOpenStack"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -28,9 +28,6 @@
                         "name": "Example2"
                     },
                     {
-                        "name": "MachineAPIMigration"
-                    },
-                    {
                         "name": "MachineAPIOperatorDisableMachineHealthCheckController"
                     },
                     {
@@ -169,6 +166,9 @@
                     },
                     {
                         "name": "KMSv1"
+                    },
+                    {
+                        "name": "MachineAPIMigration"
                     },
                     {
                         "name": "MachineAPIProviderOpenStack"


### PR DESCRIPTION
Enabling the MAPI to CAPI conversion in TechPreview for 4.19.

Required before merging:

* [x] https://github.com/openshift/cluster-capi-operator/pull/268
* [ ] https://github.com/openshift/cluster-capi-operator/pull/278
* [x] https://github.com/openshift/cluster-capi-operator/pull/282
