### PR TITLE
Disable schema checker overlap with KAL

### DIFF
--- a/tools/codegen/pkg/schemacheck/generator.go
+++ b/tools/codegen/pkg/schemacheck/generator.go
@@ -17,6 +17,7 @@ import (
 	kyaml "sigs.k8s.io/yaml"
 
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -95,6 +96,13 @@ func (g *generator) GenGroup(groupCtx generation.APIGroupContext) ([]generation.
 	errs := []error{}
 
 	comparatorOptions := options.NewComparatorOptions()
+
+	// Remove specific comparators from the default enabled list.
+	// These are all enabled by KAL now.
+	toRemove := []string{"NoBools", "NoFloats", "NoUints", "NoMaps", "ConditionsMustHaveProperSSATags"}
+	defaultSet := sets.NewString(comparatorOptions.DefaultEnabledComparators...)
+	comparatorOptions.DefaultEnabledComparators = defaultSet.Delete(toRemove...).List()
+
 	comparatorOptions.EnabledComparators = g.enabledComparators
 	comparatorOptions.DisabledComparators = g.disabledComparators
 


### PR DESCRIPTION
KAL now enables various checks to prevent bool/float/uint/map usage, and has a conditions check that checks for the correct SSA tags and that all conditions lists are now `metav1.Conditions` (apart from operators because we allow that in openshift).

These checks are no longer needed in schema checker and are creating noise (the map check doesn't allow `map[string]string` which we do allow in KAL)