### PR TITLE
(OLMv1) Update EP link for SingleOwnNamespace feature

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -501,7 +501,7 @@ var (
 						reportProblemsToJiraComponent("olm").
 						contactPerson("nschieder").
 						productScope(ocpSpecific).
-						enhancementPR("https://github.com/openshift/enhancements/pull/1774").
+						enhancementPR("https://github.com/openshift/enhancements/pull/1849").
 						enableForClusterProfile(SelfManaged, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 


### PR DESCRIPTION
https://github.com/openshift/enhancements/pull/1774 was closed in favor of https://github.com/openshift/enhancements/pull/1849