### PR TITLE
OCPBUGS-65819: fix ClusterMonitoring CRD plural name

### DIFF
--- a/config/v1alpha1/tests/clustermonitorings.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1alpha1/tests/clustermonitorings.config.openshift.io/AAA_ungated.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ClusterMonitoring"
-crdName: clustermonitoring.config.openshift.io
+crdName: clustermonitorings.config.openshift.io
 tests:
   onCreate:
     - name: Should be able to create a minimal ClusterMonitoring

--- a/config/v1alpha1/tests/clustermonitorings.config.openshift.io/ClusterMonitoringConfig.yaml
+++ b/config/v1alpha1/tests/clustermonitorings.config.openshift.io/ClusterMonitoringConfig.yaml
@@ -1,6 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1 # Hack because controller-gen complains if we don't have this
 name: "ClusterMonitoring"
-crdName: clustermonitoring.config.openshift.io
+crdName: clustermonitorings.config.openshift.io
 featureGate: ClusterMonitoringConfig
 tests:
   onCreate:

--- a/config/v1alpha1/types_cluster_monitoring.go
+++ b/config/v1alpha1/types_cluster_monitoring.go
@@ -33,7 +33,7 @@ import (
 // +openshift:api-approved.openshift.io=https://github.com/openshift/api/pull/1929
 // +openshift:file-pattern=cvoRunLevel=0000_10,operatorName=config-operator,operatorOrdering=01
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=clustermonitoring,scope=Cluster
+// +kubebuilder:resource:path=clustermonitorings,scope=Cluster
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:annotations="description=Cluster Monitoring Operators configuration API"
 // +openshift:enable:FeatureGate=ClusterMonitoringConfig

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clustermonitorings-CustomNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clustermonitorings-CustomNoUpgrade.crd.yaml
@@ -7,14 +7,14 @@ metadata:
     description: Cluster Monitoring Operators configuration API
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: DevPreviewNoUpgrade
-  name: clustermonitoring.config.openshift.io
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: clustermonitorings.config.openshift.io
 spec:
   group: config.openshift.io
   names:
     kind: ClusterMonitoring
     listKind: ClusterMonitoringList
-    plural: clustermonitoring
+    plural: clustermonitorings
     singular: clustermonitoring
   scope: Cluster
   versions:

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clustermonitorings-DevPreviewNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clustermonitorings-DevPreviewNoUpgrade.crd.yaml
@@ -7,14 +7,14 @@ metadata:
     description: Cluster Monitoring Operators configuration API
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
-  name: clustermonitoring.config.openshift.io
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  name: clustermonitorings.config.openshift.io
 spec:
   group: config.openshift.io
   names:
     kind: ClusterMonitoring
     listKind: ClusterMonitoringList
-    plural: clustermonitoring
+    plural: clustermonitorings
     singular: clustermonitoring
   scope: Cluster
   versions:

--- a/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clustermonitorings-TechPreviewNoUpgrade.crd.yaml
+++ b/config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clustermonitorings-TechPreviewNoUpgrade.crd.yaml
@@ -3,18 +3,18 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1929
-    api.openshift.io/filename-cvo-runlevel: "0000_10"
-    api.openshift.io/filename-operator: config-operator
-    api.openshift.io/filename-ordering: "01"
+    api.openshift.io/merged-by-featuregates: "true"
     description: Cluster Monitoring Operators configuration API
-    feature-gate.release.openshift.io/ClusterMonitoringConfig: "true"
-  name: clustermonitoring.config.openshift.io
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: clustermonitorings.config.openshift.io
 spec:
   group: config.openshift.io
   names:
     kind: ClusterMonitoring
     listKind: ClusterMonitoringList
-    plural: clustermonitoring
+    plural: clustermonitorings
     singular: clustermonitoring
   scope: Cluster
   versions:

--- a/config/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
+++ b/config/v1alpha1/zz_generated.featuregated-crd-manifests.yaml
@@ -45,11 +45,11 @@ clusterimagepolicies.config.openshift.io:
   - SigstoreImageVerification
   Version: v1alpha1
 
-clustermonitoring.config.openshift.io:
+clustermonitorings.config.openshift.io:
   Annotations:
     description: Cluster Monitoring Operators configuration API
   ApprovedPRNumber: https://github.com/openshift/api/pull/1929
-  CRDName: clustermonitoring.config.openshift.io
+  CRDName: clustermonitorings.config.openshift.io
   Capability: ""
   Category: ""
   FeatureGates:
@@ -61,7 +61,7 @@ clustermonitoring.config.openshift.io:
   HasStatus: true
   KindName: ClusterMonitoring
   Labels: {}
-  PluralName: clustermonitoring
+  PluralName: clustermonitorings
   PrinterColumns: []
   Scope: Cluster
   ShortNames: null

--- a/config/v1alpha1/zz_generated.featuregated-crd-manifests/clustermonitorings.config.openshift.io/ClusterMonitoringConfig.yaml
+++ b/config/v1alpha1/zz_generated.featuregated-crd-manifests/clustermonitorings.config.openshift.io/ClusterMonitoringConfig.yaml
@@ -3,18 +3,18 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.openshift.io: https://github.com/openshift/api/pull/1929
-    api.openshift.io/merged-by-featuregates: "true"
+    api.openshift.io/filename-cvo-runlevel: "0000_10"
+    api.openshift.io/filename-operator: config-operator
+    api.openshift.io/filename-ordering: "01"
     description: Cluster Monitoring Operators configuration API
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade
-  name: clustermonitoring.config.openshift.io
+    feature-gate.release.openshift.io/ClusterMonitoringConfig: "true"
+  name: clustermonitorings.config.openshift.io
 spec:
   group: config.openshift.io
   names:
     kind: ClusterMonitoring
     listKind: ClusterMonitoringList
-    plural: clustermonitoring
+    plural: clustermonitorings
     singular: clustermonitoring
   scope: Cluster
   versions:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4780,8 +4780,12 @@
           "x-kubernetes-list-type": "atomic"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -8929,8 +8933,12 @@
           "x-kubernetes-list-type": "set"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -9543,8 +9551,12 @@
           "type": "string"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -9737,8 +9749,12 @@
           "x-kubernetes-list-type": "set"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -11652,8 +11668,12 @@
           "x-kubernetes-list-type": "atomic"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",

--- a/payload-manifests/crds/0000_10_config-operator_01_clustermonitorings-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_clustermonitorings-CustomNoUpgrade.crd.yaml
@@ -7,14 +7,14 @@ metadata:
     description: Cluster Monitoring Operators configuration API
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: DevPreviewNoUpgrade
-  name: clustermonitoring.config.openshift.io
+    release.openshift.io/feature-set: CustomNoUpgrade
+  name: clustermonitorings.config.openshift.io
 spec:
   group: config.openshift.io
   names:
     kind: ClusterMonitoring
     listKind: ClusterMonitoringList
-    plural: clustermonitoring
+    plural: clustermonitorings
     singular: clustermonitoring
   scope: Cluster
   versions:

--- a/payload-manifests/crds/0000_10_config-operator_01_clustermonitorings-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_clustermonitorings-DevPreviewNoUpgrade.crd.yaml
@@ -7,14 +7,14 @@ metadata:
     description: Cluster Monitoring Operators configuration API
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: TechPreviewNoUpgrade
-  name: clustermonitoring.config.openshift.io
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  name: clustermonitorings.config.openshift.io
 spec:
   group: config.openshift.io
   names:
     kind: ClusterMonitoring
     listKind: ClusterMonitoringList
-    plural: clustermonitoring
+    plural: clustermonitorings
     singular: clustermonitoring
   scope: Cluster
   versions:

--- a/payload-manifests/crds/0000_10_config-operator_01_clustermonitorings-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_clustermonitorings-TechPreviewNoUpgrade.crd.yaml
@@ -7,14 +7,14 @@ metadata:
     description: Cluster Monitoring Operators configuration API
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    release.openshift.io/feature-set: CustomNoUpgrade
-  name: clustermonitoring.config.openshift.io
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  name: clustermonitorings.config.openshift.io
 spec:
   group: config.openshift.io
   names:
     kind: ClusterMonitoring
     listKind: ClusterMonitoringList
-    plural: clustermonitoring
+    plural: clustermonitorings
     singular: clustermonitoring
   scope: Cluster
   versions:


### PR DESCRIPTION
the ClusterMonitoring CRD kubebuilder annotation incorrectly
specified path=clustermonitoring (singular) instead of the
conventional plural form clustermonitorings.

this caused a mismatch with client-go generated code which
expects the plural form for list/watch operations, resulting
in 'resource not found' errors when the controller attempted
to watch ClusterMonitoring resources.

fixes the kubebuilder:resource annotation to use the correct
plural path=clustermonitorings.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>