### PR TITLE
CNTRLPLANE-367: Update Authentication API GoDoc for OIDC-related fields

### DIFF
--- a/config/v1/types_authentication.go
+++ b/config/v1/types_authentication.go
@@ -195,32 +195,50 @@ const (
 )
 
 type OIDCProvider struct {
-	// name of the OIDC provider
+	// name is a required field that configures the unique human-readable identifier
+	// associated with the identity provider.
+	// It is used to distinguish between multiple identity providers
+	// and has no impact on token validation or authentication mechanics.
+	//
+	// name must not be an empty string ("").
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	Name string `json:"name"`
-	// issuer describes atributes of the OIDC token issuer
+
+	// issuer is a required field that configures how the platform interacts
+	// with the identity provider and how tokens issued from the identity provider 
+	// are evaluated by the Kubernetes API server.
 	//
 	// +required
 	Issuer TokenIssuer `json:"issuer"`
 
-	// oidcClients contains configuration for the platform's clients that
-	// need to request tokens from the issuer
+	// oidcClients is an optional field that configures how on-cluster,
+	// platform clients should request tokens from the identity provider.
+	// oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
 	//
 	// +listType=map
 	// +listMapKey=componentNamespace
 	// +listMapKey=componentName
 	// +kubebuilder:validation:MaxItems=20
+	// +optional
 	OIDCClients []OIDCClientConfig `json:"oidcClients"`
 
-	// claimMappings describes rules on how to transform information from an
-	// ID token into a cluster identity
+	// claimMappings is an optional field that configures the rules to be used by
+	// the Kubernetes API server for translating claims in a JWT token, issued
+	// by the identity provider, to a cluster identity.
+	//
+	// +optional
 	ClaimMappings TokenClaimMappings `json:"claimMappings"`
 
-	// claimValidationRules are rules that are applied to validate token claims to authenticate users.
+	// claimValidationRules is an optional field that configures the rules to
+	// be used by the Kubernetes API server for validating the claims in a JWT
+	// token issued by the identity provider.
+	//
+	// Validation rules are joined via an AND operation.
 	//
 	// +listType=atomic
+	// +optional
 	ClaimValidationRules []TokenClaimValidationRule `json:"claimValidationRules,omitempty"`
 }
 
@@ -228,17 +246,22 @@ type OIDCProvider struct {
 type TokenAudience string
 
 type TokenIssuer struct {
-	// URL is the serving URL of the token issuer.
-	// Must use the https:// scheme.
+	// issuerURL is a required field that configures the URL used to issue tokens
+	// by the identity provider.
+	// The Kubernetes API server determines how authentication tokens should be handled
+	// by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+	//
+	// issuerURL must use the 'https' scheme.
 	//
 	// +kubebuilder:validation:Pattern=`^https:\/\/[^\s]`
 	// +required
 	URL string `json:"issuerURL"`
 
-	// audiences is an array of audiences that the token was issued for.
-	// Valid tokens must include at least one of these values in their
-	// "aud" claim.
-	// Must be set to exactly one value.
+	// audiences is a required field that configures the acceptable audiences
+	// the JWT token, issued by the identity provider, must be issued to.
+	// At least one of the entries must match the 'aud' claim in the JWT token.
+	//
+	// audiences must contain at least one entry and must not exceed ten entries.
 	//
 	// +listType=set
 	// +kubebuilder:validation:MinItems=1
@@ -246,23 +269,35 @@ type TokenIssuer struct {
 	// +required
 	Audiences []TokenAudience `json:"audiences"`
 
-	// CertificateAuthority is a reference to a config map in the
-	// configuration namespace. The .data of the configMap must contain
-	// the "ca-bundle.crt" key.
-	// If unset, system trust is used instead.
+	// issuerCertificateAuthority is an optional field that configures the
+	// certificate authority, used by the Kubernetes API server, to validate
+	// the connection to the identity provider when fetching discovery information.
+	//
+	// When not specified, the system trust is used.
+	//
+	// When specified, it must reference a ConfigMap in the openshift-config
+	// namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+	// key in the data field of the ConfigMap.
+	//
+	// +optional
 	CertificateAuthority ConfigMapNameReference `json:"issuerCertificateAuthority"`
 }
 
 type TokenClaimMappings struct {
-	// username is a name of the claim that should be used to construct
-	// usernames for the cluster identity.
+	// username is an optional field that configures how the username of a cluster identity
+	// should be constructed from the claims in a JWT token issued by the identity provider.
 	//
-	// Default value: "sub"
+	// +optional
 	Username UsernameClaimMapping `json:"username,omitempty"`
 
-	// groups is a name of the claim that should be used to construct
-	// groups for the cluster identity.
-	// The referenced claim must use array of strings values.
+	// groups is an optional field that configures how the groups of a cluster identity
+	// should be constructed from the claims in a JWT token issued
+	// by the identity provider.
+	// When referencing a claim, if the claim is present in the JWT
+	// token, its value must be a list of groups separated by a comma (',').
+	// For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
+	//
+	// +optional
 	Groups PrefixedClaimMapping `json:"groups,omitempty"`
 
 	// uid is an optional field for configuring the claim mapping
@@ -293,8 +328,13 @@ type TokenClaimMappings struct {
 	Extra []ExtraMapping `json:"extra,omitempty"`
 }
 
+// TokenClaimMapping allows specifying a JWT token
+// claim to be used when mapping claims from an
+// authentication token to cluster identities.
 type TokenClaimMapping struct {
-	// claim is a JWT token claim to be used in the mapping
+	// claim is a required field that configures the JWT token
+	// claim whose value is assigned to the cluster identity
+	// field associated with this mapping.
 	//
 	// +required
 	Claim string `json:"claim"`
@@ -404,66 +444,118 @@ type ExtraMapping struct {
 	ValueExpression string `json:"valueExpression"`
 }
 
+// OIDCClientConfig configures how platform clients
+// interact with identity providers as an authentication
+// method
 type OIDCClientConfig struct {
-	// componentName is the name of the component that is supposed to consume this
-	// client configuration
+	// componentName is a required field that specifies the name of the platform
+	// component being configured to use the identity provider as an authentication mode.
+	// It is used in combination with componentNamespace as a unique identifier.
+	//
+	// componentName must not be an empty string ("") and must not exceed 256 characters in length.
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
 	// +required
 	ComponentName string `json:"componentName"`
 
-	// componentNamespace is the namespace of the component that is supposed to consume this
-	// client configuration
+	// componentNamespace is a required field that specifies the namespace in which the
+	// platform component being configured to use the identity provider as an authentication
+	// mode is running.
+	// It is used in combination with componentName as a unique identifier.
+	//
+	// componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +required
 	ComponentNamespace string `json:"componentNamespace"`
 
-	// clientID is the identifier of the OIDC client from the OIDC provider
+	// clientID is a required field that configures the client identifier, from
+	// the identity provider, that the platform component uses for authentication
+	// requests made to the identity provider.
+	// The identity provider must accept this identifier for platform components
+	// to be able to use the identity provider as an authentication mode.
+	//
+	// clientID must not be an empty string ("").
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	ClientID string `json:"clientID"`
 
-	// clientSecret refers to a secret in the `openshift-config` namespace that
-	// contains the client secret in the `clientSecret` key of the `.data` field
+	// clientSecret is an optional field that configures the client secret used
+	// by the platform component when making authentication requests to the identity provider.
+	//
+	// When not specified, no client secret will be used when making authentication requests
+	// to the identity provider.
+	//
+	// When specified, clientSecret references a Secret in the 'openshift-config'
+	// namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+	// The client secret will be used when making authentication requests to the identity provider.
+	//
+	// Public clients do not require a client secret but private
+	// clients do require a client secret to work with the identity provider.
+	//
+	// +optional
 	ClientSecret SecretNameReference `json:"clientSecret"`
 
-	// extraScopes is an optional set of scopes to request tokens with.
+	// extraScopes is an optional field that configures the extra scopes that should
+	// be requested by the platform component when making authentication requests to the
+	// identity provider.
+	// This is useful if you have configured claim mappings that requires specific
+	// scopes to be requested beyond the standard OIDC scopes.
+	//
+	// When omitted, no additional scopes are requested.
 	//
 	// +listType=set
+	// +optional
 	ExtraScopes []string `json:"extraScopes"`
 }
 
+// OIDCClientStatus represents the current state
+// of platform components and how they interact with
+// the configured identity providers.
 type OIDCClientStatus struct {
-	// componentName is the name of the component that will consume a client configuration.
+	// componentName is a required field that specifies the name of the platform
+	// component using the identity provider as an authentication mode.
+	// It is used in combination with componentNamespace as a unique identifier.
+	//
+	// componentName must not be an empty string ("") and must not exceed 256 characters in length.
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=256
 	// +required
 	ComponentName string `json:"componentName"`
 
-	// componentNamespace is the namespace of the component that will consume a client configuration.
+	// componentNamespace is a required field that specifies the namespace in which the
+	// platform component using the identity provider as an authentication
+	// mode is running.
+	// It is used in combination with componentName as a unique identifier.
+	//
+	// componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +required
 	ComponentNamespace string `json:"componentNamespace"`
 
-	// currentOIDCClients is a list of clients that the component is currently using.
+	// currentOIDCClients is an optional list of clients that the component is currently using.
+	// Entries must have unique issuerURL/clientID pairs.
 	//
 	// +listType=map
 	// +listMapKey=issuerURL
 	// +listMapKey=clientID
+	// +optional
 	CurrentOIDCClients []OIDCClientReference `json:"currentOIDCClients"`
 
-	// consumingUsers is a slice of ServiceAccounts that need to have read
-	// permission on the `clientSecret` secret.
+	// consumingUsers is an optional list of ServiceAccounts requiring
+	// read permissions on the `clientSecret` secret.
+	//
+	// consumingUsers must not exceed 5 entries.
 	//
 	// +kubebuilder:validation:MaxItems=5
 	// +listType=set
+	// +optional
 	ConsumingUsers []ConsumingUser `json:"consumingUsers"`
 
 	// conditions are used to communicate the state of the `oidcClients` entry.
@@ -480,21 +572,32 @@ type OIDCClientStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// OIDCClientReference is a reference to a platform component
+// client configuration.
 type OIDCClientReference struct {
-	// OIDCName refers to the `name` of the provider from `oidcProviders`
+	// oidcProviderName is a required reference to the 'name' of the identity provider
+	// configured in 'oidcProviders' that this client is associated with.
+	//
+	// oidcProviderName must not be an empty string ("").
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	OIDCProviderName string `json:"oidcProviderName"`
 
-	// URL is the serving URL of the token issuer.
-	// Must use the https:// scheme.
+	// issuerURL is a required field that specifies the URL of the identity
+	// provider that this client is configured to make requests against.
+	//
+	// issuerURL must use the 'https' scheme.
 	//
 	// +kubebuilder:validation:Pattern=`^https:\/\/[^\s]`
 	// +required
 	IssuerURL string `json:"issuerURL"`
 
-	// clientID is the identifier of the OIDC client from the OIDC provider
+	// clientID is a required field that specifies the client identifier, from
+	// the identity provider, that the platform component is using for authentication
+	// requests made to the identity provider.
+	//
+	// clientID must not be empty.
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +required
@@ -502,35 +605,52 @@ type OIDCClientReference struct {
 }
 
 // +kubebuilder:validation:XValidation:rule="has(self.prefixPolicy) && self.prefixPolicy == 'Prefix' ? (has(self.prefix) && size(self.prefix.prefixString) > 0) : !has(self.prefix)",message="prefix must be set if prefixPolicy is 'Prefix', but must remain unset otherwise"
+// +union
 type UsernameClaimMapping struct {
 	TokenClaimMapping `json:",inline"`
 
-	// prefixPolicy specifies how a prefix should apply.
+	// prefixPolicy is an optional field that configures how a prefix should be
+	// applied to the value of the JWT claim specified in the 'claim' field.
 	//
-	// By default, claims other than `email` will be prefixed with the issuer URL to
-	// prevent naming clashes with other plugins.
+	// Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 	//
-	// Set to "NoPrefix" to disable prefixing.
+	// When set to 'Prefix', the value specified in the prefix field will be
+	// prepended to the value of the JWT claim.
+	// The prefix field must be set when prefixPolicy is 'Prefix'.
 	//
-	// Example:
-	//     (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-	//         If the JWT claim `username` contains value `userA`, the resulting
-	//         mapped value will be "myoidc:userA".
-	//     (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-	//         JWT `email` claim contains value "userA@myoidc.tld", the resulting
-	//         mapped value will be "myoidc:userA@myoidc.tld".
-	//     (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-	//         the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-	//         and `claim` is set to:
-	//         (a) "username": the mapped value will be "https://myoidc.tld#userA"
-	//         (b) "email": the mapped value will be "userA@myoidc.tld"
+	// When set to 'NoPrefix', no prefix will be prepended to the value
+	// of the JWT claim.
+	//
+	// When omitted, this means no opinion and the platform is left to choose
+	// any prefixes that are applied which is subject to change over time.
+	// Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+	// when the claim is not 'email'.
+	// As an example, consider the following scenario:
+	//    `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+	//    the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+	//    and `claim` is set to:
+	//    - "username": the mapped value will be "https://myoidc.tld#userA"
+	//    - "email": the mapped value will be "userA@myoidc.tld"
 	//
 	// +kubebuilder:validation:Enum={"", "NoPrefix", "Prefix"}
+	// +optional
+	// +unionDiscriminator
 	PrefixPolicy UsernamePrefixPolicy `json:"prefixPolicy"`
 
+	// prefix configures the prefix that should be prepended to the value
+	// of the JWT claim.
+	//
+	// prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
+	//
+	// +optional
+	// +unionMember
 	Prefix *UsernamePrefix `json:"prefix"`
 }
 
+// UsernamePrefixPolicy configures how prefixes should be applied
+// to values extracted from the JWT claims during the process of mapping
+// JWT claims to cluster identity attributes.
+// +enum
 type UsernamePrefixPolicy string
 
 var (
@@ -545,26 +665,42 @@ var (
 	Prefix UsernamePrefixPolicy = "Prefix"
 )
 
+// UsernamePrefix configures the string that should
+// be used as a prefix for username claim mappings.
 type UsernamePrefix struct {
+	// prefixString is a required field that configures the prefix that will
+	// be applied to cluster identity username attribute
+	// during the process of mapping JWT claims to cluster identity attributes.
+	//
+	// prefixString must not be an empty string ("").
+	//
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	PrefixString string `json:"prefixString"`
 }
 
+// PrefixedClaimMapping configures a claim mapping
+// that allows for an optional prefix.
 type PrefixedClaimMapping struct {
 	TokenClaimMapping `json:",inline"`
 
-	// prefix is a string to prefix the value from the token in the result of the
-	// claim mapping.
+	// prefix is an optional field that configures the prefix that will be
+	// applied to the cluster identity attribute during the process of mapping
+	// JWT claims to cluster identity attributes.
 	//
-	// By default, no prefixing occurs.
+	// When omitted (""), no prefix is applied to the cluster identity attribute.
 	//
-	// Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+	// Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
 	// an array of strings "a", "b" and  "c", the mapping will result in an
 	// array of string "myoidc:a", "myoidc:b" and "myoidc:c".
+	//
+	// +optional
 	Prefix string `json:"prefix"`
 }
 
+// TokenValidationRuleType represents the different
+// claim validation rule types that can be configured.
+// +enum
 type TokenValidationRuleType string
 
 const (
@@ -572,26 +708,45 @@ const (
 )
 
 type TokenClaimValidationRule struct {
-	// type sets the type of the validation rule
+	// type is an optional field that configures the type of the validation rule.
+	//
+	// Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+	//
+	// When set to 'RequiredClaim', the Kubernetes API server
+	// will be configured to validate that the incoming JWT
+	// contains the required claim and that its value matches
+	// the required value.
+	//
+	// Defaults to 'RequiredClaim'.
 	//
 	// +kubebuilder:validation:Enum={"RequiredClaim"}
 	// +kubebuilder:default="RequiredClaim"
 	Type TokenValidationRuleType `json:"type"`
 
-	// requiredClaim allows configuring a required claim name and its expected
-	// value
+	// requiredClaim is an optional field that configures the required claim
+	// and value that the Kubernetes API server will use to validate if an incoming
+	// JWT is valid for this identity provider.
+	//
+	// +optional
 	RequiredClaim *TokenRequiredClaim `json:"requiredClaim"`
 }
 
 type TokenRequiredClaim struct {
-	// claim is a name of a required claim. Only claims with string values are
-	// supported.
+	// claim is a required field that configures the name of the required claim.
+	// When taken from the JWT claims, claim must be a string value.
+	//
+	// claim must not be an empty string ("").
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +required
 	Claim string `json:"claim"`
 
-	// requiredValue is the required value for the claim.
+	// requiredValue is a required field that configures the value that 'claim' must
+	// have when taken from the incoming JWT claims.
+	// If the value in the JWT claims does not match, the token
+	// will be rejected for authentication.
+	//
+	// requiredValue must not be an empty string ("").
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +required

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift-CustomNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift-Default.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift-Default.crd.yaml
@@ -79,27 +79,34 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -108,18 +115,29 @@ spec:
                           type: object
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -127,25 +145,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -162,24 +183,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -188,7 +221,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -196,14 +239,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -213,10 +260,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -227,8 +279,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -236,24 +292,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -264,21 +347,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -418,16 +514,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -501,8 +610,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -514,24 +625,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/ExternalOIDC.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/ExternalOIDC.yaml
@@ -80,27 +80,34 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -109,18 +116,29 @@ spec:
                           type: object
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -128,25 +146,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -163,24 +184,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -189,7 +222,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -197,14 +240,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -214,10 +261,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -228,8 +280,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -237,24 +293,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -265,21 +348,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -419,16 +515,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -502,8 +611,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -515,24 +626,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/authentications.config.openshift.io/ExternalOIDCWithUIDAndExtraClaimMappings.yaml
@@ -80,8 +80,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -186,22 +187,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -260,18 +267,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -279,25 +297,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -314,24 +335,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -340,7 +373,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -348,14 +391,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -365,10 +412,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -379,8 +431,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -388,24 +444,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -416,21 +499,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -570,16 +666,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -653,8 +762,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -666,24 +777,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -407,11 +407,12 @@ func (ExtraMapping) SwaggerDoc() map[string]string {
 }
 
 var map_OIDCClientConfig = map[string]string{
-	"componentName":      "componentName is the name of the component that is supposed to consume this client configuration",
-	"componentNamespace": "componentNamespace is the namespace of the component that is supposed to consume this client configuration",
-	"clientID":           "clientID is the identifier of the OIDC client from the OIDC provider",
-	"clientSecret":       "clientSecret refers to a secret in the `openshift-config` namespace that contains the client secret in the `clientSecret` key of the `.data` field",
-	"extraScopes":        "extraScopes is an optional set of scopes to request tokens with.",
+	"":                   "OIDCClientConfig configures how platform clients interact with identity providers as an authentication method",
+	"componentName":      "componentName is a required field that specifies the name of the platform component being configured to use the identity provider as an authentication mode. It is used in combination with componentNamespace as a unique identifier.\n\ncomponentName must not be an empty string (\"\") and must not exceed 256 characters in length.",
+	"componentNamespace": "componentNamespace is a required field that specifies the namespace in which the platform component being configured to use the identity provider as an authentication mode is running. It is used in combination with componentName as a unique identifier.\n\ncomponentNamespace must not be an empty string (\"\") and must not exceed 63 characters in length.",
+	"clientID":           "clientID is a required field that configures the client identifier, from the identity provider, that the platform component uses for authentication requests made to the identity provider. The identity provider must accept this identifier for platform components to be able to use the identity provider as an authentication mode.\n\nclientID must not be an empty string (\"\").",
+	"clientSecret":       "clientSecret is an optional field that configures the client secret used by the platform component when making authentication requests to the identity provider.\n\nWhen not specified, no client secret will be used when making authentication requests to the identity provider.\n\nWhen specified, clientSecret references a Secret in the 'openshift-config' namespace that contains the client secret in the 'clientSecret' key of the '.data' field. The client secret will be used when making authentication requests to the identity provider.\n\nPublic clients do not require a client secret but private clients do require a client secret to work with the identity provider.",
+	"extraScopes":        "extraScopes is an optional field that configures the extra scopes that should be requested by the platform component when making authentication requests to the identity provider. This is useful if you have configured claim mappings that requires specific scopes to be requested beyond the standard OIDC scopes.\n\nWhen omitted, no additional scopes are requested.",
 }
 
 func (OIDCClientConfig) SwaggerDoc() map[string]string {
@@ -419,9 +420,10 @@ func (OIDCClientConfig) SwaggerDoc() map[string]string {
 }
 
 var map_OIDCClientReference = map[string]string{
-	"oidcProviderName": "OIDCName refers to the `name` of the provider from `oidcProviders`",
-	"issuerURL":        "URL is the serving URL of the token issuer. Must use the https:// scheme.",
-	"clientID":         "clientID is the identifier of the OIDC client from the OIDC provider",
+	"":                 "OIDCClientReference is a reference to a platform component client configuration.",
+	"oidcProviderName": "oidcProviderName is a required reference to the 'name' of the identity provider configured in 'oidcProviders' that this client is associated with.\n\noidcProviderName must not be an empty string (\"\").",
+	"issuerURL":        "issuerURL is a required field that specifies the URL of the identity provider that this client is configured to make requests against.\n\nissuerURL must use the 'https' scheme.",
+	"clientID":         "clientID is a required field that specifies the client identifier, from the identity provider, that the platform component is using for authentication requests made to the identity provider.\n\nclientID must not be empty.",
 }
 
 func (OIDCClientReference) SwaggerDoc() map[string]string {
@@ -429,10 +431,11 @@ func (OIDCClientReference) SwaggerDoc() map[string]string {
 }
 
 var map_OIDCClientStatus = map[string]string{
-	"componentName":      "componentName is the name of the component that will consume a client configuration.",
-	"componentNamespace": "componentNamespace is the namespace of the component that will consume a client configuration.",
-	"currentOIDCClients": "currentOIDCClients is a list of clients that the component is currently using.",
-	"consumingUsers":     "consumingUsers is a slice of ServiceAccounts that need to have read permission on the `clientSecret` secret.",
+	"":                   "OIDCClientStatus represents the current state of platform components and how they interact with the configured identity providers.",
+	"componentName":      "componentName is a required field that specifies the name of the platform component using the identity provider as an authentication mode. It is used in combination with componentNamespace as a unique identifier.\n\ncomponentName must not be an empty string (\"\") and must not exceed 256 characters in length.",
+	"componentNamespace": "componentNamespace is a required field that specifies the namespace in which the platform component using the identity provider as an authentication mode is running. It is used in combination with componentName as a unique identifier.\n\ncomponentNamespace must not be an empty string (\"\") and must not exceed 63 characters in length.",
+	"currentOIDCClients": "currentOIDCClients is an optional list of clients that the component is currently using. Entries must have unique issuerURL/clientID pairs.",
+	"consumingUsers":     "consumingUsers is an optional list of ServiceAccounts requiring read permissions on the `clientSecret` secret.\n\nconsumingUsers must not exceed 5 entries.",
 	"conditions":         "conditions are used to communicate the state of the `oidcClients` entry.\n\nSupported conditions include Available, Degraded and Progressing.\n\nIf Available is true, the component is successfully using the configured client. If Degraded is true, that means something has gone wrong trying to handle the client configuration. If Progressing is true, that means the component is taking some action related to the `oidcClients` entry.",
 }
 
@@ -441,11 +444,11 @@ func (OIDCClientStatus) SwaggerDoc() map[string]string {
 }
 
 var map_OIDCProvider = map[string]string{
-	"name":                 "name of the OIDC provider",
-	"issuer":               "issuer describes atributes of the OIDC token issuer",
-	"oidcClients":          "oidcClients contains configuration for the platform's clients that need to request tokens from the issuer",
-	"claimMappings":        "claimMappings describes rules on how to transform information from an ID token into a cluster identity",
-	"claimValidationRules": "claimValidationRules are rules that are applied to validate token claims to authenticate users.",
+	"name":                 "name is a required field that configures the unique human-readable identifier associated with the identity provider. It is used to distinguish between multiple identity providers and has no impact on token validation or authentication mechanics.\n\nname must not be an empty string (\"\").",
+	"issuer":               "issuer is a required field that configures how the platform interacts with the identity provider and how tokens issued from the identity provider are evaluated by the Kubernetes API server.",
+	"oidcClients":          "oidcClients is an optional field that configures how on-cluster, platform clients should request tokens from the identity provider. oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.",
+	"claimMappings":        "claimMappings is an optional field that configures the rules to be used by the Kubernetes API server for translating claims in a JWT token, issued by the identity provider, to a cluster identity.",
+	"claimValidationRules": "claimValidationRules is an optional field that configures the rules to be used by the Kubernetes API server for validating the claims in a JWT token issued by the identity provider.\n\nValidation rules are joined via an AND operation.",
 }
 
 func (OIDCProvider) SwaggerDoc() map[string]string {
@@ -453,7 +456,8 @@ func (OIDCProvider) SwaggerDoc() map[string]string {
 }
 
 var map_PrefixedClaimMapping = map[string]string{
-	"prefix": "prefix is a string to prefix the value from the token in the result of the claim mapping.\n\nBy default, no prefixing occurs.\n\nExample: if `prefix` is set to \"myoidc:\"\" and the `claim` in JWT contains an array of strings \"a\", \"b\" and  \"c\", the mapping will result in an array of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\".",
+	"":       "PrefixedClaimMapping configures a claim mapping that allows for an optional prefix.",
+	"prefix": "prefix is an optional field that configures the prefix that will be applied to the cluster identity attribute during the process of mapping JWT claims to cluster identity attributes.\n\nWhen omitted (\"\"), no prefix is applied to the cluster identity attribute.\n\nExample: if `prefix` is set to \"myoidc:\" and the `claim` in JWT contains an array of strings \"a\", \"b\" and  \"c\", the mapping will result in an array of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\".",
 }
 
 func (PrefixedClaimMapping) SwaggerDoc() map[string]string {
@@ -461,7 +465,8 @@ func (PrefixedClaimMapping) SwaggerDoc() map[string]string {
 }
 
 var map_TokenClaimMapping = map[string]string{
-	"claim": "claim is a JWT token claim to be used in the mapping",
+	"":      "TokenClaimMapping allows specifying a JWT token claim to be used when mapping claims from an authentication token to cluster identities.",
+	"claim": "claim is a required field that configures the JWT token claim whose value is assigned to the cluster identity field associated with this mapping.",
 }
 
 func (TokenClaimMapping) SwaggerDoc() map[string]string {
@@ -469,8 +474,8 @@ func (TokenClaimMapping) SwaggerDoc() map[string]string {
 }
 
 var map_TokenClaimMappings = map[string]string{
-	"username": "username is a name of the claim that should be used to construct usernames for the cluster identity.\n\nDefault value: \"sub\"",
-	"groups":   "groups is a name of the claim that should be used to construct groups for the cluster identity. The referenced claim must use array of strings values.",
+	"username": "username is an optional field that configures how the username of a cluster identity should be constructed from the claims in a JWT token issued by the identity provider.",
+	"groups":   "groups is an optional field that configures how the groups of a cluster identity should be constructed from the claims in a JWT token issued by the identity provider. When referencing a claim, if the claim is present in the JWT token, its value must be a list of groups separated by a comma (','). For example - '\"example\"' and '\"exampleOne\", \"exampleTwo\", \"exampleThree\"' are valid claim values.",
 	"uid":      "uid is an optional field for configuring the claim mapping used to construct the uid for the cluster identity.\n\nWhen using uid.claim to specify the claim it must be a single string value. When using uid.expression the expression must result in a single string value.\n\nWhen omitted, this means the user has no opinion and the platform is left to choose a default, which is subject to change over time. The current default is to use the 'sub' claim.",
 	"extra":    "extra is an optional field for configuring the mappings used to construct the extra attribute for the cluster identity. When omitted, no extra attributes will be present on the cluster identity. key values for extra mappings must be unique. A maximum of 64 extra attribute mappings may be provided.",
 }
@@ -490,8 +495,8 @@ func (TokenClaimOrExpressionMapping) SwaggerDoc() map[string]string {
 }
 
 var map_TokenClaimValidationRule = map[string]string{
-	"type":          "type sets the type of the validation rule",
-	"requiredClaim": "requiredClaim allows configuring a required claim name and its expected value",
+	"type":          "type is an optional field that configures the type of the validation rule.\n\nAllowed values are 'RequiredClaim' and omitted (not provided or an empty string).\n\nWhen set to 'RequiredClaim', the Kubernetes API server will be configured to validate that the incoming JWT contains the required claim and that its value matches the required value.\n\nDefaults to 'RequiredClaim'.",
+	"requiredClaim": "requiredClaim is an optional field that configures the required claim and value that the Kubernetes API server will use to validate if an incoming JWT is valid for this identity provider.",
 }
 
 func (TokenClaimValidationRule) SwaggerDoc() map[string]string {
@@ -499,9 +504,9 @@ func (TokenClaimValidationRule) SwaggerDoc() map[string]string {
 }
 
 var map_TokenIssuer = map[string]string{
-	"issuerURL":                  "URL is the serving URL of the token issuer. Must use the https:// scheme.",
-	"audiences":                  "audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their \"aud\" claim. Must be set to exactly one value.",
-	"issuerCertificateAuthority": "CertificateAuthority is a reference to a config map in the configuration namespace. The .data of the configMap must contain the \"ca-bundle.crt\" key. If unset, system trust is used instead.",
+	"issuerURL":                  "issuerURL is a required field that configures the URL used to issue tokens by the identity provider. The Kubernetes API server determines how authentication tokens should be handled by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.\n\nissuerURL must use the 'https' scheme.",
+	"audiences":                  "audiences is a required field that configures the acceptable audiences the JWT token, issued by the identity provider, must be issued to. At least one of the entries must match the 'aud' claim in the JWT token.\n\naudiences must contain at least one entry and must not exceed ten entries.",
+	"issuerCertificateAuthority": "issuerCertificateAuthority is an optional field that configures the certificate authority, used by the Kubernetes API server, to validate the connection to the identity provider when fetching discovery information.\n\nWhen not specified, the system trust is used.\n\nWhen specified, it must reference a ConfigMap in the openshift-config namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt' key in the data field of the ConfigMap.",
 }
 
 func (TokenIssuer) SwaggerDoc() map[string]string {
@@ -509,8 +514,8 @@ func (TokenIssuer) SwaggerDoc() map[string]string {
 }
 
 var map_TokenRequiredClaim = map[string]string{
-	"claim":         "claim is a name of a required claim. Only claims with string values are supported.",
-	"requiredValue": "requiredValue is the required value for the claim.",
+	"claim":         "claim is a required field that configures the name of the required claim. When taken from the JWT claims, claim must be a string value.\n\nclaim must not be an empty string (\"\").",
+	"requiredValue": "requiredValue is a required field that configures the value that 'claim' must have when taken from the incoming JWT claims. If the value in the JWT claims does not match, the token will be rejected for authentication.\n\nrequiredValue must not be an empty string (\"\").",
 }
 
 func (TokenRequiredClaim) SwaggerDoc() map[string]string {
@@ -518,11 +523,21 @@ func (TokenRequiredClaim) SwaggerDoc() map[string]string {
 }
 
 var map_UsernameClaimMapping = map[string]string{
-	"prefixPolicy": "prefixPolicy specifies how a prefix should apply.\n\nBy default, claims other than `email` will be prefixed with the issuer URL to prevent naming clashes with other plugins.\n\nSet to \"NoPrefix\" to disable prefixing.\n\nExample:\n    (1) `prefix` is set to \"myoidc:\" and `claim` is set to \"username\".\n        If the JWT claim `username` contains value `userA`, the resulting\n        mapped value will be \"myoidc:userA\".\n    (2) `prefix` is set to \"myoidc:\" and `claim` is set to \"email\". If the\n        JWT `email` claim contains value \"userA@myoidc.tld\", the resulting\n        mapped value will be \"myoidc:userA@myoidc.tld\".\n    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\n        the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\",\n        and `claim` is set to:\n        (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\"\n        (b) \"email\": the mapped value will be \"userA@myoidc.tld\"",
+	"prefixPolicy": "prefixPolicy is an optional field that configures how a prefix should be applied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).\n\nWhen set to 'Prefix', the value specified in the prefix field will be prepended to the value of the JWT claim. The prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value of the JWT claim.\n\nWhen omitted, this means no opinion and the platform is left to choose any prefixes that are applied which is subject to change over time. Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim when the claim is not 'email'. As an example, consider the following scenario:\n   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\n   the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\",\n   and `claim` is set to:\n   - \"username\": the mapped value will be \"https://myoidc.tld#userA\"\n   - \"email\": the mapped value will be \"userA@myoidc.tld\"",
+	"prefix":       "prefix configures the prefix that should be prepended to the value of the JWT claim.\n\nprefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.",
 }
 
 func (UsernameClaimMapping) SwaggerDoc() map[string]string {
 	return map_UsernameClaimMapping
+}
+
+var map_UsernamePrefix = map[string]string{
+	"":             "UsernamePrefix configures the string that should be used as a prefix for username claim mappings.",
+	"prefixString": "prefixString is a required field that configures the prefix that will be applied to cluster identity username attribute during the process of mapping JWT claims to cluster identity attributes.\n\nprefixString must not be an empty string (\"\").",
+}
+
+func (UsernamePrefix) SwaggerDoc() map[string]string {
+	return map_UsernamePrefix
 }
 
 var map_WebhookTokenAuthenticator = map[string]string{

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -16459,11 +16459,12 @@ func schema_openshift_api_config_v1_OIDCClientConfig(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "OIDCClientConfig configures how platform clients interact with identity providers as an authentication method",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"componentName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "componentName is the name of the component that is supposed to consume this client configuration",
+							Description: "componentName is a required field that specifies the name of the platform component being configured to use the identity provider as an authentication mode. It is used in combination with componentNamespace as a unique identifier.\n\ncomponentName must not be an empty string (\"\") and must not exceed 256 characters in length.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -16471,7 +16472,7 @@ func schema_openshift_api_config_v1_OIDCClientConfig(ref common.ReferenceCallbac
 					},
 					"componentNamespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "componentNamespace is the namespace of the component that is supposed to consume this client configuration",
+							Description: "componentNamespace is a required field that specifies the namespace in which the platform component being configured to use the identity provider as an authentication mode is running. It is used in combination with componentName as a unique identifier.\n\ncomponentNamespace must not be an empty string (\"\") and must not exceed 63 characters in length.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -16479,7 +16480,7 @@ func schema_openshift_api_config_v1_OIDCClientConfig(ref common.ReferenceCallbac
 					},
 					"clientID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "clientID is the identifier of the OIDC client from the OIDC provider",
+							Description: "clientID is a required field that configures the client identifier, from the identity provider, that the platform component uses for authentication requests made to the identity provider. The identity provider must accept this identifier for platform components to be able to use the identity provider as an authentication mode.\n\nclientID must not be an empty string (\"\").",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -16487,7 +16488,7 @@ func schema_openshift_api_config_v1_OIDCClientConfig(ref common.ReferenceCallbac
 					},
 					"clientSecret": {
 						SchemaProps: spec.SchemaProps{
-							Description: "clientSecret refers to a secret in the `openshift-config` namespace that contains the client secret in the `clientSecret` key of the `.data` field",
+							Description: "clientSecret is an optional field that configures the client secret used by the platform component when making authentication requests to the identity provider.\n\nWhen not specified, no client secret will be used when making authentication requests to the identity provider.\n\nWhen specified, clientSecret references a Secret in the 'openshift-config' namespace that contains the client secret in the 'clientSecret' key of the '.data' field. The client secret will be used when making authentication requests to the identity provider.\n\nPublic clients do not require a client secret but private clients do require a client secret to work with the identity provider.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/openshift/api/config/v1.SecretNameReference"),
 						},
@@ -16499,7 +16500,7 @@ func schema_openshift_api_config_v1_OIDCClientConfig(ref common.ReferenceCallbac
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "extraScopes is an optional set of scopes to request tokens with.",
+							Description: "extraScopes is an optional field that configures the extra scopes that should be requested by the platform component when making authentication requests to the identity provider. This is useful if you have configured claim mappings that requires specific scopes to be requested beyond the standard OIDC scopes.\n\nWhen omitted, no additional scopes are requested.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -16513,7 +16514,7 @@ func schema_openshift_api_config_v1_OIDCClientConfig(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"componentName", "componentNamespace", "clientID", "clientSecret", "extraScopes"},
+				Required: []string{"componentName", "componentNamespace", "clientID"},
 			},
 		},
 		Dependencies: []string{
@@ -16525,11 +16526,12 @@ func schema_openshift_api_config_v1_OIDCClientReference(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "OIDCClientReference is a reference to a platform component client configuration.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"oidcProviderName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "OIDCName refers to the `name` of the provider from `oidcProviders`",
+							Description: "oidcProviderName is a required reference to the 'name' of the identity provider configured in 'oidcProviders' that this client is associated with.\n\noidcProviderName must not be an empty string (\"\").",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -16537,7 +16539,7 @@ func schema_openshift_api_config_v1_OIDCClientReference(ref common.ReferenceCall
 					},
 					"issuerURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "URL is the serving URL of the token issuer. Must use the https:// scheme.",
+							Description: "issuerURL is a required field that specifies the URL of the identity provider that this client is configured to make requests against.\n\nissuerURL must use the 'https' scheme.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -16545,7 +16547,7 @@ func schema_openshift_api_config_v1_OIDCClientReference(ref common.ReferenceCall
 					},
 					"clientID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "clientID is the identifier of the OIDC client from the OIDC provider",
+							Description: "clientID is a required field that specifies the client identifier, from the identity provider, that the platform component is using for authentication requests made to the identity provider.\n\nclientID must not be empty.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -16562,11 +16564,12 @@ func schema_openshift_api_config_v1_OIDCClientStatus(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "OIDCClientStatus represents the current state of platform components and how they interact with the configured identity providers.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"componentName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "componentName is the name of the component that will consume a client configuration.",
+							Description: "componentName is a required field that specifies the name of the platform component using the identity provider as an authentication mode. It is used in combination with componentNamespace as a unique identifier.\n\ncomponentName must not be an empty string (\"\") and must not exceed 256 characters in length.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -16574,7 +16577,7 @@ func schema_openshift_api_config_v1_OIDCClientStatus(ref common.ReferenceCallbac
 					},
 					"componentNamespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "componentNamespace is the namespace of the component that will consume a client configuration.",
+							Description: "componentNamespace is a required field that specifies the namespace in which the platform component using the identity provider as an authentication mode is running. It is used in combination with componentName as a unique identifier.\n\ncomponentNamespace must not be an empty string (\"\") and must not exceed 63 characters in length.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -16591,7 +16594,7 @@ func schema_openshift_api_config_v1_OIDCClientStatus(ref common.ReferenceCallbac
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "currentOIDCClients is a list of clients that the component is currently using.",
+							Description: "currentOIDCClients is an optional list of clients that the component is currently using. Entries must have unique issuerURL/clientID pairs.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -16610,7 +16613,7 @@ func schema_openshift_api_config_v1_OIDCClientStatus(ref common.ReferenceCallbac
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "consumingUsers is a slice of ServiceAccounts that need to have read permission on the `clientSecret` secret.",
+							Description: "consumingUsers is an optional list of ServiceAccounts requiring read permissions on the `clientSecret` secret.\n\nconsumingUsers must not exceed 5 entries.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -16646,7 +16649,7 @@ func schema_openshift_api_config_v1_OIDCClientStatus(ref common.ReferenceCallbac
 						},
 					},
 				},
-				Required: []string{"componentName", "componentNamespace", "currentOIDCClients", "consumingUsers"},
+				Required: []string{"componentName", "componentNamespace"},
 			},
 		},
 		Dependencies: []string{
@@ -16662,7 +16665,7 @@ func schema_openshift_api_config_v1_OIDCProvider(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "name of the OIDC provider",
+							Description: "name is a required field that configures the unique human-readable identifier associated with the identity provider. It is used to distinguish between multiple identity providers and has no impact on token validation or authentication mechanics.\n\nname must not be an empty string (\"\").",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -16670,7 +16673,7 @@ func schema_openshift_api_config_v1_OIDCProvider(ref common.ReferenceCallback) c
 					},
 					"issuer": {
 						SchemaProps: spec.SchemaProps{
-							Description: "issuer describes atributes of the OIDC token issuer",
+							Description: "issuer is a required field that configures how the platform interacts with the identity provider and how tokens issued from the identity provider are evaluated by the Kubernetes API server.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/openshift/api/config/v1.TokenIssuer"),
 						},
@@ -16686,7 +16689,7 @@ func schema_openshift_api_config_v1_OIDCProvider(ref common.ReferenceCallback) c
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "oidcClients contains configuration for the platform's clients that need to request tokens from the issuer",
+							Description: "oidcClients is an optional field that configures how on-cluster, platform clients should request tokens from the identity provider. oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -16700,7 +16703,7 @@ func schema_openshift_api_config_v1_OIDCProvider(ref common.ReferenceCallback) c
 					},
 					"claimMappings": {
 						SchemaProps: spec.SchemaProps{
-							Description: "claimMappings describes rules on how to transform information from an ID token into a cluster identity",
+							Description: "claimMappings is an optional field that configures the rules to be used by the Kubernetes API server for translating claims in a JWT token, issued by the identity provider, to a cluster identity.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/openshift/api/config/v1.TokenClaimMappings"),
 						},
@@ -16712,7 +16715,7 @@ func schema_openshift_api_config_v1_OIDCProvider(ref common.ReferenceCallback) c
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "claimValidationRules are rules that are applied to validate token claims to authenticate users.",
+							Description: "claimValidationRules is an optional field that configures the rules to be used by the Kubernetes API server for validating the claims in a JWT token issued by the identity provider.\n\nValidation rules are joined via an AND operation.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -16725,7 +16728,7 @@ func schema_openshift_api_config_v1_OIDCProvider(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"name", "issuer", "oidcClients", "claimMappings"},
+				Required: []string{"name", "issuer"},
 			},
 		},
 		Dependencies: []string{
@@ -17863,11 +17866,12 @@ func schema_openshift_api_config_v1_PrefixedClaimMapping(ref common.ReferenceCal
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "PrefixedClaimMapping configures a claim mapping that allows for an optional prefix.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"claim": {
 						SchemaProps: spec.SchemaProps{
-							Description: "claim is a JWT token claim to be used in the mapping",
+							Description: "claim is a required field that configures the JWT token claim whose value is assigned to the cluster identity field associated with this mapping.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -17875,14 +17879,14 @@ func schema_openshift_api_config_v1_PrefixedClaimMapping(ref common.ReferenceCal
 					},
 					"prefix": {
 						SchemaProps: spec.SchemaProps{
-							Description: "prefix is a string to prefix the value from the token in the result of the claim mapping.\n\nBy default, no prefixing occurs.\n\nExample: if `prefix` is set to \"myoidc:\"\" and the `claim` in JWT contains an array of strings \"a\", \"b\" and  \"c\", the mapping will result in an array of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\".",
+							Description: "prefix is an optional field that configures the prefix that will be applied to the cluster identity attribute during the process of mapping JWT claims to cluster identity attributes.\n\nWhen omitted (\"\"), no prefix is applied to the cluster identity attribute.\n\nExample: if `prefix` is set to \"myoidc:\" and the `claim` in JWT contains an array of strings \"a\", \"b\" and  \"c\", the mapping will result in an array of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\".",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"claim", "prefix"},
+				Required: []string{"claim"},
 			},
 		},
 	}
@@ -19354,11 +19358,12 @@ func schema_openshift_api_config_v1_TokenClaimMapping(ref common.ReferenceCallba
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "TokenClaimMapping allows specifying a JWT token claim to be used when mapping claims from an authentication token to cluster identities.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"claim": {
 						SchemaProps: spec.SchemaProps{
-							Description: "claim is a JWT token claim to be used in the mapping",
+							Description: "claim is a required field that configures the JWT token claim whose value is assigned to the cluster identity field associated with this mapping.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -19379,14 +19384,14 @@ func schema_openshift_api_config_v1_TokenClaimMappings(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"username": {
 						SchemaProps: spec.SchemaProps{
-							Description: "username is a name of the claim that should be used to construct usernames for the cluster identity.\n\nDefault value: \"sub\"",
+							Description: "username is an optional field that configures how the username of a cluster identity should be constructed from the claims in a JWT token issued by the identity provider.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/openshift/api/config/v1.UsernameClaimMapping"),
 						},
 					},
 					"groups": {
 						SchemaProps: spec.SchemaProps{
-							Description: "groups is a name of the claim that should be used to construct groups for the cluster identity. The referenced claim must use array of strings values.",
+							Description: "groups is an optional field that configures how the groups of a cluster identity should be constructed from the claims in a JWT token issued by the identity provider. When referencing a claim, if the claim is present in the JWT token, its value must be a list of groups separated by a comma (','). For example - '\"example\"' and '\"exampleOne\", \"exampleTwo\", \"exampleThree\"' are valid claim values.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/openshift/api/config/v1.PrefixedClaimMapping"),
 						},
@@ -19462,20 +19467,21 @@ func schema_openshift_api_config_v1_TokenClaimValidationRule(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "type sets the type of the validation rule",
+							Description: "type is an optional field that configures the type of the validation rule.\n\nAllowed values are 'RequiredClaim' and omitted (not provided or an empty string).\n\nWhen set to 'RequiredClaim', the Kubernetes API server will be configured to validate that the incoming JWT contains the required claim and that its value matches the required value.\n\nDefaults to 'RequiredClaim'.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
+							Enum:        []interface{}{},
 						},
 					},
 					"requiredClaim": {
 						SchemaProps: spec.SchemaProps{
-							Description: "requiredClaim allows configuring a required claim name and its expected value",
+							Description: "requiredClaim is an optional field that configures the required claim and value that the Kubernetes API server will use to validate if an incoming JWT is valid for this identity provider.",
 							Ref:         ref("github.com/openshift/api/config/v1.TokenRequiredClaim"),
 						},
 					},
 				},
-				Required: []string{"type", "requiredClaim"},
+				Required: []string{"type"},
 			},
 		},
 		Dependencies: []string{
@@ -19526,7 +19532,7 @@ func schema_openshift_api_config_v1_TokenIssuer(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"issuerURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "URL is the serving URL of the token issuer. Must use the https:// scheme.",
+							Description: "issuerURL is a required field that configures the URL used to issue tokens by the identity provider. The Kubernetes API server determines how authentication tokens should be handled by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.\n\nissuerURL must use the 'https' scheme.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -19539,7 +19545,7 @@ func schema_openshift_api_config_v1_TokenIssuer(ref common.ReferenceCallback) co
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their \"aud\" claim. Must be set to exactly one value.",
+							Description: "audiences is a required field that configures the acceptable audiences the JWT token, issued by the identity provider, must be issued to. At least one of the entries must match the 'aud' claim in the JWT token.\n\naudiences must contain at least one entry and must not exceed ten entries.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -19554,13 +19560,13 @@ func schema_openshift_api_config_v1_TokenIssuer(ref common.ReferenceCallback) co
 					},
 					"issuerCertificateAuthority": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CertificateAuthority is a reference to a config map in the configuration namespace. The .data of the configMap must contain the \"ca-bundle.crt\" key. If unset, system trust is used instead.",
+							Description: "issuerCertificateAuthority is an optional field that configures the certificate authority, used by the Kubernetes API server, to validate the connection to the identity provider when fetching discovery information.\n\nWhen not specified, the system trust is used.\n\nWhen specified, it must reference a ConfigMap in the openshift-config namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt' key in the data field of the ConfigMap.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/openshift/api/config/v1.ConfigMapNameReference"),
 						},
 					},
 				},
-				Required: []string{"issuerURL", "audiences", "issuerCertificateAuthority"},
+				Required: []string{"issuerURL", "audiences"},
 			},
 		},
 		Dependencies: []string{
@@ -19576,7 +19582,7 @@ func schema_openshift_api_config_v1_TokenRequiredClaim(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"claim": {
 						SchemaProps: spec.SchemaProps{
-							Description: "claim is a name of a required claim. Only claims with string values are supported.",
+							Description: "claim is a required field that configures the name of the required claim. When taken from the JWT claims, claim must be a string value.\n\nclaim must not be an empty string (\"\").",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -19584,7 +19590,7 @@ func schema_openshift_api_config_v1_TokenRequiredClaim(ref common.ReferenceCallb
 					},
 					"requiredValue": {
 						SchemaProps: spec.SchemaProps{
-							Description: "requiredValue is the required value for the claim.",
+							Description: "requiredValue is a required field that configures the value that 'claim' must have when taken from the incoming JWT claims. If the value in the JWT claims does not match, the token will be rejected for authentication.\n\nrequiredValue must not be an empty string (\"\").",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -19717,7 +19723,7 @@ func schema_openshift_api_config_v1_UsernameClaimMapping(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"claim": {
 						SchemaProps: spec.SchemaProps{
-							Description: "claim is a JWT token claim to be used in the mapping",
+							Description: "claim is a required field that configures the JWT token claim whose value is assigned to the cluster identity field associated with this mapping.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -19725,19 +19731,33 @@ func schema_openshift_api_config_v1_UsernameClaimMapping(ref common.ReferenceCal
 					},
 					"prefixPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "prefixPolicy specifies how a prefix should apply.\n\nBy default, claims other than `email` will be prefixed with the issuer URL to prevent naming clashes with other plugins.\n\nSet to \"NoPrefix\" to disable prefixing.\n\nExample:\n    (1) `prefix` is set to \"myoidc:\" and `claim` is set to \"username\".\n        If the JWT claim `username` contains value `userA`, the resulting\n        mapped value will be \"myoidc:userA\".\n    (2) `prefix` is set to \"myoidc:\" and `claim` is set to \"email\". If the\n        JWT `email` claim contains value \"userA@myoidc.tld\", the resulting\n        mapped value will be \"myoidc:userA@myoidc.tld\".\n    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\n        the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\",\n        and `claim` is set to:\n        (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\"\n        (b) \"email\": the mapped value will be \"userA@myoidc.tld\"",
+							Description: "prefixPolicy is an optional field that configures how a prefix should be applied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).\n\nWhen set to 'Prefix', the value specified in the prefix field will be prepended to the value of the JWT claim. The prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value of the JWT claim.\n\nWhen omitted, this means no opinion and the platform is left to choose any prefixes that are applied which is subject to change over time. Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim when the claim is not 'email'. As an example, consider the following scenario:\n   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\n   the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\",\n   and `claim` is set to:\n   - \"username\": the mapped value will be \"https://myoidc.tld#userA\"\n   - \"email\": the mapped value will be \"userA@myoidc.tld\"",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
+							Enum:        []interface{}{},
 						},
 					},
 					"prefix": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/openshift/api/config/v1.UsernamePrefix"),
+							Description: "prefix configures the prefix that should be prepended to the value of the JWT claim.\n\nprefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.",
+							Ref:         ref("github.com/openshift/api/config/v1.UsernamePrefix"),
 						},
 					},
 				},
-				Required: []string{"claim", "prefixPolicy", "prefix"},
+				Required: []string{"claim"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-unions": []interface{}{
+						map[string]interface{}{
+							"discriminator": "prefixPolicy",
+							"fields-to-discriminateBy": map[string]interface{}{
+								"prefix": "Prefix",
+							},
+						},
+					},
+				},
 			},
 		},
 		Dependencies: []string{
@@ -19749,13 +19769,15 @@ func schema_openshift_api_config_v1_UsernamePrefix(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "UsernamePrefix configures the string that should be used as a prefix for username claim mappings.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"prefixString": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "prefixString is a required field that configures the prefix that will be applied to cluster identity username attribute during the process of mapping JWT claims to cluster identity attributes.\n\nprefixString must not be an empty string (\"\").",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8783,37 +8783,36 @@
       }
     },
     "com.github.openshift.api.config.v1.OIDCClientConfig": {
+      "description": "OIDCClientConfig configures how platform clients interact with identity providers as an authentication method",
       "type": "object",
       "required": [
         "componentName",
         "componentNamespace",
-        "clientID",
-        "clientSecret",
-        "extraScopes"
+        "clientID"
       ],
       "properties": {
         "clientID": {
-          "description": "clientID is the identifier of the OIDC client from the OIDC provider",
+          "description": "clientID is a required field that configures the client identifier, from the identity provider, that the platform component uses for authentication requests made to the identity provider. The identity provider must accept this identifier for platform components to be able to use the identity provider as an authentication mode.\n\nclientID must not be an empty string (\"\").",
           "type": "string",
           "default": ""
         },
         "clientSecret": {
-          "description": "clientSecret refers to a secret in the `openshift-config` namespace that contains the client secret in the `clientSecret` key of the `.data` field",
+          "description": "clientSecret is an optional field that configures the client secret used by the platform component when making authentication requests to the identity provider.\n\nWhen not specified, no client secret will be used when making authentication requests to the identity provider.\n\nWhen specified, clientSecret references a Secret in the 'openshift-config' namespace that contains the client secret in the 'clientSecret' key of the '.data' field. The client secret will be used when making authentication requests to the identity provider.\n\nPublic clients do not require a client secret but private clients do require a client secret to work with the identity provider.",
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1.SecretNameReference"
         },
         "componentName": {
-          "description": "componentName is the name of the component that is supposed to consume this client configuration",
+          "description": "componentName is a required field that specifies the name of the platform component being configured to use the identity provider as an authentication mode. It is used in combination with componentNamespace as a unique identifier.\n\ncomponentName must not be an empty string (\"\") and must not exceed 256 characters in length.",
           "type": "string",
           "default": ""
         },
         "componentNamespace": {
-          "description": "componentNamespace is the namespace of the component that is supposed to consume this client configuration",
+          "description": "componentNamespace is a required field that specifies the namespace in which the platform component being configured to use the identity provider as an authentication mode is running. It is used in combination with componentName as a unique identifier.\n\ncomponentNamespace must not be an empty string (\"\") and must not exceed 63 characters in length.",
           "type": "string",
           "default": ""
         },
         "extraScopes": {
-          "description": "extraScopes is an optional set of scopes to request tokens with.",
+          "description": "extraScopes is an optional field that configures the extra scopes that should be requested by the platform component when making authentication requests to the identity provider. This is useful if you have configured claim mappings that requires specific scopes to be requested beyond the standard OIDC scopes.\n\nWhen omitted, no additional scopes are requested.",
           "type": "array",
           "items": {
             "type": "string",
@@ -8824,6 +8823,7 @@
       }
     },
     "com.github.openshift.api.config.v1.OIDCClientReference": {
+      "description": "OIDCClientReference is a reference to a platform component client configuration.",
       "type": "object",
       "required": [
         "oidcProviderName",
@@ -8832,38 +8832,37 @@
       ],
       "properties": {
         "clientID": {
-          "description": "clientID is the identifier of the OIDC client from the OIDC provider",
+          "description": "clientID is a required field that specifies the client identifier, from the identity provider, that the platform component is using for authentication requests made to the identity provider.\n\nclientID must not be empty.",
           "type": "string",
           "default": ""
         },
         "issuerURL": {
-          "description": "URL is the serving URL of the token issuer. Must use the https:// scheme.",
+          "description": "issuerURL is a required field that specifies the URL of the identity provider that this client is configured to make requests against.\n\nissuerURL must use the 'https' scheme.",
           "type": "string",
           "default": ""
         },
         "oidcProviderName": {
-          "description": "OIDCName refers to the `name` of the provider from `oidcProviders`",
+          "description": "oidcProviderName is a required reference to the 'name' of the identity provider configured in 'oidcProviders' that this client is associated with.\n\noidcProviderName must not be an empty string (\"\").",
           "type": "string",
           "default": ""
         }
       }
     },
     "com.github.openshift.api.config.v1.OIDCClientStatus": {
+      "description": "OIDCClientStatus represents the current state of platform components and how they interact with the configured identity providers.",
       "type": "object",
       "required": [
         "componentName",
-        "componentNamespace",
-        "currentOIDCClients",
-        "consumingUsers"
+        "componentNamespace"
       ],
       "properties": {
         "componentName": {
-          "description": "componentName is the name of the component that will consume a client configuration.",
+          "description": "componentName is a required field that specifies the name of the platform component using the identity provider as an authentication mode. It is used in combination with componentNamespace as a unique identifier.\n\ncomponentName must not be an empty string (\"\") and must not exceed 256 characters in length.",
           "type": "string",
           "default": ""
         },
         "componentNamespace": {
-          "description": "componentNamespace is the namespace of the component that will consume a client configuration.",
+          "description": "componentNamespace is a required field that specifies the namespace in which the platform component using the identity provider as an authentication mode is running. It is used in combination with componentName as a unique identifier.\n\ncomponentNamespace must not be an empty string (\"\") and must not exceed 63 characters in length.",
           "type": "string",
           "default": ""
         },
@@ -8880,7 +8879,7 @@
           "x-kubernetes-list-type": "map"
         },
         "consumingUsers": {
-          "description": "consumingUsers is a slice of ServiceAccounts that need to have read permission on the `clientSecret` secret.",
+          "description": "consumingUsers is an optional list of ServiceAccounts requiring read permissions on the `clientSecret` secret.\n\nconsumingUsers must not exceed 5 entries.",
           "type": "array",
           "items": {
             "type": "string",
@@ -8889,7 +8888,7 @@
           "x-kubernetes-list-type": "set"
         },
         "currentOIDCClients": {
-          "description": "currentOIDCClients is a list of clients that the component is currently using.",
+          "description": "currentOIDCClients is an optional list of clients that the component is currently using. Entries must have unique issuerURL/clientID pairs.",
           "type": "array",
           "items": {
             "default": {},
@@ -8907,18 +8906,16 @@
       "type": "object",
       "required": [
         "name",
-        "issuer",
-        "oidcClients",
-        "claimMappings"
+        "issuer"
       ],
       "properties": {
         "claimMappings": {
-          "description": "claimMappings describes rules on how to transform information from an ID token into a cluster identity",
+          "description": "claimMappings is an optional field that configures the rules to be used by the Kubernetes API server for translating claims in a JWT token, issued by the identity provider, to a cluster identity.",
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1.TokenClaimMappings"
         },
         "claimValidationRules": {
-          "description": "claimValidationRules are rules that are applied to validate token claims to authenticate users.",
+          "description": "claimValidationRules is an optional field that configures the rules to be used by the Kubernetes API server for validating the claims in a JWT token issued by the identity provider.\n\nValidation rules are joined via an AND operation.",
           "type": "array",
           "items": {
             "default": {},
@@ -8927,17 +8924,17 @@
           "x-kubernetes-list-type": "atomic"
         },
         "issuer": {
-          "description": "issuer describes atributes of the OIDC token issuer",
+          "description": "issuer is a required field that configures how the platform interacts with the identity provider and how tokens issued from the identity provider are evaluated by the Kubernetes API server.",
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1.TokenIssuer"
         },
         "name": {
-          "description": "name of the OIDC provider",
+          "description": "name is a required field that configures the unique human-readable identifier associated with the identity provider. It is used to distinguish between multiple identity providers and has no impact on token validation or authentication mechanics.\n\nname must not be an empty string (\"\").",
           "type": "string",
           "default": ""
         },
         "oidcClients": {
-          "description": "oidcClients contains configuration for the platform's clients that need to request tokens from the issuer",
+          "description": "oidcClients is an optional field that configures how on-cluster, platform clients should request tokens from the identity provider. oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.",
           "type": "array",
           "items": {
             "default": {},
@@ -9595,19 +9592,19 @@
       }
     },
     "com.github.openshift.api.config.v1.PrefixedClaimMapping": {
+      "description": "PrefixedClaimMapping configures a claim mapping that allows for an optional prefix.",
       "type": "object",
       "required": [
-        "claim",
-        "prefix"
+        "claim"
       ],
       "properties": {
         "claim": {
-          "description": "claim is a JWT token claim to be used in the mapping",
+          "description": "claim is a required field that configures the JWT token claim whose value is assigned to the cluster identity field associated with this mapping.",
           "type": "string",
           "default": ""
         },
         "prefix": {
-          "description": "prefix is a string to prefix the value from the token in the result of the claim mapping.\n\nBy default, no prefixing occurs.\n\nExample: if `prefix` is set to \"myoidc:\"\" and the `claim` in JWT contains an array of strings \"a\", \"b\" and  \"c\", the mapping will result in an array of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\".",
+          "description": "prefix is an optional field that configures the prefix that will be applied to the cluster identity attribute during the process of mapping JWT claims to cluster identity attributes.\n\nWhen omitted (\"\"), no prefix is applied to the cluster identity attribute.\n\nExample: if `prefix` is set to \"myoidc:\" and the `claim` in JWT contains an array of strings \"a\", \"b\" and  \"c\", the mapping will result in an array of string \"myoidc:a\", \"myoidc:b\" and \"myoidc:c\".",
           "type": "string",
           "default": ""
         }
@@ -10476,13 +10473,14 @@
       "type": "object"
     },
     "com.github.openshift.api.config.v1.TokenClaimMapping": {
+      "description": "TokenClaimMapping allows specifying a JWT token claim to be used when mapping claims from an authentication token to cluster identities.",
       "type": "object",
       "required": [
         "claim"
       ],
       "properties": {
         "claim": {
-          "description": "claim is a JWT token claim to be used in the mapping",
+          "description": "claim is a required field that configures the JWT token claim whose value is assigned to the cluster identity field associated with this mapping.",
           "type": "string",
           "default": ""
         }
@@ -10504,7 +10502,7 @@
           "x-kubernetes-list-type": "map"
         },
         "groups": {
-          "description": "groups is a name of the claim that should be used to construct groups for the cluster identity. The referenced claim must use array of strings values.",
+          "description": "groups is an optional field that configures how the groups of a cluster identity should be constructed from the claims in a JWT token issued by the identity provider. When referencing a claim, if the claim is present in the JWT token, its value must be a list of groups separated by a comma (','). For example - '\"example\"' and '\"exampleOne\", \"exampleTwo\", \"exampleThree\"' are valid claim values.",
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1.PrefixedClaimMapping"
         },
@@ -10513,7 +10511,7 @@
           "$ref": "#/definitions/com.github.openshift.api.config.v1.TokenClaimOrExpressionMapping"
         },
         "username": {
-          "description": "username is a name of the claim that should be used to construct usernames for the cluster identity.\n\nDefault value: \"sub\"",
+          "description": "username is an optional field that configures how the username of a cluster identity should be constructed from the claims in a JWT token issued by the identity provider.",
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1.UsernameClaimMapping"
         }
@@ -10536,16 +10534,15 @@
     "com.github.openshift.api.config.v1.TokenClaimValidationRule": {
       "type": "object",
       "required": [
-        "type",
-        "requiredClaim"
+        "type"
       ],
       "properties": {
         "requiredClaim": {
-          "description": "requiredClaim allows configuring a required claim name and its expected value",
+          "description": "requiredClaim is an optional field that configures the required claim and value that the Kubernetes API server will use to validate if an incoming JWT is valid for this identity provider.",
           "$ref": "#/definitions/com.github.openshift.api.config.v1.TokenRequiredClaim"
         },
         "type": {
-          "description": "type sets the type of the validation rule",
+          "description": "type is an optional field that configures the type of the validation rule.\n\nAllowed values are 'RequiredClaim' and omitted (not provided or an empty string).\n\nWhen set to 'RequiredClaim', the Kubernetes API server will be configured to validate that the incoming JWT contains the required claim and that its value matches the required value.\n\nDefaults to 'RequiredClaim'.",
           "type": "string",
           "default": ""
         }
@@ -10575,12 +10572,11 @@
       "type": "object",
       "required": [
         "issuerURL",
-        "audiences",
-        "issuerCertificateAuthority"
+        "audiences"
       ],
       "properties": {
         "audiences": {
-          "description": "audiences is an array of audiences that the token was issued for. Valid tokens must include at least one of these values in their \"aud\" claim. Must be set to exactly one value.",
+          "description": "audiences is a required field that configures the acceptable audiences the JWT token, issued by the identity provider, must be issued to. At least one of the entries must match the 'aud' claim in the JWT token.\n\naudiences must contain at least one entry and must not exceed ten entries.",
           "type": "array",
           "items": {
             "type": "string",
@@ -10589,12 +10585,12 @@
           "x-kubernetes-list-type": "set"
         },
         "issuerCertificateAuthority": {
-          "description": "CertificateAuthority is a reference to a config map in the configuration namespace. The .data of the configMap must contain the \"ca-bundle.crt\" key. If unset, system trust is used instead.",
+          "description": "issuerCertificateAuthority is an optional field that configures the certificate authority, used by the Kubernetes API server, to validate the connection to the identity provider when fetching discovery information.\n\nWhen not specified, the system trust is used.\n\nWhen specified, it must reference a ConfigMap in the openshift-config namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt' key in the data field of the ConfigMap.",
           "default": {},
           "$ref": "#/definitions/com.github.openshift.api.config.v1.ConfigMapNameReference"
         },
         "issuerURL": {
-          "description": "URL is the serving URL of the token issuer. Must use the https:// scheme.",
+          "description": "issuerURL is a required field that configures the URL used to issue tokens by the identity provider. The Kubernetes API server determines how authentication tokens should be handled by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.\n\nissuerURL must use the 'https' scheme.",
           "type": "string",
           "default": ""
         }
@@ -10608,12 +10604,12 @@
       ],
       "properties": {
         "claim": {
-          "description": "claim is a name of a required claim. Only claims with string values are supported.",
+          "description": "claim is a required field that configures the name of the required claim. When taken from the JWT claims, claim must be a string value.\n\nclaim must not be an empty string (\"\").",
           "type": "string",
           "default": ""
         },
         "requiredValue": {
-          "description": "requiredValue is the required value for the claim.",
+          "description": "requiredValue is a required field that configures the value that 'claim' must have when taken from the incoming JWT claims. If the value in the JWT claims does not match, the token will be rejected for authentication.\n\nrequiredValue must not be an empty string (\"\").",
           "type": "string",
           "default": ""
         }
@@ -10693,33 +10689,42 @@
     "com.github.openshift.api.config.v1.UsernameClaimMapping": {
       "type": "object",
       "required": [
-        "claim",
-        "prefixPolicy",
-        "prefix"
+        "claim"
       ],
       "properties": {
         "claim": {
-          "description": "claim is a JWT token claim to be used in the mapping",
+          "description": "claim is a required field that configures the JWT token claim whose value is assigned to the cluster identity field associated with this mapping.",
           "type": "string",
           "default": ""
         },
         "prefix": {
+          "description": "prefix configures the prefix that should be prepended to the value of the JWT claim.\n\nprefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.",
           "$ref": "#/definitions/com.github.openshift.api.config.v1.UsernamePrefix"
         },
         "prefixPolicy": {
-          "description": "prefixPolicy specifies how a prefix should apply.\n\nBy default, claims other than `email` will be prefixed with the issuer URL to prevent naming clashes with other plugins.\n\nSet to \"NoPrefix\" to disable prefixing.\n\nExample:\n    (1) `prefix` is set to \"myoidc:\" and `claim` is set to \"username\".\n        If the JWT claim `username` contains value `userA`, the resulting\n        mapped value will be \"myoidc:userA\".\n    (2) `prefix` is set to \"myoidc:\" and `claim` is set to \"email\". If the\n        JWT `email` claim contains value \"userA@myoidc.tld\", the resulting\n        mapped value will be \"myoidc:userA@myoidc.tld\".\n    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\n        the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\",\n        and `claim` is set to:\n        (a) \"username\": the mapped value will be \"https://myoidc.tld#userA\"\n        (b) \"email\": the mapped value will be \"userA@myoidc.tld\"",
+          "description": "prefixPolicy is an optional field that configures how a prefix should be applied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).\n\nWhen set to 'Prefix', the value specified in the prefix field will be prepended to the value of the JWT claim. The prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value of the JWT claim.\n\nWhen omitted, this means no opinion and the platform is left to choose any prefixes that are applied which is subject to change over time. Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim when the claim is not 'email'. As an example, consider the following scenario:\n   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\n   the JWT claims include \"username\":\"userA\" and \"email\":\"userA@myoidc.tld\",\n   and `claim` is set to:\n   - \"username\": the mapped value will be \"https://myoidc.tld#userA\"\n   - \"email\": the mapped value will be \"userA@myoidc.tld\"",
           "type": "string",
           "default": ""
         }
-      }
+      },
+      "x-kubernetes-unions": [
+        {
+          "discriminator": "prefixPolicy",
+          "fields-to-discriminateBy": {
+            "prefix": "Prefix"
+          }
+        }
+      ]
     },
     "com.github.openshift.api.config.v1.UsernamePrefix": {
+      "description": "UsernamePrefix configures the string that should be used as a prefix for username claim mappings.",
       "type": "object",
       "required": [
         "prefixString"
       ],
       "properties": {
         "prefixString": {
+          "description": "prefixString is a required field that configures the prefix that will be applied to cluster identity username attribute during the process of mapping JWT claims to cluster identity attributes.\n\nprefixString must not be an empty string (\"\").",
           "type": "string",
           "default": ""
         }

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift-CustomNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift-Default.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift-Default.crd.yaml
@@ -79,27 +79,34 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -108,18 +115,29 @@ spec:
                           type: object
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -127,25 +145,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -162,24 +183,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -188,7 +221,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -196,14 +239,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -213,10 +260,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -227,8 +279,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -236,24 +292,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -264,21 +347,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -418,16 +514,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -501,8 +610,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -514,24 +625,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:

--- a/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_authentications-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -79,8 +79,9 @@ spec:
                   properties:
                     claimMappings:
                       description: |-
-                        claimMappings describes rules on how to transform information from an
-                        ID token into a cluster identity
+                        claimMappings is an optional field that configures the rules to be used by
+                        the Kubernetes API server for translating claims in a JWT token, issued
+                        by the identity provider, to a cluster identity.
                       properties:
                         extra:
                           description: |-
@@ -185,22 +186,28 @@ spec:
                           x-kubernetes-list-type: map
                         groups:
                           description: |-
-                            groups is a name of the claim that should be used to construct
-                            groups for the cluster identity.
-                            The referenced claim must use array of strings values.
+                            groups is an optional field that configures how the groups of a cluster identity
+                            should be constructed from the claims in a JWT token issued
+                            by the identity provider.
+                            When referencing a claim, if the claim is present in the JWT
+                            token, its value must be a list of groups separated by a comma (',').
+                            For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
                               description: |-
-                                prefix is a string to prefix the value from the token in the result of the
-                                claim mapping.
+                                prefix is an optional field that configures the prefix that will be
+                                applied to the cluster identity attribute during the process of mapping
+                                JWT claims to cluster identity attributes.
 
-                                By default, no prefixing occurs.
+                                When omitted (""), no prefix is applied to the cluster identity attribute.
 
-                                Example: if `prefix` is set to "myoidc:"" and the `claim` in JWT contains
+                                Example: if `prefix` is set to "myoidc:" and the `claim` in JWT contains
                                 an array of strings "a", "b" and  "c", the mapping will result in an
                                 array of string "myoidc:a", "myoidc:b" and "myoidc:c".
                               type: string
@@ -259,18 +266,29 @@ spec:
                             rule: 'has(self.claim) ? !has(self.expression) : has(self.expression)'
                         username:
                           description: |-
-                            username is a name of the claim that should be used to construct
-                            usernames for the cluster identity.
-
-                            Default value: "sub"
+                            username is an optional field that configures how the username of a cluster identity
+                            should be constructed from the claims in a JWT token issued by the identity provider.
                           properties:
                             claim:
-                              description: claim is a JWT token claim to be used in
-                                the mapping
+                              description: |-
+                                claim is a required field that configures the JWT token
+                                claim whose value is assigned to the cluster identity
+                                field associated with this mapping.
                               type: string
                             prefix:
+                              description: |-
+                                prefix configures the prefix that should be prepended to the value
+                                of the JWT claim.
+
+                                prefix must be set when prefixPolicy is set to 'Prefix' and must be unset otherwise.
                               properties:
                                 prefixString:
+                                  description: |-
+                                    prefixString is a required field that configures the prefix that will
+                                    be applied to cluster identity username attribute
+                                    during the process of mapping JWT claims to cluster identity attributes.
+
+                                    prefixString must not be an empty string ("").
                                   minLength: 1
                                   type: string
                               required:
@@ -278,25 +296,28 @@ spec:
                               type: object
                             prefixPolicy:
                               description: |-
-                                prefixPolicy specifies how a prefix should apply.
+                                prefixPolicy is an optional field that configures how a prefix should be
+                                applied to the value of the JWT claim specified in the 'claim' field.
 
-                                By default, claims other than `email` will be prefixed with the issuer URL to
-                                prevent naming clashes with other plugins.
+                                Allowed values are 'Prefix', 'NoPrefix', and omitted (not provided or an empty string).
 
-                                Set to "NoPrefix" to disable prefixing.
+                                When set to 'Prefix', the value specified in the prefix field will be
+                                prepended to the value of the JWT claim.
+                                The prefix field must be set when prefixPolicy is 'Prefix'.
 
-                                Example:
-                                    (1) `prefix` is set to "myoidc:" and `claim` is set to "username".
-                                        If the JWT claim `username` contains value `userA`, the resulting
-                                        mapped value will be "myoidc:userA".
-                                    (2) `prefix` is set to "myoidc:" and `claim` is set to "email". If the
-                                        JWT `email` claim contains value "userA@myoidc.tld", the resulting
-                                        mapped value will be "myoidc:userA@myoidc.tld".
-                                    (3) `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
-                                        the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
-                                        and `claim` is set to:
-                                        (a) "username": the mapped value will be "https://myoidc.tld#userA"
-                                        (b) "email": the mapped value will be "userA@myoidc.tld"
+                                When set to 'NoPrefix', no prefix will be prepended to the value
+                                of the JWT claim.
+
+                                When omitted, this means no opinion and the platform is left to choose
+                                any prefixes that are applied which is subject to change over time.
+                                Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+                                when the claim is not 'email'.
+                                As an example, consider the following scenario:
+                                   `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+                                   the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+                                   and `claim` is set to:
+                                   - "username": the mapped value will be "https://myoidc.tld#userA"
+                                   - "email": the mapped value will be "userA@myoidc.tld"
                               enum:
                               - ""
                               - NoPrefix
@@ -313,24 +334,36 @@ spec:
                               > 0) : !has(self.prefix)'
                       type: object
                     claimValidationRules:
-                      description: claimValidationRules are rules that are applied
-                        to validate token claims to authenticate users.
+                      description: |-
+                        claimValidationRules is an optional field that configures the rules to
+                        be used by the Kubernetes API server for validating the claims in a JWT
+                        token issued by the identity provider.
+
+                        Validation rules are joined via an AND operation.
                       items:
                         properties:
                           requiredClaim:
                             description: |-
-                              requiredClaim allows configuring a required claim name and its expected
-                              value
+                              requiredClaim is an optional field that configures the required claim
+                              and value that the Kubernetes API server will use to validate if an incoming
+                              JWT is valid for this identity provider.
                             properties:
                               claim:
                                 description: |-
-                                  claim is a name of a required claim. Only claims with string values are
-                                  supported.
+                                  claim is a required field that configures the name of the required claim.
+                                  When taken from the JWT claims, claim must be a string value.
+
+                                  claim must not be an empty string ("").
                                 minLength: 1
                                 type: string
                               requiredValue:
-                                description: requiredValue is the required value for
-                                  the claim.
+                                description: |-
+                                  requiredValue is a required field that configures the value that 'claim' must
+                                  have when taken from the incoming JWT claims.
+                                  If the value in the JWT claims does not match, the token
+                                  will be rejected for authentication.
+
+                                  requiredValue must not be an empty string ("").
                                 minLength: 1
                                 type: string
                             required:
@@ -339,7 +372,17 @@ spec:
                             type: object
                           type:
                             default: RequiredClaim
-                            description: type sets the type of the validation rule
+                            description: |-
+                              type is an optional field that configures the type of the validation rule.
+
+                              Allowed values are 'RequiredClaim' and omitted (not provided or an empty string).
+
+                              When set to 'RequiredClaim', the Kubernetes API server
+                              will be configured to validate that the incoming JWT
+                              contains the required claim and that its value matches
+                              the required value.
+
+                              Defaults to 'RequiredClaim'.
                             enum:
                             - RequiredClaim
                             type: string
@@ -347,14 +390,18 @@ spec:
                       type: array
                       x-kubernetes-list-type: atomic
                     issuer:
-                      description: issuer describes atributes of the OIDC token issuer
+                      description: |-
+                        issuer is a required field that configures how the platform interacts
+                        with the identity provider and how tokens issued from the identity provider
+                        are evaluated by the Kubernetes API server.
                       properties:
                         audiences:
                           description: |-
-                            audiences is an array of audiences that the token was issued for.
-                            Valid tokens must include at least one of these values in their
-                            "aud" claim.
-                            Must be set to exactly one value.
+                            audiences is a required field that configures the acceptable audiences
+                            the JWT token, issued by the identity provider, must be issued to.
+                            At least one of the entries must match the 'aud' claim in the JWT token.
+
+                            audiences must contain at least one entry and must not exceed ten entries.
                           items:
                             minLength: 1
                             type: string
@@ -364,10 +411,15 @@ spec:
                           x-kubernetes-list-type: set
                         issuerCertificateAuthority:
                           description: |-
-                            CertificateAuthority is a reference to a config map in the
-                            configuration namespace. The .data of the configMap must contain
-                            the "ca-bundle.crt" key.
-                            If unset, system trust is used instead.
+                            issuerCertificateAuthority is an optional field that configures the
+                            certificate authority, used by the Kubernetes API server, to validate
+                            the connection to the identity provider when fetching discovery information.
+
+                            When not specified, the system trust is used.
+
+                            When specified, it must reference a ConfigMap in the openshift-config
+                            namespace containing the PEM-encoded CA certificates under the 'ca-bundle.crt'
+                            key in the data field of the ConfigMap.
                           properties:
                             name:
                               description: name is the metadata.name of the referenced
@@ -378,8 +430,12 @@ spec:
                           type: object
                         issuerURL:
                           description: |-
-                            URL is the serving URL of the token issuer.
-                            Must use the https:// scheme.
+                            issuerURL is a required field that configures the URL used to issue tokens
+                            by the identity provider.
+                            The Kubernetes API server determines how authentication tokens should be handled
+                            by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+
+                            issuerURL must use the 'https' scheme.
                           pattern: ^https:\/\/[^\s]
                           type: string
                       required:
@@ -387,24 +443,51 @@ spec:
                       - issuerURL
                       type: object
                     name:
-                      description: name of the OIDC provider
+                      description: |-
+                        name is a required field that configures the unique human-readable identifier
+                        associated with the identity provider.
+                        It is used to distinguish between multiple identity providers
+                        and has no impact on token validation or authentication mechanics.
+
+                        name must not be an empty string ("").
                       minLength: 1
                       type: string
                     oidcClients:
                       description: |-
-                        oidcClients contains configuration for the platform's clients that
-                        need to request tokens from the issuer
+                        oidcClients is an optional field that configures how on-cluster,
+                        platform clients should request tokens from the identity provider.
+                        oidcClients must not exceed 20 entries and entries must have unique namespace/name pairs.
                       items:
+                        description: |-
+                          OIDCClientConfig configures how platform clients
+                          interact with identity providers as an authentication
+                          method
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that configures the client identifier, from
+                              the identity provider, that the platform component uses for authentication
+                              requests made to the identity provider.
+                              The identity provider must accept this identifier for platform components
+                              to be able to use the identity provider as an authentication mode.
+
+                              clientID must not be an empty string ("").
                             minLength: 1
                             type: string
                           clientSecret:
                             description: |-
-                              clientSecret refers to a secret in the `openshift-config` namespace that
-                              contains the client secret in the `clientSecret` key of the `.data` field
+                              clientSecret is an optional field that configures the client secret used
+                              by the platform component when making authentication requests to the identity provider.
+
+                              When not specified, no client secret will be used when making authentication requests
+                              to the identity provider.
+
+                              When specified, clientSecret references a Secret in the 'openshift-config'
+                              namespace that contains the client secret in the 'clientSecret' key of the '.data' field.
+                              The client secret will be used when making authentication requests to the identity provider.
+
+                              Public clients do not require a client secret but private
+                              clients do require a client secret to work with the identity provider.
                             properties:
                               name:
                                 description: name is the metadata.name of the referenced
@@ -415,21 +498,34 @@ spec:
                             type: object
                           componentName:
                             description: |-
-                              componentName is the name of the component that is supposed to consume this
-                              client configuration
+                              componentName is a required field that specifies the name of the platform
+                              component being configured to use the identity provider as an authentication mode.
+                              It is used in combination with componentNamespace as a unique identifier.
+
+                              componentName must not be an empty string ("") and must not exceed 256 characters in length.
                             maxLength: 256
                             minLength: 1
                             type: string
                           componentNamespace:
                             description: |-
-                              componentNamespace is the namespace of the component that is supposed to consume this
-                              client configuration
+                              componentNamespace is a required field that specifies the namespace in which the
+                              platform component being configured to use the identity provider as an authentication
+                              mode is running.
+                              It is used in combination with componentName as a unique identifier.
+
+                              componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                             maxLength: 63
                             minLength: 1
                             type: string
                           extraScopes:
-                            description: extraScopes is an optional set of scopes
-                              to request tokens with.
+                            description: |-
+                              extraScopes is an optional field that configures the extra scopes that should
+                              be requested by the platform component when making authentication requests to the
+                              identity provider.
+                              This is useful if you have configured claim mappings that requires specific
+                              scopes to be requested beyond the standard OIDC scopes.
+
+                              When omitted, no additional scopes are requested.
                             items:
                               type: string
                             type: array
@@ -569,16 +665,29 @@ spec:
                   oidcClients is where participating operators place the current OIDC client status
                   for OIDC clients that can be customized by the cluster-admin.
                 items:
+                  description: |-
+                    OIDCClientStatus represents the current state
+                    of platform components and how they interact with
+                    the configured identity providers.
                   properties:
                     componentName:
-                      description: componentName is the name of the component that
-                        will consume a client configuration.
+                      description: |-
+                        componentName is a required field that specifies the name of the platform
+                        component using the identity provider as an authentication mode.
+                        It is used in combination with componentNamespace as a unique identifier.
+
+                        componentName must not be an empty string ("") and must not exceed 256 characters in length.
                       maxLength: 256
                       minLength: 1
                       type: string
                     componentNamespace:
-                      description: componentNamespace is the namespace of the component
-                        that will consume a client configuration.
+                      description: |-
+                        componentNamespace is a required field that specifies the namespace in which the
+                        platform component using the identity provider as an authentication
+                        mode is running.
+                        It is used in combination with componentName as a unique identifier.
+
+                        componentNamespace must not be an empty string ("") and must not exceed 63 characters in length.
                       maxLength: 63
                       minLength: 1
                       type: string
@@ -652,8 +761,10 @@ spec:
                       x-kubernetes-list-type: map
                     consumingUsers:
                       description: |-
-                        consumingUsers is a slice of ServiceAccounts that need to have read
-                        permission on the `clientSecret` secret.
+                        consumingUsers is an optional list of ServiceAccounts requiring
+                        read permissions on the `clientSecret` secret.
+
+                        consumingUsers must not exceed 5 entries.
                       items:
                         description: ConsumingUser is an alias for string which we
                           add validation to. Currently only service accounts are supported.
@@ -665,24 +776,37 @@ spec:
                       type: array
                       x-kubernetes-list-type: set
                     currentOIDCClients:
-                      description: currentOIDCClients is a list of clients that the
-                        component is currently using.
+                      description: |-
+                        currentOIDCClients is an optional list of clients that the component is currently using.
+                        Entries must have unique issuerURL/clientID pairs.
                       items:
+                        description: |-
+                          OIDCClientReference is a reference to a platform component
+                          client configuration.
                         properties:
                           clientID:
-                            description: clientID is the identifier of the OIDC client
-                              from the OIDC provider
+                            description: |-
+                              clientID is a required field that specifies the client identifier, from
+                              the identity provider, that the platform component is using for authentication
+                              requests made to the identity provider.
+
+                              clientID must not be empty.
                             minLength: 1
                             type: string
                           issuerURL:
                             description: |-
-                              URL is the serving URL of the token issuer.
-                              Must use the https:// scheme.
+                              issuerURL is a required field that specifies the URL of the identity
+                              provider that this client is configured to make requests against.
+
+                              issuerURL must use the 'https' scheme.
                             pattern: ^https:\/\/[^\s]
                             type: string
                           oidcProviderName:
-                            description: OIDCName refers to the `name` of the provider
-                              from `oidcProviders`
+                            description: |-
+                              oidcProviderName is a required reference to the 'name' of the identity provider
+                              configured in 'oidcProviders' that this client is associated with.
+
+                              oidcProviderName must not be an empty string ("").
                             minLength: 1
                             type: string
                         required:


### PR DESCRIPTION
I had noticed that the GoDoc for the OIDC-related fields was a bit sparse and needed to be brought up to date with the OpenShift API conventions.

This PR attempts to improve the GoDoc for only the OIDC-related fields as part of the GA criteria for the BYO OIDC feature.