### PR TITLE
Register MutatingAdmissionPolicy in feature gates

### DIFF
--- a/features.md
+++ b/features.md
@@ -4,6 +4,7 @@
 | EventedPLEG| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
+| MutatingAdmissionPolicy| | | | | |  |
 | ShortCertRotation| | | | | |  |
 | ClusterVersionOperatorConfiguration| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | DualReplica| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |

--- a/features/features.go
+++ b/features/features.go
@@ -60,6 +60,14 @@ var (
 						enableIn(configv1.Default, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
+	FeatureGateMutatingAdmissionPolicy = newFeatureGate("MutatingAdmissionPolicy").
+						reportProblemsToJiraComponent("kube-apiserver").
+						contactPerson("benluddy").
+						productScope(kubernetes).
+						enhancementPR("https://github.com/kubernetes/enhancements/issues/3962").
+						enableIn().
+						mustRegister()
+
 	FeatureGateGatewayAPI = newFeatureGate("GatewayAPI").
 				reportProblemsToJiraComponent("Routing").
 				contactPerson("miciah").
@@ -133,12 +141,12 @@ var (
 						mustRegister()
 
 	FeatureGateAzureDedicatedHosts = newFeatureGate("AzureDedicatedHosts").
-						reportProblemsToJiraComponent("installer").
-						contactPerson("rvanderp3").
-						productScope(ocpSpecific).
-						enhancementPR("https://github.com/openshift/enhancements/pull/1783").
-						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
-						mustRegister()
+					reportProblemsToJiraComponent("installer").
+					contactPerson("rvanderp3").
+					productScope(ocpSpecific).
+					enhancementPR("https://github.com/openshift/enhancements/pull/1783").
+					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
+					mustRegister()
 
 	FeatureGateMaxUnavailableStatefulSet = newFeatureGate("MaxUnavailableStatefulSet").
 						reportProblemsToJiraComponent("apps").

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -125,6 +125,9 @@
                         "name": "MultiArchInstallAzure"
                     },
                     {
+                        "name": "MutatingAdmissionPolicy"
+                    },
+                    {
                         "name": "NewOLM"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -28,6 +28,9 @@
                         "name": "MultiArchInstallAzure"
                     },
                     {
+                        "name": "MutatingAdmissionPolicy"
+                    },
+                    {
                         "name": "NewOLM"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -37,6 +37,9 @@
                         "name": "MultiArchInstallAzure"
                     },
                     {
+                        "name": "MutatingAdmissionPolicy"
+                    },
+                    {
                         "name": "NewOLM"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-Default.yaml
@@ -128,6 +128,9 @@
                         "name": "MultiArchInstallAzure"
                     },
                     {
+                        "name": "MutatingAdmissionPolicy"
+                    },
+                    {
                         "name": "NewOLMCatalogdAPIV1Metas"
                     },
                     {

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -28,6 +28,9 @@
                         "name": "MultiArchInstallAzure"
                     },
                     {
+                        "name": "MutatingAdmissionPolicy"
+                    },
+                    {
                         "name": "ShortCertRotation"
                     }
                 ],

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -37,6 +37,9 @@
                         "name": "MultiArchInstallAzure"
                     },
                     {
+                        "name": "MutatingAdmissionPolicy"
+                    },
+                    {
                         "name": "SELinuxMount"
                     },
                     {


### PR DESCRIPTION
This adds the MAP feature gate but doesn't enable it in any feature set yet.

To be enabled in a feature set we first need to tell KASO to enable the APIs in KAS, and the gate must be registered before we can do that.

This will eventually allow our customers and developers to start playing with the feature and determining where it can be used in place of webhooks for defaulting and other mutations.