### PR TITLE
(bugfix): crdify generator returns aggregated error when validations fail

### DIFF
--- a/tools/codegen/pkg/crdify/generator.go
+++ b/tools/codegen/pkg/crdify/generator.go
@@ -210,7 +210,9 @@ func (g *generator) genGroupVersion(name string, version generation.APIVersionCo
 
 		for _, crdResults := range runResults.CRDValidation {
 			for _, err := range crdResults.Errors {
-				result.Errors = append(result.Errors, fmt.Errorf("%s: %w", crdResults.Name, errors.New(err)))
+				resErr := fmt.Errorf("%s: %w", crdResults.Name, errors.New(err))
+				result.Errors = append(result.Errors, resErr)
+				errs = append(errs, resErr)
 			}
 
 			for _, warn := range crdResults.Warnings {
@@ -220,7 +222,9 @@ func (g *generator) genGroupVersion(name string, version generation.APIVersionCo
 
 		versionedResultFunc := func(version, property string, compResult validations.ComparisonResult) {
 			for _, err := range compResult.Errors {
-				result.Errors = append(result.Errors, fmt.Errorf("(%s) %s - %s: %w", version, property, compResult.Name, errors.New(err)))
+				resErr := fmt.Errorf("(%s) %s - %s: %w", version, property, compResult.Name, errors.New(err))
+				result.Errors = append(result.Errors, resErr)
+				errs = append(errs, resErr)
 			}
 
 			for _, warn := range compResult.Warnings {
@@ -232,6 +236,10 @@ func (g *generator) genGroupVersion(name string, version generation.APIVersionCo
 		processVersionedPropertyResults(runResults.ServedVersionValidation, versionedResultFunc)
 
 		results = append(results, result)
+	}
+
+	if len(errs) > 0 {
+		return results, kerrors.NewAggregate(errs)
 	}
 
 	return results, nil


### PR DESCRIPTION
We noticed in https://github.com/openshift/api/pull/2492 that the `crdify` verification passed when we would have expected it to fail.

We noticed in the [logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_api/2492/pull-ci-openshift-api-master-verify-crdify/1970096772663480320/artifacts/test/build-log.txt) that it did properly return failed validation in the logs but still exited successfully.

This was because my original PR to add the `crdify` codegen generator did not count the errors from the comparison validations as an error to be returned and instead we only built out the generator results.

This PR updates the method where the comparison validations occur to consider errors in the validations result as a normal Go error as well, returning an aggregated error of all comparison validation errors that have occurred alongside the generator results.