### PR TITLE
OCPNODE-3874: Remove the unused constant CgroupModeV1

### DIFF
--- a/config/v1/types_node.go
+++ b/config/v1/types_node.go
@@ -79,7 +79,6 @@ type CgroupMode string
 
 const (
 	CgroupModeEmpty   CgroupMode = "" // Empty string indicates to honor user set value on the system that should not be overridden by OpenShift
-	CgroupModeV1      CgroupMode = "v1"
 	CgroupModeV2      CgroupMode = "v2"
 	CgroupModeDefault CgroupMode = CgroupModeV2
 )


### PR DESCRIPTION
- cgroupv1 support has been removed from ocp > 4.19
- It is safe to remove the unused/dead constant from the code

Reference: https://github.com/openshift/machine-config-operator/pull/5399#discussion_r2512221946 

/cc @wking 