### PR TITLE
Disable TPNU/DPNU ClientsAllowCBOR for large list decodes.

### DIFF
--- a/features.md
+++ b/features.md
@@ -1,5 +1,6 @@
 | FeatureGate | Default on Hypershift | Default on SelfManagedHA | DevPreviewNoUpgrade on Hypershift | DevPreviewNoUpgrade on SelfManagedHA | TechPreviewNoUpgrade on Hypershift | TechPreviewNoUpgrade on SelfManagedHA  |
 | ------ | --- | --- | --- | --- | --- | ---  |
+| ClientsAllowCBOR| | | | | |  |
 | ClusterAPIInstall| | | | | |  |
 | EventedPLEG| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
@@ -31,7 +32,6 @@
 | BootcNodeManagement| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | CBORServingAndStorage| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | CRDCompatibilityRequirementOperator| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
-| ClientsAllowCBOR| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ClientsPreferCBOR| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ClusterAPIInstallIBMCloud| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |
 | ClusterAPIMachineManagement| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -883,7 +883,6 @@ var (
 					contactPerson("benluddy").
 					productScope(kubernetes).
 					enhancementPR("https://github.com/kubernetes/enhancements/issues/4222").
-					enableIn(configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 					mustRegister()
 
 	FeatureClientsPreferCBOR = newFeatureGate("ClientsPreferCBOR").

--- a/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-DevPreviewNoUpgrade.yaml
@@ -15,6 +15,9 @@
             {
                 "disabled": [
                     {
+                        "name": "ClientsAllowCBOR"
+                    },
+                    {
                         "name": "ClusterAPIInstall"
                     },
                     {
@@ -111,9 +114,6 @@
                     },
                     {
                         "name": "CRDCompatibilityRequirementOperator"
-                    },
-                    {
-                        "name": "ClientsAllowCBOR"
                     },
                     {
                         "name": "ClientsPreferCBOR"

--- a/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-TechPreviewNoUpgrade.yaml
@@ -15,6 +15,9 @@
             {
                 "disabled": [
                     {
+                        "name": "ClientsAllowCBOR"
+                    },
+                    {
                         "name": "ClusterAPIInstall"
                     },
                     {
@@ -126,9 +129,6 @@
                     },
                     {
                         "name": "CRDCompatibilityRequirementOperator"
-                    },
-                    {
-                        "name": "ClientsAllowCBOR"
                     },
                     {
                         "name": "ClientsPreferCBOR"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -15,6 +15,9 @@
             {
                 "disabled": [
                     {
+                        "name": "ClientsAllowCBOR"
+                    },
+                    {
                         "name": "ClusterAPIInstall"
                     },
                     {
@@ -90,9 +93,6 @@
                     },
                     {
                         "name": "CRDCompatibilityRequirementOperator"
-                    },
-                    {
-                        "name": "ClientsAllowCBOR"
                     },
                     {
                         "name": "ClientsPreferCBOR"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -15,6 +15,9 @@
             {
                 "disabled": [
                     {
+                        "name": "ClientsAllowCBOR"
+                    },
+                    {
                         "name": "ClusterAPIInstall"
                     },
                     {
@@ -105,9 +108,6 @@
                     },
                     {
                         "name": "CRDCompatibilityRequirementOperator"
-                    },
-                    {
-                        "name": "ClientsAllowCBOR"
                     },
                     {
                         "name": "ClientsPreferCBOR"


### PR DESCRIPTION
There's an arbitrary cap on array length that prevents decoding large lists that needs to be addressed. In the meantime, this disables the client-go gate that causes clients to opt in to receiving CBOR-encoded list responses.