### PR TITLE
WRKLDS-1676: OCM config: Remove obsolete fields

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -45641,12 +45641,6 @@ func schema_openshift_api_openshiftcontrolplane_v1_OpenShiftControllerManagerCon
 							Format:      "",
 						},
 					},
-					"kubeClientConfig": {
-						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/openshift/api/config/v1.KubeClientConfig"),
-						},
-					},
 					"servingInfo": {
 						SchemaProps: spec.SchemaProps{
 							Description: "servingInfo describes how to start serving",
@@ -45751,11 +45745,11 @@ func schema_openshift_api_openshiftcontrolplane_v1_OpenShiftControllerManagerCon
 						},
 					},
 				},
-				Required: []string{"kubeClientConfig", "servingInfo", "leaderElection", "controllers", "resourceQuota", "serviceServingCert", "deployer", "build", "serviceAccount", "dockerPullSecret", "network", "ingress", "imageImport", "securityAllocator", "featureGates"},
+				Required: []string{"servingInfo", "leaderElection", "controllers", "resourceQuota", "serviceServingCert", "deployer", "build", "serviceAccount", "dockerPullSecret", "network", "ingress", "imageImport", "securityAllocator", "featureGates"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/openshift/api/config/v1.HTTPServingInfo", "github.com/openshift/api/config/v1.KubeClientConfig", "github.com/openshift/api/config/v1.LeaderElection", "github.com/openshift/api/openshiftcontrolplane/v1.BuildControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.DeployerControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.DockerPullSecretControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.ImageImportControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.IngressControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.NetworkControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.ResourceQuotaControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.SecurityAllocator", "github.com/openshift/api/openshiftcontrolplane/v1.ServiceAccountControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.ServiceServingCert"},
+			"github.com/openshift/api/config/v1.HTTPServingInfo", "github.com/openshift/api/config/v1.LeaderElection", "github.com/openshift/api/openshiftcontrolplane/v1.BuildControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.DeployerControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.DockerPullSecretControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.ImageImportControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.IngressControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.NetworkControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.ResourceQuotaControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.SecurityAllocator", "github.com/openshift/api/openshiftcontrolplane/v1.ServiceAccountControllerConfig", "github.com/openshift/api/openshiftcontrolplane/v1.ServiceServingCert"},
 	}
 }
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -26480,7 +26480,6 @@
       "description": "Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.",
       "type": "object",
       "required": [
-        "kubeClientConfig",
         "servingInfo",
         "leaderElection",
         "controllers",
@@ -26540,10 +26539,6 @@
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
-        },
-        "kubeClientConfig": {
-          "default": {},
-          "$ref": "#/definitions/com.github.openshift.api.config.v1.KubeClientConfig"
         },
         "leaderElection": {
           "description": "leaderElection defines the configuration for electing a controller instance to make changes to the cluster. If unspecified, the ControllerTTL value is checked to determine whether the legacy direct etcd election code will be used.",

--- a/openshiftcontrolplane/v1/types.go
+++ b/openshiftcontrolplane/v1/types.go
@@ -258,7 +258,10 @@ const (
 type OpenShiftControllerManagerConfig struct {
 	metav1.TypeMeta `json:",inline"`
 
-	KubeClientConfig configv1.KubeClientConfig `json:"kubeClientConfig"`
+	// KubeClientConfig is no longer being used.
+	// The field is being ignored by OCM.
+	//
+	// KubeClientConfig configv1.KubeClientConfig `json:"kubeClientConfig"`
 
 	// servingInfo describes how to start serving
 	ServingInfo *configv1.HTTPServingInfo `json:"servingInfo"`

--- a/openshiftcontrolplane/v1/zz_generated.deepcopy.go
+++ b/openshiftcontrolplane/v1/zz_generated.deepcopy.go
@@ -459,7 +459,6 @@ func (in *OpenShiftAPIServerConfig) DeepCopyObject() runtime.Object {
 func (in *OpenShiftControllerManagerConfig) DeepCopyInto(out *OpenShiftControllerManagerConfig) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	out.KubeClientConfig = in.KubeClientConfig
 	if in.ServingInfo != nil {
 		in, out := &in.ServingInfo, &out.ServingInfo
 		*out = new(configv1.HTTPServingInfo)


### PR DESCRIPTION
As OCM moves to use library-go for configuration, some fields present into OpenShiftControllerManagerConfig are no longer needed since they are actually accessed via GenericOperatorConfig.

There is no stability promise tied to these fields, they are only being used internally by OCM.

Leaving the fields there commented out as a tombstone.