### PR TITLE
Remove "techpreview" filter on verify job

### DIFF
--- a/tools/codegen/pkg/sippy/json_types.go
+++ b/tools/codegen/pkg/sippy/json_types.go
@@ -54,12 +54,6 @@ func QueriesFor(cloud, architecture, topology, networkStack, testPattern string)
 					ColumnField:   "variants",
 					Not:           false,
 					OperatorValue: "contains",
-					Value:         "FeatureSet:techpreview",
-				},
-				{
-					ColumnField:   "variants",
-					Not:           false,
-					OperatorValue: "contains",
 					Value:         fmt.Sprintf("Platform:%s", cloud),
 				},
 				{


### PR DESCRIPTION
`oc` is planning on introducing feature gated tests that would run /against/ a normal cluster (i.e. a CI job that doesn't have featureset=techpreview).  In order to collect these results, we need to remove the filter on featureset=techpreview.

For other FG, the tests only appear in jobs that are techpreview, so I believe removing this filter from Sippy's queries is a net neutral change.