### PR TITLE
OCPNODE-3006:Add clusterimgepolicy/imagepolicy to payload

### DIFF
--- a/features.md
+++ b/features.md
@@ -5,6 +5,7 @@
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
 | ShortCertRotation| | | | | |  |
+| SigstoreImageVerification| | | | | |  |
 | NoRegistryClusterOperations| | | | <span style="background-color: #519450">Enabled</span> | |  |
 | BootImageSkewEnforcement| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | ClusterVersionOperatorConfiguration| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
@@ -58,7 +59,6 @@
 | OVNObservability| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | PreconfiguredUDNAddresses| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | SignatureStores| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
-| SigstoreImageVerification| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | SigstoreImageVerificationPKI| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | StoragePerformantSecurityPolicy| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | TranslateStreamCloseWebsocketRequests| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -160,7 +160,6 @@ var (
 						contactPerson("sgrunert").
 						productScope(ocpSpecific).
 						enhancementPR(legacyFeatureGateWithoutEnhancement).
-						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateSigstoreImageVerificationPKI = newFeatureGate("SigstoreImageVerificationPKI").

--- a/hack/update-payload-crds.sh
+++ b/hack/update-payload-crds.sh
@@ -4,6 +4,7 @@ source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 crd_globs="\
     authorization/v1/zz_generated.crd-manifests/*_config-operator_*.crd*yaml\
+    config/v1/zz_generated.crd-manifests/*_config-operator_*.crd*yaml\
     machine/v1/zz_generated.crd-manifests/*.crd*yaml\
     operator/v1/zz_generated.crd-manifests//*_config-operator_*.crd*yaml\
     operator/v1alpha1/zz_generated.crd-manifests//*_config-operator_*.crd*yaml\
@@ -22,28 +23,9 @@ crd_globs="\
     operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers*.crd.yaml
     machineconfiguration/v1/zz_generated.crd-manifests/*.crd.yaml
     operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations*.crd.yaml
-    config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clusterimagepolicies*.crd.yaml
-    config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_imagepolicies*.crd.yaml
     config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clustermonitoring*.crd.yaml
     operator/v1/zz_generated.crd-manifests/*_storage_01_storages*.crd.yaml
     operator/v1/zz_generated.crd-manifests/*_csi-driver_01_clustercsidrivers*.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_03_config-operator_01_proxies.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_apiservers-*.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_authentications-*.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_consoles.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_dnses.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_featuregates.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagecontentpolicies.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagedigestmirrorsets.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_images-*.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_imagetagmirrorsets.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-*.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_networks.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_nodes-*.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_oauths.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_projects.crd.yaml
-    config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_schedulers-*.crd.yaml
     "
 
 # To allow the crd_globs to be sourced in the verify script,

--- a/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-CustomNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2310
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -17,13 +17,13 @@ spec:
     singular: clusterimagepolicy
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: |-
           ClusterImagePolicy holds cluster-wide configuration for image signature verification
 
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -47,41 +47,58 @@ spec:
             properties:
               policy:
                 description: |-
-                  policy contains configuration to allow scopes to be verified, and defines how
+                  policy is a required field that contains configuration to allow scopes to be verified, and defines how
                   images not matching the verification policy will be treated.
                 properties:
                   rootOfTrust:
-                    description: rootOfTrust specifies the root of trust for the policy.
+                    description: |-
+                      rootOfTrust is a required field that defines the root of trust for verifying image signatures during retrieval.
+                      This allows image consumers to specify policyType and corresponding configuration of the policy, matching how the policy was generated.
                     properties:
                       fulcioCAWithRekor:
                         description: |-
-                          fulcioCAWithRekor defines the root of trust based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor defines the root of trust configuration based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor is required when policyType is FulcioCAWithRekor, and forbidden otherwise
                           For more information about Fulcio and Rekor, please refer to the document at:
                           https://github.com/sigstore/fulcio and https://github.com/sigstore/rekor
                         properties:
                           fulcioCAData:
                             description: |-
-                              fulcioCAData contains inline base64-encoded data for the PEM format fulcio CA.
+                              fulcioCAData is a required field contains inline base64-encoded data for the PEM format fulcio CA.
                               fulcioCAData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the fulcioCAData must start with base64 encoding
+                                of '-----BEGIN CERTIFICATE-----'.
+                              rule: string(self).startsWith('-----BEGIN CERTIFICATE-----')
+                            - message: the fulcioCAData must end with base64 encoding
+                                of '-----END CERTIFICATE-----'.
+                              rule: string(self).endsWith('-----END CERTIFICATE-----\n')
+                                || string(self).endsWith('-----END CERTIFICATE-----')
                           fulcioSubject:
-                            description: fulcioSubject specifies OIDC issuer and the
-                              email of the Fulcio authentication configuration.
+                            description: fulcioSubject is a required field specifies
+                              OIDC issuer and the email of the Fulcio authentication
+                              configuration.
                             properties:
                               oidcIssuer:
                                 description: |-
-                                  oidcIssuer contains the expected OIDC issuer. It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL. When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
+                                  oidcIssuer is a required filed contains the expected OIDC issuer. The oidcIssuer must be a valid URL and at most 2048 characters in length.
+                                  It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL.
+                                  When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
                                   Example: "https://expected.OIDC.issuer/"
+                                maxLength: 2048
                                 type: string
                                 x-kubernetes-validations:
                                 - message: oidcIssuer must be a valid URL
                                   rule: isURL(self)
                               signedEmail:
                                 description: |-
-                                  signedEmail holds the email address the the Fulcio certificate is issued for.
+                                  signedEmail is a required field holds the email address that the Fulcio certificate is issued for.
+                                  The signedEmail must be a valid email address and at most 320 characters in length.
                                   Example: "expected-signing-user@example.com"
+                                maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid email address
@@ -92,20 +109,28 @@ spec:
                             type: object
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is a required field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - fulcioCAData
                         - fulcioSubject
                         - rekorKeyData
                         type: object
                       pki:
-                        description: pki defines the root of trust based on Bring
-                          Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and
-                          corresponding intermediate certificates.
+                        description: |-
+                          pki defines the root of trust configuration based on Bring Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and corresponding intermediate certificates.
+                          pki is required when policyType is PKI, and forbidden otherwise.
                         properties:
                           caIntermediatesData:
                             description: |-
@@ -113,6 +138,7 @@ spec:
                               caIntermediatesData requires caRootsData to be set.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caIntermediatesData must start with base64
@@ -135,6 +161,7 @@ spec:
                               of the data must not exceed 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caRootsData must start with base64 encoding
@@ -158,22 +185,22 @@ spec:
                               email:
                                 description: |-
                                   email specifies the expected email address imposed on the subject to which the certificate was issued, and must match the email address listed in the Subject Alternative Name (SAN) field of the certificate.
-                                  The email should be a valid email address and at most 320 characters in length.
+                                  The email must be a valid email address and at most 320 characters in length.
                                 maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
-                                - message: invalid email address in pkiCertificateSubject
+                                - message: invalid email address
                                   rule: self.matches('^\\S+@\\S+$')
                               hostname:
                                 description: |-
                                   hostname specifies the expected hostname imposed on the subject to which the certificate was issued, and it must match the hostname listed in the Subject Alternative Name (SAN) DNS field of the certificate.
-                                  The hostname should be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
-                                  It should consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
+                                  The hostname must be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
+                                  It must consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
                                 maxLength: 253
                                 type: string
                                 x-kubernetes-validations:
-                                - message: hostname should be a valid dns 1123 subdomain
-                                    name, optionally prefixed by '*.'. It should consist
+                                - message: hostname must be a valid dns 1123 subdomain
+                                    name, optionally prefixed by '*.'. It must consist
                                     only of lowercase alphanumeric characters, hyphens,
                                     periods and the optional preceding asterisk.
                                   rule: 'self.startsWith(''*.'') ? !format.dns1123Subdomain().validate(self.replace(''*.'',
@@ -189,33 +216,52 @@ spec:
                         type: object
                       policyType:
                         description: |-
-                          policyType serves as the union's discriminator. Users are required to assign a value to this field, choosing one of the policy types that define the root of trust.
-                          "PublicKey" indicates that the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
-                          "FulcioCAWithRekor" indicates that the policy is based on the Fulcio certification and incorporates a Rekor verification.
-                          "PKI" indicates that the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
+                          policyType is a required field specifies the type of the policy for verification. This field must correspond to how the policy was generated.
+                          Allowed values are "PublicKey", "FulcioCAWithRekor", and "PKI".
+                          When set to "PublicKey", the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
+                          When set to "FulcioCAWithRekor", the policy is based on the Fulcio certification and incorporates a Rekor verification.
+                          When set to "PKI", the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
                         enum:
                         - PublicKey
                         - FulcioCAWithRekor
                         - PKI
                         type: string
                       publicKey:
-                        description: publicKey defines the root of trust based on
-                          a sigstore public key.
+                        description: |-
+                          publicKey defines the root of trust configuration based on a sigstore public key. Optionally include a Rekor public key for Rekor verification.
+                          publicKey is required when policyType is PublicKey, and forbidden otherwise.
                         properties:
                           keyData:
                             description: |-
-                              keyData contains inline base64-encoded data for the PEM format public key.
-                              KeyData must be at most 8192 characters.
+                              keyData is a required field contains inline base64-encoded data for the PEM format public key.
+                              keyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 68
                             type: string
+                            x-kubernetes-validations:
+                            - message: the keyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the keyData must end with base64 encoding of
+                                '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is an optional field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - keyData
                         type: object
@@ -236,19 +282,19 @@ spec:
                       rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
                         ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
                   signedIdentity:
-                    description: signedIdentity specifies what image identity the
-                      signature claims about the image. The required matchPolicy field
-                      specifies the approach used in the verification process to verify
-                      the identity in the signature and the actual image identity,
-                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    description: |-
+                      signedIdentity is an optional field specifies what image identity the signature claims about the image. This is useful when the image identity in the signature differs from the original image spec, such as when mirror registry is configured for the image scope, the signature from the mirror registry contains the image identity of the mirror instead of the original scope.
+                      The required matchPolicy field specifies the approach used in the verification process to verify the identity in the signature and the actual image identity, the default matchPolicy is "MatchRepoDigestOrExact".
                     properties:
                       exactRepository:
-                        description: exactRepository is required if matchPolicy is
-                          set to "ExactRepository".
+                        description: |-
+                          exactRepository specifies the repository that must be exactly matched by the identity in the signature.
+                          exactRepository is required if matchPolicy is set to "ExactRepository". It is used to verify that the signature claims an identity matching this exact repository, rather than the original image identity.
                         properties:
                           repository:
                             description: |-
                               repository is the reference of the image identity to be matched.
+                              repository is required if matchPolicy is set to "ExactRepository".
                               The value should be a repository name (by omitting the tag or digest) in a registry implementing the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
                             maxLength: 512
                             type: string
@@ -257,21 +303,25 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - repository
                         type: object
                       matchPolicy:
                         description: |-
-                          matchPolicy sets the type of matching to be used.
-                          Valid values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
-                          If set matchPolicy to ExactRepository, then the exactRepository must be specified.
-                          If set matchPolicy to RemapIdentity, then the remapIdentity must be specified.
-                          "MatchRepoDigestOrExact" means that the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
-                          "MatchRepository" means that the identity in the signature must be in the same repository as the image identity.
-                          "ExactRepository" means that the identity in the signature must be in the same repository as a specific identity specified by "repository".
-                          "RemapIdentity" means that the signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
+                          matchPolicy is a required filed specifies matching strategy to verify the image identity in the signature against the image scope.
+                          Allowed values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
+                          When set to "MatchRepoDigestOrExact", the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
+                          When set to "MatchRepository", the identity in the signature must be in the same repository as the image identity.
+                          When set to "ExactRepository", the exactRepository must be specified. The identity in the signature must be in the same repository as a specific identity specified by "repository".
+                          When set to "RemapIdentity", the remapIdentity must be specified. The signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
                         enum:
                         - MatchRepoDigestOrExact
                         - MatchRepository
@@ -279,14 +329,16 @@ spec:
                         - RemapIdentity
                         type: string
                       remapIdentity:
-                        description: remapIdentity is required if matchPolicy is set
-                          to "RemapIdentity".
+                        description: |-
+                          remapIdentity specifies the prefix remapping rule for verifying image identity.
+                          remapIdentity is required if matchPolicy is set to "RemapIdentity". It is used to verify that the signature claims a different registry/repository prefix than the original image.
                         properties:
                           prefix:
                             description: |-
+                              prefix is required if matchPolicy is set to "RemapIdentity".
                               prefix is the prefix of the image identity to be matched.
                               If the image identity matches the specified prefix, that prefix is replaced by the specified “signedPrefix” (otherwise it is used as unchanged and no remapping takes place).
-                              This useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
+                              This is useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
                               The prefix and signedPrefix values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -297,10 +349,17 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                           signedPrefix:
                             description: |-
+                              signedPrefix is required if matchPolicy is set to "RemapIdentity".
                               signedPrefix is the prefix of the image identity to be matched in the signature. The format is the same as "prefix". The values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -311,7 +370,13 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - prefix
@@ -334,12 +399,12 @@ spec:
                 type: object
               scopes:
                 description: |-
-                  scopes defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
+                  scopes is a required field that defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
                   Scopes matching individual images are named Docker references in the fully expanded form, either using a tag or digest. For example, docker.io/library/busybox:latest (not busybox:latest).
                   More general scopes are prefixes of individual-image scopes, and specify a repository (by omitting the tag or digest), a repository
                   namespace, or a registry host (by only specifying the host name and possibly a port number) or a wildcard expression starting with `*.`, for matching all subdomains (not including a port number).
                   Wildcards are only supported for subdomain matching, and may not be used in the middle of the host, i.e.  *.example.com is a valid case, but example*.*.com is not.
-                  If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
+                  This support no more than 256 scopes in one object. If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
                   In addition to setting a policy appropriate for your own deployed applications, make sure that a policy on the OpenShift image repositories
                   quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev (or on a more general scope) allows deployment of the OpenShift images required for cluster operation.
                   If a scope is configured in both the ClusterImagePolicy and the ImagePolicy, or if the scope in ImagePolicy is nested under one of the scopes from the ClusterImagePolicy, only the policy from the ClusterImagePolicy will be applied.
@@ -429,6 +494,8 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
+                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-DevPreviewNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2310
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -17,13 +17,13 @@ spec:
     singular: clusterimagepolicy
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: |-
           ClusterImagePolicy holds cluster-wide configuration for image signature verification
 
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -47,41 +47,58 @@ spec:
             properties:
               policy:
                 description: |-
-                  policy contains configuration to allow scopes to be verified, and defines how
+                  policy is a required field that contains configuration to allow scopes to be verified, and defines how
                   images not matching the verification policy will be treated.
                 properties:
                   rootOfTrust:
-                    description: rootOfTrust specifies the root of trust for the policy.
+                    description: |-
+                      rootOfTrust is a required field that defines the root of trust for verifying image signatures during retrieval.
+                      This allows image consumers to specify policyType and corresponding configuration of the policy, matching how the policy was generated.
                     properties:
                       fulcioCAWithRekor:
                         description: |-
-                          fulcioCAWithRekor defines the root of trust based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor defines the root of trust configuration based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor is required when policyType is FulcioCAWithRekor, and forbidden otherwise
                           For more information about Fulcio and Rekor, please refer to the document at:
                           https://github.com/sigstore/fulcio and https://github.com/sigstore/rekor
                         properties:
                           fulcioCAData:
                             description: |-
-                              fulcioCAData contains inline base64-encoded data for the PEM format fulcio CA.
+                              fulcioCAData is a required field contains inline base64-encoded data for the PEM format fulcio CA.
                               fulcioCAData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the fulcioCAData must start with base64 encoding
+                                of '-----BEGIN CERTIFICATE-----'.
+                              rule: string(self).startsWith('-----BEGIN CERTIFICATE-----')
+                            - message: the fulcioCAData must end with base64 encoding
+                                of '-----END CERTIFICATE-----'.
+                              rule: string(self).endsWith('-----END CERTIFICATE-----\n')
+                                || string(self).endsWith('-----END CERTIFICATE-----')
                           fulcioSubject:
-                            description: fulcioSubject specifies OIDC issuer and the
-                              email of the Fulcio authentication configuration.
+                            description: fulcioSubject is a required field specifies
+                              OIDC issuer and the email of the Fulcio authentication
+                              configuration.
                             properties:
                               oidcIssuer:
                                 description: |-
-                                  oidcIssuer contains the expected OIDC issuer. It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL. When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
+                                  oidcIssuer is a required filed contains the expected OIDC issuer. The oidcIssuer must be a valid URL and at most 2048 characters in length.
+                                  It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL.
+                                  When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
                                   Example: "https://expected.OIDC.issuer/"
+                                maxLength: 2048
                                 type: string
                                 x-kubernetes-validations:
                                 - message: oidcIssuer must be a valid URL
                                   rule: isURL(self)
                               signedEmail:
                                 description: |-
-                                  signedEmail holds the email address the the Fulcio certificate is issued for.
+                                  signedEmail is a required field holds the email address that the Fulcio certificate is issued for.
+                                  The signedEmail must be a valid email address and at most 320 characters in length.
                                   Example: "expected-signing-user@example.com"
+                                maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid email address
@@ -92,20 +109,28 @@ spec:
                             type: object
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is a required field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - fulcioCAData
                         - fulcioSubject
                         - rekorKeyData
                         type: object
                       pki:
-                        description: pki defines the root of trust based on Bring
-                          Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and
-                          corresponding intermediate certificates.
+                        description: |-
+                          pki defines the root of trust configuration based on Bring Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and corresponding intermediate certificates.
+                          pki is required when policyType is PKI, and forbidden otherwise.
                         properties:
                           caIntermediatesData:
                             description: |-
@@ -113,6 +138,7 @@ spec:
                               caIntermediatesData requires caRootsData to be set.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caIntermediatesData must start with base64
@@ -135,6 +161,7 @@ spec:
                               of the data must not exceed 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caRootsData must start with base64 encoding
@@ -158,22 +185,22 @@ spec:
                               email:
                                 description: |-
                                   email specifies the expected email address imposed on the subject to which the certificate was issued, and must match the email address listed in the Subject Alternative Name (SAN) field of the certificate.
-                                  The email should be a valid email address and at most 320 characters in length.
+                                  The email must be a valid email address and at most 320 characters in length.
                                 maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
-                                - message: invalid email address in pkiCertificateSubject
+                                - message: invalid email address
                                   rule: self.matches('^\\S+@\\S+$')
                               hostname:
                                 description: |-
                                   hostname specifies the expected hostname imposed on the subject to which the certificate was issued, and it must match the hostname listed in the Subject Alternative Name (SAN) DNS field of the certificate.
-                                  The hostname should be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
-                                  It should consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
+                                  The hostname must be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
+                                  It must consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
                                 maxLength: 253
                                 type: string
                                 x-kubernetes-validations:
-                                - message: hostname should be a valid dns 1123 subdomain
-                                    name, optionally prefixed by '*.'. It should consist
+                                - message: hostname must be a valid dns 1123 subdomain
+                                    name, optionally prefixed by '*.'. It must consist
                                     only of lowercase alphanumeric characters, hyphens,
                                     periods and the optional preceding asterisk.
                                   rule: 'self.startsWith(''*.'') ? !format.dns1123Subdomain().validate(self.replace(''*.'',
@@ -189,33 +216,52 @@ spec:
                         type: object
                       policyType:
                         description: |-
-                          policyType serves as the union's discriminator. Users are required to assign a value to this field, choosing one of the policy types that define the root of trust.
-                          "PublicKey" indicates that the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
-                          "FulcioCAWithRekor" indicates that the policy is based on the Fulcio certification and incorporates a Rekor verification.
-                          "PKI" indicates that the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
+                          policyType is a required field specifies the type of the policy for verification. This field must correspond to how the policy was generated.
+                          Allowed values are "PublicKey", "FulcioCAWithRekor", and "PKI".
+                          When set to "PublicKey", the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
+                          When set to "FulcioCAWithRekor", the policy is based on the Fulcio certification and incorporates a Rekor verification.
+                          When set to "PKI", the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
                         enum:
                         - PublicKey
                         - FulcioCAWithRekor
                         - PKI
                         type: string
                       publicKey:
-                        description: publicKey defines the root of trust based on
-                          a sigstore public key.
+                        description: |-
+                          publicKey defines the root of trust configuration based on a sigstore public key. Optionally include a Rekor public key for Rekor verification.
+                          publicKey is required when policyType is PublicKey, and forbidden otherwise.
                         properties:
                           keyData:
                             description: |-
-                              keyData contains inline base64-encoded data for the PEM format public key.
-                              KeyData must be at most 8192 characters.
+                              keyData is a required field contains inline base64-encoded data for the PEM format public key.
+                              keyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 68
                             type: string
+                            x-kubernetes-validations:
+                            - message: the keyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the keyData must end with base64 encoding of
+                                '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is an optional field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - keyData
                         type: object
@@ -236,19 +282,19 @@ spec:
                       rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
                         ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
                   signedIdentity:
-                    description: signedIdentity specifies what image identity the
-                      signature claims about the image. The required matchPolicy field
-                      specifies the approach used in the verification process to verify
-                      the identity in the signature and the actual image identity,
-                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    description: |-
+                      signedIdentity is an optional field specifies what image identity the signature claims about the image. This is useful when the image identity in the signature differs from the original image spec, such as when mirror registry is configured for the image scope, the signature from the mirror registry contains the image identity of the mirror instead of the original scope.
+                      The required matchPolicy field specifies the approach used in the verification process to verify the identity in the signature and the actual image identity, the default matchPolicy is "MatchRepoDigestOrExact".
                     properties:
                       exactRepository:
-                        description: exactRepository is required if matchPolicy is
-                          set to "ExactRepository".
+                        description: |-
+                          exactRepository specifies the repository that must be exactly matched by the identity in the signature.
+                          exactRepository is required if matchPolicy is set to "ExactRepository". It is used to verify that the signature claims an identity matching this exact repository, rather than the original image identity.
                         properties:
                           repository:
                             description: |-
                               repository is the reference of the image identity to be matched.
+                              repository is required if matchPolicy is set to "ExactRepository".
                               The value should be a repository name (by omitting the tag or digest) in a registry implementing the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
                             maxLength: 512
                             type: string
@@ -257,21 +303,25 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - repository
                         type: object
                       matchPolicy:
                         description: |-
-                          matchPolicy sets the type of matching to be used.
-                          Valid values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
-                          If set matchPolicy to ExactRepository, then the exactRepository must be specified.
-                          If set matchPolicy to RemapIdentity, then the remapIdentity must be specified.
-                          "MatchRepoDigestOrExact" means that the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
-                          "MatchRepository" means that the identity in the signature must be in the same repository as the image identity.
-                          "ExactRepository" means that the identity in the signature must be in the same repository as a specific identity specified by "repository".
-                          "RemapIdentity" means that the signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
+                          matchPolicy is a required filed specifies matching strategy to verify the image identity in the signature against the image scope.
+                          Allowed values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
+                          When set to "MatchRepoDigestOrExact", the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
+                          When set to "MatchRepository", the identity in the signature must be in the same repository as the image identity.
+                          When set to "ExactRepository", the exactRepository must be specified. The identity in the signature must be in the same repository as a specific identity specified by "repository".
+                          When set to "RemapIdentity", the remapIdentity must be specified. The signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
                         enum:
                         - MatchRepoDigestOrExact
                         - MatchRepository
@@ -279,14 +329,16 @@ spec:
                         - RemapIdentity
                         type: string
                       remapIdentity:
-                        description: remapIdentity is required if matchPolicy is set
-                          to "RemapIdentity".
+                        description: |-
+                          remapIdentity specifies the prefix remapping rule for verifying image identity.
+                          remapIdentity is required if matchPolicy is set to "RemapIdentity". It is used to verify that the signature claims a different registry/repository prefix than the original image.
                         properties:
                           prefix:
                             description: |-
+                              prefix is required if matchPolicy is set to "RemapIdentity".
                               prefix is the prefix of the image identity to be matched.
                               If the image identity matches the specified prefix, that prefix is replaced by the specified “signedPrefix” (otherwise it is used as unchanged and no remapping takes place).
-                              This useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
+                              This is useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
                               The prefix and signedPrefix values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -297,10 +349,17 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                           signedPrefix:
                             description: |-
+                              signedPrefix is required if matchPolicy is set to "RemapIdentity".
                               signedPrefix is the prefix of the image identity to be matched in the signature. The format is the same as "prefix". The values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -311,7 +370,13 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - prefix
@@ -334,12 +399,12 @@ spec:
                 type: object
               scopes:
                 description: |-
-                  scopes defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
+                  scopes is a required field that defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
                   Scopes matching individual images are named Docker references in the fully expanded form, either using a tag or digest. For example, docker.io/library/busybox:latest (not busybox:latest).
                   More general scopes are prefixes of individual-image scopes, and specify a repository (by omitting the tag or digest), a repository
                   namespace, or a registry host (by only specifying the host name and possibly a port number) or a wildcard expression starting with `*.`, for matching all subdomains (not including a port number).
                   Wildcards are only supported for subdomain matching, and may not be used in the middle of the host, i.e.  *.example.com is a valid case, but example*.*.com is not.
-                  If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
+                  This support no more than 256 scopes in one object. If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
                   In addition to setting a policy appropriate for your own deployed applications, make sure that a policy on the OpenShift image repositories
                   quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev (or on a more general scope) allows deployment of the OpenShift images required for cluster operation.
                   If a scope is configured in both the ClusterImagePolicy and the ImagePolicy, or if the scope in ImagePolicy is nested under one of the scopes from the ClusterImagePolicy, only the policy from the ClusterImagePolicy will be applied.
@@ -429,6 +494,8 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
+                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_clusterimagepolicies-TechPreviewNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2310
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -17,13 +17,13 @@ spec:
     singular: clusterimagepolicy
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: |-
           ClusterImagePolicy holds cluster-wide configuration for image signature verification
 
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -47,41 +47,58 @@ spec:
             properties:
               policy:
                 description: |-
-                  policy contains configuration to allow scopes to be verified, and defines how
+                  policy is a required field that contains configuration to allow scopes to be verified, and defines how
                   images not matching the verification policy will be treated.
                 properties:
                   rootOfTrust:
-                    description: rootOfTrust specifies the root of trust for the policy.
+                    description: |-
+                      rootOfTrust is a required field that defines the root of trust for verifying image signatures during retrieval.
+                      This allows image consumers to specify policyType and corresponding configuration of the policy, matching how the policy was generated.
                     properties:
                       fulcioCAWithRekor:
                         description: |-
-                          fulcioCAWithRekor defines the root of trust based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor defines the root of trust configuration based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor is required when policyType is FulcioCAWithRekor, and forbidden otherwise
                           For more information about Fulcio and Rekor, please refer to the document at:
                           https://github.com/sigstore/fulcio and https://github.com/sigstore/rekor
                         properties:
                           fulcioCAData:
                             description: |-
-                              fulcioCAData contains inline base64-encoded data for the PEM format fulcio CA.
+                              fulcioCAData is a required field contains inline base64-encoded data for the PEM format fulcio CA.
                               fulcioCAData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the fulcioCAData must start with base64 encoding
+                                of '-----BEGIN CERTIFICATE-----'.
+                              rule: string(self).startsWith('-----BEGIN CERTIFICATE-----')
+                            - message: the fulcioCAData must end with base64 encoding
+                                of '-----END CERTIFICATE-----'.
+                              rule: string(self).endsWith('-----END CERTIFICATE-----\n')
+                                || string(self).endsWith('-----END CERTIFICATE-----')
                           fulcioSubject:
-                            description: fulcioSubject specifies OIDC issuer and the
-                              email of the Fulcio authentication configuration.
+                            description: fulcioSubject is a required field specifies
+                              OIDC issuer and the email of the Fulcio authentication
+                              configuration.
                             properties:
                               oidcIssuer:
                                 description: |-
-                                  oidcIssuer contains the expected OIDC issuer. It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL. When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
+                                  oidcIssuer is a required filed contains the expected OIDC issuer. The oidcIssuer must be a valid URL and at most 2048 characters in length.
+                                  It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL.
+                                  When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
                                   Example: "https://expected.OIDC.issuer/"
+                                maxLength: 2048
                                 type: string
                                 x-kubernetes-validations:
                                 - message: oidcIssuer must be a valid URL
                                   rule: isURL(self)
                               signedEmail:
                                 description: |-
-                                  signedEmail holds the email address the the Fulcio certificate is issued for.
+                                  signedEmail is a required field holds the email address that the Fulcio certificate is issued for.
+                                  The signedEmail must be a valid email address and at most 320 characters in length.
                                   Example: "expected-signing-user@example.com"
+                                maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid email address
@@ -92,20 +109,28 @@ spec:
                             type: object
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is a required field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - fulcioCAData
                         - fulcioSubject
                         - rekorKeyData
                         type: object
                       pki:
-                        description: pki defines the root of trust based on Bring
-                          Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and
-                          corresponding intermediate certificates.
+                        description: |-
+                          pki defines the root of trust configuration based on Bring Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and corresponding intermediate certificates.
+                          pki is required when policyType is PKI, and forbidden otherwise.
                         properties:
                           caIntermediatesData:
                             description: |-
@@ -113,6 +138,7 @@ spec:
                               caIntermediatesData requires caRootsData to be set.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caIntermediatesData must start with base64
@@ -135,6 +161,7 @@ spec:
                               of the data must not exceed 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caRootsData must start with base64 encoding
@@ -158,22 +185,22 @@ spec:
                               email:
                                 description: |-
                                   email specifies the expected email address imposed on the subject to which the certificate was issued, and must match the email address listed in the Subject Alternative Name (SAN) field of the certificate.
-                                  The email should be a valid email address and at most 320 characters in length.
+                                  The email must be a valid email address and at most 320 characters in length.
                                 maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
-                                - message: invalid email address in pkiCertificateSubject
+                                - message: invalid email address
                                   rule: self.matches('^\\S+@\\S+$')
                               hostname:
                                 description: |-
                                   hostname specifies the expected hostname imposed on the subject to which the certificate was issued, and it must match the hostname listed in the Subject Alternative Name (SAN) DNS field of the certificate.
-                                  The hostname should be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
-                                  It should consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
+                                  The hostname must be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
+                                  It must consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
                                 maxLength: 253
                                 type: string
                                 x-kubernetes-validations:
-                                - message: hostname should be a valid dns 1123 subdomain
-                                    name, optionally prefixed by '*.'. It should consist
+                                - message: hostname must be a valid dns 1123 subdomain
+                                    name, optionally prefixed by '*.'. It must consist
                                     only of lowercase alphanumeric characters, hyphens,
                                     periods and the optional preceding asterisk.
                                   rule: 'self.startsWith(''*.'') ? !format.dns1123Subdomain().validate(self.replace(''*.'',
@@ -189,33 +216,52 @@ spec:
                         type: object
                       policyType:
                         description: |-
-                          policyType serves as the union's discriminator. Users are required to assign a value to this field, choosing one of the policy types that define the root of trust.
-                          "PublicKey" indicates that the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
-                          "FulcioCAWithRekor" indicates that the policy is based on the Fulcio certification and incorporates a Rekor verification.
-                          "PKI" indicates that the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
+                          policyType is a required field specifies the type of the policy for verification. This field must correspond to how the policy was generated.
+                          Allowed values are "PublicKey", "FulcioCAWithRekor", and "PKI".
+                          When set to "PublicKey", the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
+                          When set to "FulcioCAWithRekor", the policy is based on the Fulcio certification and incorporates a Rekor verification.
+                          When set to "PKI", the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
                         enum:
                         - PublicKey
                         - FulcioCAWithRekor
                         - PKI
                         type: string
                       publicKey:
-                        description: publicKey defines the root of trust based on
-                          a sigstore public key.
+                        description: |-
+                          publicKey defines the root of trust configuration based on a sigstore public key. Optionally include a Rekor public key for Rekor verification.
+                          publicKey is required when policyType is PublicKey, and forbidden otherwise.
                         properties:
                           keyData:
                             description: |-
-                              keyData contains inline base64-encoded data for the PEM format public key.
-                              KeyData must be at most 8192 characters.
+                              keyData is a required field contains inline base64-encoded data for the PEM format public key.
+                              keyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 68
                             type: string
+                            x-kubernetes-validations:
+                            - message: the keyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the keyData must end with base64 encoding of
+                                '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is an optional field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - keyData
                         type: object
@@ -236,19 +282,19 @@ spec:
                       rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
                         ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
                   signedIdentity:
-                    description: signedIdentity specifies what image identity the
-                      signature claims about the image. The required matchPolicy field
-                      specifies the approach used in the verification process to verify
-                      the identity in the signature and the actual image identity,
-                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    description: |-
+                      signedIdentity is an optional field specifies what image identity the signature claims about the image. This is useful when the image identity in the signature differs from the original image spec, such as when mirror registry is configured for the image scope, the signature from the mirror registry contains the image identity of the mirror instead of the original scope.
+                      The required matchPolicy field specifies the approach used in the verification process to verify the identity in the signature and the actual image identity, the default matchPolicy is "MatchRepoDigestOrExact".
                     properties:
                       exactRepository:
-                        description: exactRepository is required if matchPolicy is
-                          set to "ExactRepository".
+                        description: |-
+                          exactRepository specifies the repository that must be exactly matched by the identity in the signature.
+                          exactRepository is required if matchPolicy is set to "ExactRepository". It is used to verify that the signature claims an identity matching this exact repository, rather than the original image identity.
                         properties:
                           repository:
                             description: |-
                               repository is the reference of the image identity to be matched.
+                              repository is required if matchPolicy is set to "ExactRepository".
                               The value should be a repository name (by omitting the tag or digest) in a registry implementing the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
                             maxLength: 512
                             type: string
@@ -257,21 +303,25 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - repository
                         type: object
                       matchPolicy:
                         description: |-
-                          matchPolicy sets the type of matching to be used.
-                          Valid values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
-                          If set matchPolicy to ExactRepository, then the exactRepository must be specified.
-                          If set matchPolicy to RemapIdentity, then the remapIdentity must be specified.
-                          "MatchRepoDigestOrExact" means that the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
-                          "MatchRepository" means that the identity in the signature must be in the same repository as the image identity.
-                          "ExactRepository" means that the identity in the signature must be in the same repository as a specific identity specified by "repository".
-                          "RemapIdentity" means that the signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
+                          matchPolicy is a required filed specifies matching strategy to verify the image identity in the signature against the image scope.
+                          Allowed values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
+                          When set to "MatchRepoDigestOrExact", the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
+                          When set to "MatchRepository", the identity in the signature must be in the same repository as the image identity.
+                          When set to "ExactRepository", the exactRepository must be specified. The identity in the signature must be in the same repository as a specific identity specified by "repository".
+                          When set to "RemapIdentity", the remapIdentity must be specified. The signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
                         enum:
                         - MatchRepoDigestOrExact
                         - MatchRepository
@@ -279,14 +329,16 @@ spec:
                         - RemapIdentity
                         type: string
                       remapIdentity:
-                        description: remapIdentity is required if matchPolicy is set
-                          to "RemapIdentity".
+                        description: |-
+                          remapIdentity specifies the prefix remapping rule for verifying image identity.
+                          remapIdentity is required if matchPolicy is set to "RemapIdentity". It is used to verify that the signature claims a different registry/repository prefix than the original image.
                         properties:
                           prefix:
                             description: |-
+                              prefix is required if matchPolicy is set to "RemapIdentity".
                               prefix is the prefix of the image identity to be matched.
                               If the image identity matches the specified prefix, that prefix is replaced by the specified “signedPrefix” (otherwise it is used as unchanged and no remapping takes place).
-                              This useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
+                              This is useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
                               The prefix and signedPrefix values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -297,10 +349,17 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                           signedPrefix:
                             description: |-
+                              signedPrefix is required if matchPolicy is set to "RemapIdentity".
                               signedPrefix is the prefix of the image identity to be matched in the signature. The format is the same as "prefix". The values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -311,7 +370,13 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - prefix
@@ -334,12 +399,12 @@ spec:
                 type: object
               scopes:
                 description: |-
-                  scopes defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
+                  scopes is a required field that defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
                   Scopes matching individual images are named Docker references in the fully expanded form, either using a tag or digest. For example, docker.io/library/busybox:latest (not busybox:latest).
                   More general scopes are prefixes of individual-image scopes, and specify a repository (by omitting the tag or digest), a repository
                   namespace, or a registry host (by only specifying the host name and possibly a port number) or a wildcard expression starting with `*.`, for matching all subdomains (not including a port number).
                   Wildcards are only supported for subdomain matching, and may not be used in the middle of the host, i.e.  *.example.com is a valid case, but example*.*.com is not.
-                  If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
+                  This support no more than 256 scopes in one object. If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
                   In addition to setting a policy appropriate for your own deployed applications, make sure that a policy on the OpenShift image repositories
                   quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev (or on a more general scope) allows deployment of the OpenShift images required for cluster operation.
                   If a scope is configured in both the ClusterImagePolicy and the ImagePolicy, or if the scope in ImagePolicy is nested under one of the scopes from the ClusterImagePolicy, only the policy from the ClusterImagePolicy will be applied.
@@ -429,6 +494,8 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
+                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/payload-manifests/crds/0000_10_config-operator_01_imagepolicies-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagepolicies-CustomNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2310
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -17,13 +17,13 @@ spec:
     singular: imagepolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: |-
           ImagePolicy holds namespace-wide configuration for image signature verification
 
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -47,41 +47,58 @@ spec:
             properties:
               policy:
                 description: |-
-                  policy contains configuration to allow scopes to be verified, and defines how
+                  policy is a required field that contains configuration to allow scopes to be verified, and defines how
                   images not matching the verification policy will be treated.
                 properties:
                   rootOfTrust:
-                    description: rootOfTrust specifies the root of trust for the policy.
+                    description: |-
+                      rootOfTrust is a required field that defines the root of trust for verifying image signatures during retrieval.
+                      This allows image consumers to specify policyType and corresponding configuration of the policy, matching how the policy was generated.
                     properties:
                       fulcioCAWithRekor:
                         description: |-
-                          fulcioCAWithRekor defines the root of trust based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor defines the root of trust configuration based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor is required when policyType is FulcioCAWithRekor, and forbidden otherwise
                           For more information about Fulcio and Rekor, please refer to the document at:
                           https://github.com/sigstore/fulcio and https://github.com/sigstore/rekor
                         properties:
                           fulcioCAData:
                             description: |-
-                              fulcioCAData contains inline base64-encoded data for the PEM format fulcio CA.
+                              fulcioCAData is a required field contains inline base64-encoded data for the PEM format fulcio CA.
                               fulcioCAData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the fulcioCAData must start with base64 encoding
+                                of '-----BEGIN CERTIFICATE-----'.
+                              rule: string(self).startsWith('-----BEGIN CERTIFICATE-----')
+                            - message: the fulcioCAData must end with base64 encoding
+                                of '-----END CERTIFICATE-----'.
+                              rule: string(self).endsWith('-----END CERTIFICATE-----\n')
+                                || string(self).endsWith('-----END CERTIFICATE-----')
                           fulcioSubject:
-                            description: fulcioSubject specifies OIDC issuer and the
-                              email of the Fulcio authentication configuration.
+                            description: fulcioSubject is a required field specifies
+                              OIDC issuer and the email of the Fulcio authentication
+                              configuration.
                             properties:
                               oidcIssuer:
                                 description: |-
-                                  oidcIssuer contains the expected OIDC issuer. It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL. When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
+                                  oidcIssuer is a required filed contains the expected OIDC issuer. The oidcIssuer must be a valid URL and at most 2048 characters in length.
+                                  It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL.
+                                  When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
                                   Example: "https://expected.OIDC.issuer/"
+                                maxLength: 2048
                                 type: string
                                 x-kubernetes-validations:
                                 - message: oidcIssuer must be a valid URL
                                   rule: isURL(self)
                               signedEmail:
                                 description: |-
-                                  signedEmail holds the email address the the Fulcio certificate is issued for.
+                                  signedEmail is a required field holds the email address that the Fulcio certificate is issued for.
+                                  The signedEmail must be a valid email address and at most 320 characters in length.
                                   Example: "expected-signing-user@example.com"
+                                maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid email address
@@ -92,20 +109,28 @@ spec:
                             type: object
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is a required field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - fulcioCAData
                         - fulcioSubject
                         - rekorKeyData
                         type: object
                       pki:
-                        description: pki defines the root of trust based on Bring
-                          Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and
-                          corresponding intermediate certificates.
+                        description: |-
+                          pki defines the root of trust configuration based on Bring Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and corresponding intermediate certificates.
+                          pki is required when policyType is PKI, and forbidden otherwise.
                         properties:
                           caIntermediatesData:
                             description: |-
@@ -113,6 +138,7 @@ spec:
                               caIntermediatesData requires caRootsData to be set.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caIntermediatesData must start with base64
@@ -135,6 +161,7 @@ spec:
                               of the data must not exceed 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caRootsData must start with base64 encoding
@@ -158,22 +185,22 @@ spec:
                               email:
                                 description: |-
                                   email specifies the expected email address imposed on the subject to which the certificate was issued, and must match the email address listed in the Subject Alternative Name (SAN) field of the certificate.
-                                  The email should be a valid email address and at most 320 characters in length.
+                                  The email must be a valid email address and at most 320 characters in length.
                                 maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
-                                - message: invalid email address in pkiCertificateSubject
+                                - message: invalid email address
                                   rule: self.matches('^\\S+@\\S+$')
                               hostname:
                                 description: |-
                                   hostname specifies the expected hostname imposed on the subject to which the certificate was issued, and it must match the hostname listed in the Subject Alternative Name (SAN) DNS field of the certificate.
-                                  The hostname should be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
-                                  It should consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
+                                  The hostname must be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
+                                  It must consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
                                 maxLength: 253
                                 type: string
                                 x-kubernetes-validations:
-                                - message: hostname should be a valid dns 1123 subdomain
-                                    name, optionally prefixed by '*.'. It should consist
+                                - message: hostname must be a valid dns 1123 subdomain
+                                    name, optionally prefixed by '*.'. It must consist
                                     only of lowercase alphanumeric characters, hyphens,
                                     periods and the optional preceding asterisk.
                                   rule: 'self.startsWith(''*.'') ? !format.dns1123Subdomain().validate(self.replace(''*.'',
@@ -189,33 +216,52 @@ spec:
                         type: object
                       policyType:
                         description: |-
-                          policyType serves as the union's discriminator. Users are required to assign a value to this field, choosing one of the policy types that define the root of trust.
-                          "PublicKey" indicates that the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
-                          "FulcioCAWithRekor" indicates that the policy is based on the Fulcio certification and incorporates a Rekor verification.
-                          "PKI" indicates that the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
+                          policyType is a required field specifies the type of the policy for verification. This field must correspond to how the policy was generated.
+                          Allowed values are "PublicKey", "FulcioCAWithRekor", and "PKI".
+                          When set to "PublicKey", the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
+                          When set to "FulcioCAWithRekor", the policy is based on the Fulcio certification and incorporates a Rekor verification.
+                          When set to "PKI", the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
                         enum:
                         - PublicKey
                         - FulcioCAWithRekor
                         - PKI
                         type: string
                       publicKey:
-                        description: publicKey defines the root of trust based on
-                          a sigstore public key.
+                        description: |-
+                          publicKey defines the root of trust configuration based on a sigstore public key. Optionally include a Rekor public key for Rekor verification.
+                          publicKey is required when policyType is PublicKey, and forbidden otherwise.
                         properties:
                           keyData:
                             description: |-
-                              keyData contains inline base64-encoded data for the PEM format public key.
-                              KeyData must be at most 8192 characters.
+                              keyData is a required field contains inline base64-encoded data for the PEM format public key.
+                              keyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 68
                             type: string
+                            x-kubernetes-validations:
+                            - message: the keyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the keyData must end with base64 encoding of
+                                '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is an optional field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - keyData
                         type: object
@@ -236,19 +282,19 @@ spec:
                       rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
                         ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
                   signedIdentity:
-                    description: signedIdentity specifies what image identity the
-                      signature claims about the image. The required matchPolicy field
-                      specifies the approach used in the verification process to verify
-                      the identity in the signature and the actual image identity,
-                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    description: |-
+                      signedIdentity is an optional field specifies what image identity the signature claims about the image. This is useful when the image identity in the signature differs from the original image spec, such as when mirror registry is configured for the image scope, the signature from the mirror registry contains the image identity of the mirror instead of the original scope.
+                      The required matchPolicy field specifies the approach used in the verification process to verify the identity in the signature and the actual image identity, the default matchPolicy is "MatchRepoDigestOrExact".
                     properties:
                       exactRepository:
-                        description: exactRepository is required if matchPolicy is
-                          set to "ExactRepository".
+                        description: |-
+                          exactRepository specifies the repository that must be exactly matched by the identity in the signature.
+                          exactRepository is required if matchPolicy is set to "ExactRepository". It is used to verify that the signature claims an identity matching this exact repository, rather than the original image identity.
                         properties:
                           repository:
                             description: |-
                               repository is the reference of the image identity to be matched.
+                              repository is required if matchPolicy is set to "ExactRepository".
                               The value should be a repository name (by omitting the tag or digest) in a registry implementing the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
                             maxLength: 512
                             type: string
@@ -257,21 +303,25 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - repository
                         type: object
                       matchPolicy:
                         description: |-
-                          matchPolicy sets the type of matching to be used.
-                          Valid values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
-                          If set matchPolicy to ExactRepository, then the exactRepository must be specified.
-                          If set matchPolicy to RemapIdentity, then the remapIdentity must be specified.
-                          "MatchRepoDigestOrExact" means that the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
-                          "MatchRepository" means that the identity in the signature must be in the same repository as the image identity.
-                          "ExactRepository" means that the identity in the signature must be in the same repository as a specific identity specified by "repository".
-                          "RemapIdentity" means that the signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
+                          matchPolicy is a required filed specifies matching strategy to verify the image identity in the signature against the image scope.
+                          Allowed values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
+                          When set to "MatchRepoDigestOrExact", the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
+                          When set to "MatchRepository", the identity in the signature must be in the same repository as the image identity.
+                          When set to "ExactRepository", the exactRepository must be specified. The identity in the signature must be in the same repository as a specific identity specified by "repository".
+                          When set to "RemapIdentity", the remapIdentity must be specified. The signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
                         enum:
                         - MatchRepoDigestOrExact
                         - MatchRepository
@@ -279,14 +329,16 @@ spec:
                         - RemapIdentity
                         type: string
                       remapIdentity:
-                        description: remapIdentity is required if matchPolicy is set
-                          to "RemapIdentity".
+                        description: |-
+                          remapIdentity specifies the prefix remapping rule for verifying image identity.
+                          remapIdentity is required if matchPolicy is set to "RemapIdentity". It is used to verify that the signature claims a different registry/repository prefix than the original image.
                         properties:
                           prefix:
                             description: |-
+                              prefix is required if matchPolicy is set to "RemapIdentity".
                               prefix is the prefix of the image identity to be matched.
                               If the image identity matches the specified prefix, that prefix is replaced by the specified “signedPrefix” (otherwise it is used as unchanged and no remapping takes place).
-                              This useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
+                              This is useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
                               The prefix and signedPrefix values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -297,10 +349,17 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                           signedPrefix:
                             description: |-
+                              signedPrefix is required if matchPolicy is set to "RemapIdentity".
                               signedPrefix is the prefix of the image identity to be matched in the signature. The format is the same as "prefix". The values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -311,7 +370,13 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - prefix
@@ -334,12 +399,12 @@ spec:
                 type: object
               scopes:
                 description: |-
-                  scopes defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
+                  scopes is a required field that defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
                   Scopes matching individual images are named Docker references in the fully expanded form, either using a tag or digest. For example, docker.io/library/busybox:latest (not busybox:latest).
                   More general scopes are prefixes of individual-image scopes, and specify a repository (by omitting the tag or digest), a repository
                   namespace, or a registry host (by only specifying the host name and possibly a port number) or a wildcard expression starting with `*.`, for matching all subdomains (not including a port number).
                   Wildcards are only supported for subdomain matching, and may not be used in the middle of the host, i.e.  *.example.com is a valid case, but example*.*.com is not.
-                  If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
+                  This support no more than 256 scopes in one object. If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
                   In addition to setting a policy appropriate for your own deployed applications, make sure that a policy on the OpenShift image repositories
                   quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev (or on a more general scope) allows deployment of the OpenShift images required for cluster operation.
                   If a scope is configured in both the ClusterImagePolicy and the ImagePolicy, or if the scope in ImagePolicy is nested under one of the scopes from the ClusterImagePolicy, only the policy from the ClusterImagePolicy will be applied.
@@ -373,8 +438,9 @@ spec:
             description: status contains the observed state of the resource.
             properties:
               conditions:
-                description: conditions provide details on the status of this API
-                  Resource.
+                description: |-
+                  conditions provide details on the status of this API Resource.
+                  condition type 'Pending' indicates that the customer resource contains a policy that cannot take effect. It is either overwritten by a global policy or the image scope is not valid.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -429,6 +495,8 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
+                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/payload-manifests/crds/0000_10_config-operator_01_imagepolicies-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagepolicies-DevPreviewNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2310
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -17,13 +17,13 @@ spec:
     singular: imagepolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: |-
           ImagePolicy holds namespace-wide configuration for image signature verification
 
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -47,41 +47,58 @@ spec:
             properties:
               policy:
                 description: |-
-                  policy contains configuration to allow scopes to be verified, and defines how
+                  policy is a required field that contains configuration to allow scopes to be verified, and defines how
                   images not matching the verification policy will be treated.
                 properties:
                   rootOfTrust:
-                    description: rootOfTrust specifies the root of trust for the policy.
+                    description: |-
+                      rootOfTrust is a required field that defines the root of trust for verifying image signatures during retrieval.
+                      This allows image consumers to specify policyType and corresponding configuration of the policy, matching how the policy was generated.
                     properties:
                       fulcioCAWithRekor:
                         description: |-
-                          fulcioCAWithRekor defines the root of trust based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor defines the root of trust configuration based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor is required when policyType is FulcioCAWithRekor, and forbidden otherwise
                           For more information about Fulcio and Rekor, please refer to the document at:
                           https://github.com/sigstore/fulcio and https://github.com/sigstore/rekor
                         properties:
                           fulcioCAData:
                             description: |-
-                              fulcioCAData contains inline base64-encoded data for the PEM format fulcio CA.
+                              fulcioCAData is a required field contains inline base64-encoded data for the PEM format fulcio CA.
                               fulcioCAData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the fulcioCAData must start with base64 encoding
+                                of '-----BEGIN CERTIFICATE-----'.
+                              rule: string(self).startsWith('-----BEGIN CERTIFICATE-----')
+                            - message: the fulcioCAData must end with base64 encoding
+                                of '-----END CERTIFICATE-----'.
+                              rule: string(self).endsWith('-----END CERTIFICATE-----\n')
+                                || string(self).endsWith('-----END CERTIFICATE-----')
                           fulcioSubject:
-                            description: fulcioSubject specifies OIDC issuer and the
-                              email of the Fulcio authentication configuration.
+                            description: fulcioSubject is a required field specifies
+                              OIDC issuer and the email of the Fulcio authentication
+                              configuration.
                             properties:
                               oidcIssuer:
                                 description: |-
-                                  oidcIssuer contains the expected OIDC issuer. It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL. When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
+                                  oidcIssuer is a required filed contains the expected OIDC issuer. The oidcIssuer must be a valid URL and at most 2048 characters in length.
+                                  It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL.
+                                  When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
                                   Example: "https://expected.OIDC.issuer/"
+                                maxLength: 2048
                                 type: string
                                 x-kubernetes-validations:
                                 - message: oidcIssuer must be a valid URL
                                   rule: isURL(self)
                               signedEmail:
                                 description: |-
-                                  signedEmail holds the email address the the Fulcio certificate is issued for.
+                                  signedEmail is a required field holds the email address that the Fulcio certificate is issued for.
+                                  The signedEmail must be a valid email address and at most 320 characters in length.
                                   Example: "expected-signing-user@example.com"
+                                maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid email address
@@ -92,20 +109,28 @@ spec:
                             type: object
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is a required field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - fulcioCAData
                         - fulcioSubject
                         - rekorKeyData
                         type: object
                       pki:
-                        description: pki defines the root of trust based on Bring
-                          Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and
-                          corresponding intermediate certificates.
+                        description: |-
+                          pki defines the root of trust configuration based on Bring Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and corresponding intermediate certificates.
+                          pki is required when policyType is PKI, and forbidden otherwise.
                         properties:
                           caIntermediatesData:
                             description: |-
@@ -113,6 +138,7 @@ spec:
                               caIntermediatesData requires caRootsData to be set.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caIntermediatesData must start with base64
@@ -135,6 +161,7 @@ spec:
                               of the data must not exceed 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caRootsData must start with base64 encoding
@@ -158,22 +185,22 @@ spec:
                               email:
                                 description: |-
                                   email specifies the expected email address imposed on the subject to which the certificate was issued, and must match the email address listed in the Subject Alternative Name (SAN) field of the certificate.
-                                  The email should be a valid email address and at most 320 characters in length.
+                                  The email must be a valid email address and at most 320 characters in length.
                                 maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
-                                - message: invalid email address in pkiCertificateSubject
+                                - message: invalid email address
                                   rule: self.matches('^\\S+@\\S+$')
                               hostname:
                                 description: |-
                                   hostname specifies the expected hostname imposed on the subject to which the certificate was issued, and it must match the hostname listed in the Subject Alternative Name (SAN) DNS field of the certificate.
-                                  The hostname should be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
-                                  It should consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
+                                  The hostname must be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
+                                  It must consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
                                 maxLength: 253
                                 type: string
                                 x-kubernetes-validations:
-                                - message: hostname should be a valid dns 1123 subdomain
-                                    name, optionally prefixed by '*.'. It should consist
+                                - message: hostname must be a valid dns 1123 subdomain
+                                    name, optionally prefixed by '*.'. It must consist
                                     only of lowercase alphanumeric characters, hyphens,
                                     periods and the optional preceding asterisk.
                                   rule: 'self.startsWith(''*.'') ? !format.dns1123Subdomain().validate(self.replace(''*.'',
@@ -189,33 +216,52 @@ spec:
                         type: object
                       policyType:
                         description: |-
-                          policyType serves as the union's discriminator. Users are required to assign a value to this field, choosing one of the policy types that define the root of trust.
-                          "PublicKey" indicates that the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
-                          "FulcioCAWithRekor" indicates that the policy is based on the Fulcio certification and incorporates a Rekor verification.
-                          "PKI" indicates that the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
+                          policyType is a required field specifies the type of the policy for verification. This field must correspond to how the policy was generated.
+                          Allowed values are "PublicKey", "FulcioCAWithRekor", and "PKI".
+                          When set to "PublicKey", the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
+                          When set to "FulcioCAWithRekor", the policy is based on the Fulcio certification and incorporates a Rekor verification.
+                          When set to "PKI", the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
                         enum:
                         - PublicKey
                         - FulcioCAWithRekor
                         - PKI
                         type: string
                       publicKey:
-                        description: publicKey defines the root of trust based on
-                          a sigstore public key.
+                        description: |-
+                          publicKey defines the root of trust configuration based on a sigstore public key. Optionally include a Rekor public key for Rekor verification.
+                          publicKey is required when policyType is PublicKey, and forbidden otherwise.
                         properties:
                           keyData:
                             description: |-
-                              keyData contains inline base64-encoded data for the PEM format public key.
-                              KeyData must be at most 8192 characters.
+                              keyData is a required field contains inline base64-encoded data for the PEM format public key.
+                              keyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 68
                             type: string
+                            x-kubernetes-validations:
+                            - message: the keyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the keyData must end with base64 encoding of
+                                '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is an optional field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - keyData
                         type: object
@@ -236,19 +282,19 @@ spec:
                       rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
                         ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
                   signedIdentity:
-                    description: signedIdentity specifies what image identity the
-                      signature claims about the image. The required matchPolicy field
-                      specifies the approach used in the verification process to verify
-                      the identity in the signature and the actual image identity,
-                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    description: |-
+                      signedIdentity is an optional field specifies what image identity the signature claims about the image. This is useful when the image identity in the signature differs from the original image spec, such as when mirror registry is configured for the image scope, the signature from the mirror registry contains the image identity of the mirror instead of the original scope.
+                      The required matchPolicy field specifies the approach used in the verification process to verify the identity in the signature and the actual image identity, the default matchPolicy is "MatchRepoDigestOrExact".
                     properties:
                       exactRepository:
-                        description: exactRepository is required if matchPolicy is
-                          set to "ExactRepository".
+                        description: |-
+                          exactRepository specifies the repository that must be exactly matched by the identity in the signature.
+                          exactRepository is required if matchPolicy is set to "ExactRepository". It is used to verify that the signature claims an identity matching this exact repository, rather than the original image identity.
                         properties:
                           repository:
                             description: |-
                               repository is the reference of the image identity to be matched.
+                              repository is required if matchPolicy is set to "ExactRepository".
                               The value should be a repository name (by omitting the tag or digest) in a registry implementing the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
                             maxLength: 512
                             type: string
@@ -257,21 +303,25 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - repository
                         type: object
                       matchPolicy:
                         description: |-
-                          matchPolicy sets the type of matching to be used.
-                          Valid values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
-                          If set matchPolicy to ExactRepository, then the exactRepository must be specified.
-                          If set matchPolicy to RemapIdentity, then the remapIdentity must be specified.
-                          "MatchRepoDigestOrExact" means that the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
-                          "MatchRepository" means that the identity in the signature must be in the same repository as the image identity.
-                          "ExactRepository" means that the identity in the signature must be in the same repository as a specific identity specified by "repository".
-                          "RemapIdentity" means that the signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
+                          matchPolicy is a required filed specifies matching strategy to verify the image identity in the signature against the image scope.
+                          Allowed values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
+                          When set to "MatchRepoDigestOrExact", the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
+                          When set to "MatchRepository", the identity in the signature must be in the same repository as the image identity.
+                          When set to "ExactRepository", the exactRepository must be specified. The identity in the signature must be in the same repository as a specific identity specified by "repository".
+                          When set to "RemapIdentity", the remapIdentity must be specified. The signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
                         enum:
                         - MatchRepoDigestOrExact
                         - MatchRepository
@@ -279,14 +329,16 @@ spec:
                         - RemapIdentity
                         type: string
                       remapIdentity:
-                        description: remapIdentity is required if matchPolicy is set
-                          to "RemapIdentity".
+                        description: |-
+                          remapIdentity specifies the prefix remapping rule for verifying image identity.
+                          remapIdentity is required if matchPolicy is set to "RemapIdentity". It is used to verify that the signature claims a different registry/repository prefix than the original image.
                         properties:
                           prefix:
                             description: |-
+                              prefix is required if matchPolicy is set to "RemapIdentity".
                               prefix is the prefix of the image identity to be matched.
                               If the image identity matches the specified prefix, that prefix is replaced by the specified “signedPrefix” (otherwise it is used as unchanged and no remapping takes place).
-                              This useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
+                              This is useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
                               The prefix and signedPrefix values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -297,10 +349,17 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                           signedPrefix:
                             description: |-
+                              signedPrefix is required if matchPolicy is set to "RemapIdentity".
                               signedPrefix is the prefix of the image identity to be matched in the signature. The format is the same as "prefix". The values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -311,7 +370,13 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - prefix
@@ -334,12 +399,12 @@ spec:
                 type: object
               scopes:
                 description: |-
-                  scopes defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
+                  scopes is a required field that defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
                   Scopes matching individual images are named Docker references in the fully expanded form, either using a tag or digest. For example, docker.io/library/busybox:latest (not busybox:latest).
                   More general scopes are prefixes of individual-image scopes, and specify a repository (by omitting the tag or digest), a repository
                   namespace, or a registry host (by only specifying the host name and possibly a port number) or a wildcard expression starting with `*.`, for matching all subdomains (not including a port number).
                   Wildcards are only supported for subdomain matching, and may not be used in the middle of the host, i.e.  *.example.com is a valid case, but example*.*.com is not.
-                  If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
+                  This support no more than 256 scopes in one object. If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
                   In addition to setting a policy appropriate for your own deployed applications, make sure that a policy on the OpenShift image repositories
                   quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev (or on a more general scope) allows deployment of the OpenShift images required for cluster operation.
                   If a scope is configured in both the ClusterImagePolicy and the ImagePolicy, or if the scope in ImagePolicy is nested under one of the scopes from the ClusterImagePolicy, only the policy from the ClusterImagePolicy will be applied.
@@ -373,8 +438,9 @@ spec:
             description: status contains the observed state of the resource.
             properties:
               conditions:
-                description: conditions provide details on the status of this API
-                  Resource.
+                description: |-
+                  conditions provide details on the status of this API Resource.
+                  condition type 'Pending' indicates that the customer resource contains a policy that cannot take effect. It is either overwritten by a global policy or the image scope is not valid.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -429,6 +495,8 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
+                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/payload-manifests/crds/0000_10_config-operator_01_imagepolicies-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_imagepolicies-TechPreviewNoUpgrade.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    api-approved.openshift.io: https://github.com/openshift/api/pull/1457
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2310
     api.openshift.io/merged-by-featuregates: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
@@ -17,13 +17,13 @@ spec:
     singular: imagepolicy
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: |-
           ImagePolicy holds namespace-wide configuration for image signature verification
 
-          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
         properties:
           apiVersion:
             description: |-
@@ -47,41 +47,58 @@ spec:
             properties:
               policy:
                 description: |-
-                  policy contains configuration to allow scopes to be verified, and defines how
+                  policy is a required field that contains configuration to allow scopes to be verified, and defines how
                   images not matching the verification policy will be treated.
                 properties:
                   rootOfTrust:
-                    description: rootOfTrust specifies the root of trust for the policy.
+                    description: |-
+                      rootOfTrust is a required field that defines the root of trust for verifying image signatures during retrieval.
+                      This allows image consumers to specify policyType and corresponding configuration of the policy, matching how the policy was generated.
                     properties:
                       fulcioCAWithRekor:
                         description: |-
-                          fulcioCAWithRekor defines the root of trust based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor defines the root of trust configuration based on the Fulcio certificate and the Rekor public key.
+                          fulcioCAWithRekor is required when policyType is FulcioCAWithRekor, and forbidden otherwise
                           For more information about Fulcio and Rekor, please refer to the document at:
                           https://github.com/sigstore/fulcio and https://github.com/sigstore/rekor
                         properties:
                           fulcioCAData:
                             description: |-
-                              fulcioCAData contains inline base64-encoded data for the PEM format fulcio CA.
+                              fulcioCAData is a required field contains inline base64-encoded data for the PEM format fulcio CA.
                               fulcioCAData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the fulcioCAData must start with base64 encoding
+                                of '-----BEGIN CERTIFICATE-----'.
+                              rule: string(self).startsWith('-----BEGIN CERTIFICATE-----')
+                            - message: the fulcioCAData must end with base64 encoding
+                                of '-----END CERTIFICATE-----'.
+                              rule: string(self).endsWith('-----END CERTIFICATE-----\n')
+                                || string(self).endsWith('-----END CERTIFICATE-----')
                           fulcioSubject:
-                            description: fulcioSubject specifies OIDC issuer and the
-                              email of the Fulcio authentication configuration.
+                            description: fulcioSubject is a required field specifies
+                              OIDC issuer and the email of the Fulcio authentication
+                              configuration.
                             properties:
                               oidcIssuer:
                                 description: |-
-                                  oidcIssuer contains the expected OIDC issuer. It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL. When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
+                                  oidcIssuer is a required filed contains the expected OIDC issuer. The oidcIssuer must be a valid URL and at most 2048 characters in length.
+                                  It will be verified that the Fulcio-issued certificate contains a (Fulcio-defined) certificate extension pointing at this OIDC issuer URL.
+                                  When Fulcio issues certificates, it includes a value based on an URL inside the client-provided ID token.
                                   Example: "https://expected.OIDC.issuer/"
+                                maxLength: 2048
                                 type: string
                                 x-kubernetes-validations:
                                 - message: oidcIssuer must be a valid URL
                                   rule: isURL(self)
                               signedEmail:
                                 description: |-
-                                  signedEmail holds the email address the the Fulcio certificate is issued for.
+                                  signedEmail is a required field holds the email address that the Fulcio certificate is issued for.
+                                  The signedEmail must be a valid email address and at most 320 characters in length.
                                   Example: "expected-signing-user@example.com"
+                                maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid email address
@@ -92,20 +109,28 @@ spec:
                             type: object
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is a required field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - fulcioCAData
                         - fulcioSubject
                         - rekorKeyData
                         type: object
                       pki:
-                        description: pki defines the root of trust based on Bring
-                          Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and
-                          corresponding intermediate certificates.
+                        description: |-
+                          pki defines the root of trust configuration based on Bring Your Own Public Key Infrastructure (BYOPKI) Root CA(s) and corresponding intermediate certificates.
+                          pki is required when policyType is PKI, and forbidden otherwise.
                         properties:
                           caIntermediatesData:
                             description: |-
@@ -113,6 +138,7 @@ spec:
                               caIntermediatesData requires caRootsData to be set.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caIntermediatesData must start with base64
@@ -135,6 +161,7 @@ spec:
                               of the data must not exceed 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 72
                             type: string
                             x-kubernetes-validations:
                             - message: the caRootsData must start with base64 encoding
@@ -158,22 +185,22 @@ spec:
                               email:
                                 description: |-
                                   email specifies the expected email address imposed on the subject to which the certificate was issued, and must match the email address listed in the Subject Alternative Name (SAN) field of the certificate.
-                                  The email should be a valid email address and at most 320 characters in length.
+                                  The email must be a valid email address and at most 320 characters in length.
                                 maxLength: 320
                                 type: string
                                 x-kubernetes-validations:
-                                - message: invalid email address in pkiCertificateSubject
+                                - message: invalid email address
                                   rule: self.matches('^\\S+@\\S+$')
                               hostname:
                                 description: |-
                                   hostname specifies the expected hostname imposed on the subject to which the certificate was issued, and it must match the hostname listed in the Subject Alternative Name (SAN) DNS field of the certificate.
-                                  The hostname should be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
-                                  It should consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
+                                  The hostname must be a valid dns 1123 subdomain name, optionally prefixed by '*.', and at most 253 characters in length.
+                                  It must consist only of lowercase alphanumeric characters, hyphens, periods and the optional preceding asterisk.
                                 maxLength: 253
                                 type: string
                                 x-kubernetes-validations:
-                                - message: hostname should be a valid dns 1123 subdomain
-                                    name, optionally prefixed by '*.'. It should consist
+                                - message: hostname must be a valid dns 1123 subdomain
+                                    name, optionally prefixed by '*.'. It must consist
                                     only of lowercase alphanumeric characters, hyphens,
                                     periods and the optional preceding asterisk.
                                   rule: 'self.startsWith(''*.'') ? !format.dns1123Subdomain().validate(self.replace(''*.'',
@@ -189,33 +216,52 @@ spec:
                         type: object
                       policyType:
                         description: |-
-                          policyType serves as the union's discriminator. Users are required to assign a value to this field, choosing one of the policy types that define the root of trust.
-                          "PublicKey" indicates that the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
-                          "FulcioCAWithRekor" indicates that the policy is based on the Fulcio certification and incorporates a Rekor verification.
-                          "PKI" indicates that the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
+                          policyType is a required field specifies the type of the policy for verification. This field must correspond to how the policy was generated.
+                          Allowed values are "PublicKey", "FulcioCAWithRekor", and "PKI".
+                          When set to "PublicKey", the policy relies on a sigstore publicKey and may optionally use a Rekor verification.
+                          When set to "FulcioCAWithRekor", the policy is based on the Fulcio certification and incorporates a Rekor verification.
+                          When set to "PKI", the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.
                         enum:
                         - PublicKey
                         - FulcioCAWithRekor
                         - PKI
                         type: string
                       publicKey:
-                        description: publicKey defines the root of trust based on
-                          a sigstore public key.
+                        description: |-
+                          publicKey defines the root of trust configuration based on a sigstore public key. Optionally include a Rekor public key for Rekor verification.
+                          publicKey is required when policyType is PublicKey, and forbidden otherwise.
                         properties:
                           keyData:
                             description: |-
-                              keyData contains inline base64-encoded data for the PEM format public key.
-                              KeyData must be at most 8192 characters.
+                              keyData is a required field contains inline base64-encoded data for the PEM format public key.
+                              keyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
+                            minLength: 68
                             type: string
+                            x-kubernetes-validations:
+                            - message: the keyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the keyData must end with base64 encoding of
+                                '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                           rekorKeyData:
                             description: |-
-                              rekorKeyData contains inline base64-encoded data for the PEM format from the Rekor public key.
+                              rekorKeyData is an optional field contains inline base64-encoded data for the PEM format from the Rekor public key.
                               rekorKeyData must be at most 8192 characters.
                             format: byte
                             maxLength: 8192
                             type: string
+                            x-kubernetes-validations:
+                            - message: the rekorKeyData must start with base64 encoding
+                                of '-----BEGIN PUBLIC KEY-----'.
+                              rule: string(self).startsWith('-----BEGIN PUBLIC KEY-----')
+                            - message: the rekorKeyData must end with base64 encoding
+                                of '-----END PUBLIC KEY-----'.
+                              rule: string(self).endsWith('-----END PUBLIC KEY-----\n')
+                                || string(self).endsWith('-----END PUBLIC KEY-----')
                         required:
                         - keyData
                         type: object
@@ -236,19 +282,19 @@ spec:
                       rule: 'has(self.policyType) && self.policyType == ''FulcioCAWithRekor''
                         ? has(self.fulcioCAWithRekor) : !has(self.fulcioCAWithRekor)'
                   signedIdentity:
-                    description: signedIdentity specifies what image identity the
-                      signature claims about the image. The required matchPolicy field
-                      specifies the approach used in the verification process to verify
-                      the identity in the signature and the actual image identity,
-                      the default matchPolicy is "MatchRepoDigestOrExact".
+                    description: |-
+                      signedIdentity is an optional field specifies what image identity the signature claims about the image. This is useful when the image identity in the signature differs from the original image spec, such as when mirror registry is configured for the image scope, the signature from the mirror registry contains the image identity of the mirror instead of the original scope.
+                      The required matchPolicy field specifies the approach used in the verification process to verify the identity in the signature and the actual image identity, the default matchPolicy is "MatchRepoDigestOrExact".
                     properties:
                       exactRepository:
-                        description: exactRepository is required if matchPolicy is
-                          set to "ExactRepository".
+                        description: |-
+                          exactRepository specifies the repository that must be exactly matched by the identity in the signature.
+                          exactRepository is required if matchPolicy is set to "ExactRepository". It is used to verify that the signature claims an identity matching this exact repository, rather than the original image identity.
                         properties:
                           repository:
                             description: |-
                               repository is the reference of the image identity to be matched.
+                              repository is required if matchPolicy is set to "ExactRepository".
                               The value should be a repository name (by omitting the tag or digest) in a registry implementing the "Docker Registry HTTP API V2". For example, docker.io/library/busybox
                             maxLength: 512
                             type: string
@@ -257,21 +303,25 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - repository
                         type: object
                       matchPolicy:
                         description: |-
-                          matchPolicy sets the type of matching to be used.
-                          Valid values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
-                          If set matchPolicy to ExactRepository, then the exactRepository must be specified.
-                          If set matchPolicy to RemapIdentity, then the remapIdentity must be specified.
-                          "MatchRepoDigestOrExact" means that the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
-                          "MatchRepository" means that the identity in the signature must be in the same repository as the image identity.
-                          "ExactRepository" means that the identity in the signature must be in the same repository as a specific identity specified by "repository".
-                          "RemapIdentity" means that the signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
+                          matchPolicy is a required filed specifies matching strategy to verify the image identity in the signature against the image scope.
+                          Allowed values are "MatchRepoDigestOrExact", "MatchRepository", "ExactRepository", "RemapIdentity". When omitted, the default value is "MatchRepoDigestOrExact".
+                          When set to "MatchRepoDigestOrExact", the identity in the signature must be in the same repository as the image identity if the image identity is referenced by a digest. Otherwise, the identity in the signature must be the same as the image identity.
+                          When set to "MatchRepository", the identity in the signature must be in the same repository as the image identity.
+                          When set to "ExactRepository", the exactRepository must be specified. The identity in the signature must be in the same repository as a specific identity specified by "repository".
+                          When set to "RemapIdentity", the remapIdentity must be specified. The signature must be in the same as the remapped image identity. Remapped image identity is obtained by replacing the "prefix" with the specified “signedPrefix” if the the image identity matches the specified remapPrefix.
                         enum:
                         - MatchRepoDigestOrExact
                         - MatchRepository
@@ -279,14 +329,16 @@ spec:
                         - RemapIdentity
                         type: string
                       remapIdentity:
-                        description: remapIdentity is required if matchPolicy is set
-                          to "RemapIdentity".
+                        description: |-
+                          remapIdentity specifies the prefix remapping rule for verifying image identity.
+                          remapIdentity is required if matchPolicy is set to "RemapIdentity". It is used to verify that the signature claims a different registry/repository prefix than the original image.
                         properties:
                           prefix:
                             description: |-
+                              prefix is required if matchPolicy is set to "RemapIdentity".
                               prefix is the prefix of the image identity to be matched.
                               If the image identity matches the specified prefix, that prefix is replaced by the specified “signedPrefix” (otherwise it is used as unchanged and no remapping takes place).
-                              This useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
+                              This is useful when verifying signatures for a mirror of some other repository namespace that preserves the vendor’s repository structure.
                               The prefix and signedPrefix values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -297,10 +349,17 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                           signedPrefix:
                             description: |-
+                              signedPrefix is required if matchPolicy is set to "RemapIdentity".
                               signedPrefix is the prefix of the image identity to be matched in the signature. The format is the same as "prefix". The values can be either host[:port] values (matching exactly the same host[:port], string), repository namespaces,
                               or repositories (i.e. they must not contain tags/digests), and match as prefixes of the fully expanded form.
                               For example, docker.io/library/busybox (not busybox) to specify that single repository, or docker.io/library (not an empty string) to specify the parent namespace of docker.io/library/busybox.
@@ -311,7 +370,13 @@ spec:
                                 should not include the tag or digest
                               rule: 'self.matches(''.*:([\\w][\\w.-]{0,127})$'')?
                                 self.matches(''^(localhost:[0-9]+)$''): true'
-                            - message: invalid repository or prefix in the signedIdentity
+                            - message: invalid repository or prefix in the signedIdentity.
+                                The repository or prefix must starts with 'localhost'
+                                or a valid '.' separated domain. If contains registry
+                                paths, the path component names must start with at
+                                least one letter or number, with following parts able
+                                to be separated by one period, one or two underscore
+                                and multiple dashes.
                               rule: self.matches('^(((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+(?::[0-9]+)?)|(localhost(?::[0-9]+)?))(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$')
                         required:
                         - prefix
@@ -334,12 +399,12 @@ spec:
                 type: object
               scopes:
                 description: |-
-                  scopes defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
+                  scopes is a required field that defines the list of image identities assigned to a policy. Each item refers to a scope in a registry implementing the "Docker Registry HTTP API V2".
                   Scopes matching individual images are named Docker references in the fully expanded form, either using a tag or digest. For example, docker.io/library/busybox:latest (not busybox:latest).
                   More general scopes are prefixes of individual-image scopes, and specify a repository (by omitting the tag or digest), a repository
                   namespace, or a registry host (by only specifying the host name and possibly a port number) or a wildcard expression starting with `*.`, for matching all subdomains (not including a port number).
                   Wildcards are only supported for subdomain matching, and may not be used in the middle of the host, i.e.  *.example.com is a valid case, but example*.*.com is not.
-                  If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
+                  This support no more than 256 scopes in one object. If multiple scopes match a given image, only the policy requirements for the most specific scope apply. The policy requirements for more general scopes are ignored.
                   In addition to setting a policy appropriate for your own deployed applications, make sure that a policy on the OpenShift image repositories
                   quay.io/openshift-release-dev/ocp-release, quay.io/openshift-release-dev/ocp-v4.0-art-dev (or on a more general scope) allows deployment of the OpenShift images required for cluster operation.
                   If a scope is configured in both the ClusterImagePolicy and the ImagePolicy, or if the scope in ImagePolicy is nested under one of the scopes from the ClusterImagePolicy, only the policy from the ClusterImagePolicy will be applied.
@@ -373,8 +438,9 @@ spec:
             description: status contains the observed state of the resource.
             properties:
               conditions:
-                description: conditions provide details on the status of this API
-                  Resource.
+                description: |-
+                  conditions provide details on the status of this API Resource.
+                  condition type 'Pending' indicates that the customer resource contains a policy that cannot take effect. It is either overwritten by a global policy or the image scope is not valid.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -429,6 +495,8 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 8
+                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - type

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -47,6 +47,9 @@
                     },
                     {
                         "name": "ShortCertRotation"
+                    },
+                    {
+                        "name": "SigstoreImageVerification"
                     }
                 ],
                 "enabled": [
@@ -271,9 +274,6 @@
                     },
                     {
                         "name": "SignatureStores"
-                    },
-                    {
-                        "name": "SigstoreImageVerification"
                     },
                     {
                         "name": "SigstoreImageVerificationPKI"

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -64,6 +64,9 @@
                         "name": "ShortCertRotation"
                     },
                     {
+                        "name": "SigstoreImageVerification"
+                    },
+                    {
                         "name": "VSphereMixedNodeEnv"
                     }
                 ],
@@ -274,9 +277,6 @@
                     },
                     {
                         "name": "SignatureStores"
-                    },
-                    {
-                        "name": "SigstoreImageVerification"
                     },
                     {
                         "name": "SigstoreImageVerificationPKI"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -29,6 +29,9 @@
                     },
                     {
                         "name": "ShortCertRotation"
+                    },
+                    {
+                        "name": "SigstoreImageVerification"
                     }
                 ],
                 "enabled": [
@@ -271,9 +274,6 @@
                     },
                     {
                         "name": "SignatureStores"
-                    },
-                    {
-                        "name": "SigstoreImageVerification"
                     },
                     {
                         "name": "SigstoreImageVerificationPKI"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -49,6 +49,9 @@
                         "name": "ShortCertRotation"
                     },
                     {
+                        "name": "SigstoreImageVerification"
+                    },
+                    {
                         "name": "VSphereMixedNodeEnv"
                     }
                 ],
@@ -274,9 +277,6 @@
                     },
                     {
                         "name": "SignatureStores"
-                    },
-                    {
-                        "name": "SigstoreImageVerification"
                     },
                     {
                         "name": "SigstoreImageVerificationPKI"


### PR DESCRIPTION
Added a commit to drop down the SigstoreImageVerification the gate from all sets

---

6b81288182527d8b26212eee6aca0b217e016076: Added commit to drop down the SigstoreImageVerification to DevPreview

- Test the cluster can launch with and without specifying techpreview
```
launch 4.20.0-0.nightly-2025-07-15-083124,https://github.com/openshift/api/pull/2384,https://github.com/openshift/machine-config-operator/pull/5143,https://github.com/openshift/cluster-update-keys/pull/74 aws,techpreview
```
- CRD, openshift policy is not available after TechPreviewNoUpgrade is enabled.

---
891ea2a0ab6149003a07a092ca3dce48ffd7bdb5: Test this PR with https://github.com/openshift/machine-config-operator/pull/5143, https://github.com/openshift/cluster-update-keys/pull/74:
- Test the cluster can launch with and without specifying `techpreview`

```
launch 4.20.0-0.nightly-2025-07-01-051543,https://github.com/openshift/machine-config-operator/pull/5143,https://github.com/openshift/api/pull/2384,https://github.com/openshift/cluster-update-keys/pull/74 aws,techpreview
```
On the TechPreviewNoUpgrade cluster, 
- Test to create v1 ClusterImagePolicy and ImagePolicy on the cluster.
- Run the migrated `openshift-tests run-test`  `OCPFeatureGate:SigstoreImageVerification` tests https://github.com/openshift/origin/pull/29973 on the cluster
