### PR TITLE
Validation expression for Template in VSphereMachineProviderSpec

### DIFF
--- a/machine/v1beta1/types_vsphereprovider.go
+++ b/machine/v1beta1/types_vsphereprovider.go
@@ -23,6 +23,7 @@ type VSphereMachineProviderSpec struct {
 	CredentialsSecret *corev1.LocalObjectReference `json:"credentialsSecret,omitempty"`
 	// template is the name, inventory path, or instance UUID of the template
 	// used to clone new machines.
+	// +kubebuilder:validation:MaxLength=80
 	Template string `json:"template"`
 	// workspace describes the workspace to use for the machine.
 	// +optional


### PR DESCRIPTION
Since Template refers to a VM template name, vSphere has a limit set to 80 characters. Hence enforcing this on an API level helps prevent failures post ProviderSpec application