### PR TITLE
CONSOLE-4882: Support mailto: links in ConsoleLink href field

### DIFF
--- a/console/v1/tests/consolelinks.console.openshift.io/AAA_ungated.yaml
+++ b/console/v1/tests/consolelinks.console.openshift.io/AAA_ungated.yaml
@@ -18,3 +18,18 @@ tests:
           href: "https://"
           location: HelpMenu
           text: foo
+    - name: Should be able to create a ConsoleLink with mailto href
+      initial: |
+        apiVersion: console.openshift.io/v1
+        kind: ConsoleLink
+        spec:
+          href: "mailto:platform-team@example.com"
+          location: HelpMenu
+          text: Contact Platform Team
+      expected: |
+        apiVersion: console.openshift.io/v1
+        kind: ConsoleLink
+        spec:
+          href: "mailto:platform-team@example.com"
+          location: HelpMenu
+          text: Contact Platform Team

--- a/console/v1/types.go
+++ b/console/v1/types.go
@@ -4,7 +4,7 @@ package v1
 type Link struct {
 	// text is the display text for the link
 	Text string `json:"text"`
-	// href is the absolute secure URL for the link (must use https)
-	// +kubebuilder:validation:Pattern=`^https://`
+	// href is the absolute URL for the link. Must use https:// for web URLs or mailto: for email links.
+	// +kubebuilder:validation:Pattern=`^(https://|mailto:)`
 	Href string `json:"href"`
 }

--- a/console/v1/zz_generated.crd-manifests/00_consolelinks.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consolelinks.crd.yaml
@@ -80,9 +80,9 @@ spec:
                 - section
                 type: object
               href:
-                description: href is the absolute secure URL for the link (must use
-                  https)
-                pattern: ^https://
+                description: 'href is the absolute URL for the link. Must use https://
+                  for web URLs or mailto: for email links.'
+                pattern: ^(https://|mailto:)
                 type: string
               location:
                 description: location determines which location in the console the

--- a/console/v1/zz_generated.crd-manifests/00_consolenotifications.crd.yaml
+++ b/console/v1/zz_generated.crd-manifests/00_consolenotifications.crd.yaml
@@ -70,9 +70,9 @@ spec:
                 description: link is an object that holds notification link details.
                 properties:
                   href:
-                    description: href is the absolute secure URL for the link (must
-                      use https)
-                    pattern: ^https://
+                    description: 'href is the absolute URL for the link. Must use
+                      https:// for web URLs or mailto: for email links.'
+                    pattern: ^(https://|mailto:)
                     type: string
                   text:
                     description: text is the display text for the link

--- a/console/v1/zz_generated.featuregated-crd-manifests/consolelinks.console.openshift.io/AAA_ungated.yaml
+++ b/console/v1/zz_generated.featuregated-crd-manifests/consolelinks.console.openshift.io/AAA_ungated.yaml
@@ -79,9 +79,9 @@ spec:
                 - section
                 type: object
               href:
-                description: href is the absolute secure URL for the link (must use
-                  https)
-                pattern: ^https://
+                description: 'href is the absolute URL for the link. Must use https://
+                  for web URLs or mailto: for email links.'
+                pattern: ^(https://|mailto:)
                 type: string
               location:
                 description: location determines which location in the console the

--- a/console/v1/zz_generated.featuregated-crd-manifests/consolenotifications.console.openshift.io/AAA_ungated.yaml
+++ b/console/v1/zz_generated.featuregated-crd-manifests/consolenotifications.console.openshift.io/AAA_ungated.yaml
@@ -69,9 +69,9 @@ spec:
                 description: link is an object that holds notification link details.
                 properties:
                   href:
-                    description: href is the absolute secure URL for the link (must
-                      use https)
-                    pattern: ^https://
+                    description: 'href is the absolute URL for the link. Must use
+                      https:// for web URLs or mailto: for email links.'
+                    pattern: ^(https://|mailto:)
                     type: string
                   text:
                     description: text is the display text for the link

--- a/console/v1/zz_generated.swagger_doc_generated.go
+++ b/console/v1/zz_generated.swagger_doc_generated.go
@@ -14,7 +14,7 @@ package v1
 var map_Link = map[string]string{
 	"":     "Represents a standard link that could be generated in HTML",
 	"text": "text is the display text for the link",
-	"href": "href is the absolute secure URL for the link (must use https)",
+	"href": "href is the absolute URL for the link. Must use https:// for web URLs or mailto: for email links.",
 }
 
 func (Link) SwaggerDoc() map[string]string {

--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -24177,7 +24177,7 @@ func schema_openshift_api_console_v1_ConsoleLinkSpec(ref common.ReferenceCallbac
 					},
 					"href": {
 						SchemaProps: spec.SchemaProps{
-							Description: "href is the absolute secure URL for the link (must use https)",
+							Description: "href is the absolute URL for the link. Must use https:// for web URLs or mailto: for email links.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -25676,7 +25676,7 @@ func schema_openshift_api_console_v1_Link(ref common.ReferenceCallback) common.O
 					},
 					"href": {
 						SchemaProps: spec.SchemaProps{
-							Description: "href is the absolute secure URL for the link (must use https)",
+							Description: "href is the absolute URL for the link. Must use https:// for web URLs or mailto: for email links.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4780,8 +4780,12 @@
           "x-kubernetes-list-type": "atomic"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -8929,8 +8933,12 @@
           "x-kubernetes-list-type": "set"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -9543,8 +9551,12 @@
           "type": "string"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -9737,8 +9749,12 @@
           "x-kubernetes-list-type": "set"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -11652,8 +11668,12 @@
           "x-kubernetes-list-type": "atomic"
         },
         "dnsRecordsType": {
-          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure When set to `External`, records are not provided by the internal infrastructure and must be configured by the user. This value may only be set when a user-managed loadbalancer is configured. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.",
-          "type": "string"
+          "description": "dnsRecordsType determines whether records for api, api-int, and ingress are provided by the internal DNS service or externally. Allowed values are `Internal`, `External`, and omitted. When set to `Internal`, records are provided by the internal infrastructure and no additional user configuration is required for the cluster to function. When set to `External`, records are not provided by the internal infrastructure and must be configured by the user on a DNS server outside the cluster. Cluster nodes must use this external server for their upstream DNS requests. This value may only be set when loadBalancer.type is set to UserManaged. When omitted, this means the user has no opinion and the platform is left to choose reasonable defaults. These defaults are subject to change over time. The current default is `Internal`.\n\nPossible enum values:\n - `\"External\"`\n - `\"Internal\"`",
+          "type": "string",
+          "enum": [
+            "External",
+            "Internal"
+          ]
         },
         "ingressIP": {
           "description": "ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.\n\nDeprecated: Use IngressIPs instead.",
@@ -13283,7 +13303,7 @@
           "$ref": "#/definitions/com.github.openshift.api.console.v1.ApplicationMenuSpec"
         },
         "href": {
-          "description": "href is the absolute secure URL for the link (must use https)",
+          "description": "href is the absolute URL for the link. Must use https:// for web URLs or mailto: for email links.",
           "type": "string",
           "default": ""
         },
@@ -14215,7 +14235,7 @@
       ],
       "properties": {
         "href": {
-          "description": "href is the absolute secure URL for the link (must use https)",
+          "description": "href is the absolute URL for the link. Must use https:// for web URLs or mailto: for email links.",
           "type": "string",
           "default": ""
         },
@@ -30640,7 +30660,7 @@
           "$ref": "#/definitions/com.github.openshift.api.operator.v1.IngressControllerHTTPHeaders"
         },
         "idleConnectionTerminationPolicy": {
-          "description": "idleConnectionTerminationPolicy maps directly to HAProxy's idle-close-on-response option and controls whether HAProxy keeps idle frontend connections open during a soft stop (router reload).\n\nAllowed values for this field are \"Immediate\" and \"Deferred\". The default value is \"Immediate\".\n\nWhen set to \"Immediate\", idle connections are closed immediately during router reloads. This ensures immediate propagation of route changes but may impact clients sensitive to connection resets.\n\nWhen set to \"Deferred\", HAProxy will maintain idle connections during a soft reload instead of closing them immediately. These connections remain open until any of the following occurs:\n\n  - A new request is received on the connection, in which\n    case HAProxy handles it in the old process and closes\n    the connection after sending the response.\n\n  - HAProxy's `timeout http-keep-alive` duration expires\n    (300 seconds in OpenShift's configuration, not\n    configurable).\n\n  - The client's keep-alive timeout expires, causing the\n    client to close the connection.\n\nSetting Deferred can help prevent errors in clients or load balancers that do not properly handle connection resets. Additionally, this option allows you to retain the pre-2.4 HAProxy behaviour: in HAProxy version 2.2 (OpenShift versions < 4.14), maintaining idle connections during a soft reload was the default behaviour, but starting with HAProxy 2.4, the default changed to closing idle connections immediately.\n\nImportant Consideration:\n\n  - Using Deferred will result in temporary inconsistencies\n    for the first request on each persistent connection\n    after a route update and router reload. This request\n    will be processed by the old HAProxy process using its\n    old configuration. Subsequent requests will use the\n    updated configuration.\n\nOperational Considerations:\n\n  - Keeping idle connections open during reloads may lead\n    to an accumulation of old HAProxy processes if\n    connections remain idle for extended periods,\n    especially in environments where frequent reloads\n    occur.\n\n  - Consider monitoring the number of HAProxy processes in\n    the router pods when Deferred is set.\n\n  - You may need to enable or adjust the\n    `ingress.operator.openshift.io/hard-stop-after`\n    duration (configured via an annotation on the\n    IngressController resource) in environments with\n    frequent reloads to prevent resource exhaustion.",
+          "description": "idleConnectionTerminationPolicy maps directly to HAProxy's idle-close-on-response option and controls whether HAProxy keeps idle frontend connections open during a soft stop (router reload).\n\nAllowed values for this field are \"Immediate\" and \"Deferred\". The default value is \"Immediate\".\n\nWhen set to \"Immediate\", idle connections are closed immediately during router reloads. This ensures immediate propagation of route changes but may impact clients sensitive to connection resets.\n\nWhen set to \"Deferred\", HAProxy will maintain idle connections during a soft reload instead of closing them immediately. These connections remain open until any of the following occurs:\n\n  - A new request is received on the connection, in which\n    case HAProxy handles it in the old process and closes\n    the connection after sending the response.\n\n  - HAProxy's `timeout http-keep-alive` duration expires.\n    By default this is 300 seconds, but it can be changed\n    using httpKeepAliveTimeout tuning option.\n\n  - The client's keep-alive timeout expires, causing the\n    client to close the connection.\n\nSetting Deferred can help prevent errors in clients or load balancers that do not properly handle connection resets. Additionally, this option allows you to retain the pre-2.4 HAProxy behaviour: in HAProxy version 2.2 (OpenShift versions < 4.14), maintaining idle connections during a soft reload was the default behaviour, but starting with HAProxy 2.4, the default changed to closing idle connections immediately.\n\nImportant Consideration:\n\n  - Using Deferred will result in temporary inconsistencies\n    for the first request on each persistent connection\n    after a route update and router reload. This request\n    will be processed by the old HAProxy process using its\n    old configuration. Subsequent requests will use the\n    updated configuration.\n\nOperational Considerations:\n\n  - Keeping idle connections open during reloads may lead\n    to an accumulation of old HAProxy processes if\n    connections remain idle for extended periods,\n    especially in environments where frequent reloads\n    occur.\n\n  - Consider monitoring the number of HAProxy processes in\n    the router pods when Deferred is set.\n\n  - You may need to enable or adjust the\n    `ingress.operator.openshift.io/hard-stop-after`\n    duration (configured via an annotation on the\n    IngressController resource) in environments with\n    frequent reloads to prevent resource exhaustion.",
           "type": "string",
           "default": "Immediate"
         },
@@ -30767,6 +30787,10 @@
         },
         "healthCheckInterval": {
           "description": "healthCheckInterval defines how long the router waits between two consecutive health checks on its configured backends.  This value is applied globally as a default for all routes, but may be overridden per-route by the route annotation \"router.openshift.io/haproxy.health.check.interval\".\n\nExpects an unsigned duration string of decimal numbers, each with optional fraction and a unit suffix, eg \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are \"ns\", \"us\" (or \"µs\" U+00B5 or \"μs\" U+03BC), \"ms\", \"s\", \"m\", \"h\".\n\nSetting this to less than 5s can cause excess traffic due to too frequent TCP health checks and accompanying SYN packet storms.  Alternatively, setting this too high can result in increased latency, due to backend servers that are no longer available, but haven't yet been detected as such.\n\nAn empty or zero healthCheckInterval means no opinion and IngressController chooses a default, which is subject to change over time. Currently the default healthCheckInterval value is 5s.\n\nCurrently the minimum allowed value is 1s and the maximum allowed value is 2147483647ms (24.85 days).  Both are subject to change over time.",
+          "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Duration"
+        },
+        "httpKeepAliveTimeout": {
+          "description": "httpKeepAliveTimeout defines the maximum allowed time to wait for a new HTTP request to appear on a connection from the client to the router.\n\nThis field expects an unsigned duration string of a decimal number, with optional fraction and a unit suffix, e.g. \"300ms\", \"1.5s\" or \"2m45s\". Valid time units are \"ms\", \"s\", \"m\". The allowed range is from 1 millisecond to 15 minutes.\n\nWhen omitted, this means the user has no opinion and the platform is left to choose a reasonable default. This default is subject to change over time. The current default is 300s.\n\nLow values (tens of milliseconds or less) can cause clients to close and reopen connections for each request, leading to reduced connection sharing. For HTTP/2, special care should be taken with low values. A few seconds is a reasonable starting point to avoid holding idle connections open while still allowing subsequent requests to reuse the connection.\n\nHigh values (minutes or more) favor connection reuse but may cause idle connections to linger longer.",
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Duration"
         },
         "maxConnections": {


### PR DESCRIPTION
Tested the change on a live cluster and worked as desired.

/assign @spadgett @JoelSpeed @everettraven 