### PR TITLE
NO-JIRA: tooling: add crdify generator to run crdify against CRD changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ verify-scripts:
 	hack/verify-payload-featuregates.sh
 
 .PHONY: verify
-verify: verify-scripts lint verify-crd-schema verify-codegen-crds
+verify: verify-scripts lint verify-crd-schema verify-crdify verify-codegen-crds
 
 .PHONY: verify-codegen-crds
 verify-codegen-crds:
@@ -82,6 +82,10 @@ verify-codegen-crds:
 .PHONY: verify-crd-schema
 verify-crd-schema:
 	bash -x hack/verify-crd-schema-checker.sh
+
+.PHONY: verify-crdify
+verify-crdify:
+	bash -x hack/verify-crdify.sh
 
 .PHONY: verify-feature-promotion
 verify-feature-promotion:

--- a/hack/verify-crdify.sh
+++ b/hack/verify-crdify.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+# Use PULL_BASE_REF for CI, otherwise use master unless overriden.
+COMPARISON_BASE=${COMPARISON_BASE:-${PULL_BASE_SHA:-"master"}}
+
+# Use a trap so this gets printed at the end of the log even when we exit early due to an error/failure
+trap 'echo This verifier checks all files that have changed. In some cases you may have changed or renamed a file that \
+already contained api violations, but you are not introducing a new violation.  In such cases it is appropriate to /override the \
+failing CI job.' EXIT
+
+GENERATOR=crdify EXTRA_ARGS=--crdify:comparison-base=${COMPARISON_BASE} ${SCRIPT_ROOT}/hack/update-codegen.sh

--- a/tools/codegen/cmd/crdify.go
+++ b/tools/codegen/cmd/crdify.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/openshift/api/tools/codegen/pkg/crdify"
+	"github.com/openshift/api/tools/codegen/pkg/generation"
+	"github.com/spf13/cobra"
+)
+
+var crdifyComparisonBase = "master"
+
+func newCrdifyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "crdify",
+		Short: "crdify verifies compatibility of CRD API schemas",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			genCtx, err := generation.NewContext(generation.Options{
+				BaseDir:          baseDir,
+				APIGroupVersions: apiGroupVersions,
+			})
+			if err != nil {
+				return fmt.Errorf("could not build generation context: %w", err)
+			}
+
+			gen := crdify.NewGenerator(crdify.WithComparisonBase(crdifyComparisonBase))
+
+			return executeGenerators(genCtx, gen)
+		},
+	}
+
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(newCrdifyCommand())
+	rootCmd.PersistentFlags().StringVar(&crdifyComparisonBase, "crdify:comparison-base", crdifyComparisonBase, "base branch/commit to compare against")
+}

--- a/tools/codegen/pkg/crdify/generator.go
+++ b/tools/codegen/pkg/crdify/generator.go
@@ -1,0 +1,334 @@
+package crdify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	gitobject "github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/openshift/api/tools/codegen/pkg/generation"
+	"github.com/spf13/afero"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/loaders/composite"
+	"sigs.k8s.io/crdify/pkg/loaders/file"
+	"sigs.k8s.io/crdify/pkg/loaders/git"
+	"sigs.k8s.io/crdify/pkg/loaders/scheme"
+	"sigs.k8s.io/crdify/pkg/runner"
+	"sigs.k8s.io/crdify/pkg/validations"
+	kyaml "sigs.k8s.io/yaml"
+)
+
+type generatorOption func(*generator)
+
+// WithComparisonBase configures the git base used by the crdify generator
+// to load the "old" CRD.
+func WithComparisonBase(base string) generatorOption {
+	return func(g *generator) {
+		g.comparisonBase = base
+	}
+}
+
+// WithConfig configures the crdify configuration used by the crdify generator.
+func WithConfig(cfg *config.Config) generatorOption {
+	return func(g *generator) {
+		g.cfg = cfg
+	}
+}
+
+// WithValidationRegistry configures the validation registry used by the crdify generator.
+func WithValidationRegistry(registry validations.Registry) generatorOption {
+	return func(g *generator) {
+		g.validationRegistry = registry
+	}
+}
+
+// WithDisabled configures whether or not the crdify generator is disabled.
+func WithDisabled(disabled bool) generatorOption {
+	return func(g *generator) {
+		g.disabled = disabled
+	}
+}
+
+// generator implements the generation.Generator interface.
+// It is designed to verify the CRD schema updates for a particular API group.
+type generator struct {
+	disabled           bool
+	comparisonBase     string
+	cfg                *config.Config
+	validationRegistry validations.Registry
+}
+
+// NewGenerator returns a new generation.Generator
+// that runs crdify validations.
+// Optionally, callers can provide configuration
+// options to change the default behavior of the generator.
+func NewGenerator(opts ...generatorOption) generation.Generator {
+	defaultGenerator := &generator{
+		comparisonBase: "master",
+		cfg: &config.Config{
+			// Do not fail on currently unhandled changes.
+			// This matches the existing usage for crd-schema-checker
+			// where it will only fail if it identifies an explicitly
+			// failed validation.
+			// This is less strict than the default behavior of crdify,
+			// but also will result in less noise.
+			// We have confidence in our API reviewers to appropriately
+			// catch breaking changes that there are not validations for
+			// yet, and to check the presubmit jobs that run
+			// this generator for any warnings that may be present.
+			UnhandledEnforcement: config.EnforcementPolicyWarn,
+			Conversion:           config.ConversionPolicyNone,
+			Validations: []config.ValidationConfig{
+				// Allow addition of new enums
+				{
+					Name:        "enum",
+					Enforcement: config.EnforcementPolicyError,
+					Configuration: map[string]interface{}{
+						"additionPolicy": "Allow",
+					},
+				},
+				// Ignore any incompatibility detection
+				// for descriptions changes.
+				{
+					Name:        "description",
+					Enforcement: config.EnforcementPolicyNone,
+				},
+			},
+		},
+		validationRegistry: runner.DefaultRegistry(),
+	}
+
+	for _, opt := range opts {
+		opt(defaultGenerator)
+	}
+
+	return defaultGenerator
+}
+
+// Name returns the name of the generator.
+func (g *generator) Name() string {
+	return "crdify"
+}
+
+// ApplyConfig creates returns a new generator based on the configuration passed.
+// If the crdify configuration is empty, the existing generator is returned.
+func (g *generator) ApplyConfig(cfg *generation.Config) generation.Generator {
+	if cfg == nil || cfg.Crdify == nil {
+		return g
+	}
+
+	return NewGenerator(
+		WithDisabled(cfg.Crdify.Disabled),
+		WithConfig(cfg.Crdify.Config),
+		WithComparisonBase(g.comparisonBase),
+	)
+}
+
+// GenGroup runs the crdify generator against the given group context.
+func (g *generator) GenGroup(groupCtx generation.APIGroupContext) ([]generation.Result, error) {
+	if g.disabled {
+		klog.V(2).Infof("Skipping crdify check for %s", groupCtx.Name)
+		return nil, nil
+	}
+
+	errs := []error{}
+	results := []generation.Result{}
+
+	for _, version := range groupCtx.Versions {
+		klog.V(1).Infof("Verifying API schema for %s/%s", groupCtx.Name, version.Name)
+
+		r, err := g.genGroupVersion(groupCtx.Name, version)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("could not run crdify generator for group/version %s/%s: %w", groupCtx.Name, version.Name, err))
+		}
+
+		results = append(results, r...)
+	}
+
+	if len(errs) > 0 {
+		return results, kerrors.NewAggregate(errs)
+	}
+
+	return results, nil
+}
+
+// genGroupVersion runs the crdify generator against a particular version of the API group.
+func (g *generator) genGroupVersion(name string, version generation.APIVersionContext) ([]generation.Result, error) {
+	crdPaths, err := getCRDPathsForVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("getting CRD paths: %w", err)
+	}
+
+	results := []generation.Result{}
+	errs := []error{}
+
+	loader := composite.NewComposite(
+		map[string]composite.Loader{
+			scheme.SchemeFile: file.New(afero.OsFs{}),
+			scheme.SchemeGit:  git.New(),
+		},
+	)
+
+	for _, crdPath := range crdPaths {
+		oldCrd, err := loader.Load(context.TODO(), fmt.Sprintf("git://%s?path=%s", g.comparisonBase, crdPath))
+		if err != nil {
+			if errors.Is(err, gitobject.ErrFileNotFound) {
+				// No previous CRD existed for this path, ignore this path.
+				continue
+			}
+
+			errs = append(errs, fmt.Errorf("loading old CRD: %w", err))
+			continue
+		}
+
+		newCrd, err := loader.Load(context.TODO(), fmt.Sprintf("file://%s", crdPath))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("loading new CRD: %w", err))
+			continue
+		}
+
+		run, err := runner.New(g.cfg, g.validationRegistry)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("creating validation runner: %w", err))
+		}
+
+		runResults := run.Run(oldCrd, newCrd)
+
+		result := generation.Result{
+			Generator: g.Name(),
+			Group:     name,
+			Version:   version.Name,
+			Manifest:  crdPath,
+		}
+
+		for _, crdResults := range runResults.CRDValidation {
+			for _, err := range crdResults.Errors {
+				result.Errors = append(result.Errors, fmt.Errorf("%s: %w", crdResults.Name, errors.New(err)))
+			}
+
+			for _, warn := range crdResults.Warnings {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("%s: %s", crdResults.Name, warn))
+			}
+		}
+
+		versionedResultFunc := func(version, property string, compResult validations.ComparisonResult) {
+			for _, err := range compResult.Errors {
+				result.Errors = append(result.Errors, fmt.Errorf("(%s) %s - %s: %w", version, property, compResult.Name, errors.New(err)))
+			}
+
+			for _, warn := range compResult.Warnings {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("(%s) %s - %s: %s", version, property, compResult.Name, warn))
+			}
+		}
+
+		processVersionedPropertyResults(runResults.SameVersionValidation, versionedResultFunc)
+		processVersionedPropertyResults(runResults.ServedVersionValidation, versionedResultFunc)
+
+		results = append(results, result)
+	}
+
+	return results, nil
+}
+
+// processVersionedPropertyResults iterates over all version-property pairs and calls the provided processing function
+func processVersionedPropertyResults(vpr map[string]map[string][]validations.ComparisonResult, processFunc func(version, property string, cr validations.ComparisonResult)) {
+	for version, versionResults := range vpr {
+		for property, propertyResults := range versionResults {
+			for _, versionedPropertyResult := range propertyResults {
+				processFunc(version, property, versionedPropertyResult)
+			}
+		}
+	}
+}
+
+const (
+	// featureGatedCRDManifests is the folder name we use to generate
+	// partial CRD manifests.
+	featureGatedCRDManifests   = "zz_generated.featuregated-crd-manifests"
+	manualOverrideCRDManifests = "manual-override-crd-manifests"
+)
+
+// getCRDPathsForVersion returns a string slice containing all the relative paths
+// for CRDs in the provided generation.APIVersionContext.
+// A nil slice and an error are returned if any error occurs while building the
+// set of relative paths.
+func getCRDPathsForVersion(version generation.APIVersionContext) ([]string, error) {
+	contexts := []string{}
+
+	currDir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("getting current working directory: %w", err)
+	}
+
+	relativePath, err := filepath.Rel(currDir, version.Path)
+	if err != nil {
+		return nil, fmt.Errorf("determining relative path for version context: %w", err)
+	}
+
+	err = recursiveCRDFilesForPath(relativePath, sets.New(featureGatedCRDManifests, manualOverrideCRDManifests), func(path string) {
+		contexts = append(contexts, path)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("recursively building CRD file paths: %w", err)
+	}
+
+	return contexts, nil
+}
+
+func recursiveCRDFilesForPath(baseDir string, directoryIgnoreSet sets.Set[string], handleFunc func(path string)) error {
+	dirEntries, err := os.ReadDir(baseDir)
+	if err != nil {
+		return fmt.Errorf("getting entries for directory %q: %w", baseDir, err)
+	}
+
+	for _, fileInfo := range dirEntries {
+		filePath := filepath.Join(baseDir, fileInfo.Name())
+		if fileInfo.IsDir() {
+			if directoryIgnoreSet.Has(fileInfo.Name()) {
+				continue
+			}
+
+			err := recursiveCRDFilesForPath(filePath, directoryIgnoreSet, handleFunc)
+			if err != nil {
+				return fmt.Errorf("recursing into directory %s: %w", filePath, err)
+			}
+		}
+
+		if filepath.Ext(fileInfo.Name()) != ".yaml" {
+			continue
+		}
+
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("could not read file %s: %v", filePath, err)
+		}
+
+		partialObject := &metav1.PartialObjectMetadata{}
+		if err := kyaml.Unmarshal(data, partialObject); err != nil {
+			return fmt.Errorf("could not unmarshal YAML for type meta inspection: %v", err)
+		}
+
+		// Ignore any file that doesn't have a kind of CustomResourceDefinition.
+		if !isCustomResourceDefinition(partialObject) {
+			continue
+		}
+
+		handleFunc(filePath)
+	}
+
+	return nil
+}
+
+// isCustomResourceDefinition returns true if the object is a CustomResourceDefinition.
+// This is determined by the object having a Kind of CustomResourceDefinition and the
+// correct APIVersion.
+func isCustomResourceDefinition(partialObject *metav1.PartialObjectMetadata) bool {
+	return partialObject.APIVersion == apiextensionsv1.SchemeGroupVersion.String() && partialObject.Kind == "CustomResourceDefinition"
+}

--- a/tools/codegen/pkg/generation/types.go
+++ b/tools/codegen/pkg/generation/types.go
@@ -1,11 +1,19 @@
 package generation
 
+import (
+	crdifycfg "sigs.k8s.io/crdify/pkg/config"
+)
+
 // Config represents the configuration of a API group version
 // and the configuration for each generator within it.
 type Config struct {
 	// Compatibility represents the configuration of the compatiblity generator.
 	// When omitted, the default configuration will be used.
 	Compatibility *CompatibilityConfig `json:"compatibility,omitempty"`
+
+	// Crdify represents the configuration of the crdify generator.
+	// When omitted, the default configuration will be used.
+	Crdify *CrdifyConfig `json:"crdify,omitempty"`
 
 	// Deepcopy represents the configuration of the deepcopy generator.
 	// When omitted, the default configuration will be used.
@@ -46,6 +54,16 @@ type CompatibilityConfig struct {
 	// Disabled determines whether the compatibility generator should be run or not.
 	// This generator is enabled by default so this field defaults to false.
 	Disabled bool `json:"disabled,omitempty"`
+}
+
+type CrdifyConfig struct {
+	// Disabled determines whether the crdify generator should be run or not.
+	// This generator is enabled by default so this field defaults to false.
+	Disabled bool `json:"disabled,omitempty"`
+
+	// Config configures the validations that crdify performs and how they should be run.
+	// When omitted, a default configuration is used.
+	Config *crdifycfg.Config `json:"config,omitempty"`
 }
 
 // DeepcopyConfig is the configuration for the deepcopy generator.

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/openshift/crd-schema-checker v0.0.0-20250905140724-c313b6407231
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3
+	github.com/spf13/afero v1.14.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7
 	github.com/vmware-archive/yaml-patch v0.0.11
@@ -30,6 +31,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-tools v0.18.0
+	sigs.k8s.io/crdify v0.5.0
 	sigs.k8s.io/kube-api-linter v0.0.0-20250808120943-48643eb2563d
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -246,7 +248,6 @@ require (
 	github.com/skeema/knownhosts v1.2.2 // indirect
 	github.com/sonatard/noctx v0.1.0 // indirect
 	github.com/sourcegraph/go-diff v0.7.0 // indirect
-	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.12.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1001,6 +1001,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUo
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
+sigs.k8s.io/crdify v0.5.0 h1:mrMH9CgXQPTZUpTU6Klqfnlys8bggv/7uvLT2lXSP7A=
+sigs.k8s.io/crdify v0.5.0/go.mod h1:ZIFxaYNgKYmFtZCLPysncXQ8oqwnNlHQbRUfxJHZwzU=
 sigs.k8s.io/kube-api-linter v0.0.0-20250808120943-48643eb2563d h1:BcgCRoMLmIxRTLokQ1K1LAle+21fKPqgA6OvzN04xEg=
 sigs.k8s.io/kube-api-linter v0.0.0-20250808120943-48643eb2563d/go.mod h1:Jxl3NU9lRf9WJ8dgwgF4U6tLF229jR/KEvtxSwRAKnE=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -2409,6 +2409,23 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
+# sigs.k8s.io/crdify v0.5.0
+## explicit; go 1.24.0
+sigs.k8s.io/crdify/pkg/config
+sigs.k8s.io/crdify/pkg/loaders/composite
+sigs.k8s.io/crdify/pkg/loaders/file
+sigs.k8s.io/crdify/pkg/loaders/git
+sigs.k8s.io/crdify/pkg/loaders/scheme
+sigs.k8s.io/crdify/pkg/runner
+sigs.k8s.io/crdify/pkg/slices
+sigs.k8s.io/crdify/pkg/validations
+sigs.k8s.io/crdify/pkg/validations/crd/existingfieldremoval
+sigs.k8s.io/crdify/pkg/validations/crd/scope
+sigs.k8s.io/crdify/pkg/validations/crd/storedversionremoval
+sigs.k8s.io/crdify/pkg/validations/property
+sigs.k8s.io/crdify/pkg/validators/crd
+sigs.k8s.io/crdify/pkg/validators/version/same
+sigs.k8s.io/crdify/pkg/validators/version/served
 # sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8
 ## explicit; go 1.23
 sigs.k8s.io/json

--- a/tools/vendor/sigs.k8s.io/crdify/LICENSE
+++ b/tools/vendor/sigs.k8s.io/crdify/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/config/config.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/config/config.go
@@ -1,0 +1,264 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"sigs.k8s.io/yaml"
+)
+
+// EnforcementPolicy is a representation of how validations
+// should be enforced.
+type EnforcementPolicy string
+
+const (
+	// EnforcementPolicyError is used to represent that a validation
+	// should report an error when identifying incompatible changes.
+	EnforcementPolicyError EnforcementPolicy = "Error"
+
+	// EnforcementPolicyWarn is used to represent that a validation
+	// should report a warning when identifying incompatible changes.
+	EnforcementPolicyWarn EnforcementPolicy = "Warn"
+
+	// EnforcementPolicyNone is used to represent that a validation
+	// should not report anything when identifying incompatible changes.
+	EnforcementPolicyNone EnforcementPolicy = "None"
+)
+
+// ConversionPolicy is a representation of how the served version
+// validator should react when a CRD specifies a conversion
+// strategy.
+type ConversionPolicy string
+
+const (
+	// ConversionPolicyNone is used to represent that the served
+	// version validator should not treat CRDs with a conversion strategy
+	// differently and should run all the validations on detected changes
+	// across served versions of the CRD.
+	ConversionPolicyNone ConversionPolicy = "None"
+
+	// ConversionPolicyIgnore is used to represent that the served
+	// version validator should treat CRDs with a conversion strategy
+	// specified as a valid reason to skip running the validations
+	// on changes across served versions of the CRD.
+	ConversionPolicyIgnore ConversionPolicy = "Ignore"
+)
+
+// Config is the configuration used for dictating how validations
+// and validators should be configured.
+type Config struct {
+	// validations is an optional field used to configure the set of
+	// validations that should be run during comparisons.
+	//
+	// Configuration of validations is strictly additive.
+	// Default behaviors of validations will be used in the
+	// event they are not included in the set of configured validations.
+	Validations []ValidationConfig `json:"validations"`
+
+	// unhandledEnforcement is an optional field used to configure
+	// how changes that have not been handled by an existing validation
+	// should be treated.
+	//
+	// Allowed values are Error, Warn, and None.
+	//
+	// When set to Error, any unhandled changes will result in an error.
+	//
+	// When set to Warn, any unhandled changes will result in a warning.
+	//
+	// When set to None, unhandled changes will be ignored.
+	// Defaults to Error.
+	UnhandledEnforcement EnforcementPolicy `json:"unhandledEnforcement"`
+
+	// conversion is an optional field used to configure how validations
+	// are run against served versions of the CRD.
+	//
+	// Allowed values are None and Ignore.
+	//
+	// When set to Ignore, if a conversion strategy of "Webhook" is specified served
+	// versions will not be validated.
+	//
+	// When set to None, even if a conversion strategy of "Webhook" is specified served
+	// versions will be validated.
+	// Defaults to None.
+	Conversion ConversionPolicy `json:"conversion"`
+}
+
+// ValidationConfig is used to dictate how individual validations
+// should be configured.
+type ValidationConfig struct {
+	// name is a required field used to specify a validation.
+	// name must be a known validation.
+	Name string `json:"name"`
+
+	// enforcement is a required field used to specify how a validation
+	// should be enforced.
+	//
+	// Allowed values are Error, Warn, and None.
+	//
+	// When set to Error, any incompatibilities found by the validation
+	// will result in an error message.
+	//
+	// When set to Warn, any incompatibilities found by the validation
+	// will result in a warning message.
+	//
+	// When set to None, the validation will not be run.
+	Enforcement EnforcementPolicy `json:"enforcement"`
+
+	// configuration is an optional field used to specify a configuration
+	// for the validation.
+	Configuration map[string]interface{} `json:"configuration"`
+}
+
+// Load reads a file into a Config object and validates it.
+// If there are any errors encountered while loading the file contents
+// into the Config object a nil value and error will be returned.
+// Otherwise, a pointer to the Config object will be returned alongside a nil error.
+func Load(configFile string) (*Config, error) {
+	cfg := &Config{}
+
+	if configFile != "" {
+		//nolint:gosec
+		file, err := os.Open(configFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading config file %q: %w", configFile, err)
+		}
+
+		configBytes, err := io.ReadAll(file)
+		if err != nil {
+			return nil, fmt.Errorf("reading config file %q: %w", configFile, err)
+		}
+
+		err = file.Close()
+		if err != nil {
+			log.Print("failed to close config file after reading", configFile, err)
+		}
+
+		err = yaml.Unmarshal(configBytes, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshalling config file %q contents: %w", configFile, err)
+		}
+	}
+
+	err := ValidateConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// ValidateConfig ensures a valid Config object.
+// It will set defaults where appropriate and return an error
+// if user specified values are invalid.
+func ValidateConfig(cfg *Config) error {
+	if cfg == nil {
+		// nothing to validate
+		return nil
+	}
+
+	validationErr := ValidateValidations(cfg.Validations...)
+	unhandledEnforcementErr := ValidateEnforcementPolicy(&cfg.UnhandledEnforcement, false)
+	conversionErr := ValidateConversionPolicy(&cfg.Conversion)
+
+	return errors.Join(validationErr, unhandledEnforcementErr, conversionErr)
+}
+
+// ValidateConversionPolicy ensures the provided ConversionPolicy
+// is valid.
+// It will modify the ConversionPolicy to set it to the
+// default value of "None" if it is the empty string ("").
+// Returns an error if an invalid ConversionPolicy is specified.
+func ValidateConversionPolicy(policy *ConversionPolicy) error {
+	if policy == nil {
+		// nothing to validate
+		return nil
+	}
+
+	var err error
+
+	switch *policy {
+	case ConversionPolicyNone, ConversionPolicyIgnore:
+		// do nothing, valid values
+	case ConversionPolicy(""):
+		// default to None
+		*policy = ConversionPolicyNone
+	default:
+		err = fmt.Errorf("%w: %q", errUnknownConversionPolicy, *policy)
+	}
+
+	return err
+}
+
+var errUnknownConversionPolicy = errors.New("unknown conversion policy")
+
+// ValidateEnforcementPolicy ensures the provided EnforcementPolicy
+// is valid.
+// It will modify the EnforcementPolicy to set it to the
+// default value of "Error" if it is the empty string ("") and the EnforcementPolicy
+// is not required.
+// Returns an error if an invalid EnforcementPolicy is specified.
+func ValidateEnforcementPolicy(policy *EnforcementPolicy, required bool) error {
+	if policy == nil {
+		// nothing to validate
+		return nil
+	}
+
+	var err error
+
+	switch *policy {
+	case EnforcementPolicyError, EnforcementPolicyWarn, EnforcementPolicyNone:
+		// do nothing, valid values
+	case EnforcementPolicy(""):
+		if required {
+			err = errEnforcementRequired
+			break
+		}
+		// default to error
+		*policy = EnforcementPolicyError
+	default:
+		err = fmt.Errorf("%w: %q", errUnknownEnforcement, string(*policy))
+	}
+
+	return err
+}
+
+var (
+	errEnforcementRequired = errors.New("enforcement is required")
+	errUnknownEnforcement  = errors.New("unknown enforcement")
+)
+
+// ValidateValidations loops through the provided ValidationConfig
+// items to ensure they are valid.
+// Returns an aggregated error of the invalid ValidationConfig items.
+func ValidateValidations(validations ...ValidationConfig) error {
+	errs := []error{}
+
+	for i, validation := range validations {
+		if validation.Name == "" {
+			errs = append(errs, fmt.Errorf("validations[%d] is invalid: %w", i, errNameRequired))
+		}
+
+		errs = append(errs, ValidateEnforcementPolicy(&validation.Enforcement, true))
+	}
+
+	return errors.Join(errs...)
+}
+
+var errNameRequired = errors.New("name is required")

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/loaders/composite/composite.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/loaders/composite/composite.go
@@ -1,0 +1,78 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package composite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+// Loader is used to load a CustomResourceDefinition from a source location.
+type Loader interface {
+	// Load uses the provided context and URL to determine how to
+	// source a CustomResourceDefinition.
+	// Upon successful sourcing, a non-nil CustomResourceDefinition and a nil error should be returned.
+	// Upon failed sourcing, a nil CustomResourceDefinition and a non-nil error should be returned.
+	Load(context.Context, *url.URL) (*apiextensionsv1.CustomResourceDefinition, error)
+}
+
+// Composite is a utility type that is used to encapsulate
+// the behavior of multiple loaders into a single implementation.
+// It uses the scheme of a URL as the key for which encapsulated Loader
+// to execute.
+type Composite struct {
+	// loaders is the set of loaders than can be used
+	loaders map[string]Loader
+}
+
+// NewComposite creates a new Composite loader configured with the provided
+// loaders.
+func NewComposite(loaders map[string]Loader) *Composite {
+	composite := &Composite{
+		loaders: loaders,
+	}
+
+	return composite
+}
+
+// Load is used to source a CustomResourceDefinition using the provided context and source string.
+// The source string is expected to be a parseable URL using Go's net/url.Parse() function.
+// Depending on the scheme of the parsed URL, Load will call a nested Loader implementation
+// to source the CustomResourceDefinition.
+func (c *Composite) Load(ctx context.Context, location string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	locationURL, err := url.Parse(location)
+	if err != nil {
+		log.Fatalf("parsing source: %v", err)
+	}
+
+	loader, ok := c.loaders[locationURL.Scheme]
+	if !ok {
+		return nil, fmt.Errorf("%w : %q", errNoLoader, locationURL.Scheme)
+	}
+
+	crd, err := loader.Load(ctx, locationURL)
+	if err != nil {
+		return nil, fmt.Errorf("loading CustomResourceDefinition: %w", err)
+	}
+
+	return crd, nil
+}
+
+var errNoLoader = errors.New("no loader found for provided scheme")

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/loaders/file/file.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/loaders/file/file.go
@@ -1,0 +1,74 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// File is a Loader implementation to load a CustomResourceDefinition
+// from a file.
+type File struct {
+	// filesystem is the filesystem used to load the file containing
+	// the CustomResourceDefinition.
+	filesystem afero.Fs
+}
+
+// New returns a new instance of the File Loader
+// using the provided afero.Fs as the underlying file system.
+func New(filesystem afero.Fs) *File {
+	return &File{
+		filesystem: filesystem,
+	}
+}
+
+// Load parses the hostname and path of the provided URL to determine the file containing the CustomResourceDefinition
+// and reads it into a new CustomResourceDefinition object.
+func (f *File) Load(_ context.Context, location *url.URL) (*apiextensionsv1.CustomResourceDefinition, error) {
+	filePath, err := filepath.Abs(path.Join(location.Hostname(), location.Path))
+	if err != nil {
+		return nil, fmt.Errorf("ensuring absolute path: %w", err)
+	}
+
+	file, err := f.filesystem.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening file %q: %w", filePath, err)
+	}
+	//nolint:errcheck
+	defer file.Close()
+
+	fileBytes, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("reading file %q: %w", filePath, err)
+	}
+
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+
+	err = yaml.Unmarshal(fileBytes, crd)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling contents of file %q: %w", filePath, err)
+	}
+
+	return crd, nil
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/loaders/git/git.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/loaders/git/git.go
@@ -1,0 +1,103 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// Git is a Loader implementation for loading a CustomResourceDefinition
+// from a git repository.
+type Git struct{}
+
+// New returns a new instance of the Git Loader.
+func New() *Git {
+	return &Git{}
+}
+
+// Load loads the CustomResourceDefinition from the git revision and file path specified in the URL.
+// It reads a query key named 'path' for the file path and uses the hostname for the revision.
+// For example, 'git://main?path=foo/bar/file.yaml' would source the CustomResourceDefinition from the
+// main branch of the git repository using the file 'foo/bar/file.yaml'.
+func (g *Git) Load(_ context.Context, location *url.URL) (*apiextensionsv1.CustomResourceDefinition, error) {
+	filePath := location.Query().Get("path")
+
+	repo, err := gogit.PlainOpen("")
+	if err != nil {
+		return nil, fmt.Errorf("opening repository: %w", err)
+	}
+
+	rev := plumbing.Revision(location.Hostname())
+
+	hash, err := repo.ResolveRevision(rev)
+	if err != nil {
+		return nil, fmt.Errorf("calculating hash for revision %q: %w", rev, err)
+	}
+
+	crd, err := LoadCRDFileFromRepositoryWithRef(repo, hash, filePath)
+	if err != nil {
+		return nil, fmt.Errorf("loading CRD: %w", err)
+	}
+
+	return crd, nil
+}
+
+// LoadCRDFileFromRepositoryWithRef loads a CustomResourceDefinition from the provided
+// git.Repository using the provided git ref and file name.
+func LoadCRDFileFromRepositoryWithRef(repo *gogit.Repository, ref *plumbing.Hash, filename string) (*apiextensionsv1.CustomResourceDefinition, error) {
+	commit, err := repo.CommitObject(*ref)
+	if err != nil {
+		return nil, fmt.Errorf("getting commit object from repo for ref %v: %w", ref, err)
+	}
+
+	tree, err := repo.TreeObject(commit.TreeHash)
+	if err != nil {
+		return nil, fmt.Errorf("getting tree object from repo for tree hash %v: %w", commit.TreeHash, err)
+	}
+
+	file, err := tree.File(filename)
+	if err != nil {
+		return nil, fmt.Errorf("getting file %q from repo for tree hash %v: %w", filename, commit.TreeHash, err)
+	}
+
+	reader, err := file.Reader()
+	if err != nil {
+		return nil, fmt.Errorf("getting reader for blob for file %q from repo with ref %v: %w", filename, commit.TreeHash, err)
+	}
+	//nolint:errcheck
+	defer reader.Close()
+
+	crdBytes, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("reading content of blob for file %q from repo with ref %v: %w", filename, commit.TreeHash, err)
+	}
+
+	loadedCRD := &apiextensionsv1.CustomResourceDefinition{}
+
+	err = yaml.Unmarshal(crdBytes, loadedCRD)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling content of blob for file %q from repo with ref %v: %w", filename, commit.TreeHash, err)
+	}
+
+	return loadedCRD, nil
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/loaders/scheme/schemes.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/loaders/scheme/schemes.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheme
+
+// Scheme is representation of the schemes that correspond
+// to Loader types.
+type Scheme string
+
+const (
+	// SchemeKubernetes represents the scheme used to
+	// signal that a Loader should load from Kubernetes.
+	SchemeKubernetes = "kube"
+
+	// SchemeGit represents the scheme used to signal
+	// that a Loader should load from a git repository.
+	SchemeGit = "git"
+
+	// SchemeFile represents the scheme used to signal
+	// that a Loader should load from a file.
+	SchemeFile = "file"
+)

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/runner/registry.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/runner/registry.go
@@ -1,0 +1,50 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"sigs.k8s.io/crdify/pkg/validations"
+	"sigs.k8s.io/crdify/pkg/validations/crd/existingfieldremoval"
+	"sigs.k8s.io/crdify/pkg/validations/crd/scope"
+	"sigs.k8s.io/crdify/pkg/validations/crd/storedversionremoval"
+	"sigs.k8s.io/crdify/pkg/validations/property"
+)
+
+//nolint:gochecknoglobals
+var defaultRegistry = validations.NewRegistry()
+
+func init() {
+	existingfieldremoval.Register(defaultRegistry)
+	scope.Register(defaultRegistry)
+	storedversionremoval.Register(defaultRegistry)
+	property.RegisterDefault(defaultRegistry)
+	property.RegisterEnum(defaultRegistry)
+	property.RegisterMaximum(defaultRegistry)
+	property.RegisterMaxItems(defaultRegistry)
+	property.RegisterMaxLength(defaultRegistry)
+	property.RegisterMaxProperties(defaultRegistry)
+	property.RegisterMinimum(defaultRegistry)
+	property.RegisterMinItems(defaultRegistry)
+	property.RegisterMinLength(defaultRegistry)
+	property.RegisterMinProperties(defaultRegistry)
+	property.RegisterRequired(defaultRegistry)
+	property.RegisterType(defaultRegistry)
+	property.RegisterDescription(defaultRegistry)
+}
+
+// DefaultRegistry returns a pre-configured validations.Registry.
+func DefaultRegistry() validations.Registry {
+	return defaultRegistry
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/runner/results.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/runner/results.go
@@ -1,0 +1,299 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+// Results is a utility type to hold the validation results of
+// running different validators.
+type Results struct {
+	// CRDValidation is the set of validation comparison results
+	// at the whole CustomResourceDefinition scope
+	CRDValidation []validations.ComparisonResult `json:"crdValidation,omitempty"`
+
+	// SameVersionValidation is the set of validation comparison
+	// results at the CustomResourceDefinition version level. Specifically
+	// for same version comparisons across an old and new CustomResourceDefinition
+	// instance (i.e comparing v1alpha1 with v1alpha1)
+	SameVersionValidation map[string]map[string][]validations.ComparisonResult `json:"sameVersionValidation,omitempty"`
+
+	// ServedVersionValidation is the set of validation comparison
+	// results at the CustomResourceDefinition version level. Specifically
+	// for served version comparisons across an old and new CustomResourceDefinition
+	// instance (i.e comparing v1alpha1 with v1 if both are served)
+	ServedVersionValidation map[string]map[string][]validations.ComparisonResult `json:"servedVersionValidation,omitempty"`
+}
+
+// Format is a representation of an output format.
+type Format string
+
+const (
+	// FormatJSON represents a JSON output format.
+	FormatJSON Format = "json"
+
+	// FormatYAML represents a YAML output format.
+	FormatYAML Format = "yaml"
+
+	// FormatPlainText represents a PlainText output format.
+	FormatPlainText Format = "plaintext"
+
+	// FormatMarkdown represents a Markdown output format.
+	FormatMarkdown Format = "markdown"
+)
+
+// Render returns the string representation of the provided
+// format or an error if one is encountered.
+// Currently supported render formats are json, yaml, plaintext, and markdown.
+// Unknown formats will result in an error.
+func (rr *Results) Render(format Format) (string, error) {
+	switch format {
+	case FormatJSON:
+		return rr.RenderJSON()
+	case FormatYAML:
+		return rr.RenderYAML()
+	case FormatMarkdown:
+		return rr.RenderMarkdown(), nil
+	case FormatPlainText:
+		return rr.RenderPlainText(), nil
+	default:
+		return "", fmt.Errorf("%w : %q", errUnknownRenderFormat, format)
+	}
+}
+
+var errUnknownRenderFormat = errors.New("unknown render format")
+
+// RenderJSON returns a string of the results rendered in JSON or an error.
+func (rr *Results) RenderJSON() (string, error) {
+	outBytes, err := json.MarshalIndent(rr, "", " ")
+	return string(outBytes), err
+}
+
+// RenderYAML returns a string of the results rendered in YAML or an error.
+func (rr *Results) RenderYAML() (string, error) {
+	outBytes, err := yaml.Marshal(rr)
+	return string(outBytes), err
+}
+
+// RenderMarkdown returns a string of the results rendered as Markdown
+//
+//nolint:dupl
+func (rr *Results) RenderMarkdown() string { //nolint:gocognit,cyclop
+	var out strings.Builder
+
+	out.WriteString("# CRD Validations\n")
+
+	for _, result := range rr.CRDValidation {
+		if len(result.Errors) > 0 {
+			for _, err := range result.Errors {
+				out.WriteString(fmt.Sprintf("- **%s** - `ERROR` - %s\n", result.Name, err))
+			}
+		}
+
+		if len(result.Warnings) > 0 {
+			for _, err := range result.Warnings {
+				out.WriteString(fmt.Sprintf("- **%s** - `WARNING` - %s\n", result.Name, err))
+			}
+		}
+
+		if len(result.Errors) == 0 && len(result.Warnings) == 0 {
+			out.WriteString(fmt.Sprintf("- **%s** - ✓\n", result.Name))
+		}
+	}
+
+	out.WriteString("\n\n")
+	out.WriteString("# Same Version Validations\n")
+
+	for version, result := range rr.SameVersionValidation {
+		for property, results := range result {
+			for _, propertyResult := range results {
+				if len(propertyResult.Errors) > 0 {
+					for _, err := range propertyResult.Errors {
+						out.WriteString(fmt.Sprintf("- **%s** - *%s* - %s - `ERROR` - %s\n", version, property, propertyResult.Name, err))
+					}
+				}
+
+				if len(propertyResult.Warnings) > 0 {
+					for _, err := range propertyResult.Warnings {
+						out.WriteString(fmt.Sprintf("- **%s** - *%s* - %s - `WARNING` - %s\n", version, property, propertyResult.Name, err))
+					}
+				}
+
+				if len(propertyResult.Errors) == 0 && len(propertyResult.Warnings) == 0 {
+					out.WriteString(fmt.Sprintf("- **%s** - *%s* - %s - ✓\n", version, property, propertyResult.Name))
+				}
+			}
+		}
+	}
+
+	out.WriteString("\n\n")
+	out.WriteString("# Served Version Validations\n")
+
+	for version, result := range rr.ServedVersionValidation {
+		for property, results := range result {
+			for _, propertyResult := range results {
+				if len(propertyResult.Errors) > 0 {
+					for _, err := range propertyResult.Errors {
+						out.WriteString(fmt.Sprintf("- **%s** - *%s* - %s - `ERROR` - %s\n", version, property, propertyResult.Name, err))
+					}
+				}
+
+				if len(propertyResult.Warnings) > 0 {
+					for _, err := range propertyResult.Warnings {
+						out.WriteString(fmt.Sprintf("- **%s** - *%s* - %s - `WARNING` - %s\n", version, property, propertyResult.Name, err))
+					}
+				}
+
+				if len(propertyResult.Errors) == 0 && len(propertyResult.Warnings) == 0 {
+					out.WriteString(fmt.Sprintf("- **%s** - *%s* - %s - ✓\n", version, property, propertyResult.Name))
+				}
+			}
+		}
+	}
+
+	return out.String()
+}
+
+// RenderPlainText returns a string of the results rendered as PlainText
+//
+//nolint:dupl
+func (rr *Results) RenderPlainText() string { //nolint:gocognit,cyclop
+	var out strings.Builder
+
+	out.WriteString("CRD Validations\n")
+
+	for _, result := range rr.CRDValidation {
+		if len(result.Errors) > 0 {
+			for _, err := range result.Errors {
+				out.WriteString(fmt.Sprintf("- %s - ERROR - %s\n", result.Name, err))
+			}
+		}
+
+		if len(result.Warnings) > 0 {
+			for _, err := range result.Warnings {
+				out.WriteString(fmt.Sprintf("- %s - WARNING - %s\n", result.Name, err))
+			}
+		}
+
+		if len(result.Errors) == 0 && len(result.Warnings) == 0 {
+			out.WriteString(fmt.Sprintf("- %s - ✓\n", result.Name))
+		}
+	}
+
+	out.WriteString("\n\n")
+	out.WriteString("Same Version Validations\n")
+
+	for version, result := range rr.SameVersionValidation {
+		for property, results := range result {
+			for _, propertyResult := range results {
+				if len(propertyResult.Errors) > 0 {
+					for _, err := range propertyResult.Errors {
+						out.WriteString(fmt.Sprintf("- %s - %s - %s - ERROR - %s\n", version, property, propertyResult.Name, err))
+					}
+				}
+
+				if len(propertyResult.Warnings) > 0 {
+					for _, err := range propertyResult.Warnings {
+						out.WriteString(fmt.Sprintf("- %s - %s - %s - WARNING - %s\n", version, property, propertyResult.Name, err))
+					}
+				}
+
+				if len(propertyResult.Errors) == 0 && len(propertyResult.Warnings) == 0 {
+					out.WriteString(fmt.Sprintf("- %s - %s - %s - ✓\n", version, property, propertyResult.Name))
+				}
+			}
+		}
+	}
+
+	out.WriteString("\n\n")
+	out.WriteString("Served Version Validations\n")
+
+	for version, result := range rr.ServedVersionValidation {
+		for property, results := range result {
+			for _, propertyResult := range results {
+				if len(propertyResult.Errors) > 0 {
+					for _, err := range propertyResult.Errors {
+						out.WriteString(fmt.Sprintf("- %s - %s - %s - ERROR - %s\n", version, property, propertyResult.Name, err))
+					}
+				}
+
+				if len(propertyResult.Warnings) > 0 {
+					for _, err := range propertyResult.Warnings {
+						out.WriteString(fmt.Sprintf("- %s - %s - %s - WARNING - %s\n", version, property, propertyResult.Name, err))
+					}
+				}
+
+				if len(propertyResult.Errors) == 0 && len(propertyResult.Warnings) == 0 {
+					out.WriteString(fmt.Sprintf("- %s - %s - %s - ✓\n", version, property, propertyResult.Name))
+				}
+			}
+		}
+	}
+
+	return out.String()
+}
+
+// HasFailures returns a boolean signaling if any of the validation results contain any errors.
+func (rr *Results) HasFailures() bool {
+	return rr.HasCRDValidationFailures() || rr.HasSameVersionValidationFailures() || rr.HasServedVersionValidationFailures()
+}
+
+// HasCRDValidationFailures returns a boolean signaling if the CRD scoped validations contain any errors.
+func (rr *Results) HasCRDValidationFailures() bool {
+	for _, result := range rr.CRDValidation {
+		if len(result.Errors) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasSameVersionValidationFailures returns a boolean signaling if the same version validations contain any errors.
+func (rr *Results) HasSameVersionValidationFailures() bool {
+	for _, versionResults := range rr.SameVersionValidation {
+		for _, propertyResults := range versionResults {
+			for _, result := range propertyResults {
+				if len(result.Errors) > 0 {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// HasServedVersionValidationFailures returns a boolean signaling if the served version validations contain any errors.
+func (rr *Results) HasServedVersionValidationFailures() bool {
+	for _, versionResults := range rr.ServedVersionValidation {
+		for _, propertyResults := range versionResults {
+			for _, result := range propertyResults {
+				if len(result.Errors) > 0 {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/runner/runner.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/runner/runner.go
@@ -1,0 +1,74 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+	"sigs.k8s.io/crdify/pkg/validators/crd"
+	"sigs.k8s.io/crdify/pkg/validators/version/same"
+	"sigs.k8s.io/crdify/pkg/validators/version/served"
+)
+
+// Runner is a utility struct for running
+// - Whole CRD validations
+// - Same version validations
+// - Served version validations.
+type Runner struct {
+	crdValidator           *crd.Validator
+	sameVersionValidator   *same.Validator
+	servedVersionValidator *served.Validator
+}
+
+// New returns a new instance of a Runner using the provided Config and validations.Registry
+// to build the CRD, same version, and served version validators.
+// It returns an error if any errors are encountered.
+func New(cfg *config.Config, registry validations.Registry) (*Runner, error) {
+	initialValidations, err := validations.LoadValidationsFromRegistry(registry)
+	if err != nil {
+		return nil, fmt.Errorf("loading validations from registry: %w", err)
+	}
+
+	configuredValidations, err := validations.ConfigureValidations(initialValidations, registry, *cfg)
+	if err != nil {
+		return nil, fmt.Errorf("configuring validations: %w", err)
+	}
+
+	vals := slices.Collect(maps.Values(configuredValidations))
+
+	crdComparators := validations.ComparatorsForValidations[apiextensionsv1.CustomResourceDefinition](vals...)
+	propertyComparators := validations.ComparatorsForValidations[apiextensionsv1.JSONSchemaProps](vals...)
+
+	return &Runner{
+		crdValidator:           crd.New(crd.WithComparators(crdComparators...)),
+		sameVersionValidator:   same.New(same.WithComparators(propertyComparators...), same.WithUnhandledEnforcementPolicy(cfg.UnhandledEnforcement)),
+		servedVersionValidator: served.New(served.WithComparators(propertyComparators...), served.WithUnhandledEnforcementPolicy(cfg.UnhandledEnforcement), served.WithConversionPolicy(cfg.Conversion)),
+	}, nil
+}
+
+// Run executes all the validators and collects the results into a utility struct for
+// reporting and evaluating the results.
+func (i *Runner) Run(oldCrd, newCrd *apiextensionsv1.CustomResourceDefinition) *Results {
+	return &Results{
+		CRDValidation:           i.crdValidator.Validate(oldCrd, newCrd),
+		SameVersionValidation:   i.sameVersionValidator.Validate(oldCrd, newCrd),
+		ServedVersionValidation: i.servedVersionValidator.Validate(oldCrd, newCrd),
+	}
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/slices/translate.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/slices/translate.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package slices
+
+// Translate is a generic function for translating an input slice
+// of type S into a new slice of type E.
+func Translate[S any, E any](translation func(S) E, in ...S) []E {
+	e := []E{}
+
+	for _, s := range in {
+		e = append(e, translation(s))
+	}
+
+	return e
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/compare.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/compare.go
@@ -1,0 +1,82 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/crdify/pkg/config"
+)
+
+// CompareVersions calculates the diff in the provided old and new CustomResourceDefinitionVersions and
+// compares the differing properties using the provided comparators.
+// An 'unhandled' comparator will be injected to evaluate any unhandled changes by the provided comparators
+// that will be enforced based on the provided unhandled enforcement policy.
+// Returns a map[string][]ComparisonResult, where the map key is the flattened property path (i.e ^.spec.foo.bar).
+func CompareVersions(a, b apiextensionsv1.CustomResourceDefinitionVersion, unhandledEnforcement config.EnforcementPolicy, comparators ...Comparator[apiextensionsv1.JSONSchemaProps]) map[string][]ComparisonResult {
+	oldFlattened := FlattenCRDVersion(a)
+	newFlattened := FlattenCRDVersion(b)
+
+	diffs := FlattenedCRDVersionDiff(oldFlattened, newFlattened)
+
+	result := map[string][]ComparisonResult{}
+
+	for property, diff := range diffs {
+		result[property] = CompareProperties(diff.Old, diff.New, unhandledEnforcement, comparators...)
+	}
+
+	return result
+}
+
+// CompareProperties compares the provided JSONSchemaProps using the provided comparators.
+// An 'unhandled' comparator will be injected to evaluate any unhandled changes by the provided
+// comparators that will be enforced based on the provided unhandled enforcement policy.
+// Returns a slice containing all the comparison results.
+func CompareProperties(a, b *apiextensionsv1.JSONSchemaProps, unhandledEnforcement config.EnforcementPolicy, comparators ...Comparator[apiextensionsv1.JSONSchemaProps]) []ComparisonResult {
+	result := []ComparisonResult{}
+	aCopy, bCopy := a.DeepCopy(), b.DeepCopy()
+
+	for _, comparator := range comparators {
+		comparisonResult := comparator.Compare(aCopy, bCopy)
+		result = append(result, comparisonResult)
+	}
+
+	// checking for unhandled changes is _always_ performed last.
+	result = append(result, checkUnhandled(aCopy, bCopy, unhandledEnforcement))
+
+	return result
+}
+
+// checkUnhandled is a utility function for checking if a provided set of comparators
+// handled validating all differences between the JSONSchemaProps.
+// It returns a ComparisonResult so that the results are treated generically just like a standard Comparator.
+func checkUnhandled(a, b *apiextensionsv1.JSONSchemaProps, enforcement config.EnforcementPolicy) ComparisonResult {
+	var err error
+
+	if !equality.Semantic.DeepEqual(a, b) {
+		diff := cmp.Diff(a, b)
+		err = fmt.Errorf("%w :\n%s", ErrUnhandledChangesFound, diff)
+	}
+
+	return HandleErrors("unhandled", enforcement, err)
+}
+
+// ErrUnhandledChangesFound represents an error state where changes have been found that are not
+// handled by an existing validation check.
+var ErrUnhandledChangesFound = errors.New("unhandled changes found")

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/crd/existingfieldremoval/existingfieldremoval.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/crd/existingfieldremoval/existingfieldremoval.go
@@ -1,0 +1,105 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package existingfieldremoval
+
+import (
+	"errors"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+var (
+	_ validations.Validation                                           = (*ExistingFieldRemoval)(nil)
+	_ validations.Comparator[apiextensionsv1.CustomResourceDefinition] = (*ExistingFieldRemoval)(nil)
+)
+
+const name = "existingFieldRemoval"
+
+// Register registers the ExistingFieldRemoval validation
+// with the provided validation registry.
+func Register(registry validations.Registry) {
+	registry.Register(name, factory)
+}
+
+// factory is a function used to initialize an ExistingFieldRemoval validation
+// implementation based on the provided configuration.
+func factory(_ map[string]interface{}) (validations.Validation, error) {
+	return &ExistingFieldRemoval{}, nil
+}
+
+// ExistingFieldRemoval is a validations.Validation implementation
+// used to check if any existing fields have been removed from one
+// CRD instance to another.
+type ExistingFieldRemoval struct {
+	// enforcement is the EnforcementPolicy that this validation
+	// should use when performing its validation logic
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the ExistingFieldRemoval validation.
+func (efr *ExistingFieldRemoval) Name() string {
+	return name
+}
+
+// SetEnforcement sets the EnforcementPolicy for the ExistingFieldRemoval validation.
+func (efr *ExistingFieldRemoval) SetEnforcement(policy config.EnforcementPolicy) {
+	efr.enforcement = policy
+}
+
+// Compare compares an old and a new CustomResourceDefintion, checking for any fields that were removed
+// from the old CustomResourceDefinition in the new CustomResourceDefinition.
+func (efr *ExistingFieldRemoval) Compare(a, b *apiextensionsv1.CustomResourceDefinition) validations.ComparisonResult {
+	errs := []error{}
+
+	for _, newVersion := range b.Spec.Versions {
+		existingVersion := validations.GetCRDVersionByName(a, newVersion.Name)
+		if existingVersion == nil {
+			continue
+		}
+
+		existingFields := getFields(existingVersion)
+		newFields := getFields(&newVersion)
+
+		removedFields := existingFields.Difference(newFields)
+		for _, removedField := range removedFields.UnsortedList() {
+			errs = append(errs, fmt.Errorf("%w : %v.%v", ErrRemovedExistingField, newVersion.Name, removedField))
+		}
+	}
+
+	return validations.HandleErrors(efr.Name(), efr.enforcement, errs...)
+}
+
+// ErrRemovedExistingField represents an error state where existing fields have been removed
+// from the CustomResourceDefinition.
+var ErrRemovedExistingField = errors.New("removed field")
+
+// getFields returns a set of all the fields for the provided CustomResourceDefinitionVersion.
+func getFields(v *apiextensionsv1.CustomResourceDefinitionVersion) sets.Set[string] {
+	fields := sets.New[string]()
+
+	validations.SchemaHas(v.Schema.OpenAPIV3Schema, field.NewPath("^"), field.NewPath("^"), nil,
+		func(s *apiextensionsv1.JSONSchemaProps, fldPath, simpleLocation *field.Path, _ []*apiextensionsv1.JSONSchemaProps) bool {
+			fields.Insert(simpleLocation.String())
+			return false
+		},
+	)
+
+	return fields
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/crd/scope/scope.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/crd/scope/scope.go
@@ -1,0 +1,76 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scope
+
+import (
+	"errors"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+var (
+	_ validations.Validation                                           = (*Scope)(nil)
+	_ validations.Comparator[apiextensionsv1.CustomResourceDefinition] = (*Scope)(nil)
+)
+
+const name = "scope"
+
+// Register registers the Scope validation
+// with the provided validation registry.
+func Register(registry validations.Registry) {
+	registry.Register(name, factory)
+}
+
+// factory is a function used to initialize a Scope validation
+// implementation based on the provided configuration.
+func factory(_ map[string]interface{}) (validations.Validation, error) {
+	return &Scope{}, nil
+}
+
+// Scope is a validations.Validation implementation
+// used to check if the scope has changed from one
+// CRD instance to another.
+type Scope struct {
+	// enforcement is the EnforcementPolicy that this validation
+	// should use when performing its validation logic
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the Scope validation.
+func (s *Scope) Name() string {
+	return name
+}
+
+// SetEnforcement sets the EnforcementPolicy for the Scope validation.
+func (s *Scope) SetEnforcement(enforcement config.EnforcementPolicy) {
+	s.enforcement = enforcement
+}
+
+// Compare compares an old and a new CustomResourceDefintion, checking for any change to the scope from the
+// old CustomResourceDefinition to the new CustomResourceDefinition.
+func (s *Scope) Compare(a, b *apiextensionsv1.CustomResourceDefinition) validations.ComparisonResult {
+	var err error
+	if a.Spec.Scope != b.Spec.Scope {
+		err = fmt.Errorf("%w : %q -> %q", ErrChangedScope, a.Spec.Scope, b.Spec.Scope)
+	}
+
+	return validations.HandleErrors(s.Name(), s.enforcement, err)
+}
+
+// ErrChangedScope represents an error state where the scope of the CustomResourceDefinition has changed.
+var ErrChangedScope = errors.New("scope changed")

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/crd/storedversionremoval/storedversionremoval.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/crd/storedversionremoval/storedversionremoval.go
@@ -1,0 +1,94 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storedversionremoval
+
+import (
+	"errors"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+var (
+	_ validations.Validation                                           = (*StoredVersionRemoval)(nil)
+	_ validations.Comparator[apiextensionsv1.CustomResourceDefinition] = (*StoredVersionRemoval)(nil)
+)
+
+const name = "storedVersionRemoval"
+
+// Register registers the StoredVersionRemoval validation
+// with the provided validation registry.
+func Register(registry validations.Registry) {
+	registry.Register(name, factory)
+}
+
+// factory is a function used to initialize a StoredVersionRemoval validation
+// implementation based on the provided configuration.
+func factory(_ map[string]interface{}) (validations.Validation, error) {
+	return &StoredVersionRemoval{}, nil
+}
+
+// StoredVersionRemoval is a validations.Validation implementation
+// used to check if any versions existing in the set of stored versions
+// has been removed in the new instance of the CustomResourceDefinition.
+type StoredVersionRemoval struct {
+	// enforcement is the EnforcementPolicy that this validation
+	// should use when performing its validation logic
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the StoredVersionRemoval validation.
+func (svr *StoredVersionRemoval) Name() string {
+	return name
+}
+
+// SetEnforcement sets the EnforcementPolicy for the StoredVersionRemoval validation.
+func (svr *StoredVersionRemoval) SetEnforcement(enforcement config.EnforcementPolicy) {
+	svr.enforcement = enforcement
+}
+
+// Compare compares an old and a new CustomResourceDefintion, checking for removal of
+// any stored versions present in the old CustomResourceDefinition in the new instance
+// of the CustomResourceDefinition.
+func (svr *StoredVersionRemoval) Compare(a, b *apiextensionsv1.CustomResourceDefinition) validations.ComparisonResult {
+	newVersions := sets.New[string]()
+	for _, version := range b.Spec.Versions {
+		if !newVersions.Has(version.Name) {
+			newVersions.Insert(version.Name)
+		}
+	}
+
+	removedVersions := []string{}
+
+	for _, storedVersion := range a.Status.StoredVersions {
+		if !newVersions.Has(storedVersion) {
+			removedVersions = append(removedVersions, storedVersion)
+		}
+	}
+
+	var err error
+	if len(removedVersions) > 0 {
+		err = fmt.Errorf("%w : %v", ErrRemovedStoredVersions, removedVersions)
+	}
+
+	return validations.HandleErrors(svr.Name(), svr.enforcement, err)
+}
+
+// ErrRemovedStoredVersions represents an error state where stored versions have been removed
+// from the CustomResourceDefinition.
+var ErrRemovedStoredVersions = errors.New("stored versions removed")

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/default.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/default.go
@@ -1,0 +1,95 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+const defaultValidationName = "default"
+
+var (
+	_ validations.Validation                                  = (*Default)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*Default)(nil)
+)
+
+// RegisterDefault registers the Default validation
+// with the provided validation registry.
+func RegisterDefault(registry validations.Registry) {
+	registry.Register(defaultValidationName, defaultFactory)
+}
+
+// defaultFactory is a function used to initialize a Default validation
+// implementation based on the provided configuration.
+func defaultFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &Default{}, nil
+}
+
+// Default is a Validation that can be used to identify
+// incompatible changes to the default value of CRD properties.
+type Default struct {
+	// enforcement is the EnforcementPolicy that this validation
+	// should use when performing its validation logic
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the Default validation.
+func (d *Default) Name() string {
+	return defaultValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the Default validation.
+func (d *Default) SetEnforcement(policy config.EnforcementPolicy) {
+	d.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for changes to the default value of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.Default field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (d *Default) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	var err error
+
+	switch {
+	case a.Default == nil && b.Default != nil:
+		err = fmt.Errorf("%w : %q", ErrNetNewDefaultConstraint, string(b.Default.Raw))
+	case a.Default != nil && b.Default == nil:
+		err = fmt.Errorf("%w : %q", ErrRemovedDefault, string(a.Default.Raw))
+	case a.Default != nil && b.Default != nil && !bytes.Equal(a.Default.Raw, b.Default.Raw):
+		err = fmt.Errorf("%w : %q -> %q", ErrChangedDefault, string(a.Default.Raw), string(b.Default.Raw))
+	}
+
+	// reset values
+	a.Default = nil
+	b.Default = nil
+
+	return validations.HandleErrors(d.Name(), d.enforcement, err)
+}
+
+var (
+	// ErrNetNewDefaultConstraint represents an error state where a net new default was added to a property.
+	ErrNetNewDefaultConstraint = errors.New("default added when there was none previously")
+	// ErrRemovedDefault represents an error state where the default value was removed for a property.
+	ErrRemovedDefault = errors.New("default value removed")
+	// ErrChangedDefault represents an error state where the default value was changed for a property.
+	ErrChangedDefault = errors.New("default value changed")
+)

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/description.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/description.go
@@ -1,0 +1,83 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"errors"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+const descriptionValidationName = "description"
+
+var (
+	_ validations.Validation                                  = (*Description)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*Description)(nil)
+)
+
+// RegisterDescription registers the Description validation
+// with the provided validation registry.
+func RegisterDescription(registry validations.Registry) {
+	registry.Register(descriptionValidationName, descriptionFactory)
+}
+
+// descriptionFactory is a function used to initialize a Description validation
+// implementation based on the provided configuration.
+func descriptionFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &Description{}, nil
+}
+
+// Description is a Validation that can be used to identify
+// incompatible changes to the description of CRD properties.
+type Description struct {
+	// enforcement is the EnforcementPolicy that this validation
+	// should use when performing its validation logic
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the Description validation.
+func (d *Description) Name() string {
+	return descriptionValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the Description validation.
+func (d *Description) SetEnforcement(policy config.EnforcementPolicy) {
+	d.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for changes to the description of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.Description field will be reset to '""' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (d *Description) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	var err error
+
+	if a.Description != b.Description {
+		err = fmt.Errorf("%w : %q -> %q", ErrChangedDescription, a.Description, b.Description)
+	}
+
+	// reset values
+	a.Description = ""
+	b.Description = ""
+
+	return validations.HandleErrors(d.Name(), d.enforcement, err)
+}
+
+// ErrChangedDescription represents an error state where the description was changed for a property.
+var ErrChangedDescription = errors.New("description changed")

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/enum.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/enum.go
@@ -1,0 +1,185 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+const enumValidationName = "enum"
+
+var (
+	_ validations.Validation                                  = (*Enum)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*Enum)(nil)
+)
+
+// RegisterEnum registers the Enum validation
+// with the provided validation registry.
+func RegisterEnum(registry validations.Registry) {
+	registry.Register(enumValidationName, enumFactory)
+}
+
+// enumFactory is a function used to initialize an Enum validation
+// implementation based on the provided configuration.
+func enumFactory(cfg map[string]interface{}) (validations.Validation, error) {
+	enumCfg := &EnumConfig{}
+
+	err := ConfigToType(cfg, enumCfg)
+	if err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	err = ValidateEnumConfig(enumCfg)
+	if err != nil {
+		return nil, fmt.Errorf("validating enum config: %w", err)
+	}
+
+	return &Enum{EnumConfig: *enumCfg}, nil
+}
+
+// ValidateEnumConfig validates the provided EnumConfig
+// setting default values where appropriate.
+// Currently the defaulting behavior defaults the
+// EnumConfig.AdditionPolicy to AdditionPolicyDisallow
+// if it is set to the empty string ("").
+func ValidateEnumConfig(in *EnumConfig) error {
+	if in == nil {
+		// nothing to validate
+		return nil
+	}
+
+	switch in.AdditionPolicy {
+	case AdditionPolicyAllow, AdditionPolicyDisallow:
+		// do nothing, valid case
+	case AdditionPolicy(""):
+		// default to disallow
+		in.AdditionPolicy = AdditionPolicyDisallow
+	default:
+		return fmt.Errorf("%w : %q", errUnknownAdditionPolicy, in.AdditionPolicy)
+	}
+
+	return nil
+}
+
+var errUnknownAdditionPolicy = errors.New("unknown addition policy")
+
+// AdditionPolicy is used to represent how the Enum validation
+// should determine compatibility of adding new enum values to an
+// existing enum constraint.
+type AdditionPolicy string
+
+const (
+	// AdditionPolicyAllow signals that adding new enum values to
+	// an existing enum constraint should be considered a compatible change.
+	AdditionPolicyAllow AdditionPolicy = "Allow"
+
+	// AdditionPolicyDisallow signals that adding new enum values to
+	// an existing enum constraint should be considered an incompatible change.
+	AdditionPolicyDisallow AdditionPolicy = "Disallow"
+)
+
+// EnumConfig contains additional configurations for the Enum validation.
+type EnumConfig struct {
+	// additionPolicy is how adding enums to an existing set of
+	// enums should be treated.
+	// Allowed values are Allow and Disallow.
+	// When set to Allow, adding new values to an existing set
+	// of enums will not be flagged.
+	// When set to Disallow, adding new values to an existing
+	// set of enums will be flagged.
+	// Defaults to Disallow.
+	AdditionPolicy AdditionPolicy `json:"additionPolicy,omitempty"`
+}
+
+// Enum is a Validation that can be used to identify
+// incompatible changes to the enum values of CRD properties.
+type Enum struct {
+	// EnumConfig is the set of additional configuration options
+	EnumConfig
+
+	// enforcement is the EnforcementPolicy that this validation
+	// should use when performing its validation logic
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the Enum validation.
+func (e *Enum) Name() string {
+	return enumValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the Enum validation.
+func (e *Enum) SetEnforcement(policy config.EnforcementPolicy) {
+	e.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the enum constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.Enum field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (e *Enum) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	oldEnums := sets.New[string]()
+	for _, json := range a.Enum {
+		oldEnums.Insert(string(json.Raw))
+	}
+
+	newEnums := sets.New[string]()
+	for _, json := range b.Enum {
+		newEnums.Insert(string(json.Raw))
+	}
+
+	removedEnums := oldEnums.Difference(newEnums)
+	addedEnums := newEnums.Difference(oldEnums)
+
+	var err error
+
+	switch {
+	case oldEnums.Len() == 0 && newEnums.Len() > 0:
+		newEnumSlice := newEnums.UnsortedList()
+		slices.Sort(newEnumSlice)
+		err = fmt.Errorf("%w : %v", ErrNetNewEnumConstraint, newEnumSlice)
+	case removedEnums.Len() > 0:
+		removedEnumSlice := removedEnums.UnsortedList()
+		slices.Sort(removedEnumSlice)
+		err = fmt.Errorf("%w : %v", ErrRemovedEnums, removedEnumSlice)
+	case addedEnums.Len() > 0 && e.AdditionPolicy != AdditionPolicyAllow:
+		addedEnumSlice := addedEnums.UnsortedList()
+		slices.Sort(addedEnumSlice)
+		err = fmt.Errorf("%w : %v", ErrAddedEnums, addedEnumSlice)
+	}
+
+	a.Enum = nil
+	b.Enum = nil
+
+	return validations.HandleErrors(e.Name(), e.enforcement, err)
+}
+
+var (
+	// ErrNetNewEnumConstraint represents an error state where a net new enum constraint was added to a property.
+	ErrNetNewEnumConstraint = errors.New("enum constraint added when there was none previously")
+	// ErrRemovedEnums represents an error state where at least one previously allowed enum value was removed
+	// from the enum constraint on a property.
+	ErrRemovedEnums = errors.New("allowed enum values removed")
+	// ErrAddedEnums represents an error state where at least one enum value, that was not previously allowed,
+	// was added to the enum constraint on a property.
+	ErrAddedEnums = errors.New("allowed enum values added")
+)

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/max.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/max.go
@@ -1,0 +1,253 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:dupl
+package property
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+// MaxOptions is an abstraction for the common
+// options for all the "Maximum" related constraints
+// on CRD properties.
+type MaxOptions struct {
+	enforcement config.EnforcementPolicy
+}
+
+// MaxVerification is a generic helper function for comparing
+// two cmp.Ordered values. It returns an error if:
+// - older value is nil and newer value is not nil
+// - older and newer values are not nil, newer is less than older.
+func MaxVerification[T cmp.Ordered](older, newer *T) error {
+	var err error
+
+	switch {
+	case older == nil && newer != nil:
+		err = fmt.Errorf("%w : %v", ErrNetNewMaximumConstraint, *newer)
+	case older != nil && newer != nil && *newer < *older:
+		err = fmt.Errorf("%w : %v -> %v", ErrMaximumIncreased, *older, *newer)
+	}
+
+	return err
+}
+
+var (
+	// ErrNetNewMaximumConstraint represents an error state where a net new maximum constraint was added to a property.
+	ErrNetNewMaximumConstraint = errors.New("maximum constraint added when there was none previously")
+	// ErrMaximumIncreased represents an error state where a maximum constaint on a property was decreased.
+	ErrMaximumIncreased = errors.New("maximum decreased")
+)
+
+var (
+	_ validations.Validation                                  = (*Maximum)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*Maximum)(nil)
+)
+
+const maximumValidationName = "maximum"
+
+// RegisterMaximum registers the Maximum validation
+// with the provided validation registry.
+func RegisterMaximum(registry validations.Registry) {
+	registry.Register(maximumValidationName, maximumFactory)
+}
+
+// maximumFactory is a function used to initialize a Maximum validation
+// implementation based on the provided configuration.
+func maximumFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &Maximum{}, nil
+}
+
+// Maximum is a Validation that can be used to identify
+// incompatible changes to the maximum constraints of CRD properties.
+type Maximum struct {
+	MaxOptions
+}
+
+// Name returns the name of the Maximum validation.
+func (m *Maximum) Name() string {
+	return maximumValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the Maximum validation.
+func (m *Maximum) SetEnforcement(policy config.EnforcementPolicy) {
+	m.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the maximum constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.Maximum field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (m *Maximum) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	err := MaxVerification(a.Maximum, b.Maximum)
+
+	a.Maximum = nil
+	b.Maximum = nil
+
+	return validations.HandleErrors(m.Name(), m.enforcement, err)
+}
+
+var (
+	_ validations.Validation                                  = (*MaxItems)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*MaxItems)(nil)
+)
+
+const maxItemsValidationName = "maxItems"
+
+// RegisterMaxItems registers the MaxItems validation
+// with the provided validation registry.
+func RegisterMaxItems(registry validations.Registry) {
+	registry.Register(maxItemsValidationName, maxItemsFactory)
+}
+
+// maxItemsFactory is a function used to initialize a MaxItems validation
+// implementation based on the provided configuration.
+func maxItemsFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &MaxItems{}, nil
+}
+
+// MaxItems is a Validation that can be used to identify
+// incompatible changes to the maxItems constraints of CRD properties.
+type MaxItems struct {
+	MaxOptions
+}
+
+// Name returns the name of the MaxItems validation.
+func (m *MaxItems) Name() string {
+	return maxItemsValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the MaxItems validation.
+func (m *MaxItems) SetEnforcement(policy config.EnforcementPolicy) {
+	m.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the maxItems constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.MaxItems field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (m *MaxItems) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	err := MaxVerification(a.MaxItems, b.MaxItems)
+
+	a.MaxItems = nil
+	b.MaxItems = nil
+
+	return validations.HandleErrors(m.Name(), m.enforcement, err)
+}
+
+var (
+	_ validations.Validation                                  = (*MaxLength)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*MaxLength)(nil)
+)
+
+const maxLengthValidationName = "maxLength"
+
+// RegisterMaxLength registers the MaxLength validation
+// with the provided validation registry.
+func RegisterMaxLength(registry validations.Registry) {
+	registry.Register(maxLengthValidationName, maxLengthFactory)
+}
+
+// maxLengthFactory is a function used to initialize a MaxLength validation
+// implementation based on the provided configuration.
+func maxLengthFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &MaxLength{}, nil
+}
+
+// MaxLength is a Validation that can be used to identify
+// incompatible changes to the maxLength constraints of CRD properties.
+type MaxLength struct {
+	MaxOptions
+}
+
+// Name returns the name of the MaxLength validation.
+func (m *MaxLength) Name() string {
+	return maxLengthValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the MaxLength validation.
+func (m *MaxLength) SetEnforcement(policy config.EnforcementPolicy) {
+	m.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the maxLength constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.MaxLength field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (m *MaxLength) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	err := MaxVerification(a.MaxLength, b.MaxLength)
+
+	a.MaxLength = nil
+	b.MaxLength = nil
+
+	return validations.HandleErrors(m.Name(), m.enforcement, err)
+}
+
+var (
+	_ validations.Validation                                  = (*MaxProperties)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*MaxProperties)(nil)
+)
+
+const maxPropertiesValidationName = "maxProperties"
+
+// RegisterMaxProperties registers the MaxProperties validation
+// with the provided validation registry.
+func RegisterMaxProperties(registry validations.Registry) {
+	registry.Register(maxPropertiesValidationName, maxPropertiesFactory)
+}
+
+// maxPropertiesFactory is a function used to initialize a MaxProperties validation
+// implementation based on the provided configuration.
+func maxPropertiesFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &MaxProperties{}, nil
+}
+
+// MaxProperties is a Validation that can be used to identify
+// incompatible changes to the maxProperties constraints of CRD properties.
+type MaxProperties struct {
+	MaxOptions
+}
+
+// Name returns the name of the MaxProperties validation.
+func (m *MaxProperties) Name() string {
+	return maxPropertiesValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the MaxProperties validation.
+func (m *MaxProperties) SetEnforcement(policy config.EnforcementPolicy) {
+	m.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the maxProperties constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.MaxProperties field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (m *MaxProperties) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	err := MaxVerification(a.MaxProperties, b.MaxProperties)
+
+	a.MaxProperties = nil
+	b.MaxProperties = nil
+
+	return validations.HandleErrors(m.Name(), m.enforcement, err)
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/min.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/min.go
@@ -1,0 +1,253 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:dupl
+package property
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+// MinOptions is an abstraction for the common
+// options for all the "Minimum" related constraints
+// on CRD properties.
+type MinOptions struct {
+	enforcement config.EnforcementPolicy
+}
+
+// MinVerification is a generic helper function for comparing
+// two cmp.Ordered values. It returns an error if:
+// - older value is nil and newer value is not nil
+// - older and newer values are not nil, newer is greater than older.
+func MinVerification[T cmp.Ordered](older, newer *T) error {
+	var err error
+
+	switch {
+	case older == nil && newer != nil:
+		err = fmt.Errorf("%w : %v", ErrNetNewMinimumConstraint, *newer)
+	case older != nil && newer != nil && *newer > *older:
+		err = fmt.Errorf("%w : %v -> %v", ErrMinimumIncreased, *older, *newer)
+	}
+
+	return err
+}
+
+var (
+	// ErrNetNewMinimumConstraint represents an error state where a net new minimum constraint was added to a property.
+	ErrNetNewMinimumConstraint = errors.New("minimum constraint added when there was none previously")
+	// ErrMinimumIncreased represents an error state where a minimum constaint on a property was increased.
+	ErrMinimumIncreased = errors.New("minimum increased")
+)
+
+var (
+	_ validations.Validation                                  = (*Minimum)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*Minimum)(nil)
+)
+
+const minimumValidationName = "minimum"
+
+// RegisterMinimum registers the Minimum validation
+// with the provided validation registry.
+func RegisterMinimum(registry validations.Registry) {
+	registry.Register(minimumValidationName, minimumFactory)
+}
+
+// minimumFactory is a function used to initialize a Minimum validation
+// implementation based on the provided configuration.
+func minimumFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &Minimum{}, nil
+}
+
+// Minimum is a Validation that can be used to identify
+// incompatible changes to the minimum constraints of CRD properties.
+type Minimum struct {
+	MinOptions
+}
+
+// Name returns the name of the Minimum validation.
+func (m *Minimum) Name() string {
+	return minimumValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the Minimum validation.
+func (m *Minimum) SetEnforcement(policy config.EnforcementPolicy) {
+	m.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the minimum constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.Minimum field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (m *Minimum) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	err := MinVerification(a.Minimum, b.Minimum)
+
+	a.Minimum = nil
+	b.Minimum = nil
+
+	return validations.HandleErrors(m.Name(), m.enforcement, err)
+}
+
+var (
+	_ validations.Validation                                  = (*MinItems)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*MinItems)(nil)
+)
+
+const minItemsValidationName = "minItems"
+
+// RegisterMinItems registers the MinItems validation
+// with the provided validation registry.
+func RegisterMinItems(registry validations.Registry) {
+	registry.Register(minItemsValidationName, minItemsFactory)
+}
+
+// minItemsFactory is a function used to initialize a MinItems validation
+// implementation based on the provided configuration.
+func minItemsFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &MinItems{}, nil
+}
+
+// MinItems is a Validation that can be used to identify
+// incompatible changes to the minItems constraints of CRD properties.
+type MinItems struct {
+	MinOptions
+}
+
+// Name returns the name of the MinItems validation.
+func (m *MinItems) Name() string {
+	return minItemsValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the MinItems validation.
+func (m *MinItems) SetEnforcement(policy config.EnforcementPolicy) {
+	m.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the minItems constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.MinItems field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (m *MinItems) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	err := MinVerification(a.MinItems, b.MinItems)
+
+	a.MinItems = nil
+	b.MinItems = nil
+
+	return validations.HandleErrors(m.Name(), m.enforcement, err)
+}
+
+var (
+	_ validations.Validation                                  = (*MinLength)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*MinLength)(nil)
+)
+
+const minLengthValidationName = "minLength"
+
+// RegisterMinLength registers the MinLength validation
+// with the provided validation registry.
+func RegisterMinLength(registry validations.Registry) {
+	registry.Register(minLengthValidationName, minLengthFactory)
+}
+
+// minLengthFactory is a function used to initialize a MinLength validation
+// implementation based on the provided configuration.
+func minLengthFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &MinLength{}, nil
+}
+
+// MinLength is a Validation that can be used to identify
+// incompatible changes to the minLength constraints of CRD properties.
+type MinLength struct {
+	MinOptions
+}
+
+// Name returns the name of the MinLength validation.
+func (m *MinLength) Name() string {
+	return minLengthValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the MinLength validation.
+func (m *MinLength) SetEnforcement(policy config.EnforcementPolicy) {
+	m.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the minLength constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.MinLength field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (m *MinLength) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	err := MinVerification(a.MinLength, b.MinLength)
+
+	a.MinLength = nil
+	b.MinLength = nil
+
+	return validations.HandleErrors(m.Name(), m.enforcement, err)
+}
+
+var (
+	_ validations.Validation                                  = (*MinProperties)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*MinProperties)(nil)
+)
+
+const minPropertiesValidationName = "minProperties"
+
+// RegisterMinProperties registers the MinProperties validation
+// with the provided validation registry.
+func RegisterMinProperties(registry validations.Registry) {
+	registry.Register(minPropertiesValidationName, minPropertiesFactory)
+}
+
+// minPropertiesFactory is a function used to initialize a MinProperties validation
+// implementation based on the provided configuration.
+func minPropertiesFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &MinProperties{}, nil
+}
+
+// MinProperties is a Validation that can be used to identify
+// incompatible changes to the minProperties constraints of CRD properties.
+type MinProperties struct {
+	MinOptions
+}
+
+// Name returns the name of the MinProperties validation.
+func (m *MinProperties) Name() string {
+	return minPropertiesValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the MinProperties validation.
+func (m *MinProperties) SetEnforcement(policy config.EnforcementPolicy) {
+	m.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the minProperties constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.MinProperties field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (m *MinProperties) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	err := MinVerification(a.MinProperties, b.MinProperties)
+
+	a.MinProperties = nil
+	b.MinProperties = nil
+
+	return validations.HandleErrors(m.Name(), m.enforcement, err)
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/required.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/required.go
@@ -1,0 +1,85 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"errors"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+var (
+	_ validations.Validation                                  = (*Required)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*Required)(nil)
+)
+
+const requiredValidationName = "required"
+
+// RegisterRequired registers the Required validation
+// with the provided validation registry.
+func RegisterRequired(registry validations.Registry) {
+	registry.Register(requiredValidationName, requiredFactory)
+}
+
+// requiredFactory is a function used to initialize a Required validation
+// implementation based on the provided configuration.
+func requiredFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &Required{}, nil
+}
+
+// Required is a Validation that can be used to identify
+// incompatible changes to the required constraints of CRD properties.
+type Required struct {
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the Required validation.
+func (r *Required) Name() string {
+	return requiredValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the Required validation.
+func (r *Required) SetEnforcement(policy config.EnforcementPolicy) {
+	r.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the required constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.Required field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (r *Required) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	oldRequired := sets.New(a.Required...)
+	newRequired := sets.New(b.Required...)
+	diffRequired := newRequired.Difference(oldRequired)
+
+	var err error
+
+	if diffRequired.Len() > 0 {
+		err = fmt.Errorf("%w: %v", ErrNewRequiredFields, diffRequired.UnsortedList())
+	}
+
+	a.Required = nil
+	b.Required = nil
+
+	return validations.HandleErrors(r.Name(), r.enforcement, err)
+}
+
+// ErrNewRequiredFields represents an error state where a property has new required fields.
+var ErrNewRequiredFields = errors.New("new required fields")

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/type.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/type.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"errors"
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+var (
+	_ validations.Validation                                  = (*Type)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*Type)(nil)
+)
+
+const typeValidationName = "type"
+
+// RegisterType registers the Type validation
+// with the provided validation registry.
+func RegisterType(registry validations.Registry) {
+	registry.Register(typeValidationName, typeFactory)
+}
+
+// typeFactory is a function used to initialize a Type validation
+// implementation based on the provided configuration.
+func typeFactory(_ map[string]interface{}) (validations.Validation, error) {
+	return &Type{}, nil
+}
+
+// Type is a Validation that can be used to identify
+// incompatible changes to the type constraints of CRD properties.
+type Type struct {
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the Type validation.
+func (t *Type) Name() string {
+	return typeValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the Type validation.
+func (t *Type) SetEnforcement(policy config.EnforcementPolicy) {
+	t.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the type constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.Type field will be reset to '""' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (t *Type) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	var err error
+	if a.Type != b.Type {
+		err = fmt.Errorf("%w : %q -> %q", ErrTypeChanged, a.Type, b.Type)
+	}
+
+	a.Type = ""
+	b.Type = ""
+
+	return validations.HandleErrors(t.Name(), t.enforcement, err)
+}
+
+// ErrTypeChanged represents an error state when a property type changed.
+var ErrTypeChanged = errors.New("type changed")

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/util.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/property/util.go
@@ -1,0 +1,36 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ConfigToType is a utility function for unmarshalling unstructured data (map[string]interface{})
+// into a concrete type.
+func ConfigToType[T any](in map[string]interface{}, out *T) error {
+	jsonBytes, err := json.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("marshalling input to JSON: %w", err)
+	}
+
+	err = json.Unmarshal(jsonBytes, out)
+	if err != nil {
+		return fmt.Errorf("unmarshalling input to output: %w", err)
+	}
+
+	return nil
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/registry.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/registry.go
@@ -1,0 +1,132 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+)
+
+// Comparable is a generic interface that represents either a
+// CustomResourceDefinition or a JSONSchemaProps.
+type Comparable interface {
+	apiextensionsv1.CustomResourceDefinition | apiextensionsv1.JSONSchemaProps
+}
+
+// Comparator is a generic interface for comparing two objects and getting back
+// a ComparisonResult.
+type Comparator[T Comparable] interface {
+	// Compare compares two instances of type T and returns a ComparisonResult
+	Compare(a, b *T) ComparisonResult
+}
+
+// Validation is an interface to represent the minimal set of
+// functionality that needs to be implemented by a validation.
+type Validation interface {
+	// Name is the name of the validation
+	Name() string
+	// SetEnforcement sets the enforcement policy for the validation
+	SetEnforcement(policy config.EnforcementPolicy)
+}
+
+// ComparisonResult contains the results of running a Comparator.
+type ComparisonResult struct {
+	// Name is the name of the Comparator implementation that
+	// performed the comparison
+	Name string `json:"name"`
+
+	// Errors is the set of errors encountered during comparison
+	Errors []string `json:"errors,omitempty"`
+
+	// Warnings is the set of warnings encountered during comparison
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// Factory is a function used for creating a Validation based on a
+// provided configuration. Should return an error if the Validation
+// cannot be successfully created with the provided configuration.
+type Factory func(config map[string]interface{}) (Validation, error)
+
+// Registry is a registry for Validations.
+type Registry interface {
+	// Register registers a name and how to create an instance of a Validation with that name
+	Register(name string, validation Factory)
+
+	// Registered returns a list of the registered Validation names
+	Registered() []string
+
+	// Validation returns a Validation for the provided name and configuration
+	Validation(name string, config map[string]interface{}) (Validation, error)
+}
+
+// validationRegistry is an implementation of Registry.
+type validationRegistry struct {
+	lock        sync.Mutex
+	validations map[string]Factory
+}
+
+// NewRegistry creates a new Registry.
+func NewRegistry() Registry {
+	return &validationRegistry{
+		lock:        sync.Mutex{},
+		validations: make(map[string]Factory),
+	}
+}
+
+// Register registers a name and how to create an instance of a Validation with that name.
+// If a validation has already been registered, this method will panic.
+func (vr *validationRegistry) Register(name string, validation Factory) {
+	vr.lock.Lock()
+	defer vr.lock.Unlock()
+
+	if _, ok := vr.validations[name]; ok {
+		panic(fmt.Sprintf("validation %q has already been registered", name))
+	}
+
+	vr.validations[name] = validation
+}
+
+// Registered returns the set of registered validation names.
+func (vr *validationRegistry) Registered() []string {
+	vr.lock.Lock()
+	defer vr.lock.Unlock()
+
+	keys := []string{}
+
+	for k := range vr.validations {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+// Validation creates the Validation for the provided validation name and configuration if it is registered.
+func (vr *validationRegistry) Validation(name string, config map[string]interface{}) (Validation, error) {
+	vr.lock.Lock()
+	defer vr.lock.Unlock()
+
+	factory, ok := vr.validations[name]
+	if !ok {
+		return nil, fmt.Errorf("%w : %q", errUnknownValidation, name)
+	}
+
+	return factory(config)
+}
+
+var errUnknownValidation = errors.New("unknown validation")

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validations/util.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validations/util.go
@@ -1,0 +1,326 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/slices"
+)
+
+// GetCRDVersionByName returns a CustomResourceDefinitionVersion with the provided name from the provided CustomResourceDefinition.
+func GetCRDVersionByName(crd *apiextensionsv1.CustomResourceDefinition, name string) *apiextensionsv1.CustomResourceDefinitionVersion {
+	if crd == nil {
+		return nil
+	}
+
+	for _, version := range crd.Spec.Versions {
+		if version.Name == name {
+			return &version
+		}
+	}
+
+	return nil
+}
+
+// FlattenCRDVersion flattens the provided CustomResourceDefinition into a mapping of
+// property path (i.e ^.spec.foo.bar) to its JSONSchemaProps.
+func FlattenCRDVersion(crdVersion apiextensionsv1.CustomResourceDefinitionVersion) map[string]*apiextensionsv1.JSONSchemaProps {
+	flatMap := map[string]*apiextensionsv1.JSONSchemaProps{}
+
+	SchemaHas(crdVersion.Schema.OpenAPIV3Schema,
+		field.NewPath("^"),
+		field.NewPath("^"),
+		nil,
+		func(s *apiextensionsv1.JSONSchemaProps, _, simpleLocation *field.Path, _ []*apiextensionsv1.JSONSchemaProps) bool {
+			flatMap[simpleLocation.String()] = s.DeepCopy()
+			return false
+		},
+	)
+
+	return flatMap
+}
+
+// Diff is a utility struct for holding an old and new JSONSchemaProps.
+type Diff struct {
+	Old *apiextensionsv1.JSONSchemaProps
+	New *apiextensionsv1.JSONSchemaProps
+}
+
+// FlattenedCRDVersionDiff calculates differences between flattened CRD versions.
+// Returns the set of differing properties as a map of the property path (i.e ^.spec.foo.bar)
+// to the Diff (old and new JSONSchemaProps).
+func FlattenedCRDVersionDiff(a, b map[string]*apiextensionsv1.JSONSchemaProps) map[string]Diff {
+	diffMap := map[string]Diff{}
+
+	for prop, oldSchema := range a {
+		// Create a copy of the old schema and set the properties to nil.
+		// In theory this will make it so we don't provide a diff for a parent property
+		// based on changes to the children properties. The changes to the children
+		// properties should still be evaluated since we are looping through a flattened
+		// map of all the properties for the CRD version
+		oldSchemaCopy := DropChildrenPropertiesFromJSONSchema(oldSchema)
+		newSchema, ok := b[prop]
+
+		// In the event the property no longer exists on the new version
+		// create a diff entry with the new value being empty
+		if !ok {
+			diffMap[prop] = Diff{Old: oldSchemaCopy, New: &apiextensionsv1.JSONSchemaProps{}}
+			// Continue as there is no newSchema to copy and evaluate for this prop.
+			continue
+		}
+
+		// Do the same copy and unset logic for the new schema properties
+		// before comparison to ensure we are only comparing the individual properties
+		newSchemaCopy := DropChildrenPropertiesFromJSONSchema(newSchema)
+
+		if !equality.Semantic.DeepEqual(oldSchemaCopy, newSchemaCopy) {
+			diffMap[prop] = Diff{Old: oldSchemaCopy, New: newSchemaCopy}
+		}
+	}
+
+	return diffMap
+}
+
+// DropChildrenPropertiesFromJSONSchema sets properties on a schema
+// associated with children schemas to `nil`. Useful when calculating
+// differences between a before and after of a given schema
+// without the changes to its children schemas influencing the
+// diff calculation.
+// Returns a copy of the provided apiextensionsv1.JSONSchemaProps with children schemas dropped.
+func DropChildrenPropertiesFromJSONSchema(schema *apiextensionsv1.JSONSchemaProps) *apiextensionsv1.JSONSchemaProps {
+	schemaCopy := schema.DeepCopy()
+	schemaCopy.Properties = nil
+	schemaCopy.Items = nil
+
+	return schemaCopy
+}
+
+// SchemaWalkerFunc is a function that walks a JSONSchemaProps.
+// ancestry is an order list of ancestors of s, where index 0 is the root and index len-1 is the direct parent.
+type SchemaWalkerFunc func(s *apiextensionsv1.JSONSchemaProps, fldPath, simpleLocation *field.Path, ancestry []*apiextensionsv1.JSONSchemaProps) bool
+
+// SchemaHas recursively traverses the Schema and calls the `pred`
+// predicate to see if the schema contains specific values.
+//
+// The predicate MUST NOT keep a copy of the json schema NOR modify the
+// schema.
+//
+//nolint:gocognit,cyclop
+func SchemaHas(s *apiextensionsv1.JSONSchemaProps, fldPath, simpleLocation *field.Path, ancestry []*apiextensionsv1.JSONSchemaProps, pred SchemaWalkerFunc) bool {
+	if s == nil {
+		return false
+	}
+
+	if pred(s, fldPath, simpleLocation, ancestry) {
+		return true
+	}
+
+	//nolint:gocritic
+	nextAncestry := append(ancestry, s)
+
+	if s.Items != nil {
+		if s.Items != nil && schemaHasRecurse(s.Items.Schema, fldPath.Child("items"), simpleLocation.Key("*"), nextAncestry, pred) {
+			return true
+		}
+
+		for i := range s.Items.JSONSchemas {
+			if schemaHasRecurse(&s.Items.JSONSchemas[i], fldPath.Child("items", "jsonSchemas").Index(i), simpleLocation.Index(i), nextAncestry, pred) {
+				return true
+			}
+		}
+	}
+
+	for i := range s.AllOf {
+		if schemaHasRecurse(&s.AllOf[i], fldPath.Child("allOf").Index(i), simpleLocation, nextAncestry, pred) {
+			return true
+		}
+	}
+
+	for i := range s.AnyOf {
+		if schemaHasRecurse(&s.AnyOf[i], fldPath.Child("anyOf").Index(i), simpleLocation, nextAncestry, pred) {
+			return true
+		}
+	}
+
+	for i := range s.OneOf {
+		if schemaHasRecurse(&s.OneOf[i], fldPath.Child("oneOf").Index(i), simpleLocation, nextAncestry, pred) {
+			return true
+		}
+	}
+
+	if schemaHasRecurse(s.Not, fldPath.Child("not"), simpleLocation, nextAncestry, pred) {
+		return true
+	}
+
+	for propertyName, s := range s.Properties {
+		if schemaHasRecurse(&s, fldPath.Child("properties").Key(propertyName), simpleLocation.Child(propertyName), nextAncestry, pred) {
+			return true
+		}
+	}
+
+	if s.AdditionalProperties != nil {
+		if schemaHasRecurse(s.AdditionalProperties.Schema, fldPath.Child("additionalProperties", "schema"), simpleLocation.Key("*"), nextAncestry, pred) {
+			return true
+		}
+	}
+
+	for patternName, s := range s.PatternProperties {
+		if schemaHasRecurse(&s, fldPath.Child("allOf").Key(patternName), simpleLocation, nextAncestry, pred) {
+			return true
+		}
+	}
+
+	if s.AdditionalItems != nil {
+		if schemaHasRecurse(s.AdditionalItems.Schema, fldPath.Child("additionalItems", "schema"), simpleLocation, nextAncestry, pred) {
+			return true
+		}
+	}
+
+	for _, s := range s.Definitions {
+		if schemaHasRecurse(&s, fldPath.Child("definitions"), simpleLocation, nextAncestry, pred) {
+			return true
+		}
+	}
+
+	for dependencyName, d := range s.Dependencies {
+		if schemaHasRecurse(d.Schema, fldPath.Child("dependencies").Key(dependencyName).Child("schema"), simpleLocation, nextAncestry, pred) {
+			return true
+		}
+	}
+
+	return false
+}
+
+//nolint:gochecknoglobals
+var schemaPool = sync.Pool{
+	New: func() any {
+		return new(apiextensionsv1.JSONSchemaProps)
+	},
+}
+
+func schemaHasRecurse(s *apiextensionsv1.JSONSchemaProps, fldPath, simpleLocation *field.Path, ancestry []*apiextensionsv1.JSONSchemaProps, pred SchemaWalkerFunc) bool {
+	if s == nil {
+		return false
+	}
+
+	schema, ok := schemaPool.Get().(*apiextensionsv1.JSONSchemaProps)
+	if !ok {
+		return false
+	}
+	defer schemaPool.Put(schema)
+
+	*schema = *s
+
+	return SchemaHas(schema, fldPath, simpleLocation, ancestry, pred)
+}
+
+// ComparatorsForValidations extracts the Comparators of type T from the provided set of Validations.
+func ComparatorsForValidations[T Comparable](vals ...Validation) []Comparator[T] {
+	comparators := []Comparator[T]{}
+
+	for _, val := range vals {
+		comp, ok := val.(Comparator[T])
+		if !ok {
+			continue
+		}
+
+		comparators = append(comparators, comp)
+	}
+
+	return comparators
+}
+
+// LoadValidationsFromRegistry initializes all validations registered with the provided
+// registry using an empty configuration.
+// It returns the validations in a map to make it easier to update the Validations in one-shot operations.
+// Any errors encountered during the initialization process are aggregated and returned as a single error.
+func LoadValidationsFromRegistry(registry Registry) (map[string]Validation, error) {
+	vals := map[string]Validation{}
+	errs := []error{}
+
+	for _, validation := range registry.Registered() {
+		val, err := registry.Validation(validation, make(map[string]interface{}))
+		if err != nil {
+			errs = append(errs, fmt.Errorf("initializing validation %q: %w", validation, err))
+		}
+
+		val.SetEnforcement(config.EnforcementPolicyError)
+
+		vals[validation] = val
+	}
+
+	return vals, errors.Join(errs...)
+}
+
+// ConfigureValidations is a utility function for configuring the provided set of validations
+// using the provided registyr and configuration.
+// It returns a copy of the original validations mapping with validations that had specific
+// configurations replaced with a newly initialized validation.
+// Any errors encountered during the initialization process are aggregated and returned as a single error.
+func ConfigureValidations(validations map[string]Validation, registry Registry, cfg config.Config) (map[string]Validation, error) {
+	modified := validations
+	errs := []error{}
+
+	for _, validation := range cfg.Validations {
+		val, err := registry.Validation(validation.Name, validation.Configuration)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("configuring validation %q: %w", validation.Name, err))
+			continue
+		}
+
+		switch validation.Enforcement {
+		case config.EnforcementPolicyError, config.EnforcementPolicyWarn, config.EnforcementPolicyNone:
+			val.SetEnforcement(validation.Enforcement)
+		default:
+			errs = append(errs, fmt.Errorf("configuring validation %q: %w : %q", validation.Name, errUnknownEnforcementPolicy, validation.Enforcement))
+		}
+
+		modified[validation.Name] = val
+	}
+
+	return modified, errors.Join(errs...)
+}
+
+var errUnknownEnforcementPolicy = errors.New("unknown enforcement policy")
+
+// HandleErrors is a utility function for Comparators to generate a ComparisonResult
+// based on the provided Comparator name, enforcement policy, and any errors it encountered.
+func HandleErrors(name string, policy config.EnforcementPolicy, errs ...error) ComparisonResult {
+	result := ComparisonResult{
+		Name: name,
+	}
+
+	switch policy {
+	case config.EnforcementPolicyError:
+		if errors.Join(errs...) != nil {
+			result.Errors = slices.Translate(func(err error) string { return err.Error() }, errs...)
+		}
+	case config.EnforcementPolicyWarn:
+		if errors.Join(errs...) != nil {
+			result.Warnings = slices.Translate(func(err error) string { return err.Error() }, errs...)
+		}
+	case config.EnforcementPolicyNone:
+		return result
+	}
+
+	return result
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validators/crd/crd.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validators/crd/crd.go
@@ -1,0 +1,62 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crd
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+// Validator validates Kubernetes CustomResourceDefinitions using the configured validations.
+type Validator struct {
+	comparators []validations.Comparator[apiextensionsv1.CustomResourceDefinition]
+}
+
+// ValidatorOption configures a Validator.
+type ValidatorOption func(*Validator)
+
+// WithComparators configures a Validator with the provided CustomResourceDefinition Comparators.
+// Each call to WithComparators is a replacement, not additive.
+func WithComparators(comparators ...validations.Comparator[apiextensionsv1.CustomResourceDefinition]) ValidatorOption {
+	return func(v *Validator) {
+		v.comparators = comparators
+	}
+}
+
+// New returns a new Validator for validating an old and new CustomResourceDefinition
+// configured with the provided ValidatorOptions.
+func New(opts ...ValidatorOption) *Validator {
+	validator := &Validator{
+		comparators: []validations.Comparator[apiextensionsv1.CustomResourceDefinition]{},
+	}
+
+	for _, opt := range opts {
+		opt(validator)
+	}
+
+	return validator
+}
+
+// Validate runs the validations configured in the Validator.
+func (v *Validator) Validate(a, b *apiextensionsv1.CustomResourceDefinition) []validations.ComparisonResult {
+	result := []validations.ComparisonResult{}
+
+	for _, comparator := range v.comparators {
+		compResult := comparator.Compare(a, b)
+		result = append(result, compResult)
+	}
+
+	return result
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validators/version/same/same.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validators/version/same/same.go
@@ -1,0 +1,86 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package same
+
+import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+// Validator validates Kubernetes CustomResourceDefinitions using the configured validations.
+type Validator struct {
+	comparators          []validations.Comparator[apiextensionsv1.JSONSchemaProps]
+	unhandledEnforcement config.EnforcementPolicy
+}
+
+// ValidatorOption configures a Validator.
+type ValidatorOption func(*Validator)
+
+// WithComparators configures a Validator with the provided JSONSchemaProps Comparators.
+// Each call to WithComparators is a replacement, not additive.
+func WithComparators(comparators ...validations.Comparator[apiextensionsv1.JSONSchemaProps]) ValidatorOption {
+	return func(v *Validator) {
+		v.comparators = comparators
+	}
+}
+
+// WithUnhandledEnforcementPolicy sets the unhandled enforcement policy for the validator.
+func WithUnhandledEnforcementPolicy(policy config.EnforcementPolicy) ValidatorOption {
+	return func(v *Validator) {
+		if policy == "" {
+			policy = config.EnforcementPolicyError
+		}
+
+		v.unhandledEnforcement = policy
+	}
+}
+
+// New creates a new Validator to validate the same versions of an old and new CustomResourceDefinition
+// configured with the provided ValidatorOptions.
+func New(opts ...ValidatorOption) *Validator {
+	validator := &Validator{
+		comparators:          []validations.Comparator[apiextensionsv1.JSONSchemaProps]{},
+		unhandledEnforcement: config.EnforcementPolicyError,
+	}
+
+	for _, opt := range opts {
+		opt(validator)
+	}
+
+	return validator
+}
+
+// Validate runs the validations configured in the Validator.
+func (v *Validator) Validate(a, b *apiextensionsv1.CustomResourceDefinition) map[string]map[string][]validations.ComparisonResult {
+	result := map[string]map[string][]validations.ComparisonResult{}
+
+	for _, oldVersion := range a.Spec.Versions {
+		newVersion := validations.GetCRDVersionByName(b, oldVersion.Name)
+		// in this case, there is nothing to compare. Generally, the removal
+		// of an existing version is a breaking change. It may be considered safe
+		// if there are no CRs stored at that version or migration has successfully
+		// occurred. Since the safety of this varies and we don't have explicit
+		// knowledge of this we assume a separate check will be in place to capture
+		// this as a breaking change.
+		if newVersion == nil {
+			continue
+		}
+
+		result[oldVersion.Name] = validations.CompareVersions(*oldVersion.DeepCopy(), *newVersion.DeepCopy(), v.unhandledEnforcement, v.comparators...)
+	}
+
+	return result
+}

--- a/tools/vendor/sigs.k8s.io/crdify/pkg/validators/version/served/served.go
+++ b/tools/vendor/sigs.k8s.io/crdify/pkg/validators/version/served/served.go
@@ -1,0 +1,205 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package served
+
+import (
+	"fmt"
+	"slices"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	versionhelper "k8s.io/apimachinery/pkg/version"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+// Validator validates Kubernetes CustomResourceDefinitions using the configured validations.
+type Validator struct {
+	comparators          []validations.Comparator[apiextensionsv1.JSONSchemaProps]
+	conversionPolicy     config.ConversionPolicy
+	unhandledEnforcement config.EnforcementPolicy
+}
+
+// ValidatorOption configures a Validator.
+type ValidatorOption func(*Validator)
+
+// WithComparators configures a Validator with the provided JSONSchemaProps Comparators.
+// Each call to WithComparators is a replacement, not additive.
+func WithComparators(comparators ...validations.Comparator[apiextensionsv1.JSONSchemaProps]) ValidatorOption {
+	return func(v *Validator) {
+		v.comparators = comparators
+	}
+}
+
+// WithUnhandledEnforcementPolicy sets the unhandled enforcement policy for the validator.
+func WithUnhandledEnforcementPolicy(policy config.EnforcementPolicy) ValidatorOption {
+	return func(v *Validator) {
+		if policy == "" {
+			policy = config.EnforcementPolicyError
+		}
+
+		v.unhandledEnforcement = policy
+	}
+}
+
+// WithConversionPolicy sets the conversion policy for the validator.
+func WithConversionPolicy(policy config.ConversionPolicy) ValidatorOption {
+	return func(v *Validator) {
+		if policy == "" {
+			policy = config.ConversionPolicyNone
+		}
+
+		v.conversionPolicy = policy
+	}
+}
+
+// New creates a new Validator to validate the served versions of an old and new CustomResourceDefinition
+// configured with the provided ValidatorOptions.
+func New(opts ...ValidatorOption) *Validator {
+	validator := &Validator{
+		comparators:          []validations.Comparator[apiextensionsv1.JSONSchemaProps]{},
+		conversionPolicy:     config.ConversionPolicyNone,
+		unhandledEnforcement: config.EnforcementPolicyError,
+	}
+
+	for _, opt := range opts {
+		opt(validator)
+	}
+
+	return validator
+}
+
+// Validate runs the validations configured in the Validator.
+func (v *Validator) Validate(a, b *apiextensionsv1.CustomResourceDefinition) map[string]map[string][]validations.ComparisonResult {
+	result := map[string]map[string][]validations.ComparisonResult{}
+
+	// If conversion webhook is specified and conversion policy is ignore, pass check
+	if v.conversionPolicy == config.ConversionPolicyIgnore && b.Spec.Conversion != nil && b.Spec.Conversion.Strategy == apiextensionsv1.WebhookConverter {
+		return result
+	}
+
+	aResults := v.compareVersionPairs(a)
+	bResults := v.compareVersionPairs(b)
+	subtractExistingIssues(bResults, aResults)
+
+	return bResults
+}
+
+func (v *Validator) compareVersionPairs(crd *apiextensionsv1.CustomResourceDefinition) map[string]map[string][]validations.ComparisonResult {
+	result := map[string]map[string][]validations.ComparisonResult{}
+
+	for resultVersionPair, versions := range makeVersionPairs(crd) {
+		result[resultVersionPair] = validations.CompareVersions(versions[0], versions[1], v.unhandledEnforcement, v.comparators...)
+	}
+
+	return result
+}
+
+func makeVersionPairs(crd *apiextensionsv1.CustomResourceDefinition) map[string][2]apiextensionsv1.CustomResourceDefinitionVersion {
+	servedVersions := make([]apiextensionsv1.CustomResourceDefinitionVersion, 0, len(crd.Spec.Versions))
+
+	for _, version := range crd.Spec.Versions {
+		if version.Served {
+			servedVersions = append(servedVersions, version)
+		}
+	}
+
+	if len(servedVersions) < 2 {
+		return nil
+	}
+
+	slices.SortFunc(servedVersions, func(a, b apiextensionsv1.CustomResourceDefinitionVersion) int {
+		return versionhelper.CompareKubeAwareVersionStrings(a.Name, b.Name)
+	})
+
+	pairs := make(map[string][2]apiextensionsv1.CustomResourceDefinitionVersion, numUnidirectionalPermutations(servedVersions))
+
+	for i, iVersion := range servedVersions[:len(servedVersions)-1] {
+		for _, jVersion := range servedVersions[i+1:] {
+			resultVersionPair := fmt.Sprintf("%s -> %s", iVersion.Name, jVersion.Name)
+			pairs[resultVersionPair] = [2]apiextensionsv1.CustomResourceDefinitionVersion{iVersion, jVersion}
+		}
+	}
+
+	return pairs
+}
+
+func numUnidirectionalPermutations[T any](in []T) int {
+	n := len(in)
+
+	return (n * (n - 1)) / 2
+}
+
+// subtractExistingIssues removes errors and warnings from b's results that are also found in a's results.
+func subtractExistingIssues(b, a map[string]map[string][]validations.ComparisonResult) {
+	sliceToMapByName := func(in []validations.ComparisonResult) map[string]*validations.ComparisonResult {
+		out := make(map[string]*validations.ComparisonResult, len(in))
+
+		for i := range in {
+			v := &in[i]
+			out[v.Name] = v
+		}
+
+		return out
+	}
+
+	for versionPair, bVersionPairResults := range b {
+		aVersionPairResults, ok := a[versionPair]
+		if !ok {
+			// If the version pair is not found in a, that means
+			// b introduced a new version, so we'll keep _all_
+			// of the comparison results for this pair
+			continue
+		}
+
+		for fieldPath, bFieldPathResults := range bVersionPairResults {
+			aFieldPathResults, ok := aVersionPairResults[fieldPath]
+			if !ok {
+				// If this field path is not found in a's results
+				// for this version pair, that means b introduced a new field
+				// in an existing schema, so we'll keep _all_ of the comparison
+				// results for this field path.
+				continue
+			}
+
+			aResultMap := sliceToMapByName(aFieldPathResults)
+			bResultMap := sliceToMapByName(bFieldPathResults)
+
+			for validationName, bValidationResult := range bResultMap {
+				aValidationResult, ok := aResultMap[validationName]
+				if !ok {
+					// If a's results do not include results for this validation,
+					// that means we ran a new validation for b that we did not
+					// run for a. We never intend to do that, so if that is somehow
+					// the case, let's panic and say what our programmer intent was.
+					panic(fmt.Sprintf("Validation %q not found in a's results for version pair %q. This should never happen because this validator uses the same validation configuration for CRDs a and b.", validationName, versionPair))
+				}
+
+				bValidationResult.Errors = slices.DeleteFunc(bValidationResult.Errors, func(bErr string) bool {
+					return slices.Contains(aValidationResult.Errors, bErr)
+				})
+				if len(bValidationResult.Errors) == 0 {
+					bValidationResult.Errors = nil
+				}
+
+				bValidationResult.Warnings = slices.DeleteFunc(bValidationResult.Warnings, func(bWarn string) bool {
+					return slices.Contains(aValidationResult.Warnings, bWarn)
+				})
+				if len(bValidationResult.Warnings) == 0 {
+					bValidationResult.Warnings = nil
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds a new codegen generator to run [kubernetes-sigs/crdify](https://github.com/kubernetes-sigs/crdify) checks against OpenShift APIs for validating change compatibility.