### PR TITLE
CONSOLE-4665: Disable serving of old v1alpha1 CRD version

### DIFF
--- a/console/v1/manual-override-crd-manifests/consoleplugins.console.openshift.io/AAA_ungated.yaml
+++ b/console/v1/manual-override-crd-manifests/consoleplugins.console.openshift.io/AAA_ungated.yaml
@@ -152,5 +152,5 @@ spec:
         - metadata
         - spec
         type: object
-    served: true
+    served: false
     storage: false

--- a/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/90_consoleplugins.crd.yaml
@@ -498,5 +498,5 @@ spec:
         - metadata
         - spec
         type: object
-    served: true
+    served: false
     storage: false


### PR DESCRIPTION
Before removing of ConsolePlugin v1alpha1 CRD we need to set the serving of the old API version to false, based on the [docs](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/).

This is a followup of [slack conversation](https://redhat-internal.slack.com/archives/C07UX8H24G7/p1747852644645089)

/assign @JoelSpeed 
@spadgett FYI