### PR TITLE
hack: switch to `/usr/bin/env bash`

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is meant to be the entrypoint for OpenShift Bash scripts to import all of the support
 # libraries at once in order to make Bash script preambles as minimal as possible. This script recur-

--- a/hack/update-codegen-crds.sh
+++ b/hack/update-codegen-crds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-compatibility.sh
+++ b/hack/update-compatibility.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-deepcopy.sh
+++ b/hack/update-deepcopy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-openapi.sh
+++ b/hack/update-openapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-payload-crds.sh
+++ b/hack/update-payload-crds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-payload-featuregates.sh
+++ b/hack/update-payload-featuregates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-prerelease-lifecycle-gen.sh
+++ b/hack/update-prerelease-lifecycle-gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/update-swagger-docs.sh
+++ b/hack/update-swagger-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-codegen-crds.sh
+++ b/hack/verify-codegen-crds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-compatibility.sh
+++ b/hack/verify-compatibility.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-crd-schema-checker.sh
+++ b/hack/verify-crd-schema-checker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-crdify.sh
+++ b/hack/verify-crdify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ ! -f ./_output/tools/bin/yq ]; then
     mkdir -p ./_output/tools/bin

--- a/hack/verify-deepcopy.sh
+++ b/hack/verify-deepcopy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-group-versions.sh
+++ b/hack/verify-group-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o nounset
 set -o pipefail

--- a/hack/verify-integration-tests.sh
+++ b/hack/verify-integration-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o nounset
 set -o pipefail

--- a/hack/verify-openapi.sh
+++ b/hack/verify-openapi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-payload-crds.sh
+++ b/hack/verify-payload-crds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 source "$(dirname "${BASH_SOURCE}")/update-payload-crds.sh"

--- a/hack/verify-payload-featuregates.sh
+++ b/hack/verify-payload-featuregates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-prerelease-lifecycle-gen.sh
+++ b/hack/verify-prerelease-lifecycle-gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-promoted-features-pass-tests.sh
+++ b/hack/verify-promoted-features-pass-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-protobuf.sh
+++ b/hack/verify-protobuf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 

--- a/hack/verify-swagger-docs.sh
+++ b/hack/verify-swagger-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 


### PR DESCRIPTION
There are systems which do not have `/bin/bash` available. We now switch to `/usr/bin/env bash` To support those development machines, too.

PTAL @JoelSpeed @everettraven 