### PR TITLE
Use separate serialization linting config for Machine API provider types

### DIFF
--- a/.golangci.go-validated.yaml
+++ b/.golangci.go-validated.yaml
@@ -1,0 +1,58 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - kubeapilinter
+  settings:
+    custom:
+      kubeapilinter:
+        path: tools/_output/bin/kube-api-linter.so
+        description: kubeapilinter is the Kube-API-Linter and lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters:
+            enable:
+            - optionalfields
+            disable:
+            - "*"
+          lintersConfig:
+            optionalfields:
+              pointers:
+                preference: Always
+                policy: SuggestFix
+              omitEmpty:
+                # This will force omitempty on optional fields.
+                # This is in line with upstream guidance where optional fields should be omitted
+                # from the serialized output unless they are non-zero.
+                policy: SuggestFix
+              omitzero:
+                # This will force omitzero on optional struct fields.
+                # This means they can be omitted correctly and prevents the need for pointers to structs.
+                policy: SuggestFix
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+    rules:
+    - linters:
+      - kubeapilinter
+      # This regex must always be updated in tandem with the regex in .golangci.yaml that prevents `optionalfields` from being applied to the files in the path-except.
+      path-except: machine/v1beta1/(types_awsprovider.go|types_azureprovider.go|types_gcpprovider.go|types_vsphereprovider.go)|machine/v1alpha1/types_openstack.go
+issues:
+  # We have a lot of existing issues.
+  # Want to make sure that those adding new fields have an
+  # opportunity to fix them when running the linter locally.
+  max-issues-per-linter: 1000
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -73,6 +73,12 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      - linters:
+        - kubeapilinter
+        # This regex must always be updated in tandem with the regex in .golangci.go-validated.yaml that prevents `optionalfields` from being applied to the files in the path.
+        path: machine/v1beta1/(types_awsprovider.go|types_azureprovider.go|types_gcpprovider.go|types_vsphereprovider.go)|machine/v1alpha1/types_openstack.go
+        text: "optionalfields"
 issues:
   # We have a lot of existing issues.
   # Want to make sure that those adding new fields have an

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -15,4 +15,11 @@ if [[ ${HOME} == "/" ]]; then
   HOME="/tmp"
 fi
 
+# We have two separate configs so that we can have different config for types that are go-validated vs openapi validated.
+# Init sets errexit so we must unset that for the rest of this script to correctly propagate the exit code.
+set +e
+
 "${GOLANGCI_LINT}" $@
+status=$?
+
+"${GOLANGCI_LINT}" $@ --config=.golangci.go-validated.yaml && exit ${status}


### PR DESCRIPTION
Certain API types we look after are handled by Go based validation, and not openapi based validation. In these cases we should follow the upstream guidance on optional field serialization for built-in types, which means they will always need to be pointers.

This PR introduces a separate configuration that runs optionalfields with a different config on a subset of our APIs.
