### PR TITLE
[release-4.20] OCPBUGS-61977: Add 'AGE' print column to MachineConfigNode object

### DIFF
--- a/machineconfiguration/v1/types_machineconfignode.go
+++ b/machineconfiguration/v1/types_machineconfignode.go
@@ -17,6 +17,7 @@ import (
 // +kubebuilder:printcolumn:name="DesiredConfig",type="string",JSONPath=.spec.configVersion.desired,priority=0
 // +kubebuilder:printcolumn:name="CurrentConfig",type="string",JSONPath=.status.configVersion.current,priority=0
 // +kubebuilder:printcolumn:name="Updated",type="string",JSONPath=.status.conditions[?(@.type=="Updated")].status,priority=0
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",priority=0
 // +kubebuilder:printcolumn:name="UpdatePrepared",type="string",JSONPath=.status.conditions[?(@.type=="UpdatePrepared")].status,priority=1
 // +kubebuilder:printcolumn:name="UpdateExecuted",type="string",JSONPath=.status.conditions[?(@.type=="UpdateExecuted")].status,priority=1
 // +kubebuilder:printcolumn:name="UpdatePostActionComplete",type="string",JSONPath=.status.conditions[?(@.type=="UpdatePostActionComplete")].status,priority=1

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-CustomNoUpgrade.crd.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Default.crd.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-DevPreviewNoUpgrade.crd.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-TechPreviewNoUpgrade.crd.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -141,6 +141,9 @@ machineconfignodes.machineconfiguration.openshift.io:
   - jsonPath: .status.conditions[?(@.type=="Updated")].status
     name: Updated
     type: string
+  - jsonPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
     name: UpdatePrepared
     priority: 1

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/IrreconcilableMachineConfig.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/IrreconcilableMachineConfig.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/MachineConfigNodes.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/MachineConfigNodes.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-CustomNoUpgrade.crd.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Default.crd.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-DevPreviewNoUpgrade.crd.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-TechPreviewNoUpgrade.crd.yaml
@@ -32,6 +32,9 @@ spec:
     - jsonPath: .status.conditions[?(@.type=="Updated")].status
       name: Updated
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .status.conditions[?(@.type=="UpdatePrepared")].status
       name: UpdatePrepared
       priority: 1


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/api/pull/2476 since the automated cherry-pick in #2486 did not include correct generated files.

The diff for the generated files can be seen here https://github.com/openshift/api/commit/ca2a6f5d05d3ba4edbd38ffa3b0891415a5d7c66.