### PR TITLE
CORS-4041: Remove the TagManager from the GCP Custom Endpoints

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/GCPCustomAPIEndpoints.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/GCPCustomAPIEndpoints.yaml
@@ -213,7 +213,7 @@ tests:
                 dnsType: PlatformDefault
               serviceEndpoints:
                 - {name: "UnknownService", url: "https://compute-myendpoint1.p.googleapis.com"}
-      expectedStatusError: "[status.platformStatus.gcp.serviceEndpoints[0].name: Unsupported value: \"UnknownService\": supported values: \"Compute\", \"Container\", \"CloudResourceManager\", \"DNS\", \"File\", \"IAM\", \"ServiceUsage\", \"Storage\", \"TagManager\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation"
+      expectedStatusError: "[status.platformStatus.gcp.serviceEndpoints[0].name: Unsupported value: \"UnknownService\": supported values: \"Compute\", \"Container\", \"CloudResourceManager\", \"DNS\", \"File\", \"IAM\", \"ServiceUsage\", \"Storage\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation"
     - name: Service Endpoint End Slash
       initial: |
         apiVersion: config.openshift.io/v1

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -630,7 +630,7 @@ const (
 )
 
 // GCPServiceEndpointName is the name of the GCP Service Endpoint.
-// +kubebuilder:validation:Enum=Compute;Container;CloudResourceManager;DNS;File;IAM;ServiceUsage;Storage;TagManager
+// +kubebuilder:validation:Enum=Compute;Container;CloudResourceManager;DNS;File;IAM;ServiceUsage;Storage
 type GCPServiceEndpointName string
 
 const (
@@ -657,9 +657,6 @@ const (
 
 	// GCPServiceEndpointNameStorage is the name used for the GCP Storage Service endpoint.
 	GCPServiceEndpointNameStorage GCPServiceEndpointName = "Storage"
-
-	// GCPServiceEndpointNameTagManager is the name used for the GCP Tag Manager Service endpoint.
-	GCPServiceEndpointNameTagManager GCPServiceEndpointName = "TagManager"
 )
 
 // GCPServiceEndpoint store the configuration of a custom url to
@@ -755,7 +752,7 @@ type GCPPlatformStatus struct {
 	// The maximum number of endpoint overrides allowed is 9.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=9
+	// +kubebuilder:validation:MaxItems=8
 	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, x.name == y.name))",message="only 1 endpoint override is permitted per GCP service name"
 	// +optional
 	// +openshift:enable:FeatureGate=GCPCustomAPIEndpoints

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1917,7 +1917,6 @@ spec:
                               - IAM
                               - ServiceUsage
                               - Storage
-                              - TagManager
                               type: string
                             url:
                               description: |-
@@ -1943,7 +1942,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 9
+                        maxItems: 8
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1917,7 +1917,6 @@ spec:
                               - IAM
                               - ServiceUsage
                               - Storage
-                              - TagManager
                               type: string
                             url:
                               description: |-
@@ -1943,7 +1942,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 9
+                        maxItems: 8
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1916,7 +1916,6 @@ spec:
                               - IAM
                               - ServiceUsage
                               - Storage
-                              - TagManager
                               type: string
                             url:
                               description: |-
@@ -1942,7 +1941,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 9
+                        maxItems: 8
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPCustomAPIEndpoints.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPCustomAPIEndpoints.yaml
@@ -1513,7 +1513,6 @@ spec:
                               - IAM
                               - ServiceUsage
                               - Storage
-                              - TagManager
                               type: string
                             url:
                               description: |-
@@ -1539,7 +1538,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 9
+                        maxItems: 8
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -2197,7 +2197,6 @@ spec:
                                       - IAM
                                       - ServiceUsage
                                       - Storage
-                                      - TagManager
                                       type: string
                                     url:
                                       description: |-
@@ -2223,7 +2222,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 9
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -2197,7 +2197,6 @@ spec:
                                       - IAM
                                       - ServiceUsage
                                       - Storage
-                                      - TagManager
                                       type: string
                                     url:
                                       description: |-
@@ -2223,7 +2222,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 9
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -2196,7 +2196,6 @@ spec:
                                       - IAM
                                       - ServiceUsage
                                       - Storage
-                                      - TagManager
                                       type: string
                                     url:
                                       description: |-
@@ -2222,7 +2221,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 9
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPCustomAPIEndpoints.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPCustomAPIEndpoints.yaml
@@ -1811,7 +1811,6 @@ spec:
                                       - IAM
                                       - ServiceUsage
                                       - Storage
-                                      - TagManager
                                       type: string
                                     url:
                                       description: |-
@@ -1837,7 +1836,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 9
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -1917,7 +1917,6 @@ spec:
                               - IAM
                               - ServiceUsage
                               - Storage
-                              - TagManager
                               type: string
                             url:
                               description: |-
@@ -1943,7 +1942,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 9
+                        maxItems: 8
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -1917,7 +1917,6 @@ spec:
                               - IAM
                               - ServiceUsage
                               - Storage
-                              - TagManager
                               type: string
                             url:
                               description: |-
@@ -1943,7 +1942,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 9
+                        maxItems: 8
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -1916,7 +1916,6 @@ spec:
                               - IAM
                               - ServiceUsage
                               - Storage
-                              - TagManager
                               type: string
                             url:
                               description: |-
@@ -1942,7 +1941,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 9
+                        maxItems: 8
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -2197,7 +2197,6 @@ spec:
                                       - IAM
                                       - ServiceUsage
                                       - Storage
-                                      - TagManager
                                       type: string
                                     url:
                                       description: |-
@@ -2223,7 +2222,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 9
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -2197,7 +2197,6 @@ spec:
                                       - IAM
                                       - ServiceUsage
                                       - Storage
-                                      - TagManager
                                       type: string
                                     url:
                                       description: |-
@@ -2223,7 +2222,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 9
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -2196,7 +2196,6 @@ spec:
                                       - IAM
                                       - ServiceUsage
                                       - Storage
-                                      - TagManager
                                       type: string
                                     url:
                                       description: |-
@@ -2222,7 +2221,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 9
+                                maxItems: 8
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name


### PR DESCRIPTION
** The tag manager or tagging does appear to have a service in GCP, but this particular one is NOT used. Instead openshift uses the cloud resource manager service, so there is no need to support Tag Manager. 
** The origin of the changes stemmed from https://issues.redhat.com/browse/CORS-2389. The [tech-preview] feature gate was added during the openshift-4.19 release. The TagManager value is removed during the openshift-4.20 release. The feature as a whole was not officially released during openshift-4.19, and the openshift installer is currently the only user for this feature, so the impact is very low. 