### PR TITLE
MCO-1663: add explicit opt-out for boot image update in 4.18

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -50986,7 +50986,7 @@ func schema_openshift_api_operator_v1_MachineManagerSelector(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"mode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "mode determines how machine managers will be selected for updates. Valid values are All and Partial. All means that every resource matched by the machine manager will be updated. Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated.",
+							Description: "mode determines how machine managers will be selected for updates. Valid values are All and Partial. All means that every resource matched by the machine manager will be updated. Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated. None means that every resource matched by the machine manager will not be updated.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -53434,6 +53434,7 @@ func schema_openshift_api_operator_v1_PartialSelector(ref common.ReferenceCallba
 						},
 					},
 				},
+				Required: []string{"machineResourceSelector"},
 			},
 		},
 		Dependencies: []string{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -29738,7 +29738,7 @@
       ],
       "properties": {
         "mode": {
-          "description": "mode determines how machine managers will be selected for updates. Valid values are All and Partial. All means that every resource matched by the machine manager will be updated. Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated.",
+          "description": "mode determines how machine managers will be selected for updates. Valid values are All and Partial. All means that every resource matched by the machine manager will be updated. Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated. None means that every resource matched by the machine manager will not be updated.",
           "type": "string",
           "default": ""
         },
@@ -31169,6 +31169,9 @@
     "com.github.openshift.api.operator.v1.PartialSelector": {
       "description": "PartialSelector provides label selector(s) that can be used to match machine management resources.",
       "type": "object",
+      "required": [
+        "machineResourceSelector"
+      ],
       "properties": {
         "machineResourceSelector": {
           "description": "machineResourceSelector is a label selector that can be used to select machine resources like MachineSets.",

--- a/operator/v1/types_machineconfiguration.go
+++ b/operator/v1/types_machineconfiguration.go
@@ -152,8 +152,9 @@ type MachineManagerSelector struct {
 	// Valid values are All and Partial.
 	// All means that every resource matched by the machine manager will be updated.
 	// Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated.
+	// None means that every resource matched by the machine manager will not be updated.
 	// +unionDiscriminator
-	// +kubebuilder:validation:Required
+	// +required
 	Mode MachineManagerSelectorMode `json:"mode"`
 
 	// partial provides label selector(s) that can be used to match machine management resources.
@@ -165,12 +166,12 @@ type MachineManagerSelector struct {
 // PartialSelector provides label selector(s) that can be used to match machine management resources.
 type PartialSelector struct {
 	// machineResourceSelector is a label selector that can be used to select machine resources like MachineSets.
-	// +kubebuilder:validation:Required
+	// +required
 	MachineResourceSelector *metav1.LabelSelector `json:"machineResourceSelector,omitempty"`
 }
 
 // MachineManagerSelectorMode is a string enum used in the MachineManagerSelector union discriminator.
-// +kubebuilder:validation:Enum:="All";"Partial"
+// +kubebuilder:validation:Enum:="All";"Partial";"None"
 type MachineManagerSelectorMode string
 
 const (
@@ -180,6 +181,9 @@ const (
 	// Partial represents a configuration mode that will register resources specified by the parent MachineManager only
 	// if they match with the label selector.
 	Partial MachineManagerSelectorMode = "Partial"
+
+	// None represents a configuration mode that excludes all resources specified by the parent MachineManager from boot image updates.
+	None MachineManagerSelectorMode = "None"
 )
 
 // MachineManagerManagedResourceType is a string enum used in the MachineManager type to describe the resource

--- a/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations.crd.yaml
@@ -116,9 +116,11 @@ spec:
                                 Valid values are All and Partial.
                                 All means that every resource matched by the machine manager will be updated.
                                 Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated.
+                                None means that every resource matched by the machine manager will not be updated.
                               enum:
                               - All
                               - Partial
+                              - None
                               type: string
                             partial:
                               description: |-

--- a/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/ManagedBootImages.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/machineconfigurations.operator.openshift.io/ManagedBootImages.yaml
@@ -117,9 +117,11 @@ spec:
                                 Valid values are All and Partial.
                                 All means that every resource matched by the machine manager will be updated.
                                 Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated.
+                                None means that every resource matched by the machine manager will not be updated.
                               enum:
                               - All
                               - Partial
+                              - None
                               type: string
                             partial:
                               description: |-

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1389,7 +1389,7 @@ func (MachineManager) SwaggerDoc() map[string]string {
 }
 
 var map_MachineManagerSelector = map[string]string{
-	"mode":    "mode determines how machine managers will be selected for updates. Valid values are All and Partial. All means that every resource matched by the machine manager will be updated. Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated.",
+	"mode":    "mode determines how machine managers will be selected for updates. Valid values are All and Partial. All means that every resource matched by the machine manager will be updated. Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated. None means that every resource matched by the machine manager will not be updated.",
 	"partial": "partial provides label selector(s) that can be used to match machine management resources. Only permitted when mode is set to \"Partial\".",
 }
 

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfigurations.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfigurations.crd.yaml
@@ -116,9 +116,11 @@ spec:
                                 Valid values are All and Partial.
                                 All means that every resource matched by the machine manager will be updated.
                                 Partial requires specified selector(s) and allows customisation of which resources matched by the machine manager will be updated.
+                                None means that every resource matched by the machine manager will not be updated.
                               enum:
                               - All
                               - Partial
+                              - None
                               type: string
                             partial:
                               description: |-


### PR DESCRIPTION
This adds the explicit "None" boot image configuration option in 4.18, which was introduced in 4.19 via https://github.com/openshift/api/pull/2223. This would allow users to explicitly opt-out of boot image updates in 4.18, prior to upgrading to 4.19.