### PR TITLE
Revert "CNTRLPLANE-72: remove RoleBindingRestriction CRD from payload"

### DIFF
--- a/hack/update-payload-crds.sh
+++ b/hack/update-payload-crds.sh
@@ -3,6 +3,7 @@
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
 crd_globs="\
+    authorization/v1/zz_generated.crd-manifests/*_config-operator_*.crd*yaml\
     machine/v1/zz_generated.crd-manifests/*.crd*yaml\
     operator/v1/zz_generated.crd-manifests//*_config-operator_*.crd*yaml\
     operator/v1alpha1/zz_generated.crd-manifests//*_config-operator_*.crd*yaml\

--- a/payload-manifests/crds/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
+++ b/payload-manifests/crds/0000_03_config-operator_01_rolebindingrestrictions.crd.yaml
@@ -1,0 +1,225 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/bootstrap-required: "true"
+  name: rolebindingrestrictions.authorization.openshift.io
+spec:
+  group: authorization.openshift.io
+  names:
+    kind: RoleBindingRestriction
+    listKind: RoleBindingRestrictionList
+    plural: rolebindingrestrictions
+    singular: rolebindingrestriction
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          RoleBindingRestriction is an object that can be matched against a subject
+          (user, group, or service account) to determine whether rolebindings on that
+          subject are allowed in the namespace to which the RoleBindingRestriction
+          belongs.  If any one of those RoleBindingRestriction objects matches
+          a subject, rolebindings on that subject in the namespace are allowed.
+
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the matcher.
+            properties:
+              grouprestriction:
+                description: grouprestriction matches against group subjects.
+                nullable: true
+                properties:
+                  groups:
+                    description: |-
+                      groups is a list of groups used to match against an individual user's
+                      groups. If the user is a member of one of the whitelisted groups, the user
+                      is allowed to be bound to a role.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  labels:
+                    description: Selectors specifies a list of label selectors over
+                      group labels.
+                    items:
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    nullable: true
+                    type: array
+                type: object
+              serviceaccountrestriction:
+                description: serviceaccountrestriction matches against service-account
+                  subjects.
+                nullable: true
+                properties:
+                  namespaces:
+                    description: namespaces specifies a list of literal namespace
+                      names.
+                    items:
+                      type: string
+                    type: array
+                  serviceaccounts:
+                    description: serviceaccounts specifies a list of literal service-account
+                      names.
+                    items:
+                      description: |-
+                        ServiceAccountReference specifies a service account and namespace by their
+                        names.
+                      properties:
+                        name:
+                          description: name is the name of the service account.
+                          type: string
+                        namespace:
+                          description: |-
+                            namespace is the namespace of the service account.  Service accounts from
+                            inside the whitelisted namespaces are allowed to be bound to roles.  If
+                            Namespace is empty, then the namespace of the RoleBindingRestriction in
+                            which the ServiceAccountReference is embedded is used.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              userrestriction:
+                description: userrestriction matches against user subjects.
+                nullable: true
+                properties:
+                  groups:
+                    description: groups specifies a list of literal group names.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  labels:
+                    description: Selectors specifies a list of label selectors over
+                      user labels.
+                    items:
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    nullable: true
+                    type: array
+                  users:
+                    description: users specifies a list of literal user names.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
Reverts openshift/api#2138

Opening to run payload tests while investigating [OCPBUGS-58231](https://issues.redhat.com//browse/OCPBUGS-58231)

Narrowing down timeline for regressions to [4.20.0-0.nightly-2025-06-27-202106](https://sippy.dptools.openshift.org/sippy-ng/release/4.20/tags/4.20.0-0.nightly-2025-06-27-202106) and the [diff](https://sippy.dptools.openshift.org/api/payloads/diff?fromPayload=4.20.0-0.nightly-2025-06-27-150956&toPayload=4.20.0-0.nightly-2025-06-27-202106) show this as one of the changes.

Verified via multiple aggregate runs of
```
/payload-aggregate periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-ovn-fips 10
```

That the regression failure we have seen in payloads / ci / other suspected reverts is not present in these runs
```
: [sig-auth][Feature:SCC][Early] should not have pod creation failures during install [Suite:openshift/conformance/parallel] expand_less
Run #0: Failed expand_less 	5s
{  fail [github.com/openshift/origin/test/extended/authorization/scc.go:76]: 1 pods failed before test on SCC errors
Error creating: pods "event-exporter-867d8cd5d4-" is forbidden: unable to validate against any security context constraint: provider "restricted-v2": Forbidden: not usable by user or serviceaccount for ReplicaSet.apps/v1/event-exporter-867d8cd5d4 -n openshift-e2e-loki happened 11 times

Ginkgo exit error 1: exit with code 1}
```