### PR TITLE
CNTRLPLANE-1540: Add support for goaway-chance in the Kube API Server…

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -52217,12 +52217,19 @@ func schema_openshift_api_operator_v1_KubeAPIServerSpec(ref common.ReferenceCall
 							Format:      "int32",
 						},
 					},
+					"goawayChance": {
+						SchemaProps: spec.SchemaProps{
+							Description: "goawayChance sets the goaway-chance on the kube-apiserver configuration. It is the probability to send a GOAWAY to HTTP/2 clients. When a client received GOAWAY, the in-flight requests will not be affected and new requests will use a new TCP connection to triggering re-balancing to another server. Default to 0, means never send GOAWAY. Max is 0.02 to prevent breaking the apiserver. When not specified, the default value is 0.001. This setting has no effect on a single node topology,",
+							Default:     "0.001",
+							Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+						},
+					},
 				},
 				Required: []string{"managementState", "forceRedeploymentReason"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/apimachinery/pkg/runtime.RawExtension"},
+			"k8s.io/apimachinery/pkg/api/resource.Quantity", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
 	}
 }
 

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -30300,6 +30300,11 @@
           "type": "string",
           "default": ""
         },
+        "goawayChance": {
+          "description": "goawayChance sets the goaway-chance on the kube-apiserver configuration. It is the probability to send a GOAWAY to HTTP/2 clients. When a client received GOAWAY, the in-flight requests will not be affected and new requests will use a new TCP connection to triggering re-balancing to another server. Default to 0, means never send GOAWAY. Max is 0.02 to prevent breaking the apiserver. When not specified, the default value is 0.001. This setting has no effect on a single node topology,",
+          "default": "0.001",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+        },
         "logLevel": {
           "description": "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands.\n\nValid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\".",
           "type": "string"

--- a/operator/v1/tests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/tests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -14,6 +14,7 @@ tests:
         spec:
           logLevel: Normal
           operatorLogLevel: Normal
+          goawayChance: "0.001"
   onUpdate:
     - name: Should reject multiple nodes with nonzero target revisions
       initialCRDPatches:
@@ -140,6 +141,7 @@ tests:
         spec:
           logLevel: Normal
           operatorLogLevel: Normal
+          goawayChance: "0.001"
         status:
           nodeStatuses:
           - nodeName: a
@@ -166,6 +168,7 @@ tests:
         spec:
           logLevel: Normal
           operatorLogLevel: Normal
+          goawayChance: "0.001"
         status:
           nodeStatuses:
           - nodeName: a
@@ -192,6 +195,7 @@ tests:
         spec:
           logLevel: Normal
           operatorLogLevel: Normal
+          goawayChance: "0.001"
         status:
           nodeStatuses:
           - nodeName: a

--- a/operator/v1/tests/kubeapiservers.operator.openshift.io/GoawayChance.yaml
+++ b/operator/v1/tests/kubeapiservers.operator.openshift.io/GoawayChance.yaml
@@ -1,0 +1,48 @@
+apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
+name: "KubeAPIServer"
+crdName: kubeapiservers.operator.openshift.io
+tests:
+  onCreate:
+    - name: Should be able to create default goaway chance
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec: {} # No spec is required for a KubeAPIServer
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+          goawayChance: "0.001"
+    - name: Should be able to create a normal goaway chance
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec:
+          goawayChance: "0.005"
+      expected: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        spec:
+          logLevel: Normal
+          operatorLogLevel: Normal
+          goawayChance: "0.005"
+    - name: Should not be able to create with less than 0
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        metadata:
+          name: gg1
+        spec:
+          goawayChance: "-1"
+      expectedError: "must be positive or zero"
+    - name: Should not be able to create with more than 0.02
+      initial: |
+        apiVersion: operator.openshift.io/v1
+        kind: KubeAPIServer
+        metadata:
+          name: gg2
+        spec:
+          goawayChance: "0.03"
+      expectedError: "must be less than or equal to 0.02"

--- a/operator/v1/types_kubeapiserver.go
+++ b/operator/v1/types_kubeapiserver.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -35,6 +36,19 @@ type KubeAPIServer struct {
 
 type KubeAPIServerSpec struct {
 	StaticPodOperatorSpec `json:",inline"`
+
+	// goawayChance sets the goaway-chance on the kube-apiserver configuration.
+	// It is the probability to send a GOAWAY to HTTP/2 clients. When a client received
+	// GOAWAY, the in-flight requests will not be affected and new requests will use
+	// a new TCP connection to triggering re-balancing to another server.
+	// Default to 0, means never send GOAWAY. Max is 0.02 to prevent breaking the apiserver.
+	// When not specified, the default value is 0.001. This setting has no effect on a single node topology,
+	// +kubebuilder:default:="0.001"
+	// +kubebuilder:validation:XValidation:rule="isQuantity(self) && quantity(self).compareTo(quantity('0')) >= 0",message="must be positive or zero"
+	// +kubebuilder:validation:XValidation:rule="isQuantity(self) && quantity(self).compareTo(quantity('0.02')) <= 0",message="must be less than or equal to 0.02"
+	// +default="0.001"
+	// +optional
+	GoawayChance resource.Quantity `json:"goawayChance,omitempty"`
 }
 
 type KubeAPIServerStatus struct {

--- a/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -59,6 +59,27 @@ spec:
                   This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work
                   this time instead of failing again on the same config.
                 type: string
+              goawayChance:
+                anyOf:
+                - type: integer
+                - type: string
+                default: "0.001"
+                description: |-
+                  goawayChance sets the goaway-chance on the kube-apiserver configuration.
+                  It is the probability to send a GOAWAY to HTTP/2 clients. When a client received
+                  GOAWAY, the in-flight requests will not be affected and new requests will use
+                  a new TCP connection to triggering re-balancing to another server.
+                  Default to 0, means never send GOAWAY. Max is 0.02 to prevent breaking the apiserver.
+                  When not specified, the default value is 0.001. This setting has no effect on a single node topology,
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: must be positive or zero
+                  rule: isQuantity(self) && quantity(self).compareTo(quantity('0'))
+                    >= 0
+                - message: must be less than or equal to 0.02
+                  rule: isQuantity(self) && quantity(self).compareTo(quantity('0.02'))
+                    <= 0
               logLevel:
                 default: Normal
                 description: |-

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -2793,6 +2793,7 @@ func (in *KubeAPIServerList) DeepCopyObject() runtime.Object {
 func (in *KubeAPIServerSpec) DeepCopyInto(out *KubeAPIServerSpec) {
 	*out = *in
 	in.StaticPodOperatorSpec.DeepCopyInto(&out.StaticPodOperatorSpec)
+	out.GoawayChance = in.GoawayChance.DeepCopy()
 	return
 }
 

--- a/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/kubeapiservers.operator.openshift.io/AAA_ungated.yaml
@@ -60,6 +60,27 @@ spec:
                   This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work
                   this time instead of failing again on the same config.
                 type: string
+              goawayChance:
+                anyOf:
+                - type: integer
+                - type: string
+                default: "0.001"
+                description: |-
+                  goawayChance sets the goaway-chance on the kube-apiserver configuration.
+                  It is the probability to send a GOAWAY to HTTP/2 clients. When a client received
+                  GOAWAY, the in-flight requests will not be affected and new requests will use
+                  a new TCP connection to triggering re-balancing to another server.
+                  Default to 0, means never send GOAWAY. Max is 0.02 to prevent breaking the apiserver.
+                  When not specified, the default value is 0.001. This setting has no effect on a single node topology,
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: must be positive or zero
+                  rule: isQuantity(self) && quantity(self).compareTo(quantity('0'))
+                    >= 0
+                - message: must be less than or equal to 0.02
+                  rule: isQuantity(self) && quantity(self).compareTo(quantity('0.02'))
+                    <= 0
               logLevel:
                 default: Normal
                 description: |-

--- a/operator/v1/zz_generated.swagger_doc_generated.go
+++ b/operator/v1/zz_generated.swagger_doc_generated.go
@@ -1314,6 +1314,14 @@ func (KubeAPIServerList) SwaggerDoc() map[string]string {
 	return map_KubeAPIServerList
 }
 
+var map_KubeAPIServerSpec = map[string]string{
+	"goawayChance": "goawayChance sets the goaway-chance on the kube-apiserver configuration. It is the probability to send a GOAWAY to HTTP/2 clients. When a client received GOAWAY, the in-flight requests will not be affected and new requests will use a new TCP connection to triggering re-balancing to another server. Default to 0, means never send GOAWAY. Max is 0.02 to prevent breaking the apiserver. When not specified, the default value is 0.001. This setting has no effect on a single node topology,",
+}
+
+func (KubeAPIServerSpec) SwaggerDoc() map[string]string {
+	return map_KubeAPIServerSpec
+}
+
 var map_KubeAPIServerStatus = map[string]string{
 	"serviceAccountIssuers": "serviceAccountIssuers tracks history of used service account issuers. The item without expiration time represents the currently used service account issuer. The other items represents service account issuers that were used previously and are still being trusted. The default expiration for the items is set by the platform and it defaults to 24h. see: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection",
 }

--- a/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
+++ b/payload-manifests/crds/0000_20_kube-apiserver_01_kubeapiservers.crd.yaml
@@ -59,6 +59,27 @@ spec:
                   This provides a mechanism to kick a previously failed deployment and provide a reason why you think it will work
                   this time instead of failing again on the same config.
                 type: string
+              goawayChance:
+                anyOf:
+                - type: integer
+                - type: string
+                default: "0.001"
+                description: |-
+                  goawayChance sets the goaway-chance on the kube-apiserver configuration.
+                  It is the probability to send a GOAWAY to HTTP/2 clients. When a client received
+                  GOAWAY, the in-flight requests will not be affected and new requests will use
+                  a new TCP connection to triggering re-balancing to another server.
+                  Default to 0, means never send GOAWAY. Max is 0.02 to prevent breaking the apiserver.
+                  When not specified, the default value is 0.001. This setting has no effect on a single node topology,
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+                x-kubernetes-validations:
+                - message: must be positive or zero
+                  rule: isQuantity(self) && quantity(self).compareTo(quantity('0'))
+                    >= 0
+                - message: must be less than or equal to 0.02
+                  rule: isQuantity(self) && quantity(self).compareTo(quantity('0.02'))
+                    <= 0
               logLevel:
                 default: Normal
                 description: |-


### PR DESCRIPTION
… Operator

This adds a new quantity (in lieu for a float64 setting in KAS) that will control the HTTP2 goaway chance on the kube-apiserver.

This feature already exists with a default value of 0.001, backported with supportex to 4.18. We take the exact same default value, just making it a first class citizen on the apiserver cluster CRD.