### PR TITLE
MCO-1962: Move skew enforcement feature gate to tech preview

### DIFF
--- a/features.md
+++ b/features.md
@@ -5,7 +5,6 @@
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
 | ShortCertRotation| | | | | |  |
-| BootImageSkewEnforcement| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | ClusterAPIMachineManagementVSphere| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | Example2| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | ExternalSnapshotMetadata| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
@@ -27,6 +26,7 @@
 | AzureDedicatedHosts| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | AzureDualStackInstall| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | AzureMultiDisk| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
+| BootImageSkewEnforcement| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | BootcNodeManagement| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | CBORServingAndStorage| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ClientsAllowCBOR| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -366,7 +366,7 @@ var (
 						contactPerson("djoshy").
 						productScope(ocpSpecific).
 						enhancementPR("https://github.com/openshift/enhancements/pull/1761").
-						enableIn(configv1.DevPreviewNoUpgrade).
+						enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateBootcNodeManagement = newFeatureGate("BootcNodeManagement").

--- a/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml
@@ -46,6 +46,98 @@ spec:
             description: spec is the specification of the desired behavior of the
               Machine Config Operator
             properties:
+              bootImageSkewEnforcement:
+                description: |-
+                  bootImageSkewEnforcement allows an admin to configure how boot image version skew is
+                  enforced on the cluster.
+                  When omitted, this will default to Automatic for clusters that support automatic boot image updates.
+                  For clusters that do not support automatic boot image updates, cluster upgrades will be disabled until
+                  a skew enforcement mode has been specified.
+                  When version skew is being enforced, cluster upgrades will be disabled until the version skew is deemed
+                  acceptable for the current release payload.
+                properties:
+                  manual:
+                    description: |-
+                      manual describes the current boot image of the cluster.
+                      This should be set to the oldest boot image used amongst all machine resources in the cluster.
+                      This must include either the RHCOS version of the boot image or the OCP release version which shipped with that
+                      RHCOS boot image.
+                      Required when mode is set to "Manual" and forbidden otherwise.
+                    properties:
+                      mode:
+                        description: |-
+                          mode is used to configure which boot image field is defined in Manual mode.
+                          Valid values are OCPVersion and RHCOSVersion.
+                          OCPVersion means that the cluster admin is expected to set the OCP version associated with the last boot image update
+                          in the OCPVersion field.
+                          RHCOSVersion means that the cluster admin is expected to set the RHCOS version associated with the last boot image update
+                          in the RHCOSVersion field.
+                          This field is required.
+                        enum:
+                        - OCPVersion
+                        - RHCOSVersion
+                        type: string
+                      ocpVersion:
+                        description: |-
+                          ocpVersion provides a string which represents the OCP version of the boot image.
+                          This field must match the OCP semver compatible format of x.y.z. This field must be between
+                          5 and 10 characters long.
+                          Required when mode is set to "OCPVersion" and forbidden otherwise.
+                        maxLength: 10
+                        minLength: 5
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ocpVersion must match the OCP semver compatible
+                            format of x.y.z
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.[0-9]+$')
+                      rhcosVersion:
+                        description: |-
+                          rhcosVersion provides a string which represents the RHCOS version of the boot image
+                          This field must match rhcosVersion formatting of [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber] or the legacy
+                          format of [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]. This field must be between
+                          14 and 21 characters long.
+                          Required when mode is set to "RHCOSVersion" and forbidden otherwise.
+                        maxLength: 21
+                        minLength: 14
+                        type: string
+                        x-kubernetes-validations:
+                        - message: rhcosVersion must match format [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber]
+                            or must match legacy format [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.([0-9]{8}|[0-9]{12})-[0-9]+$')
+                    required:
+                    - mode
+                    type: object
+                    x-kubernetes-validations:
+                    - message: ocpVersion is required when mode is OCPVersion, and
+                        forbidden otherwise
+                      rule: 'has(self.mode) && (self.mode ==''OCPVersion'') ?  has(self.ocpVersion)
+                        : !has(self.ocpVersion)'
+                    - message: rhcosVersion is required when mode is RHCOSVersion,
+                        and forbidden otherwise
+                      rule: 'has(self.mode) && (self.mode ==''RHCOSVersion'') ?  has(self.rhcosVersion)
+                        : !has(self.rhcosVersion)'
+                  mode:
+                    description: |-
+                      mode determines the underlying behavior of skew enforcement mechanism.
+                      Valid values are Manual and None.
+                      Manual means that the cluster admin is expected to perform manual boot image updates and store the OCP
+                      & RHCOS version associated with the last boot image update in the manual field.
+                      In Manual mode, the MCO will prevent upgrades when the boot image skew exceeds the
+                      skew limit described by the release image.
+                      None means that the MCO will no longer monitor the boot image skew. This may affect
+                      the cluster's ability to scale.
+                      This field is required.
+                    enum:
+                    - Manual
+                    - None
+                    type: string
+                required:
+                - mode
+                type: object
+                x-kubernetes-validations:
+                - message: manual is required when mode is Manual, and forbidden otherwise
+                  rule: 'has(self.mode) && (self.mode ==''Manual'') ?  has(self.manual)
+                    : !has(self.manual)'
               failedRevisionLimit:
                 description: |-
                   failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api
@@ -690,6 +782,140 @@ spec:
             description: status is the most recently observed status of the Machine
               Config Operator
             properties:
+              bootImageSkewEnforcementStatus:
+                description: |-
+                  bootImageSkewEnforcementStatus reflects what the latest cluster-validated boot image skew enforcement
+                  configuration is and will be used by Machine Config Controller while performing boot image skew enforcement.
+                  When omitted, the MCO has no knowledge of how to enforce boot image skew. When the MCO does not know how
+                  boot image skew should be enforced, cluster upgrades will be blocked until it can either automatically
+                  determine skew enforcement or there is an explicit skew enforcement configuration provided in the
+                  spec.bootImageSkewEnforcement field.
+                properties:
+                  automatic:
+                    description: |-
+                      automatic describes the current boot image of the cluster.
+                      This will be populated by the MCO when performing boot image updates. This value will be compared against
+                      the cluster's skew limit to determine skew compliance.
+                      Required when mode is set to "Automatic" and forbidden otherwise.
+                    minProperties: 1
+                    properties:
+                      ocpVersion:
+                        description: |-
+                          ocpVersion provides a string which represents the OCP version of the boot image.
+                          This field must match the OCP semver compatible format of x.y.z. This field must be between
+                          5 and 10 characters long.
+                        maxLength: 10
+                        minLength: 5
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ocpVersion must match the OCP semver compatible
+                            format of x.y.z
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.[0-9]+$')
+                      rhcosVersion:
+                        description: |-
+                          rhcosVersion provides a string which represents the RHCOS version of the boot image
+                          This field must match rhcosVersion formatting of [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber] or the legacy
+                          format of [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]. This field must be between
+                          14 and 21 characters long.
+                        maxLength: 21
+                        minLength: 14
+                        type: string
+                        x-kubernetes-validations:
+                        - message: rhcosVersion must match format [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber]
+                            or must match legacy format [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.([0-9]{8}|[0-9]{12})-[0-9]+$')
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of ocpVersion or rhcosVersion is required
+                      rule: has(self.ocpVersion) || has(self.rhcosVersion)
+                  manual:
+                    description: |-
+                      manual describes the current boot image of the cluster.
+                      This will be populated by the MCO using the values provided in the spec.bootImageSkewEnforcement.manual field.
+                      This value will be compared against the cluster's skew limit to determine skew compliance.
+                      Required when mode is set to "Manual" and forbidden otherwise.
+                    properties:
+                      mode:
+                        description: |-
+                          mode is used to configure which boot image field is defined in Manual mode.
+                          Valid values are OCPVersion and RHCOSVersion.
+                          OCPVersion means that the cluster admin is expected to set the OCP version associated with the last boot image update
+                          in the OCPVersion field.
+                          RHCOSVersion means that the cluster admin is expected to set the RHCOS version associated with the last boot image update
+                          in the RHCOSVersion field.
+                          This field is required.
+                        enum:
+                        - OCPVersion
+                        - RHCOSVersion
+                        type: string
+                      ocpVersion:
+                        description: |-
+                          ocpVersion provides a string which represents the OCP version of the boot image.
+                          This field must match the OCP semver compatible format of x.y.z. This field must be between
+                          5 and 10 characters long.
+                          Required when mode is set to "OCPVersion" and forbidden otherwise.
+                        maxLength: 10
+                        minLength: 5
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ocpVersion must match the OCP semver compatible
+                            format of x.y.z
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.[0-9]+$')
+                      rhcosVersion:
+                        description: |-
+                          rhcosVersion provides a string which represents the RHCOS version of the boot image
+                          This field must match rhcosVersion formatting of [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber] or the legacy
+                          format of [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]. This field must be between
+                          14 and 21 characters long.
+                          Required when mode is set to "RHCOSVersion" and forbidden otherwise.
+                        maxLength: 21
+                        minLength: 14
+                        type: string
+                        x-kubernetes-validations:
+                        - message: rhcosVersion must match format [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber]
+                            or must match legacy format [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.([0-9]{8}|[0-9]{12})-[0-9]+$')
+                    required:
+                    - mode
+                    type: object
+                    x-kubernetes-validations:
+                    - message: ocpVersion is required when mode is OCPVersion, and
+                        forbidden otherwise
+                      rule: 'has(self.mode) && (self.mode ==''OCPVersion'') ?  has(self.ocpVersion)
+                        : !has(self.ocpVersion)'
+                    - message: rhcosVersion is required when mode is RHCOSVersion,
+                        and forbidden otherwise
+                      rule: 'has(self.mode) && (self.mode ==''RHCOSVersion'') ?  has(self.rhcosVersion)
+                        : !has(self.rhcosVersion)'
+                  mode:
+                    description: |-
+                      mode determines the underlying behavior of skew enforcement mechanism.
+                      Valid values are Automatic, Manual and None.
+                      Automatic means that the MCO will perform boot image updates and store the
+                      OCP & RHCOS version associated with the last boot image update in the automatic field.
+                      Manual means that the cluster admin is expected to perform manual boot image updates and store the OCP
+                      & RHCOS version associated with the last boot image update in the manual field.
+                      In Automatic and Manual mode, the MCO will prevent upgrades when the boot image skew exceeds the
+                      skew limit described by the release image.
+                      None means that the MCO will no longer monitor the boot image skew. This may affect
+                      the cluster's ability to scale.
+                      This field is required.
+                    enum:
+                    - Automatic
+                    - Manual
+                    - None
+                    type: string
+                required:
+                - mode
+                type: object
+                x-kubernetes-validations:
+                - message: automatic is required when mode is Automatic, and forbidden
+                    otherwise
+                  rule: 'has(self.mode) && (self.mode == ''Automatic'') ?  has(self.automatic)
+                    : !has(self.automatic)'
+                - message: manual is required when mode is Manual, and forbidden otherwise
+                  rule: 'has(self.mode) && (self.mode == ''Manual'') ?  has(self.manual)
+                    : !has(self.manual)'
               conditions:
                 description: conditions is a list of conditions and their status
                 items:
@@ -1292,6 +1518,25 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: when skew enforcement is in Automatic mode, a boot image configuration
+            is required
+          rule: 'self.?status.bootImageSkewEnforcementStatus.mode.orValue("") == ''Automatic''
+            ? self.?spec.managedBootImages.hasValue() || self.?status.managedBootImagesStatus.hasValue()
+            : true'
+        - message: when skew enforcement is in Automatic mode, managedBootImages must
+            contain a MachineManager opting in all MachineAPI MachineSets
+          rule: 'self.?status.bootImageSkewEnforcementStatus.mode.orValue("") == ''Automatic''
+            ? !(self.?spec.managedBootImages.machineManagers.hasValue()) || self.spec.managedBootImages.machineManagers.exists(m,
+            m.selection.mode == ''All'' && m.resource == ''machinesets'' && m.apiGroup
+            == ''machine.openshift.io'') : true'
+        - message: when skew enforcement is in Automatic mode, managedBootImagesStatus
+            must contain a MachineManager opting in all MachineAPI MachineSets
+          rule: 'self.?status.bootImageSkewEnforcementStatus.mode.orValue("") == ''Automatic''
+            ? !(self.?status.managedBootImagesStatus.machineManagers.hasValue()) ||
+            self.status.managedBootImagesStatus.machineManagers.exists(m, m.selection.mode
+            == ''All'' && m.resource == ''machinesets'' && m.apiGroup == ''machine.openshift.io''):
+            true'
     served: true
     storage: true
     subresources:

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfigurations-TechPreviewNoUpgrade.crd.yaml
@@ -46,6 +46,98 @@ spec:
             description: spec is the specification of the desired behavior of the
               Machine Config Operator
             properties:
+              bootImageSkewEnforcement:
+                description: |-
+                  bootImageSkewEnforcement allows an admin to configure how boot image version skew is
+                  enforced on the cluster.
+                  When omitted, this will default to Automatic for clusters that support automatic boot image updates.
+                  For clusters that do not support automatic boot image updates, cluster upgrades will be disabled until
+                  a skew enforcement mode has been specified.
+                  When version skew is being enforced, cluster upgrades will be disabled until the version skew is deemed
+                  acceptable for the current release payload.
+                properties:
+                  manual:
+                    description: |-
+                      manual describes the current boot image of the cluster.
+                      This should be set to the oldest boot image used amongst all machine resources in the cluster.
+                      This must include either the RHCOS version of the boot image or the OCP release version which shipped with that
+                      RHCOS boot image.
+                      Required when mode is set to "Manual" and forbidden otherwise.
+                    properties:
+                      mode:
+                        description: |-
+                          mode is used to configure which boot image field is defined in Manual mode.
+                          Valid values are OCPVersion and RHCOSVersion.
+                          OCPVersion means that the cluster admin is expected to set the OCP version associated with the last boot image update
+                          in the OCPVersion field.
+                          RHCOSVersion means that the cluster admin is expected to set the RHCOS version associated with the last boot image update
+                          in the RHCOSVersion field.
+                          This field is required.
+                        enum:
+                        - OCPVersion
+                        - RHCOSVersion
+                        type: string
+                      ocpVersion:
+                        description: |-
+                          ocpVersion provides a string which represents the OCP version of the boot image.
+                          This field must match the OCP semver compatible format of x.y.z. This field must be between
+                          5 and 10 characters long.
+                          Required when mode is set to "OCPVersion" and forbidden otherwise.
+                        maxLength: 10
+                        minLength: 5
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ocpVersion must match the OCP semver compatible
+                            format of x.y.z
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.[0-9]+$')
+                      rhcosVersion:
+                        description: |-
+                          rhcosVersion provides a string which represents the RHCOS version of the boot image
+                          This field must match rhcosVersion formatting of [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber] or the legacy
+                          format of [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]. This field must be between
+                          14 and 21 characters long.
+                          Required when mode is set to "RHCOSVersion" and forbidden otherwise.
+                        maxLength: 21
+                        minLength: 14
+                        type: string
+                        x-kubernetes-validations:
+                        - message: rhcosVersion must match format [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber]
+                            or must match legacy format [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.([0-9]{8}|[0-9]{12})-[0-9]+$')
+                    required:
+                    - mode
+                    type: object
+                    x-kubernetes-validations:
+                    - message: ocpVersion is required when mode is OCPVersion, and
+                        forbidden otherwise
+                      rule: 'has(self.mode) && (self.mode ==''OCPVersion'') ?  has(self.ocpVersion)
+                        : !has(self.ocpVersion)'
+                    - message: rhcosVersion is required when mode is RHCOSVersion,
+                        and forbidden otherwise
+                      rule: 'has(self.mode) && (self.mode ==''RHCOSVersion'') ?  has(self.rhcosVersion)
+                        : !has(self.rhcosVersion)'
+                  mode:
+                    description: |-
+                      mode determines the underlying behavior of skew enforcement mechanism.
+                      Valid values are Manual and None.
+                      Manual means that the cluster admin is expected to perform manual boot image updates and store the OCP
+                      & RHCOS version associated with the last boot image update in the manual field.
+                      In Manual mode, the MCO will prevent upgrades when the boot image skew exceeds the
+                      skew limit described by the release image.
+                      None means that the MCO will no longer monitor the boot image skew. This may affect
+                      the cluster's ability to scale.
+                      This field is required.
+                    enum:
+                    - Manual
+                    - None
+                    type: string
+                required:
+                - mode
+                type: object
+                x-kubernetes-validations:
+                - message: manual is required when mode is Manual, and forbidden otherwise
+                  rule: 'has(self.mode) && (self.mode ==''Manual'') ?  has(self.manual)
+                    : !has(self.manual)'
               failedRevisionLimit:
                 description: |-
                   failedRevisionLimit is the number of failed static pod installer revisions to keep on disk and in the api
@@ -690,6 +782,140 @@ spec:
             description: status is the most recently observed status of the Machine
               Config Operator
             properties:
+              bootImageSkewEnforcementStatus:
+                description: |-
+                  bootImageSkewEnforcementStatus reflects what the latest cluster-validated boot image skew enforcement
+                  configuration is and will be used by Machine Config Controller while performing boot image skew enforcement.
+                  When omitted, the MCO has no knowledge of how to enforce boot image skew. When the MCO does not know how
+                  boot image skew should be enforced, cluster upgrades will be blocked until it can either automatically
+                  determine skew enforcement or there is an explicit skew enforcement configuration provided in the
+                  spec.bootImageSkewEnforcement field.
+                properties:
+                  automatic:
+                    description: |-
+                      automatic describes the current boot image of the cluster.
+                      This will be populated by the MCO when performing boot image updates. This value will be compared against
+                      the cluster's skew limit to determine skew compliance.
+                      Required when mode is set to "Automatic" and forbidden otherwise.
+                    minProperties: 1
+                    properties:
+                      ocpVersion:
+                        description: |-
+                          ocpVersion provides a string which represents the OCP version of the boot image.
+                          This field must match the OCP semver compatible format of x.y.z. This field must be between
+                          5 and 10 characters long.
+                        maxLength: 10
+                        minLength: 5
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ocpVersion must match the OCP semver compatible
+                            format of x.y.z
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.[0-9]+$')
+                      rhcosVersion:
+                        description: |-
+                          rhcosVersion provides a string which represents the RHCOS version of the boot image
+                          This field must match rhcosVersion formatting of [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber] or the legacy
+                          format of [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]. This field must be between
+                          14 and 21 characters long.
+                        maxLength: 21
+                        minLength: 14
+                        type: string
+                        x-kubernetes-validations:
+                        - message: rhcosVersion must match format [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber]
+                            or must match legacy format [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.([0-9]{8}|[0-9]{12})-[0-9]+$')
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of ocpVersion or rhcosVersion is required
+                      rule: has(self.ocpVersion) || has(self.rhcosVersion)
+                  manual:
+                    description: |-
+                      manual describes the current boot image of the cluster.
+                      This will be populated by the MCO using the values provided in the spec.bootImageSkewEnforcement.manual field.
+                      This value will be compared against the cluster's skew limit to determine skew compliance.
+                      Required when mode is set to "Manual" and forbidden otherwise.
+                    properties:
+                      mode:
+                        description: |-
+                          mode is used to configure which boot image field is defined in Manual mode.
+                          Valid values are OCPVersion and RHCOSVersion.
+                          OCPVersion means that the cluster admin is expected to set the OCP version associated with the last boot image update
+                          in the OCPVersion field.
+                          RHCOSVersion means that the cluster admin is expected to set the RHCOS version associated with the last boot image update
+                          in the RHCOSVersion field.
+                          This field is required.
+                        enum:
+                        - OCPVersion
+                        - RHCOSVersion
+                        type: string
+                      ocpVersion:
+                        description: |-
+                          ocpVersion provides a string which represents the OCP version of the boot image.
+                          This field must match the OCP semver compatible format of x.y.z. This field must be between
+                          5 and 10 characters long.
+                          Required when mode is set to "OCPVersion" and forbidden otherwise.
+                        maxLength: 10
+                        minLength: 5
+                        type: string
+                        x-kubernetes-validations:
+                        - message: ocpVersion must match the OCP semver compatible
+                            format of x.y.z
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.[0-9]+$')
+                      rhcosVersion:
+                        description: |-
+                          rhcosVersion provides a string which represents the RHCOS version of the boot image
+                          This field must match rhcosVersion formatting of [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber] or the legacy
+                          format of [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]. This field must be between
+                          14 and 21 characters long.
+                          Required when mode is set to "RHCOSVersion" and forbidden otherwise.
+                        maxLength: 21
+                        minLength: 14
+                        type: string
+                        x-kubernetes-validations:
+                        - message: rhcosVersion must match format [major].[minor].[datestamp(YYYYMMDD)]-[buildnumber]
+                            or must match legacy format [major].[minor].[timestamp(YYYYMMDDHHmm)]-[buildnumber]
+                          rule: self.matches('^[0-9]+\\.[0-9]+\\.([0-9]{8}|[0-9]{12})-[0-9]+$')
+                    required:
+                    - mode
+                    type: object
+                    x-kubernetes-validations:
+                    - message: ocpVersion is required when mode is OCPVersion, and
+                        forbidden otherwise
+                      rule: 'has(self.mode) && (self.mode ==''OCPVersion'') ?  has(self.ocpVersion)
+                        : !has(self.ocpVersion)'
+                    - message: rhcosVersion is required when mode is RHCOSVersion,
+                        and forbidden otherwise
+                      rule: 'has(self.mode) && (self.mode ==''RHCOSVersion'') ?  has(self.rhcosVersion)
+                        : !has(self.rhcosVersion)'
+                  mode:
+                    description: |-
+                      mode determines the underlying behavior of skew enforcement mechanism.
+                      Valid values are Automatic, Manual and None.
+                      Automatic means that the MCO will perform boot image updates and store the
+                      OCP & RHCOS version associated with the last boot image update in the automatic field.
+                      Manual means that the cluster admin is expected to perform manual boot image updates and store the OCP
+                      & RHCOS version associated with the last boot image update in the manual field.
+                      In Automatic and Manual mode, the MCO will prevent upgrades when the boot image skew exceeds the
+                      skew limit described by the release image.
+                      None means that the MCO will no longer monitor the boot image skew. This may affect
+                      the cluster's ability to scale.
+                      This field is required.
+                    enum:
+                    - Automatic
+                    - Manual
+                    - None
+                    type: string
+                required:
+                - mode
+                type: object
+                x-kubernetes-validations:
+                - message: automatic is required when mode is Automatic, and forbidden
+                    otherwise
+                  rule: 'has(self.mode) && (self.mode == ''Automatic'') ?  has(self.automatic)
+                    : !has(self.automatic)'
+                - message: manual is required when mode is Manual, and forbidden otherwise
+                  rule: 'has(self.mode) && (self.mode == ''Manual'') ?  has(self.manual)
+                    : !has(self.manual)'
               conditions:
                 description: conditions is a list of conditions and their status
                 items:
@@ -1292,6 +1518,25 @@ spec:
         required:
         - spec
         type: object
+        x-kubernetes-validations:
+        - message: when skew enforcement is in Automatic mode, a boot image configuration
+            is required
+          rule: 'self.?status.bootImageSkewEnforcementStatus.mode.orValue("") == ''Automatic''
+            ? self.?spec.managedBootImages.hasValue() || self.?status.managedBootImagesStatus.hasValue()
+            : true'
+        - message: when skew enforcement is in Automatic mode, managedBootImages must
+            contain a MachineManager opting in all MachineAPI MachineSets
+          rule: 'self.?status.bootImageSkewEnforcementStatus.mode.orValue("") == ''Automatic''
+            ? !(self.?spec.managedBootImages.machineManagers.hasValue()) || self.spec.managedBootImages.machineManagers.exists(m,
+            m.selection.mode == ''All'' && m.resource == ''machinesets'' && m.apiGroup
+            == ''machine.openshift.io'') : true'
+        - message: when skew enforcement is in Automatic mode, managedBootImagesStatus
+            must contain a MachineManager opting in all MachineAPI MachineSets
+          rule: 'self.?status.bootImageSkewEnforcementStatus.mode.orValue("") == ''Automatic''
+            ? !(self.?status.managedBootImagesStatus.machineManagers.hasValue()) ||
+            self.status.managedBootImagesStatus.machineManagers.exists(m, m.selection.mode
+            == ''All'' && m.resource == ''machinesets'' && m.apiGroup == ''machine.openshift.io''):
+            true'
     served: true
     storage: true
     subresources:

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -15,9 +15,6 @@
             {
                 "disabled": [
                     {
-                        "name": "BootImageSkewEnforcement"
-                    },
-                    {
                         "name": "ClusterAPIInstall"
                     },
                     {
@@ -108,6 +105,9 @@
                     },
                     {
                         "name": "AzureWorkloadIdentity"
+                    },
+                    {
+                        "name": "BootImageSkewEnforcement"
                     },
                     {
                         "name": "BootcNodeManagement"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -15,9 +15,6 @@
             {
                 "disabled": [
                     {
-                        "name": "BootImageSkewEnforcement"
-                    },
-                    {
                         "name": "ClusterAPIInstall"
                     },
                     {
@@ -90,6 +87,9 @@
                     },
                     {
                         "name": "AzureWorkloadIdentity"
+                    },
+                    {
+                        "name": "BootImageSkewEnforcement"
                     },
                     {
                         "name": "BootcNodeManagement"


### PR DESCRIPTION
As skew enforcement is considered a pre-requisite for bringing [dual stream support](https://issues.redhat.com/browse/OCPSTRAT-1150) to GA, we need to accelerate the timeline for this feature and start off with an MVP in tech preview. 