### PR TITLE
CORS-4096: Add DNS Record Type for IPv6 Domain mapping

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -59694,7 +59694,7 @@ func schema_openshift_api_operatoringress_v1_DNSRecordSpec(ref common.ReferenceC
 					},
 					"recordType": {
 						SchemaProps: spec.SchemaProps{
-							Description: "recordType is the DNS record type. For example, \"A\" or \"CNAME\".",
+							Description: "recordType is the DNS record type. For example, \"A\", \"AAAA\", or \"CNAME\".",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -34908,7 +34908,7 @@
           "default": 0
         },
         "recordType": {
-          "description": "recordType is the DNS record type. For example, \"A\" or \"CNAME\".",
+          "description": "recordType is the DNS record type. For example, \"A\", \"AAAA\", or \"CNAME\".",
           "type": "string",
           "default": ""
         },

--- a/operatoringress/v1/types.go
+++ b/operatoringress/v1/types.go
@@ -51,7 +51,7 @@ type DNSRecordSpec struct {
 	// +kubebuilder:validation:MinItems=1
 	// +required
 	Targets []string `json:"targets"`
-	// recordType is the DNS record type. For example, "A" or "CNAME".
+	// recordType is the DNS record type. For example, "A", "AAAA", or "CNAME".
 	// +required
 	RecordType DNSRecordType `json:"recordType"`
 	// recordTTL is the record TTL in seconds. If zero, the default is 30.
@@ -128,7 +128,7 @@ type DNSZoneCondition struct {
 }
 
 // DNSRecordType is a DNS resource record type.
-// +kubebuilder:validation:Enum=CNAME;A
+// +kubebuilder:validation:Enum=CNAME;A;AAAA
 type DNSRecordType string
 
 const (
@@ -137,6 +137,9 @@ const (
 
 	// ARecordType is an RFC 1035 A record.
 	ARecordType DNSRecordType = "A"
+
+	// AAAARecordType is an RFC 3596 AAAA record that is used to map a domain name to an IPv6 address.
+	AAAARecordType DNSRecordType = "AAAA"
 )
 
 // DNSManagementPolicy is a policy for configuring how the dns controller

--- a/operatoringress/v1/zz_generated.crd-manifests/0000_50_dns_01_dnsrecords.crd.yaml
+++ b/operatoringress/v1/zz_generated.crd-manifests/0000_50_dns_01_dnsrecords.crd.yaml
@@ -83,11 +83,12 @@ spec:
                 minimum: 0
                 type: integer
               recordType:
-                description: recordType is the DNS record type. For example, "A" or
-                  "CNAME".
+                description: recordType is the DNS record type. For example, "A",
+                  "AAAA", or "CNAME".
                 enum:
                 - CNAME
                 - A
+                - AAAA
                 type: string
               targets:
                 description: targets are record targets.

--- a/operatoringress/v1/zz_generated.featuregated-crd-manifests/dnsrecords.ingress.operator.openshift.io/AAA_ungated.yaml
+++ b/operatoringress/v1/zz_generated.featuregated-crd-manifests/dnsrecords.ingress.operator.openshift.io/AAA_ungated.yaml
@@ -84,11 +84,12 @@ spec:
                 minimum: 0
                 type: integer
               recordType:
-                description: recordType is the DNS record type. For example, "A" or
-                  "CNAME".
+                description: recordType is the DNS record type. For example, "A",
+                  "AAAA", or "CNAME".
                 enum:
                 - CNAME
                 - A
+                - AAAA
                 type: string
               targets:
                 description: targets are record targets.

--- a/operatoringress/v1/zz_generated.swagger_doc_generated.go
+++ b/operatoringress/v1/zz_generated.swagger_doc_generated.go
@@ -35,7 +35,7 @@ var map_DNSRecordSpec = map[string]string{
 	"":                    "DNSRecordSpec contains the details of a DNS record.",
 	"dnsName":             "dnsName is the hostname of the DNS record",
 	"targets":             "targets are record targets.",
-	"recordType":          "recordType is the DNS record type. For example, \"A\" or \"CNAME\".",
+	"recordType":          "recordType is the DNS record type. For example, \"A\", \"AAAA\", or \"CNAME\".",
 	"recordTTL":           "recordTTL is the record TTL in seconds. If zero, the default is 30. RecordTTL will not be used in AWS regions Alias targets, but will be used in CNAME targets, per AWS API contract.",
 	"dnsManagementPolicy": "dnsManagementPolicy denotes the current policy applied on the DNS record. Records that have policy set as \"Unmanaged\" are ignored by the ingress operator.  This means that the DNS record on the cloud provider is not managed by the operator, and the \"Published\" status condition will be updated to \"Unknown\" status, since it is externally managed. Any existing record on the cloud provider can be deleted at the discretion of the cluster admin.\n\nThis field defaults to Managed. Valid values are \"Managed\" and \"Unmanaged\".",
 }


### PR DESCRIPTION
operatoringress/v1/types.go:

** Add the new DNS Record Type for "AAAA" which is an RFC 3596 record used to map a domain name to an IPv6 address.

Intention/Function Examples:

** Cluster Ingress operator will use this new record type when a DNS record for IPv6 addresses is to be created. ** Openshift Installer will use this new record type when a DNS record for IPv6 addresses is to be created.