### PR TITLE
[WIP] OCPBUGS-62145: User response does not include list of groups user is part of

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -67476,6 +67476,7 @@ func schema_openshift_api_user_v1_User(ref common.ReferenceCallback) common.Open
 					"groups": {
 						SchemaProps: spec.SchemaProps{
 							Description: "groups specifies group names this user is a member of. This field is deprecated and will be removed in a future release. Instead, create a Group object containing the name of this User.",
+							Default:     []interface{}{},
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -39365,6 +39365,7 @@
         "groups": {
           "description": "groups specifies group names this user is a member of. This field is deprecated and will be removed in a future release. Instead, create a Group object containing the name of this User.",
           "type": "array",
+          "default": [],
           "items": {
             "type": "string",
             "default": ""

--- a/user/v1/types.go
+++ b/user/v1/types.go
@@ -36,6 +36,7 @@ type User struct {
 	// groups specifies group names this user is a member of.
 	// This field is deprecated and will be removed in a future release.
 	// Instead, create a Group object containing the name of this User.
+	// +default=[]
 	Groups []string `json:"groups" protobuf:"bytes,4,rep,name=groups"`
 }
 


### PR DESCRIPTION
## Summary

The User resource's `groups` field was returning `null` when not populated, causing issues with the Pipelines Operator's role-based approval functionality.

This change adds a default empty array for the `groups` field in the User API schema, ensuring it returns `[]` instead of `null` when the user is not a member of any groups.

  Changes:
  - Added `// +default=[]` marker to User.Groups field in user/v1/types.go
  - Regenerated OpenAPI schema with default empty array



Fixes: [OCPBUGS-62145 ](https://issues.redhat.com/browse/OCPBUGS-62145) 