### PR TITLE
OCPBUGS-56382: Fix validation for Resource field in MOSB API

### DIFF
--- a/machineconfiguration/v1/types_machineosbuild.go
+++ b/machineconfiguration/v1/types_machineosbuild.go
@@ -179,10 +179,10 @@ type ObjectReference struct {
 	Group string `json:"group"`
 	// resource of the referent.
 	// This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-	// and should start and end with an alphanumeric character.
+	// and should start with an alphabetic character and end with an alphanumeric character.
 	// Example: "deployments", "deploymentconfigs", "pods", etc.
 	// +required
-	// +kubebuilder:validation:XValidation:rule=`!format.dns1123Label().validate(self).hasValue()`,message="the value must consist of only lowercase alphanumeric characters and hyphens"
+	// +kubebuilder:validation:XValidation:rule=`!format.dns1035Label().validate(self).hasValue()`,message="a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character"
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	Resource string `json:"resource"`

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosbuilds.crd.yaml
@@ -206,15 +206,16 @@ spec:
                         description: |-
                           resource of the referent.
                           This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-                          and should start and end with an alphanumeric character.
+                          and should start with an alphabetic character and end with an alphanumeric character.
                           Example: "deployments", "deploymentconfigs", "pods", etc.
                         maxLength: 63
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
-                        - message: the value must consist of only lowercase alphanumeric
-                            characters and hyphens
-                          rule: '!format.dns1123Label().validate(self).hasValue()'
+                        - message: a DNS-1035 label must consist of lower case alphanumeric
+                            characters or '-', start with an alphabetic character,
+                            and end with an alphanumeric character
+                          rule: '!format.dns1035Label().validate(self).hasValue()'
                     required:
                     - group
                     - name
@@ -367,15 +368,16 @@ spec:
                       description: |-
                         resource of the referent.
                         This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-                        and should start and end with an alphanumeric character.
+                        and should start with an alphabetic character and end with an alphanumeric character.
                         Example: "deployments", "deploymentconfigs", "pods", etc.
                       maxLength: 63
                       minLength: 1
                       type: string
                       x-kubernetes-validations:
-                      - message: the value must consist of only lowercase alphanumeric
-                          characters and hyphens
-                        rule: '!format.dns1123Label().validate(self).hasValue()'
+                      - message: a DNS-1035 label must consist of lower case alphanumeric
+                          characters or '-', start with an alphabetic character, and
+                          end with an alphanumeric character
+                        rule: '!format.dns1035Label().validate(self).hasValue()'
                   required:
                   - group
                   - name

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineosconfigs.crd.yaml
@@ -317,15 +317,16 @@ spec:
                     description: |-
                       resource of the referent.
                       This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-                      and should start and end with an alphanumeric character.
+                      and should start with an alphabetic character and end with an alphanumeric character.
                       Example: "deployments", "deploymentconfigs", "pods", etc.
                     maxLength: 63
                     minLength: 1
                     type: string
                     x-kubernetes-validations:
-                    - message: the value must consist of only lowercase alphanumeric
-                        characters and hyphens
-                      rule: '!format.dns1123Label().validate(self).hasValue()'
+                    - message: a DNS-1035 label must consist of lower case alphanumeric
+                        characters or '-', start with an alphabetic character, and
+                        end with an alphanumeric character
+                      rule: '!format.dns1035Label().validate(self).hasValue()'
                 required:
                 - group
                 - name

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineosbuilds.machineconfiguration.openshift.io/OnClusterBuild.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineosbuilds.machineconfiguration.openshift.io/OnClusterBuild.yaml
@@ -207,15 +207,16 @@ spec:
                         description: |-
                           resource of the referent.
                           This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-                          and should start and end with an alphanumeric character.
+                          and should start with an alphabetic character and end with an alphanumeric character.
                           Example: "deployments", "deploymentconfigs", "pods", etc.
                         maxLength: 63
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
-                        - message: the value must consist of only lowercase alphanumeric
-                            characters and hyphens
-                          rule: '!format.dns1123Label().validate(self).hasValue()'
+                        - message: a DNS-1035 label must consist of lower case alphanumeric
+                            characters or '-', start with an alphabetic character,
+                            and end with an alphanumeric character
+                          rule: '!format.dns1035Label().validate(self).hasValue()'
                     required:
                     - group
                     - name
@@ -368,15 +369,16 @@ spec:
                       description: |-
                         resource of the referent.
                         This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-                        and should start and end with an alphanumeric character.
+                        and should start with an alphabetic character and end with an alphanumeric character.
                         Example: "deployments", "deploymentconfigs", "pods", etc.
                       maxLength: 63
                       minLength: 1
                       type: string
                       x-kubernetes-validations:
-                      - message: the value must consist of only lowercase alphanumeric
-                          characters and hyphens
-                        rule: '!format.dns1123Label().validate(self).hasValue()'
+                      - message: a DNS-1035 label must consist of lower case alphanumeric
+                          characters or '-', start with an alphabetic character, and
+                          end with an alphanumeric character
+                        rule: '!format.dns1035Label().validate(self).hasValue()'
                   required:
                   - group
                   - name

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineosconfigs.machineconfiguration.openshift.io/OnClusterBuild.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineosconfigs.machineconfiguration.openshift.io/OnClusterBuild.yaml
@@ -318,15 +318,16 @@ spec:
                     description: |-
                       resource of the referent.
                       This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-                      and should start and end with an alphanumeric character.
+                      and should start with an alphabetic character and end with an alphanumeric character.
                       Example: "deployments", "deploymentconfigs", "pods", etc.
                     maxLength: 63
                     minLength: 1
                     type: string
                     x-kubernetes-validations:
-                    - message: the value must consist of only lowercase alphanumeric
-                        characters and hyphens
-                      rule: '!format.dns1123Label().validate(self).hasValue()'
+                    - message: a DNS-1035 label must consist of lower case alphanumeric
+                        characters or '-', start with an alphabetic character, and
+                        end with an alphanumeric character
+                      rule: '!format.dns1035Label().validate(self).hasValue()'
                 required:
                 - group
                 - name

--- a/machineconfiguration/v1/zz_generated.swagger_doc_generated.go
+++ b/machineconfiguration/v1/zz_generated.swagger_doc_generated.go
@@ -530,7 +530,7 @@ func (MachineOSConfigReference) SwaggerDoc() map[string]string {
 var map_ObjectReference = map[string]string{
 	"":          "ObjectReference contains enough information to let you inspect or modify the referred object.",
 	"group":     "group of the referent. The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character. Example: \"\", \"apps\", \"build.openshift.io\", etc.",
-	"resource":  "resource of the referent. This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens, and should start and end with an alphanumeric character. Example: \"deployments\", \"deploymentconfigs\", \"pods\", etc.",
+	"resource":  "resource of the referent. This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens, and should start with an alphabetic character and end with an alphanumeric character. Example: \"deployments\", \"deploymentconfigs\", \"pods\", etc.",
 	"namespace": "namespace of the referent. This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens, and should start and end with an alphanumeric character.",
 	"name":      "name of the referent. The name must contain only lowercase alphanumeric characters, '-' or '.' and start/end with an alphanumeric character.",
 }

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosbuilds.crd.yaml
@@ -206,15 +206,16 @@ spec:
                         description: |-
                           resource of the referent.
                           This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-                          and should start and end with an alphanumeric character.
+                          and should start with an alphabetic character and end with an alphanumeric character.
                           Example: "deployments", "deploymentconfigs", "pods", etc.
                         maxLength: 63
                         minLength: 1
                         type: string
                         x-kubernetes-validations:
-                        - message: the value must consist of only lowercase alphanumeric
-                            characters and hyphens
-                          rule: '!format.dns1123Label().validate(self).hasValue()'
+                        - message: a DNS-1035 label must consist of lower case alphanumeric
+                            characters or '-', start with an alphabetic character,
+                            and end with an alphanumeric character
+                          rule: '!format.dns1035Label().validate(self).hasValue()'
                     required:
                     - group
                     - name
@@ -367,15 +368,16 @@ spec:
                       description: |-
                         resource of the referent.
                         This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-                        and should start and end with an alphanumeric character.
+                        and should start with an alphabetic character and end with an alphanumeric character.
                         Example: "deployments", "deploymentconfigs", "pods", etc.
                       maxLength: 63
                       minLength: 1
                       type: string
                       x-kubernetes-validations:
-                      - message: the value must consist of only lowercase alphanumeric
-                          characters and hyphens
-                        rule: '!format.dns1123Label().validate(self).hasValue()'
+                      - message: a DNS-1035 label must consist of lower case alphanumeric
+                          characters or '-', start with an alphabetic character, and
+                          end with an alphanumeric character
+                        rule: '!format.dns1035Label().validate(self).hasValue()'
                   required:
                   - group
                   - name

--- a/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineosconfigs.crd.yaml
@@ -317,15 +317,16 @@ spec:
                     description: |-
                       resource of the referent.
                       This value should consist of at most 63 characters, and of only lowercase alphanumeric characters and hyphens,
-                      and should start and end with an alphanumeric character.
+                      and should start with an alphabetic character and end with an alphanumeric character.
                       Example: "deployments", "deploymentconfigs", "pods", etc.
                     maxLength: 63
                     minLength: 1
                     type: string
                     x-kubernetes-validations:
-                    - message: the value must consist of only lowercase alphanumeric
-                        characters and hyphens
-                      rule: '!format.dns1123Label().validate(self).hasValue()'
+                    - message: a DNS-1035 label must consist of lower case alphanumeric
+                        characters or '-', start with an alphabetic character, and
+                        end with an alphanumeric character
+                      rule: '!format.dns1035Label().validate(self).hasValue()'
                 required:
                 - group
                 - name


### PR DESCRIPTION
Fix the validation for the Resource field in the MOSB API to be of dns1035Label.

Fixes https://issues.redhat.com/browse/OCPBUGS-56382