### PR TITLE
NO-JIRA: New rules about CO's conditions

### DIFF
--- a/config/v1/types_cluster_operator.go
+++ b/config/v1/types_cluster_operator.go
@@ -158,11 +158,13 @@ const (
 	OperatorAvailable ClusterStatusConditionType = "Available"
 
 	// Progressing indicates that the component (operator and all configured operands)
-	// is actively rolling out new code, propagating config changes, or otherwise
+	// is actively rolling out new code, propagating config changes (e.g, a version change), or otherwise
 	// moving from one steady state to another. Operators should not report
-	// progressing when they are reconciling (without action) a previously known
-	// state. If the observed cluster state has changed and the component is
-	// reacting to it (scaling up for instance), Progressing should become true
+	// Progressing when they are reconciling (without action) a previously known
+	// state. Operators should not report Progressing only because DaemonSets owned by them
+	// are adjusting to a new node from cluster scaleup or a node rebooting from cluster upgrade.
+	// If the observed cluster state has changed and the component is
+	// reacting to it (updated proxy configuration for instance), Progressing should become true
 	// since it is moving from one steady state to another.
 	// A component in a cluster with less than 250 nodes must complete a version
 	// change within a limited period of time: 90 minutes for Machine Config Operator and 20 minutes for others.


### PR DESCRIPTION
This pull introduces a few new rules about Cluster Operator's conditions

- Operators MUST not go `Available=False` or `Degraded=True` in an HA cluster during an uneventful CI upgrade. This has been exercised in CI [OTA-700](https://issues.redhat.com/browse/OTA-700) and [TRT-1578](https://issues.redhat.com/browse/TRT-1578). It is expected to invest effort to fix bugs in this area.

- Operators MUST complete their upgrade within `20m` (with an exception of MCO within `90m`) in a cluster up to 250 nodes. This formalizes the changes introduced from [cluster-version-operator#1165](https://github.com/openshift/cluster-version-operator/pull/1165) where CVO begins complaining (Failing=Unknown) whenever an operator takes longer to upgrade than the given time. We plan to extend the CI coverage for this as well and spot violating cases and work on their fixes with the component team.

After this pull gets in, I will use API docs to update [dev-guide](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/clusteroperator.md#conditions).

