### PR TITLE
Fix broken ControlPlaneMachineSet integration tests

### DIFF
--- a/machine/v1/tests/controlplanemachinesets.machine.openshift.io/CPMSMachineNamePrefix.yaml
+++ b/machine/v1/tests/controlplanemachinesets.machine.openshift.io/CPMSMachineNamePrefix.yaml
@@ -1,8 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
-name: "ControlPlaneMachineSet (+CPMSMachineNamePrefix)"
+name: "ControlPlaneMachineSet (+CPMSMachineNamePrefix +MachineAPIMigration)"
 crdName: controlplanemachinesets.machine.openshift.io
 featureGates:
   - CPMSMachineNamePrefix
+  - MachineAPIMigration
 tests:
   onCreate:
     - name: Should be able to create a minimal ControlPlaneMachineSet


### PR DESCRIPTION
Colliding promotions for CPMSMachineNamePrefix to default and MachineAPIMigration to tech preview broke this test suite on the default feature set. For now, disable the suite in the default feature set by requiring the MachineAPIMigration gate.