### PR TITLE
OCPEDGE-1775: Enable separation of conflicting enum values, and drop DualReplica to DevPreview

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/HighlyAvailableArbiter+DualReplica.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/HighlyAvailableArbiter+DualReplica.yaml
@@ -1,0 +1,142 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "Infrastructure"
+crdName: infrastructures.config.openshift.io
+featureGates:
+- DualReplica
+- HighlyAvailableArbiter
+tests:
+  onCreate:
+    - name: Should be able to create a minimal Infrastructure
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {} # No spec is required for a Infrastructure
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec: {}
+  onUpdate:
+    - name: status should allow controlPlaneTopology value for `HighlyAvailableArbiter`
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailableArbiter
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws: {}
+            type: AWS
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailableArbiter
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              cloudLoadBalancerConfig:
+                dnsType: PlatformDefault
+            type: AWS
+    - name: should not allow changing infrastructureTopology value to `HighlyAvailableArbiter`
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: HighlyAvailableArbiter
+          platform: AWS
+          platformStatus:
+            aws: {}
+            type: AWS
+      expectedStatusError: 'status.infrastructureTopology: Unsupported value: "HighlyAvailableArbiter": supported values: "HighlyAvailable", "SingleReplica"'
+    - name: status should allow controlPlaneTopology value for `DualReplica`
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: DualReplica
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws: {}
+            type: AWS
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: DualReplica
+          cpuPartitioning: None
+          infrastructureTopology: HighlyAvailable
+          platform: AWS
+          platformStatus:
+            aws:
+              cloudLoadBalancerConfig:
+                dnsType: PlatformDefault
+            type: AWS
+    - name: should not allow changing infrastructureTopology value to `DualReplica`
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            aws: {}
+            type: AWS
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Infrastructure
+        spec:
+          platformSpec:
+            type: AWS
+            aws: {}
+        status:
+          controlPlaneTopology: HighlyAvailable
+          infrastructureTopology: DualReplica
+          platform: AWS
+          platformStatus:
+            aws: {}
+            type: AWS
+      expectedStatusError: 'status.infrastructureTopology: Unsupported value: "DualReplica": supported values: "HighlyAvailable", "SingleReplica"'

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -99,7 +99,9 @@ type InfrastructureStatus struct {
 	// its components are not visible within the cluster.
 	// +kubebuilder:default=HighlyAvailable
 	// +openshift:validation:FeatureGateAwareEnum:featureGate="",enum=HighlyAvailable;SingleReplica;External
-	// +openshift:validation:FeatureGateAwareEnum:featureGate=HighlyAvailableArbiter;DualReplica,enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;DualReplica;External
+	// +openshift:validation:FeatureGateAwareEnum:featureGate=HighlyAvailableArbiter,enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;External
+	// +openshift:validation:FeatureGateAwareEnum:featureGate=DualReplica,enum=HighlyAvailable;SingleReplica;DualReplica;External
+	// +openshift:validation:FeatureGateAwareEnum:requiredFeatureGate=HighlyAvailableArbiter;DualReplica,enum=HighlyAvailable;HighlyAvailableArbiter;SingleReplica;DualReplica;External
 	ControlPlaneTopology TopologyMode `json:"controlPlaneTopology"`
 
 	// infrastructureTopology expresses the expectations for infrastructure services that do not run on control

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1130,7 +1130,6 @@ spec:
                 - HighlyAvailable
                 - HighlyAvailableArbiter
                 - SingleReplica
-                - DualReplica
                 - External
                 type: string
               cpuPartitioning:

--- a/config/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -320,6 +320,7 @@ infrastructures.config.openshift.io:
   - GCPCustomAPIEndpoints
   - GCPLabelsTags
   - HighlyAvailableArbiter
+  - HighlyAvailableArbiter+DualReplica
   - NutanixMultiSubnets
   - VSphereHostVMGroupZonal
   - VSphereMultiNetworks

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DualReplica.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/DualReplica.yaml
@@ -1036,7 +1036,6 @@ spec:
                   its components are not visible within the cluster.
                 enum:
                 - HighlyAvailable
-                - HighlyAvailableArbiter
                 - SingleReplica
                 - DualReplica
                 - External

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/HighlyAvailableArbiter+DualReplica.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/HighlyAvailableArbiter+DualReplica.yaml
@@ -6,6 +6,7 @@ metadata:
     api.openshift.io/filename-cvo-runlevel: "0000_10"
     api.openshift.io/filename-operator: config-operator
     api.openshift.io/filename-ordering: "01"
+    feature-gate.release.openshift.io/DualReplica: "true"
     feature-gate.release.openshift.io/HighlyAvailableArbiter: "true"
     release.openshift.io/bootstrap-required: "true"
   name: infrastructures.config.openshift.io
@@ -1038,6 +1039,7 @@ spec:
                 - HighlyAvailable
                 - HighlyAvailableArbiter
                 - SingleReplica
+                - DualReplica
                 - External
                 type: string
               cpuPartitioning:

--- a/features.md
+++ b/features.md
@@ -6,6 +6,7 @@
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
 | ClusterVersionOperatorConfiguration| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
+| DualReplica| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | Example2| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | NewOLMCatalogdAPIV1Metas| | | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMPreflightPermissionChecks| | | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
@@ -22,7 +23,6 @@
 | ClusterMonitoringConfig| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ConsolePluginContentSecurityPolicy| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | DNSNameResolver| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
-| DualReplica| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | DyanmicServiceEndpointIBMCloud| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | DynamicResourceAllocation| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | EtcdBackendQuota| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -787,7 +787,7 @@ var (
 		// TODO: Do not go GA until jira issue is resolved: https://issues.redhat.com/browse/OCPEDGE-1637
 		// Annotations must correctly handle either DualReplica or HighlyAvailableArbiter going GA with
 		// the other still in TechPreview.
-		enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+		enableIn(configv1.DevPreviewNoUpgrade).
 		mustRegister()
 
 	FeatureGateGatewayAPIController = newFeatureGate("GatewayAPIController").

--- a/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter+DualReplica.yaml
+++ b/machineconfiguration/v1/tests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter+DualReplica.yaml
@@ -1,0 +1,202 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "Optimistically missing"
+crdName: controllerconfigs.machineconfiguration.openshift.io
+featureGates:
+- DualReplica
+- HighlyAvailableArbiter
+tests:
+  onCreate:
+    - name: Should be able to create a minimal ControllerConfig
+      initial: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: HighlyAvailableArbiter
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK
+      expected: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: HighlyAvailableArbiter
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK
+    - name: Should be able to create a minimal ControllerConfig
+      initial: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: DualReplica
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK
+      expected: |
+        apiVersion: machineconfiguration.openshift.io/v1
+        kind: ControllerConfig
+        spec:
+          additionalTrustBundle: Y2VydGlmaWNhdGUK
+          baseOSContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          baseOSExtensionsContainerImage: example.com/example/openshift-release-dev@sha256:d98795f7932441b30bb8bcfbbf05912875383fad1f2b3be08a22ec148d68607e
+          cloudProviderCAData: null
+          cloudProviderConfig: ""
+          clusterDNSIP: fd02::a
+          dns:
+            apiVersion: config.openshift.io/v1
+            kind: DNS
+            spec:
+              baseDomain: fake.redhat.com
+          images:
+            machineConfigOperator: rexample.com/example/openshift-release-dev@sha256:2c3ea52ac3a41c6d58e85977c3149413e3fa4b70eb2397426456863adbf43306
+          infra:
+            apiVersion: config.openshift.io/v1
+            kind: Infrastructure
+            spec:
+              cloudConfig:
+                name: ""
+              platformSpec:
+                type: None
+            status:
+              apiServerInternalURI: https://api-int.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              apiServerURL: https://api.cnfde4.sno.ptp.lab.eng.bos.redhat.com:6443
+              cpuPartitioning: "None"
+              controlPlaneTopology: DualReplica
+              etcdDiscoveryDomain: ""
+              infrastructureName: cnfde4-sxhr7
+              infrastructureTopology: HighlyAvailable
+              platform: None
+              platformStatus:
+                type: None
+          ipFamilies: IPv6
+          kubeAPIServerServingCAData: Y2VydGlmaWNhdGUK
+          network: null
+          networkType: OVNKubernetes
+          osImageURL: example.com/example/openshift-release-dev@sha256:eacdc37aec78fdbf8caa9601e4012ab31453cf59b086474901900e853e803ea8
+          platform: none
+          proxy: null
+          pullSecret:
+            name: pull-secret
+            namespace: openshift-config
+          releaseImage: ""
+          rootCAData: Y2VydGlmaWNhdGUK

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1402,7 +1402,6 @@ spec:
                         - HighlyAvailable
                         - HighlyAvailableArbiter
                         - SingleReplica
-                        - DualReplica
                         - External
                         type: string
                       cpuPartitioning:

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -36,6 +36,7 @@ controllerconfigs.machineconfiguration.openshift.io:
   - GCPCustomAPIEndpoints
   - GCPLabelsTags
   - HighlyAvailableArbiter
+  - HighlyAvailableArbiter+DualReplica
   - NutanixMultiSubnets
   - VSphereMultiNetworks
   - VSphereMultiVCenters

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter+DualReplica.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter+DualReplica.yaml
@@ -7,6 +7,7 @@ metadata:
     api.openshift.io/filename-operator: machine-config
     api.openshift.io/filename-ordering: "01"
     feature-gate.release.openshift.io/DualReplica: "true"
+    feature-gate.release.openshift.io/HighlyAvailableArbiter: "true"
   labels:
     openshift.io/operator-managed: ""
   name: controllerconfigs.machineconfiguration.openshift.io
@@ -1329,6 +1330,7 @@ spec:
                           its components are not visible within the cluster.
                         enum:
                         - HighlyAvailable
+                        - HighlyAvailableArbiter
                         - SingleReplica
                         - DualReplica
                         - External

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/HighlyAvailableArbiter.yaml
@@ -1331,7 +1331,6 @@ spec:
                         - HighlyAvailable
                         - HighlyAvailableArbiter
                         - SingleReplica
-                        - DualReplica
                         - External
                         type: string
                       cpuPartitioning:

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1130,7 +1130,6 @@ spec:
                 - HighlyAvailable
                 - HighlyAvailableArbiter
                 - SingleReplica
-                - DualReplica
                 - External
                 type: string
               cpuPartitioning:

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -1402,7 +1402,6 @@ spec:
                         - HighlyAvailable
                         - HighlyAvailableArbiter
                         - SingleReplica
-                        - DualReplica
                         - External
                         type: string
                       cpuPartitioning:

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -22,6 +22,9 @@
                         "name": "ClusterVersionOperatorConfiguration"
                     },
                     {
+                        "name": "DualReplica"
+                    },
+                    {
                         "name": "EventedPLEG"
                     },
                     {
@@ -112,9 +115,6 @@
                     },
                     {
                         "name": "DisableKubeletCloudCredentialProviders"
-                    },
-                    {
-                        "name": "DualReplica"
                     },
                     {
                         "name": "DyanmicServiceEndpointIBMCloud"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -22,6 +22,9 @@
                         "name": "ClusterVersionOperatorConfiguration"
                     },
                     {
+                        "name": "DualReplica"
+                    },
+                    {
                         "name": "EventedPLEG"
                     },
                     {
@@ -103,9 +106,6 @@
                     },
                     {
                         "name": "DisableKubeletCloudCredentialProviders"
-                    },
-                    {
-                        "name": "DualReplica"
                     },
                     {
                         "name": "DyanmicServiceEndpointIBMCloud"


### PR DESCRIPTION
CC @eggfoobar 

This updates the way we apply manifests to make sure that where we have combinations (A+B), that these are applied after the constituent gates.

This means that we can control the order, and, where there are multiple gates affecting a single validation (enum), we can choose how to apply for either of the gates being enabled, or both gates being enabled.

This also drops the DualReplica gate to DevPreview, which is why we needed to find a solution for this