### PR TITLE
CNF-13731: Add HTTP01ChallengeProxy

### DIFF
--- a/config/v1/tests/apiservers.config.openshift.io/HTTP01ChallengeProxy.yaml
+++ b/config/v1/tests/apiservers.config.openshift.io/HTTP01ChallengeProxy.yaml
@@ -1,0 +1,105 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "APIServer"
+crdName: apiservers.config.openshift.io
+featureGate: HTTP01ChallengeProxy
+tests:
+  onCreate:
+    - name: Should be able to create with HTTP01ChallengeProxy DefaultDeployment mode
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          http01ChallengeProxy:
+            mode: DefaultDeployment
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          audit:
+            profile: Default
+          http01ChallengeProxy:
+            mode: DefaultDeployment
+    - name: Should be able to create with HTTP01ChallengeProxy CustomDeployment mode
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          http01ChallengeProxy:
+            mode: CustomDeployment
+            customDeployment:
+              internalPort: 8888
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          audit:
+            profile: Default
+          http01ChallengeProxy:
+            mode: CustomDeployment
+            customDeployment:
+              internalPort: 8888
+    - name: Should be able to create with HTTP01ChallengeProxy CustomDeployment mode with custom port
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          http01ChallengeProxy:
+            mode: CustomDeployment
+            customDeployment:
+              internalPort: 9999
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          audit:
+            profile: Default
+          http01ChallengeProxy:
+            mode: CustomDeployment
+            customDeployment:
+              internalPort: 9999
+    - name: Should reject CustomDeployment mode without customDeployment field
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          http01ChallengeProxy:
+            mode: CustomDeployment
+      expectedError: "customDeployment is required when mode is CustomDeployment and forbidden otherwise"
+    - name: Should reject DefaultDeployment mode with customDeployment field
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          http01ChallengeProxy:
+            mode: DefaultDeployment
+            customDeployment:
+              internalPort: 8888
+      expectedError: "customDeployment is required when mode is CustomDeployment and forbidden otherwise"
+    - name: Should reject invalid mode
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          http01ChallengeProxy:
+            mode: InvalidMode
+      expectedError: "spec.http01ChallengeProxy.mode: Unsupported value: \"InvalidMode\": supported values: \"DefaultDeployment\", \"CustomDeployment\""
+    - name: Should reject port below minimum
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          http01ChallengeProxy:
+            mode: CustomDeployment
+            customDeployment:
+              internalPort: 1023
+      expectedError: "spec.http01ChallengeProxy.customDeployment.internalPort: Invalid value: 1023: spec.http01ChallengeProxy.customDeployment.internalPort in body should be greater than or equal to 1024"
+    - name: Should reject port above maximum
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: APIServer
+        spec:
+          http01ChallengeProxy:
+            mode: CustomDeployment
+            customDeployment:
+              internalPort: 65536
+      expectedError: "spec.http01ChallengeProxy.customDeployment.internalPort: Invalid value: 65536: spec.http01ChallengeProxy.customDeployment.internalPort in body should be less than or equal to 65535"

--- a/config/v1/types_apiserver.go
+++ b/config/v1/types_apiserver.go
@@ -68,6 +68,12 @@ type APIServerSpec struct {
 	// +optional
 	// +kubebuilder:default={profile: Default}
 	Audit Audit `json:"audit"`
+	// http01ChallengeProxy contains configuration for the HTTP01 challenge proxy
+	// that redirects traffic from the API endpoint on port 80 to ingress routers.
+	// This enables cert-manager to perform HTTP01 ACME challenges for API endpoint certificates.
+	// +openshift:enable:FeatureGate=HTTP01ChallengeProxy
+	// +optional
+	HTTP01ChallengeProxy *HTTP01ChallengeProxySpec `json:"http01ChallengeProxy,omitempty"`
 }
 
 // AuditProfileType defines the audit policy profile type.
@@ -233,6 +239,36 @@ const (
 	// encryption is still performed at the datastore layer.
 	EncryptionTypeKMS EncryptionType = "KMS"
 )
+
+// +union
+// +kubebuilder:validation:XValidation:rule="self.mode == 'CustomDeployment' ? has(self.customDeployment) : !has(self.customDeployment)",message="customDeployment is required when mode is CustomDeployment and forbidden otherwise"
+type HTTP01ChallengeProxySpec struct {
+	// mode controls whether the HTTP01 challenge proxy is active and how it should be deployed.
+	// DefaultDeployment enables the proxy with default configuration.
+	// CustomDeployment enables the proxy with user-specified configuration.
+	// +kubebuilder:validation:Enum=DefaultDeployment;CustomDeployment
+	// +required
+	// +unionDiscriminator
+	Mode string `json:"mode,omitempty"`
+
+	// customDeployment contains configuration options when mode is CustomDeployment.
+	// This field is only valid when mode is CustomDeployment.
+	// +optional
+	// +unionMember
+	CustomDeployment *HTTP01ChallengeProxyCustomDeploymentSpec `json:"customDeployment,omitempty"`
+}
+
+// +kubebuilder:validation:MinProperties=1
+type HTTP01ChallengeProxyCustomDeploymentSpec struct {
+	// internalPort specifies the internal port used by the proxy service.
+	// Valid values are 1024-65535. Defaults to 8888.
+	// This port is used to avoid conflicts with other workloads that may require port 8888 on the host.
+	// +kubebuilder:validation:Minimum=1024
+	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:default=8888
+	// +optional
+	InternalPort int32 `json:"internalPort,omitempty"`
+}
 
 type APIServerStatus struct {
 }

--- a/features/features.go
+++ b/features/features.go
@@ -866,4 +866,12 @@ var (
 						enhancementPR("https://github.com/openshift/enhancements/pull/1492").
 						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
+
+	FeatureGateHTTP01ChallengeProxy = newFeatureGate("HTTP01ChallengeProxy").
+					reportProblemsToJiraComponent("kube-apiserver").
+					contactPerson("sebrandon1").
+					productScope(ocpSpecific).
+					enhancementPR("https://github.com/openshift/enhancements/pull/1773").
+					enableIn(configv1.TechPreviewNoUpgrade).
+					mustRegister()
 )


### PR DESCRIPTION
Related to: https://github.com/openshift/enhancements/pull/1773

This is my first attempt at a FeatureGate so I'm expecting this to need a bunch of work.

### Additions to API Specification and Validation:

* Added `HTTP01ChallengeProxy` configuration to the `APIServerSpec` struct, allowing users to enable and configure the HTTP01 challenge proxy for API endpoint certificates. This includes options for `DefaultDeployment` and `CustomDeployment` modes. (`config/v1/types_apiserver.go`, [[1]](diffhunk://#diff-616d67895c3421c2d091662d30ed47b4b6f0b57db9411e29618d22b964ddb9efR71-R76) [[2]](diffhunk://#diff-616d67895c3421c2d091662d30ed47b4b6f0b57db9411e29618d22b964ddb9efR243-R272)

### Feature Gate Registration:

* Registered the new `HTTP01ChallengeProxy` feature gate in `features.go`, enabling it in the `TechPreviewNoUpgrade` scope and providing metadata such as a contact person and enhancement proposal link. (`features/features.go`, [features/features.goR869-R876](diffhunk://#diff-a8b6135d50534471326ea7bcd20e0f5eae25353f7788338060f718128a6a0b34R869-R876))

### Test Cases for Validation:

* Added comprehensive test cases in `HTTP01ChallengeProxy.yaml` to validate the behavior of the `HTTP01ChallengeProxy` configuration. Tests cover valid configurations, invalid modes, and boundary conditions for the `internalPort` field. (`config/v1/tests/apiservers.config.openshift.io/HTTP01ChallengeProxy.yaml`, [config/v1/tests/apiservers.config.openshift.io/HTTP01ChallengeProxy.yamlR1-R105](diffhunk://#diff-286873dc3e2d6b3790998283ffbed751db492cc94e68c2c7ba3845ee8310fcd6R1-R105))