### PR TITLE
Migrate away from deprecated ioutil

### DIFF
--- a/config/v1/types_infrastructure_test.go
+++ b/config/v1/types_infrastructure_test.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -24,7 +24,7 @@ func TestInfrastructureStatusDefault(t *testing.T) {
 	filePaths := []string{infraCRDDefaultFilePath, infraCRDTestPreviewFilePath}
 
 	for _, filepath := range filePaths {
-		infraCRDBytes, err := ioutil.ReadFile(path.Join("zz_generated.crd-manifests", filepath))
+		infraCRDBytes, err := os.ReadFile(path.Join("zz_generated.crd-manifests", filepath))
 		if err != nil {
 			t.Fatalf("failed to read infrastructure CRD file %q: %v", filepath, err)
 		}

--- a/payload-command/render/renderassets/assets.go
+++ b/payload-command/render/renderassets/assets.go
@@ -2,7 +2,6 @@ package assets
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,7 +96,7 @@ func (a Asset) WriteFile(path string) error {
 		perms = a.FilePermission
 	}
 	fmt.Printf("Writing asset: %s\n", f)
-	return ioutil.WriteFile(f, a.Data, os.FileMode(perms))
+	return os.WriteFile(f, a.Data, os.FileMode(perms))
 }
 
 // MustCreateAssetFromTemplate process the given template using and return an asset.
@@ -224,7 +223,7 @@ func LoadFilesRecursively(dir string, predicates ...FileInfoPredicate) (map[stri
 				}
 			}
 
-			bs, err := ioutil.ReadFile(path)
+			bs, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}

--- a/tools/codegen/pkg/swaggerdocs/generator.go
+++ b/tools/codegen/pkg/swaggerdocs/generator.go
@@ -2,7 +2,7 @@ package swaggerdocs
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/openshift/api/tools/codegen/pkg/generation"
@@ -126,7 +126,7 @@ func (g *generator) generateGroupVersion(groupName string, version generation.AP
 		return fmt.Errorf("error generating swagger docs: %w", err)
 	}
 
-	if err := ioutil.WriteFile(outFilePath, generatedDocs, 0644); err != nil {
+	if err := os.WriteFile(outFilePath, generatedDocs, 0644); err != nil {
 		return fmt.Errorf("error writing swagger docs output: %w", err)
 	}
 

--- a/tools/codegen/pkg/swaggerdocs/swaggerdocs.go
+++ b/tools/codegen/pkg/swaggerdocs/swaggerdocs.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"go/format"
-	"io/ioutil"
+	"os"
 	"reflect"
 
 	kruntime "k8s.io/apimachinery/pkg/runtime"
@@ -65,7 +65,7 @@ func verifySwaggerDocs(packageName, filePath string, docsForTypes []kruntime.Kub
 	}
 
 	// Verify that the existing data matches the generated data.
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("error reading existing swagger docs file: %w", err)
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

**Migration from `ioutil` to `os` for file operations:**

* Replaced `ioutil.ReadFile` with `os.ReadFile` and `ioutil.WriteFile` with `os.WriteFile` across multiple files, including `config/v1/types_infrastructure_test.go`, `payload-command/render/renderassets/assets.go`, `tools/codegen/pkg/swaggerdocs/generator.go`, and `tools/codegen/pkg/swaggerdocs/swaggerdocs.go`. [[1]](diffhunk://#diff-1ceb683bc84cb6cc4fc9d52860554d4549cf111dd845ebdfea6e38e0d7fbb9d1L4-R4) [[2]](diffhunk://#diff-1ceb683bc84cb6cc4fc9d52860554d4549cf111dd845ebdfea6e38e0d7fbb9d1L27-R27) [[3]](diffhunk://#diff-35a7001b412f82246ea4360b9ffd19705da9a7312044e70e687c8948e62783ebL5) [[4]](diffhunk://#diff-35a7001b412f82246ea4360b9ffd19705da9a7312044e70e687c8948e62783ebL100-R99) [[5]](diffhunk://#diff-35a7001b412f82246ea4360b9ffd19705da9a7312044e70e687c8948e62783ebL227-R226) [[6]](diffhunk://#diff-02832d7470022e56676ed8b99aa5f47500252be3bd1ecb1edbe88f9d54e4cfd4L5-R5) [[7]](diffhunk://#diff-02832d7470022e56676ed8b99aa5f47500252be3bd1ecb1edbe88f9d54e4cfd4L129-R129) [[8]](diffhunk://#diff-4b41a0ae8b889c2a14e5caa386faf638ee5da4fe3977e96cad81201ab60b0e32L8-R8) [[9]](diffhunk://#diff-4b41a0ae8b889c2a14e5caa386faf638ee5da4fe3977e96cad81201ab60b0e32L68-R68)

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52