### PR TITLE
Fix feature promotion check single node variant name

### DIFF
--- a/tools/codegen/cmd/featuregate-test-analyzer.go
+++ b/tools/codegen/cmd/featuregate-test-analyzer.go
@@ -371,14 +371,14 @@ var (
 		{
 			Cloud:        "aws",
 			Architecture: "amd64",
-			Topology:     "single-node",
+			Topology:     "single",
 		},
 
 		// TODO restore these once we run TechPreview jobs that contain them
 		//{
 		//	Cloud:        "metal-ipi",
 		//	Architecture: "amd64",
-		//	Topology:     "single-node",
+		//	Topology:     "single",
 		//},
 	}
 


### PR DESCRIPTION
The sippy variant is `single`, not `single-node`, for example see https://sippy.dptools.openshift.org/sippy-ng/tests/4.20/analysis?test=%5Bsig-cli%5D%5BOCPFeatureGate%3AUpgradeStatus%5D%20oc%20amd%20upgrade%20status%20never%20fails&filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-cli%5D%5BOCPFeatureGate%3AUpgradeStatus%5D%20oc%20amd%20upgrade%20status%20never%20fails%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22Topology%3Asingle%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D

CC @petr-muller  