### PR TITLE
CORS-4221: Remove the OAUTH and STS endpoints

### DIFF
--- a/config/v1/tests/infrastructures.config.openshift.io/GCPCustomAPIEndpoints.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/GCPCustomAPIEndpoints.yaml
@@ -213,7 +213,7 @@ tests:
                 dnsType: PlatformDefault
               serviceEndpoints:
                 - {name: "UnknownService", url: "https://compute-myendpoint1.p.googleapis.com"}
-      expectedStatusError: "[status.platformStatus.gcp.serviceEndpoints[0].name: Unsupported value: \"UnknownService\": supported values: \"Compute\", \"Container\", \"CloudResourceManager\", \"DNS\", \"File\", \"IAM\", \"IAMCredentials\", \"OAuth\", \"ServiceUsage\", \"Storage\", \"STS\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]"
+      expectedStatusError: "[status.platformStatus.gcp.serviceEndpoints[0].name: Unsupported value: \"UnknownService\": supported values: \"Compute\", \"Container\", \"CloudResourceManager\", \"DNS\", \"File\", \"IAM\", \"IAMCredentials\", \"ServiceUsage\", \"Storage\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]"
     - name: Service Endpoint End Slash
       initial: |
         apiVersion: config.openshift.io/v1

--- a/config/v1/tests/infrastructures.config.openshift.io/GCPCustomAPIEndpointsInstall.yaml
+++ b/config/v1/tests/infrastructures.config.openshift.io/GCPCustomAPIEndpointsInstall.yaml
@@ -213,7 +213,7 @@ tests:
                 dnsType: PlatformDefault
               serviceEndpoints:
                 - {name: "UnknownService", url: "https://compute-myendpoint1.p.googleapis.com"}
-      expectedStatusError: "[status.platformStatus.gcp.serviceEndpoints[0].name: Unsupported value: \"UnknownService\": supported values: \"Compute\", \"Container\", \"CloudResourceManager\", \"DNS\", \"File\", \"IAM\", \"IAMCredentials\", \"OAuth\", \"ServiceUsage\", \"Storage\", \"STS\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]"
+      expectedStatusError: "[status.platformStatus.gcp.serviceEndpoints[0].name: Unsupported value: \"UnknownService\": supported values: \"Compute\", \"Container\", \"CloudResourceManager\", \"DNS\", \"File\", \"IAM\", \"IAMCredentials\", \"ServiceUsage\", \"Storage\", <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]"
     - name: Service Endpoint End Slash
       initial: |
         apiVersion: config.openshift.io/v1

--- a/config/v1/types_infrastructure.go
+++ b/config/v1/types_infrastructure.go
@@ -650,7 +650,7 @@ const (
 )
 
 // GCPServiceEndpointName is the name of the GCP Service Endpoint.
-// +kubebuilder:validation:Enum=Compute;Container;CloudResourceManager;DNS;File;IAM;IAMCredentials;OAuth;ServiceUsage;Storage;STS
+// +kubebuilder:validation:Enum=Compute;Container;CloudResourceManager;DNS;File;IAM;IAMCredentials;ServiceUsage;Storage
 type GCPServiceEndpointName string
 
 const (
@@ -675,17 +675,11 @@ const (
 	// GCPServiceEndpointNameIAMCredentials is the name used for the GCP IAM Credentials Service endpoint.
 	GCPServiceEndpointNameIAMCredentials GCPServiceEndpointName = "IAMCredentials"
 
-	// GCPServiceEndpointNameOAuth is the name used for the GCP OAuth2 Service endpoint.
-	GCPServiceEndpointNameOAuth GCPServiceEndpointName = "OAuth"
-
 	// GCPServiceEndpointNameServiceUsage is the name used for the GCP Service Usage Service endpoint.
 	GCPServiceEndpointNameServiceUsage GCPServiceEndpointName = "ServiceUsage"
 
 	// GCPServiceEndpointNameStorage is the name used for the GCP Storage Service endpoint.
 	GCPServiceEndpointNameStorage GCPServiceEndpointName = "Storage"
-
-	// GCPServiceEndpointNameSTS is the name used for the GCP STS Service endpoint.
-	GCPServiceEndpointNameSTS GCPServiceEndpointName = "STS"
 )
 
 // GCPServiceEndpoint store the configuration of a custom url to
@@ -694,8 +688,8 @@ type GCPServiceEndpoint struct {
 	// name is the name of the GCP service whose endpoint is being overridden.
 	// This must be provided and cannot be empty.
 	//
-	// Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-	// Storage, and TagManager.
+	// Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+	// ServiceUsage, and Storage.
 	//
 	// As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
 	// Service will be directed to the endpoint specified in the url field.
@@ -779,7 +773,7 @@ type GCPPlatformStatus struct {
 	// The maximum number of endpoint overrides allowed is 11.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=11
+	// +kubebuilder:validation:MaxItems=9
 	// +kubebuilder:validation:XValidation:rule="self.all(x, self.exists_one(y, x.name == y.name))",message="only 1 endpoint override is permitted per GCP service name"
 	// +optional
 	// +openshift:enable:FeatureGate=GCPCustomAPIEndpointsInstall

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -2006,8 +2006,8 @@ spec:
                                 name is the name of the GCP service whose endpoint is being overridden.
                                 This must be provided and cannot be empty.
 
-                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                Storage, and TagManager.
+                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                ServiceUsage, and Storage.
 
                                 As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                 Service will be directed to the endpoint specified in the url field.
@@ -2019,10 +2019,8 @@ spec:
                               - File
                               - IAM
                               - IAMCredentials
-                              - OAuth
                               - ServiceUsage
                               - Storage
-                              - STS
                               type: string
                             url:
                               description: |-
@@ -2048,7 +2046,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 11
+                        maxItems: 9
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -2006,8 +2006,8 @@ spec:
                                 name is the name of the GCP service whose endpoint is being overridden.
                                 This must be provided and cannot be empty.
 
-                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                Storage, and TagManager.
+                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                ServiceUsage, and Storage.
 
                                 As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                 Service will be directed to the endpoint specified in the url field.
@@ -2019,10 +2019,8 @@ spec:
                               - File
                               - IAM
                               - IAMCredentials
-                              - OAuth
                               - ServiceUsage
                               - Storage
-                              - STS
                               type: string
                             url:
                               description: |-
@@ -2048,7 +2046,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 11
+                        maxItems: 9
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -2006,8 +2006,8 @@ spec:
                                 name is the name of the GCP service whose endpoint is being overridden.
                                 This must be provided and cannot be empty.
 
-                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                Storage, and TagManager.
+                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                ServiceUsage, and Storage.
 
                                 As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                 Service will be directed to the endpoint specified in the url field.
@@ -2019,10 +2019,8 @@ spec:
                               - File
                               - IAM
                               - IAMCredentials
-                              - OAuth
                               - ServiceUsage
                               - Storage
-                              - STS
                               type: string
                             url:
                               description: |-
@@ -2048,7 +2046,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 11
+                        maxItems: 9
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPCustomAPIEndpointsInstall.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/infrastructures.config.openshift.io/GCPCustomAPIEndpointsInstall.yaml
@@ -1598,8 +1598,8 @@ spec:
                                 name is the name of the GCP service whose endpoint is being overridden.
                                 This must be provided and cannot be empty.
 
-                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                Storage, and TagManager.
+                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                ServiceUsage, and Storage.
 
                                 As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                 Service will be directed to the endpoint specified in the url field.
@@ -1611,10 +1611,8 @@ spec:
                               - File
                               - IAM
                               - IAMCredentials
-                              - OAuth
                               - ServiceUsage
                               - Storage
-                              - STS
                               type: string
                             url:
                               description: |-
@@ -1640,7 +1638,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 11
+                        maxItems: 9
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/config/v1/zz_generated.swagger_doc_generated.go
+++ b/config/v1/zz_generated.swagger_doc_generated.go
@@ -1643,7 +1643,7 @@ func (GCPResourceTag) SwaggerDoc() map[string]string {
 
 var map_GCPServiceEndpoint = map[string]string{
 	"":     "GCPServiceEndpoint store the configuration of a custom url to override existing defaults of GCP Services.",
-	"name": "name is the name of the GCP service whose endpoint is being overridden. This must be provided and cannot be empty.\n\nAllowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage, Storage, and TagManager.\n\nAs an example, when setting the name to Compute all requests made by the caller to the GCP Compute Service will be directed to the endpoint specified in the url field.",
+	"name": "name is the name of the GCP service whose endpoint is being overridden. This must be provided and cannot be empty.\n\nAllowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials, ServiceUsage, and Storage.\n\nAs an example, when setting the name to Compute all requests made by the caller to the GCP Compute Service will be directed to the endpoint specified in the url field.",
 	"url":  "url is a fully qualified URI that overrides the default endpoint for a client using the GCP service specified in the name field. url is required, must use the scheme https, must not be more than 253 characters in length, and must be a valid URL according to Go's net/url package (https://pkg.go.dev/net/url#URL)\n\nAn example of a valid endpoint that overrides the Compute Service: \"https://compute-myendpoint1.p.googleapis.com\"",
 }
 

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -2286,8 +2286,8 @@ spec:
                                         name is the name of the GCP service whose endpoint is being overridden.
                                         This must be provided and cannot be empty.
 
-                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                        Storage, and TagManager.
+                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                        ServiceUsage, and Storage.
 
                                         As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                         Service will be directed to the endpoint specified in the url field.
@@ -2299,10 +2299,8 @@ spec:
                                       - File
                                       - IAM
                                       - IAMCredentials
-                                      - OAuth
                                       - ServiceUsage
                                       - Storage
-                                      - STS
                                       type: string
                                     url:
                                       description: |-
@@ -2328,7 +2326,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 11
+                                maxItems: 9
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -2286,8 +2286,8 @@ spec:
                                         name is the name of the GCP service whose endpoint is being overridden.
                                         This must be provided and cannot be empty.
 
-                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                        Storage, and TagManager.
+                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                        ServiceUsage, and Storage.
 
                                         As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                         Service will be directed to the endpoint specified in the url field.
@@ -2299,10 +2299,8 @@ spec:
                                       - File
                                       - IAM
                                       - IAMCredentials
-                                      - OAuth
                                       - ServiceUsage
                                       - Storage
-                                      - STS
                                       type: string
                                     url:
                                       description: |-
@@ -2328,7 +2326,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 11
+                                maxItems: 9
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -2286,8 +2286,8 @@ spec:
                                         name is the name of the GCP service whose endpoint is being overridden.
                                         This must be provided and cannot be empty.
 
-                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                        Storage, and TagManager.
+                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                        ServiceUsage, and Storage.
 
                                         As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                         Service will be directed to the endpoint specified in the url field.
@@ -2299,10 +2299,8 @@ spec:
                                       - File
                                       - IAM
                                       - IAMCredentials
-                                      - OAuth
                                       - ServiceUsage
                                       - Storage
-                                      - STS
                                       type: string
                                     url:
                                       description: |-
@@ -2328,7 +2326,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 11
+                                maxItems: 9
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPCustomAPIEndpointsInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/controllerconfigs.machineconfiguration.openshift.io/GCPCustomAPIEndpointsInstall.yaml
@@ -1899,8 +1899,8 @@ spec:
                                         name is the name of the GCP service whose endpoint is being overridden.
                                         This must be provided and cannot be empty.
 
-                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                        Storage, and TagManager.
+                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                        ServiceUsage, and Storage.
 
                                         As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                         Service will be directed to the endpoint specified in the url field.
@@ -1912,10 +1912,8 @@ spec:
                                       - File
                                       - IAM
                                       - IAMCredentials
-                                      - OAuth
                                       - ServiceUsage
                                       - Storage
-                                      - STS
                                       type: string
                                     url:
                                       description: |-
@@ -1941,7 +1939,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 11
+                                maxItems: 9
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -12939,7 +12939,7 @@ func schema_openshift_api_config_v1_GCPServiceEndpoint(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "name is the name of the GCP service whose endpoint is being overridden. This must be provided and cannot be empty.\n\nAllowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage, Storage, and TagManager.\n\nAs an example, when setting the name to Compute all requests made by the caller to the GCP Compute Service will be directed to the endpoint specified in the url field.",
+							Description: "name is the name of the GCP service whose endpoint is being overridden. This must be provided and cannot be empty.\n\nAllowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials, ServiceUsage, and Storage.\n\nAs an example, when setting the name to Compute all requests made by the caller to the GCP Compute Service will be directed to the endpoint specified in the url field.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -6682,7 +6682,7 @@
       ],
       "properties": {
         "name": {
-          "description": "name is the name of the GCP service whose endpoint is being overridden. This must be provided and cannot be empty.\n\nAllowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage, Storage, and TagManager.\n\nAs an example, when setting the name to Compute all requests made by the caller to the GCP Compute Service will be directed to the endpoint specified in the url field.",
+          "description": "name is the name of the GCP service whose endpoint is being overridden. This must be provided and cannot be empty.\n\nAllowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials, ServiceUsage, and Storage.\n\nAs an example, when setting the name to Compute all requests made by the caller to the GCP Compute Service will be directed to the endpoint specified in the url field.",
           "type": "string",
           "default": ""
         },

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-CustomNoUpgrade.crd.yaml
@@ -2006,8 +2006,8 @@ spec:
                                 name is the name of the GCP service whose endpoint is being overridden.
                                 This must be provided and cannot be empty.
 
-                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                Storage, and TagManager.
+                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                ServiceUsage, and Storage.
 
                                 As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                 Service will be directed to the endpoint specified in the url field.
@@ -2019,10 +2019,8 @@ spec:
                               - File
                               - IAM
                               - IAMCredentials
-                              - OAuth
                               - ServiceUsage
                               - Storage
-                              - STS
                               type: string
                             url:
                               description: |-
@@ -2048,7 +2046,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 11
+                        maxItems: 9
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-DevPreviewNoUpgrade.crd.yaml
@@ -2006,8 +2006,8 @@ spec:
                                 name is the name of the GCP service whose endpoint is being overridden.
                                 This must be provided and cannot be empty.
 
-                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                Storage, and TagManager.
+                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                ServiceUsage, and Storage.
 
                                 As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                 Service will be directed to the endpoint specified in the url field.
@@ -2019,10 +2019,8 @@ spec:
                               - File
                               - IAM
                               - IAMCredentials
-                              - OAuth
                               - ServiceUsage
                               - Storage
-                              - STS
                               type: string
                             url:
                               description: |-
@@ -2048,7 +2046,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 11
+                        maxItems: 9
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_infrastructures-TechPreviewNoUpgrade.crd.yaml
@@ -2006,8 +2006,8 @@ spec:
                                 name is the name of the GCP service whose endpoint is being overridden.
                                 This must be provided and cannot be empty.
 
-                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                Storage, and TagManager.
+                                Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                ServiceUsage, and Storage.
 
                                 As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                 Service will be directed to the endpoint specified in the url field.
@@ -2019,10 +2019,8 @@ spec:
                               - File
                               - IAM
                               - IAMCredentials
-                              - OAuth
                               - ServiceUsage
                               - Storage
-                              - STS
                               type: string
                             url:
                               description: |-
@@ -2048,7 +2046,7 @@ spec:
                           - name
                           - url
                           type: object
-                        maxItems: 11
+                        maxItems: 9
                         type: array
                         x-kubernetes-list-map-keys:
                         - name

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-CustomNoUpgrade.crd.yaml
@@ -2286,8 +2286,8 @@ spec:
                                         name is the name of the GCP service whose endpoint is being overridden.
                                         This must be provided and cannot be empty.
 
-                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                        Storage, and TagManager.
+                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                        ServiceUsage, and Storage.
 
                                         As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                         Service will be directed to the endpoint specified in the url field.
@@ -2299,10 +2299,8 @@ spec:
                                       - File
                                       - IAM
                                       - IAMCredentials
-                                      - OAuth
                                       - ServiceUsage
                                       - Storage
-                                      - STS
                                       type: string
                                     url:
                                       description: |-
@@ -2328,7 +2326,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 11
+                                maxItems: 9
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-DevPreviewNoUpgrade.crd.yaml
@@ -2286,8 +2286,8 @@ spec:
                                         name is the name of the GCP service whose endpoint is being overridden.
                                         This must be provided and cannot be empty.
 
-                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                        Storage, and TagManager.
+                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                        ServiceUsage, and Storage.
 
                                         As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                         Service will be directed to the endpoint specified in the url field.
@@ -2299,10 +2299,8 @@ spec:
                                       - File
                                       - IAM
                                       - IAMCredentials
-                                      - OAuth
                                       - ServiceUsage
                                       - Storage
-                                      - STS
                                       type: string
                                     url:
                                       description: |-
@@ -2328,7 +2326,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 11
+                                maxItems: 9
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name

--- a/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_controllerconfigs-TechPreviewNoUpgrade.crd.yaml
@@ -2286,8 +2286,8 @@ spec:
                                         name is the name of the GCP service whose endpoint is being overridden.
                                         This must be provided and cannot be empty.
 
-                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, ServiceUsage,
-                                        Storage, and TagManager.
+                                        Allowed values are Compute, Container, CloudResourceManager, DNS, File, IAM, IAMCredentials,
+                                        ServiceUsage, and Storage.
 
                                         As an example, when setting the name to Compute all requests made by the caller to the GCP Compute
                                         Service will be directed to the endpoint specified in the url field.
@@ -2299,10 +2299,8 @@ spec:
                                       - File
                                       - IAM
                                       - IAMCredentials
-                                      - OAuth
                                       - ServiceUsage
                                       - Storage
-                                      - STS
                                       type: string
                                     url:
                                       description: |-
@@ -2328,7 +2326,7 @@ spec:
                                   - name
                                   - url
                                   type: object
-                                maxItems: 11
+                                maxItems: 9
                                 type: array
                                 x-kubernetes-list-map-keys:
                                 - name


### PR DESCRIPTION
** The GCP endpoints for oauth and sts should not be overridden using the Private Service Connect. While these appear to be services just like the others (ex compute) they are not to be overridden as per google. Remove the option to override these endpoints.