### PR TITLE
OCPBUGS-59940: ConsoleLink CRD has incorrect additionalPrinterColumns entry

### DIFF
--- a/console/v1/types_console_cli_download.go
+++ b/console/v1/types_console_cli_download.go
@@ -18,7 +18,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:metadata:annotations="description=Extension for configuring openshift web console command line interface (CLI) downloads."
 // +kubebuilder:metadata:annotations="displayName=ConsoleCLIDownload"
 // +kubebuilder:printcolumn:name=Display name,JSONPath=.spec.displayName,type=string
-// +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,type=string
+// +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,type=date
 // +openshift:compatibility-gen:level=2
 type ConsoleCLIDownload struct {
 	metav1.TypeMeta `json:",inline"`

--- a/console/v1/zz_generated.crd-manifests/00_consoleclidownloads.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consoleclidownloads.crd.yaml
@@ -26,7 +26,7 @@ spec:
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
-      type: string
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/console/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/console/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -22,7 +22,7 @@ consoleclidownloads.console.openshift.io:
     type: string
   - jsonPath: .metadata.creationTimestamp
     name: Age
-    type: string
+    type: date
   Scope: Cluster
   ShortNames: null
   TopLevelFeatureGates: []

--- a/console/v1/zz_generated.featuregated-crd-manifests/consoleclidownloads.console.openshift.io/AAA_ungated.yaml
+++ b/console/v1/zz_generated.featuregated-crd-manifests/consoleclidownloads.console.openshift.io/AAA_ungated.yaml
@@ -25,7 +25,7 @@ spec:
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
-      type: string
+      type: date
     name: v1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
### Bug fix for master

The ConsoleLink CRD has an `additionalPrinterColumns` entry for `Menu` that is not valid. The correct column name is `Location`.

 - name: Menu
  type: string
  jsonPath: .spec.menu
should be changed to

 - name: Location
  type: string
  jsonPath: .spec.location