### PR TITLE
OCPBUGS-61858: Use pointer type for HTTPKeepAliveTimeout in IngressController API

### DIFF
--- a/operator/v1/types_ingress.go
+++ b/operator/v1/types_ingress.go
@@ -1912,7 +1912,7 @@ type IngressControllerTuningOptions struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=16
 	// +optional
-	HTTPKeepAliveTimeout metav1.Duration `json:"httpKeepAliveTimeout,omitempty"`
+	HTTPKeepAliveTimeout *metav1.Duration `json:"httpKeepAliveTimeout,omitempty"`
 
 	// tlsInspectDelay defines how long the router can hold data to find a
 	// matching route.

--- a/operator/v1/zz_generated.deepcopy.go
+++ b/operator/v1/zz_generated.deepcopy.go
@@ -2564,7 +2564,11 @@ func (in *IngressControllerTuningOptions) DeepCopyInto(out *IngressControllerTun
 		*out = new(metav1.Duration)
 		**out = **in
 	}
-	out.HTTPKeepAliveTimeout = in.HTTPKeepAliveTimeout
+	if in.HTTPKeepAliveTimeout != nil {
+		in, out := &in.HTTPKeepAliveTimeout, &out.HTTPKeepAliveTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	if in.TLSInspectDelay != nil {
 		in, out := &in.TLSInspectDelay, &out.TLSInspectDelay
 		*out = new(metav1.Duration)


### PR DESCRIPTION
This commit addresses the problem of the creation of the default IngressController without `HTTPKeepAliveTimeout` tuning option by the cluster ingress operator:
```
"IngressController.operator.openshift.io \"default\" is invalid: spec.tuningOptions.httpKeepAliveTimeout: Invalid value: \"string\": httpKeepAliveTimeout must be greater than or equal to 1 millisecond"
```

The CEL expression which checks the minimal value prevents the creation of `IngressController` with unspecified (zero value) `HTTPKeepAliveTimeout`.

Follow-up of https://github.com/openshift/api/pull/2547.