### PR TITLE
makefile: bump-publish-kubebuilder-tools to 1.33.2

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -37,7 +37,7 @@ publish-kubebuilder-tools:
 	@# Pull secret should be the standard pull secret used for spinning up OpenShift clusters, if you do not have one, follow https://docs.google.com/document/d/1ez2jrjiIQJChobfSu2ISJ5uM_-3HGouamL_xIa2_1W4/edit#heading=h.me93l6citmsq
 	@# This also expects you to be already authenticated with the OpenShift GCE devel project on Google Cloud, if you are not,
 	@# follow the 'Create the Service Account and grant permissions' and 'Generate an access key' @# steps at https://docs.google.com/document/d/1qm37EKkjgoPtjW4909UClzvsjQO5VSpPUvFO_hW_PEg
-	go run ./publish-kubebuilder-tools/main.go -version v1.32.1 -output-dir /tmp/kubebuilder-tools -payload=registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2025-01-30-154351 -pull-secret $(PULL_SECRET) -index-file ../envtest-releases.yaml
+	go run ./publish-kubebuilder-tools/main.go -version v1.33.2 -output-dir /tmp/kubebuilder-tools -payload=registry.ci.openshift.org/ocp/release:4.20.0-0.ci-2025-07-17-072431 -pull-secret $(PULL_SECRET) -index-file ../envtest-releases.yaml
 
 #############################################
 #


### PR DESCRIPTION
Add to Makefile the newest version used to publish kubebuilder tools.