### PR TITLE
OCPBUGS-60457: payload-command: remove authentication CR from hypershift payload

### DIFF
--- a/payload-command/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
+++ b/payload-command/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
@@ -3,7 +3,6 @@ kind: Authentication
 metadata:
   name: cluster
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
 spec: {}


### PR DESCRIPTION
When the creation of the Authentication `cluster` CR migrated from the CAO to the payload command, the exclusion from the hypershift cluster profile was not maintained.

https://github.com/openshift/cluster-authentication-operator/commit/16b98a82107ebb3a0e040f8465973af3c3ca2a7e

Due to CEL that only allows setting of the oidcClients at create time, this races with hypershift controllers to do the initial `create`.

https://github.com/openshift/api/blob/master/config/v1/types_authentication.go#L8