### PR TITLE
OCPBUGS-59939: ConsoleLink CRD has incorrect additionalPrinterColumns entry

### DIFF
--- a/console/v1/types_console_link.go
+++ b/console/v1/types_console_link.go
@@ -19,7 +19,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:metadata:annotations="displayName=ConsoleLinks"
 // +kubebuilder:printcolumn:name=Text,JSONPath=.spec.text,type=string
 // +kubebuilder:printcolumn:name=URL,JSONPath=.spec.href,type=string
-// +kubebuilder:printcolumn:name=Menu,JSONPath=.spec.menu,type=string
+// +kubebuilder:printcolumn:name=Location,JSONPath=.spec.location,type=string
 // +kubebuilder:printcolumn:name=Age,JSONPath=.metadata.creationTimestamp,type=date
 // +openshift:compatibility-gen:level=2
 type ConsoleLink struct {

--- a/console/v1/zz_generated.crd-manifests/00_consolelinks.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consolelinks.crd.yaml
@@ -26,8 +26,8 @@ spec:
     - jsonPath: .spec.href
       name: URL
       type: string
-    - jsonPath: .spec.menu
-      name: Menu
+    - jsonPath: .spec.location
+      name: Location
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/console/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/console/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -85,8 +85,8 @@ consolelinks.console.openshift.io:
   - jsonPath: .spec.href
     name: URL
     type: string
-  - jsonPath: .spec.menu
-    name: Menu
+  - jsonPath: .spec.location
+    name: Location
     type: string
   - jsonPath: .metadata.creationTimestamp
     name: Age

--- a/console/v1/zz_generated.featuregated-crd-manifests/consolelinks.console.openshift.io/AAA_ungated.yaml
+++ b/console/v1/zz_generated.featuregated-crd-manifests/consolelinks.console.openshift.io/AAA_ungated.yaml
@@ -25,8 +25,8 @@ spec:
     - jsonPath: .spec.href
       name: URL
       type: string
-    - jsonPath: .spec.menu
-      name: Menu
+    - jsonPath: .spec.location
+      name: Location
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
### Bug fix for master

The ConsoleLink CRD has an `additionalPrinterColumns` entry for `Menu` that is not valid. The correct column name is `Location`.

 - name: Menu
  type: string
  jsonPath: .spec.menu
should be changed to

 - name: Location
  type: string
  jsonPath: .spec.location