### PR TITLE
OPRUN-4281: Disable OLMv1 Boxcutter FeatureGate

### DIFF
--- a/features.md
+++ b/features.md
@@ -5,12 +5,12 @@
 | EventedPLEG| | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | |  |
 | MultiArchInstallAzure| | | | | |  |
+| NewOLMBoxCutterRuntime| | | | | |  |
 | ShortCertRotation| | | | | |  |
 | ClusterAPIMachineManagementVSphere| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | Example2| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | ExternalSnapshotMetadata| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
 | IngressControllerDynamicConfigurationManager| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | |  |
-| NewOLMBoxCutterRuntime| | | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMCatalogdAPIV1Metas| | | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMOwnSingleNamespace| | | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMPreflightPermissionChecks| | | | <span style="background-color: #519450">Enabled</span> | | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -518,7 +518,6 @@ var (
 						contactPerson("pegoncal").
 						productScope(ocpSpecific).
 						enhancementPR("https://github.com/openshift/enhancements/pull/1890").
-						enableForClusterProfile(SelfManaged, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateInsightsOnDemandDataGather = newFeatureGate("InsightsOnDemandDataGather").

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -33,6 +33,9 @@
                         "name": "MultiArchInstallAzure"
                     },
                     {
+                        "name": "NewOLMBoxCutterRuntime"
+                    },
+                    {
                         "name": "ShortCertRotation"
                     }
                 ],
@@ -255,9 +258,6 @@
                     },
                     {
                         "name": "NewOLM"
-                    },
-                    {
-                        "name": "NewOLMBoxCutterRuntime"
                     },
                     {
                         "name": "NewOLMCatalogdAPIV1Metas"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -45,6 +45,9 @@
                         "name": "MultiArchInstallAzure"
                     },
                     {
+                        "name": "NewOLMBoxCutterRuntime"
+                    },
+                    {
                         "name": "ProvisioningRequestAvailable"
                     },
                     {
@@ -258,9 +261,6 @@
                     },
                     {
                         "name": "NewOLM"
-                    },
-                    {
-                        "name": "NewOLMBoxCutterRuntime"
                     },
                     {
                         "name": "NewOLMCatalogdAPIV1Metas"


### PR DESCRIPTION
The OLM team has decided to hold back the release of the Boxcutter integration from TechPreview for 4.21. This PR keeps the FeatureGate but removes it from all of the different profiles to avoid it showing up in the featuregates cluster resource and potentially confuse users.