### PR TITLE
Switch to invoking codegen once in general updates

### DIFF
--- a/tools/codegen/cmd/crdify.go
+++ b/tools/codegen/cmd/crdify.go
@@ -23,9 +23,7 @@ func newCrdifyCommand() *cobra.Command {
 				return fmt.Errorf("could not build generation context: %w", err)
 			}
 
-			gen := crdify.NewGenerator(crdify.WithComparisonBase(crdifyComparisonBase))
-
-			return executeGenerators(genCtx, gen)
+			return executeGenerators(genCtx, newCrdifyGenerator())
 		},
 	}
 
@@ -35,4 +33,8 @@ func newCrdifyCommand() *cobra.Command {
 func init() {
 	rootCmd.AddCommand(newCrdifyCommand())
 	rootCmd.PersistentFlags().StringVar(&crdifyComparisonBase, "crdify:comparison-base", crdifyComparisonBase, "base branch/commit to compare against")
+}
+
+func newCrdifyGenerator() generation.Generator {
+	return crdify.NewGenerator(crdify.WithComparisonBase(crdifyComparisonBase))
 }

--- a/tools/codegen/cmd/root.go
+++ b/tools/codegen/cmd/root.go
@@ -136,7 +136,10 @@ func allGenerators() []generation.Generator {
 		newCompatibilityGenerator(),
 		newDeepcopyGenerator(),
 		newSwaggerDocsGenerator(),
+		// The empty partial schema, schema patch and manifest merge must run in order.
+		newEmptyPartialSchemaGenerator(),
 		newSchemaPatchGenerator(),
+		newCRDManifestMerger(),
 	}
 }
 
@@ -144,7 +147,12 @@ func allGenerators() []generation.Generator {
 // the root command is executed with the --verify flag.
 func allVerifiers() []generation.Generator {
 	return []generation.Generator{
-		newSchemaCheckGenerator(),
+		// Schema checker and crdify are invoked separately as we can override these
+		// depending on circumstances.
+		// All generators/verifiers that are part of codegen and executed with a bare
+		// codegen invocation must be absolutely required/not overrideable.
+		// newSchemaCheckGenerator(),
+		// newCrdifyGenerator(),
 	}
 }
 


### PR DESCRIPTION
This updates some of our main makefile entry points to invoke codegen only once.

Codegen runs many different tasks, and a number of those tasks require parsing the "world". Parsing the world takes time, and a not insignificant amount of time, and realistically we only need to do it once.

So, the general `make update` and `make verify` entrypoints will now invoke codegen with no argument for the generator to run. This means it will run each of the generators included in `root.go` within a single invocation, which means the environment parsing is now shared among all generators.

In my local testing, this is saving approximately 20% of the runtime (260s vs 330s) of `make update`, but over time as we fix things like the protobuf inclusion in `codegen`, I think the gains will become larger.

CC @mdbooth since you've mentioned to me how slow this stuff is recently 