### PR TITLE
Fix kubebuilder tools/envtest index for v1.33.2 (add v prefix)

### DIFF
--- a/envtest-releases.yaml
+++ b/envtest-releases.yaml
@@ -51,16 +51,16 @@ releases:
         envtest-v1.32.1-linux-arm64.tar.gz:
             hash: 0bc52e6344ae0753715bc39c2878696c72a3129356df484835586165238361c109ad3e1ebd354af8ecdf1026c3a2b98ed225ad0c6dd348cb3ff128a7cfdcc2f8
             selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.32.1-linux-arm64.tar.gz
-    1.33.2:
-        envtest-1.33.2-darwin-amd64.tar.gz:
-            hash: 6010906133e390970eac6f700377a2d1a911bfce332905652529772722cd7ca37cdc43840cd166b7fbdebfdb4a5ab2d44ad319ce2d5308b5b4fa9b65dcd8ab88
-            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-1.33.2-darwin-amd64.tar.gz
-        envtest-1.33.2-darwin-arm64.tar.gz:
-            hash: 10faa97261845d620d531ccfdada7ffd18229b83862c4039d7abda6fd2c521e3d3e119d61f198447952321e44609fae99d224435d3603138e02a6c67ba4f48d6
-            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-1.33.2-darwin-arm64.tar.gz
-        envtest-1.33.2-linux-amd64.tar.gz:
-            hash: cd2ac59e78d8299b983e411f873c9216901b5bda9092bdec27c6946d85e1c906c3b687bbcf821db93ac968daa179a1fe2e97b2996ca00417ca9f07c1dfe87158
-            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-1.33.2-linux-amd64.tar.gz
-        envtest-1.33.2-linux-arm64.tar.gz:
-            hash: 4e6c8800b94a7ed9ffff45ec9afda307f27028a9f910b0b82ff593059c9c4428bb16cb1796aa80d91b6540b5e9a85a056e59ce237985bd829484d8445adb926d
-            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-1.33.2-linux-arm64.tar.gz
+    v1.33.2:
+        envtest-v1.33.2-darwin-amd64.tar.gz:
+            hash: d032acdc6f365059e20e22de6f78dd298e4cc48b379639c777032a97b7fe6a1d0c933f2a48879506231d57e4be9407ffc56b46485958023a766c4db3f1efb89e
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.33.2-darwin-amd64.tar.gz
+        envtest-v1.33.2-darwin-arm64.tar.gz:
+            hash: 51aa29ab015a1d1825e7155137fe30a2aafd311faf63486118d0dd026a9163c65d61e004a42b8e3ff624529734610b4dafdc12220d11d6c159ca9b3622f64497
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.33.2-darwin-arm64.tar.gz
+        envtest-v1.33.2-linux-amd64.tar.gz:
+            hash: 4f2749f668c49ac67651ca2c284252eea722aa37389c3808957a0e1a7783adf1c183aa07ff9623357b761b96022828bbd09dff019527032a474d923676835faf
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.33.2-linux-amd64.tar.gz
+        envtest-v1.33.2-linux-arm64.tar.gz:
+            hash: 9936eba66fd0170808268da4c0609b7e7d4d1b0de8607b0d3a9091539b4ec881041a9e08e7b4839708b11139bcc850acd34dfc0305ed955cc61fc3fae9da58f5
+            selfLink: https://storage.googleapis.com/openshift-kubebuilder-tools/envtest-v1.33.2-linux-arm64.tar.gz

--- a/tools/publish-kubebuilder-tools/README.md
+++ b/tools/publish-kubebuilder-tools/README.md
@@ -11,7 +11,7 @@ The archives are then optionally published to the release buck `openshift-kubebu
 
 `-pull-secret <string>`: The path to an OpenShift pull secret file that can pull from `registry.ci.openshift.org`
 `-payload <string>`: The payload image that should be used to create the artifacts. This should be from the CI stream. The format will be `registry.ci.openshift.org/ocp/release:<version>`
-`-version <string>`: The Kubernetes version to represent in the archives. This should be the Kubernetes release version from the payload, eg `1.29.1`.
+`-version <string>`: The Kubernetes version to represent in the archives. This should be the Kubernetes release version from the payload with the `v` prefix specified. eg `v1.29.1`.
 `-output-dir <string>`: A working directory to store the archives. The binaries will be extracted here and the archives will be created here.
 `-skip-upload <bool>`: Skip uploading the artifacts to the GCS bucket. This can be used if you are not authenticated to GCP.
 `-index-file <string>`: The path to the index file that should be updated with the new archives. This is optional and will default to `./envtest-releases.yaml`.

--- a/tools/publish-kubebuilder-tools/main.go
+++ b/tools/publish-kubebuilder-tools/main.go
@@ -44,6 +44,11 @@ func main() {
 		panic("output is required")
 	}
 
+	// We only expect Kubernetes versions that begin with the v prefix.
+	if !strings.HasPrefix(*version, "v") {
+		panic("Kubernetes version must begin with the v prefix. Example: v1.33.2")
+	}
+
 	// Decrypt the pull secret to get the bearer token.
 	registryAuthToken, err := getRegistryAuthToken(*pullSecretFile)
 	if err != nil {


### PR DESCRIPTION
- first commit rectifies issue with the previous https://github.com/openshift/api/pull/2407 PR by adding a `v` prefix version in the index
- second commit adds requirement about the `v` prefix in the documentation + a check in the tool to ensure it is specified.

Thanks @theobarberbany for the report.