### PR TITLE
OWNERS: update approvers/reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,7 @@
 reviewers:
-  - deads2k
   - JoelSpeed
   - everettraven
 approvers:
   - deads2k
   - JoelSpeed
+  - everettraven


### PR DESCRIPTION
to include everettraven and remove deads2k.

I've been shadowing @JoelSpeed as an API reviewer for ~8 months now and have actively been contributing to reviews and API-related tooling to improve the API review process.

As per a conversation with Joel, I'm adding myself as an approver and removing David Eads as a reviewer