### PR TITLE
Register v1 (cluster)imagepolicy

### DIFF
--- a/config/v1/register.go
+++ b/config/v1/register.go
@@ -72,6 +72,10 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ImageDigestMirrorSetList{},
 		&ImageTagMirrorSet{},
 		&ImageTagMirrorSetList{},
+		&ImagePolicy{},
+		&ImagePolicyList{},
+		&ClusterImagePolicy{},
+		&ClusterImagePolicyList{},
 	)
 	metav1.AddToGroupVersion(scheme, GroupVersion)
 	return nil


### PR DESCRIPTION

Register v1 type of ClusterImagePolicy and ImagePolicy. Follow-up PR of https://github.com/openshift/api/pull/2310