### PR TITLE
WIP: features: Add a TestOCAdminUpgradeTechPreview feature gate

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -728,6 +728,14 @@ var (
 					enableIn(configv1.DevPreviewNoUpgrade).
 					mustRegister()
 
+	_ = newFeatureGate("TestOCAdminUpgradeTechPreview").
+		reportProblemsToJiraComponent("oc / update").
+		contactPerson("wking").
+		productScope(ocpSpecific).
+		enhancementPR(legacyFeatureGateWithoutEnhancement).
+		enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+		mustRegister()
+
 	FeatureGateGCPCustomAPIEndpoints = newFeatureGate("GCPCustomAPIEndpoints").
 						reportProblemsToJiraComponent("Installer").
 						contactPerson("barbacbd").


### PR DESCRIPTION
This feature gate is only tied to the CI suite (hence the `Test...` prefix), and enables the `tests` image to exercise tech-preview 'oc adm upgrade ...'  command-line functionality when run against this cluster.  This is different from many feature gates, where the feature gate covers both "implement the functionality" (e.g. API properties in CustomResourceDefinitions or in-cluster controller behavior" and "run the tests that exercise that functionality".  Because the functionality is in the command line, we can exercise tech-preview command-line behavior even against default feature set clusters, as we point out [in docs][1]:

> The `oc adm upgrade recommend` command is a Technology Preview feature only...
>
> Your cluster does not need to be a Technology Preview-enabled cluster in order for you to use the `oc adm upgrade recommend` command.

By including the new feature gate in the default feature set, default-feature-set CI runs will exercise the tech-preview functionality, and confirm that the documented "works vs. default clusters" claim remains accurate.

There's a chance that instability in the tech-preview `oc` functionality destabilizes CI results for those default feature-set clusters, but we can mitigate that risk by running more tests before merging changes, and backstop with very-easy-to-approve reverts and removals of any unstable tests if necessary to recover the default-CI job signal.

An alternative approach would be to define a new CI-job flavor between the current "tech-preview features against tech-preview clusters" and "GA features against GA clusters" to run "tech-preview features against GA clusters".  But I currently expect these tech-preview command-line features to be rare and stable enough for it to not be worth the investment of building out a new job flavor.  We can revisit that approach if it does turn out to cause problems for default-CI job signal.

I've gone with the generic `TestOCAdminUpgradeTechPreview` name because there are currently several tech-preview subcommands under `oc adm upgrade ...`, including `OC_ENABLE_CMD_UPGRADE_STATUS`, `OC_ENABLE_CMD_UPGRADE_ROLLBACK`, and `OC_ENABLE_CMD_UPGRADE_RECOMMEND`.  If API approvers accept the idea that tech-preview 'oc adm upgrade ...' functionality should be tested against default-feature-set clusters, then it seems like they'd rather not bother reviewing each tech-preview idea and agreeing that it to should be tested against default-feature-set clusters.  But if the API approvers do want to review this decision on a feature-by-feature basis, I could pivot to a more specific name.

[1]: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/updating_clusters/performing-a-cluster-update#update-upgrading-oc-adm-upgrade-recommend_updating-cluster-cli