### PR TITLE
MCO-2005: Include missing OSImageStream TP CRDs

### DIFF
--- a/hack/update-payload-crds.sh
+++ b/hack/update-payload-crds.sh
@@ -23,6 +23,7 @@ crd_globs="\
     operator/v1/zz_generated.crd-manifests/0000_50_openshift-controller-manager_02_openshiftcontrollermanagers*.crd.yaml
     machineconfiguration/v1/zz_generated.crd-manifests/*.crd.yaml
     machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_internalreleaseimages-*.crd.yaml
+    machineconfiguration/v1alpha1/zz_generated.crd-manifests/0000_80_machine-config_01_osimagestreams-*.crd.yaml
     operator/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfigurations*.crd.yaml
     config/v1alpha1/zz_generated.crd-manifests/0000_10_config-operator_01_clustermonitoring*.crd.yaml
     operator/v1/zz_generated.crd-manifests/*_storage_01_storages*.crd.yaml

--- a/payload-manifests/crds/0000_80_machine-config_01_osimagestreams-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_osimagestreams-CustomNoUpgrade.crd.yaml
@@ -1,0 +1,167 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2555
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: CustomNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: osimagestreams.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: OSImageStream
+    listKind: OSImageStreamList
+    plural: osimagestreams
+    singular: osimagestream
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          OSImageStream describes a set of streams and associated images available
+          for the MachineConfigPools to be used as base OS images.
+
+          The resource is a singleton named "cluster".
+
+          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec contains the desired OSImageStream config configuration.
+            type: object
+          status:
+            description: |-
+              status describes the last observed state of this OSImageStream.
+              Populated by the MachineConfigOperator after reading release metadata.
+              When not present, the controller has not yet reconciled this resource.
+            properties:
+              availableStreams:
+                description: |-
+                  availableStreams is a list of the available OS Image Streams that can be
+                  used as the base image for MachineConfigPools.
+                  availableStreams is required, must have at least one item, must not exceed
+                  100 items, and must have unique entries keyed on the name field.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        name is the required identifier of the stream.
+
+                        name is determined by the operator based on the OCI label of the
+                        discovered OS or Extension Image.
+
+                        Must be a valid RFC 1123 subdomain between 1 and 253 characters in length,
+                        consisting of lowercase alphanumeric characters, hyphens ('-'), and periods ('.').
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: a RFC 1123 subdomain must consist of lower case alphanumeric
+                          characters, '-' or '.', and must start and end with an alphanumeric
+                          character.
+                        rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                    osExtensionsImage:
+                      description: |-
+                        osExtensionsImage is a required OS Extensions Image referenced by digest.
+
+                        osExtensionsImage bundles the extra repositories used to enable extensions, augmenting
+                        the base operating system without modifying the underlying immutable osImage.
+
+                        The format of the image pull spec is: host[:port][/namespace]/name@sha256:<digest>,
+                        where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                        The length of the whole spec must be between 1 to 447 characters.
+                      maxLength: 447
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                          suffix, where '<digest>' is 64 characters long
+                        rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                      - message: the OCI Image name should follow the host[:port][/namespace]/name
+                          format, resembling a valid URL without the scheme
+                        rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                    osImage:
+                      description: |-
+                        osImage is a required OS Image referenced by digest.
+
+                        osImage contains the immutable, fundamental operating system components, including the kernel
+                        and base utilities, that define the core environment for the node's host operating system.
+
+                        The format of the image pull spec is: host[:port][/namespace]/name@sha256:<digest>,
+                        where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                        The length of the whole spec must be between 1 to 447 characters.
+                      maxLength: 447
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                          suffix, where '<digest>' is 64 characters long
+                        rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                      - message: the OCI Image name should follow the host[:port][/namespace]/name
+                          format, resembling a valid URL without the scheme
+                        rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                  required:
+                  - name
+                  - osExtensionsImage
+                  - osImage
+                  type: object
+                maxItems: 100
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              defaultStream:
+                description: |-
+                  defaultStream is the name of the stream that should be used as the default
+                  when no specific stream is requested by a MachineConfigPool.
+
+                  It must be a valid RFC 1123 subdomain between 1 and 253 characters in length,
+                  consisting of lowercase alphanumeric characters, hyphens ('-'), and periods ('.'),
+                  and must reference the name of one of the streams in availableStreams.
+                maxLength: 253
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: a RFC 1123 subdomain must consist of lower case alphanumeric
+                    characters, '-' or '.', and must start and end with an alphanumeric
+                    character.
+                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+            required:
+            - availableStreams
+            - defaultStream
+            type: object
+            x-kubernetes-validations:
+            - message: defaultStream must reference a stream name from availableStreams
+              rule: self.defaultStream in self.availableStreams.map(s, s.name)
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: osimagestream is a singleton, .metadata.name must be 'cluster'
+          rule: self.metadata.name == 'cluster'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_osimagestreams-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_osimagestreams-DevPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,167 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2555
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: DevPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: osimagestreams.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: OSImageStream
+    listKind: OSImageStreamList
+    plural: osimagestreams
+    singular: osimagestream
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          OSImageStream describes a set of streams and associated images available
+          for the MachineConfigPools to be used as base OS images.
+
+          The resource is a singleton named "cluster".
+
+          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec contains the desired OSImageStream config configuration.
+            type: object
+          status:
+            description: |-
+              status describes the last observed state of this OSImageStream.
+              Populated by the MachineConfigOperator after reading release metadata.
+              When not present, the controller has not yet reconciled this resource.
+            properties:
+              availableStreams:
+                description: |-
+                  availableStreams is a list of the available OS Image Streams that can be
+                  used as the base image for MachineConfigPools.
+                  availableStreams is required, must have at least one item, must not exceed
+                  100 items, and must have unique entries keyed on the name field.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        name is the required identifier of the stream.
+
+                        name is determined by the operator based on the OCI label of the
+                        discovered OS or Extension Image.
+
+                        Must be a valid RFC 1123 subdomain between 1 and 253 characters in length,
+                        consisting of lowercase alphanumeric characters, hyphens ('-'), and periods ('.').
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: a RFC 1123 subdomain must consist of lower case alphanumeric
+                          characters, '-' or '.', and must start and end with an alphanumeric
+                          character.
+                        rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                    osExtensionsImage:
+                      description: |-
+                        osExtensionsImage is a required OS Extensions Image referenced by digest.
+
+                        osExtensionsImage bundles the extra repositories used to enable extensions, augmenting
+                        the base operating system without modifying the underlying immutable osImage.
+
+                        The format of the image pull spec is: host[:port][/namespace]/name@sha256:<digest>,
+                        where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                        The length of the whole spec must be between 1 to 447 characters.
+                      maxLength: 447
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                          suffix, where '<digest>' is 64 characters long
+                        rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                      - message: the OCI Image name should follow the host[:port][/namespace]/name
+                          format, resembling a valid URL without the scheme
+                        rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                    osImage:
+                      description: |-
+                        osImage is a required OS Image referenced by digest.
+
+                        osImage contains the immutable, fundamental operating system components, including the kernel
+                        and base utilities, that define the core environment for the node's host operating system.
+
+                        The format of the image pull spec is: host[:port][/namespace]/name@sha256:<digest>,
+                        where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                        The length of the whole spec must be between 1 to 447 characters.
+                      maxLength: 447
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                          suffix, where '<digest>' is 64 characters long
+                        rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                      - message: the OCI Image name should follow the host[:port][/namespace]/name
+                          format, resembling a valid URL without the scheme
+                        rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                  required:
+                  - name
+                  - osExtensionsImage
+                  - osImage
+                  type: object
+                maxItems: 100
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              defaultStream:
+                description: |-
+                  defaultStream is the name of the stream that should be used as the default
+                  when no specific stream is requested by a MachineConfigPool.
+
+                  It must be a valid RFC 1123 subdomain between 1 and 253 characters in length,
+                  consisting of lowercase alphanumeric characters, hyphens ('-'), and periods ('.'),
+                  and must reference the name of one of the streams in availableStreams.
+                maxLength: 253
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: a RFC 1123 subdomain must consist of lower case alphanumeric
+                    characters, '-' or '.', and must start and end with an alphanumeric
+                    character.
+                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+            required:
+            - availableStreams
+            - defaultStream
+            type: object
+            x-kubernetes-validations:
+            - message: defaultStream must reference a stream name from availableStreams
+              rule: self.defaultStream in self.availableStreams.map(s, s.name)
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: osimagestream is a singleton, .metadata.name must be 'cluster'
+          rule: self.metadata.name == 'cluster'
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/payload-manifests/crds/0000_80_machine-config_01_osimagestreams-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_osimagestreams-TechPreviewNoUpgrade.crd.yaml
@@ -1,0 +1,167 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/2555
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: TechPreviewNoUpgrade
+  labels:
+    openshift.io/operator-managed: ""
+  name: osimagestreams.machineconfiguration.openshift.io
+spec:
+  group: machineconfiguration.openshift.io
+  names:
+    kind: OSImageStream
+    listKind: OSImageStreamList
+    plural: osimagestreams
+    singular: osimagestream
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          OSImageStream describes a set of streams and associated images available
+          for the MachineConfigPools to be used as base OS images.
+
+          The resource is a singleton named "cluster".
+
+          Compatibility level 4: No compatibility is provided, the API can change at any point for any reason. These capabilities should not be used by applications needing long term support.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec contains the desired OSImageStream config configuration.
+            type: object
+          status:
+            description: |-
+              status describes the last observed state of this OSImageStream.
+              Populated by the MachineConfigOperator after reading release metadata.
+              When not present, the controller has not yet reconciled this resource.
+            properties:
+              availableStreams:
+                description: |-
+                  availableStreams is a list of the available OS Image Streams that can be
+                  used as the base image for MachineConfigPools.
+                  availableStreams is required, must have at least one item, must not exceed
+                  100 items, and must have unique entries keyed on the name field.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        name is the required identifier of the stream.
+
+                        name is determined by the operator based on the OCI label of the
+                        discovered OS or Extension Image.
+
+                        Must be a valid RFC 1123 subdomain between 1 and 253 characters in length,
+                        consisting of lowercase alphanumeric characters, hyphens ('-'), and periods ('.').
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: a RFC 1123 subdomain must consist of lower case alphanumeric
+                          characters, '-' or '.', and must start and end with an alphanumeric
+                          character.
+                        rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+                    osExtensionsImage:
+                      description: |-
+                        osExtensionsImage is a required OS Extensions Image referenced by digest.
+
+                        osExtensionsImage bundles the extra repositories used to enable extensions, augmenting
+                        the base operating system without modifying the underlying immutable osImage.
+
+                        The format of the image pull spec is: host[:port][/namespace]/name@sha256:<digest>,
+                        where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                        The length of the whole spec must be between 1 to 447 characters.
+                      maxLength: 447
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                          suffix, where '<digest>' is 64 characters long
+                        rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                      - message: the OCI Image name should follow the host[:port][/namespace]/name
+                          format, resembling a valid URL without the scheme
+                        rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                    osImage:
+                      description: |-
+                        osImage is a required OS Image referenced by digest.
+
+                        osImage contains the immutable, fundamental operating system components, including the kernel
+                        and base utilities, that define the core environment for the node's host operating system.
+
+                        The format of the image pull spec is: host[:port][/namespace]/name@sha256:<digest>,
+                        where the digest must be 64 characters long, and consist only of lowercase hexadecimal characters, a-f and 0-9.
+                        The length of the whole spec must be between 1 to 447 characters.
+                      maxLength: 447
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                      - message: the OCI Image reference must end with a valid '@sha256:<digest>'
+                          suffix, where '<digest>' is 64 characters long
+                        rule: (self.split('@').size() == 2 && self.split('@')[1].matches('^sha256:[a-f0-9]{64}$'))
+                      - message: the OCI Image name should follow the host[:port][/namespace]/name
+                          format, resembling a valid URL without the scheme
+                        rule: (self.split('@')[0].matches('^([a-zA-Z0-9-]+\\.)+[a-zA-Z0-9-]+(:[0-9]{2,5})?/([a-zA-Z0-9-_]{0,61}/)?[a-zA-Z0-9-_.]*?$'))
+                  required:
+                  - name
+                  - osExtensionsImage
+                  - osImage
+                  type: object
+                maxItems: 100
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              defaultStream:
+                description: |-
+                  defaultStream is the name of the stream that should be used as the default
+                  when no specific stream is requested by a MachineConfigPool.
+
+                  It must be a valid RFC 1123 subdomain between 1 and 253 characters in length,
+                  consisting of lowercase alphanumeric characters, hyphens ('-'), and periods ('.'),
+                  and must reference the name of one of the streams in availableStreams.
+                maxLength: 253
+                minLength: 1
+                type: string
+                x-kubernetes-validations:
+                - message: a RFC 1123 subdomain must consist of lower case alphanumeric
+                    characters, '-' or '.', and must start and end with an alphanumeric
+                    character.
+                  rule: '!format.dns1123Subdomain().validate(self).hasValue()'
+            required:
+            - availableStreams
+            - defaultStream
+            type: object
+            x-kubernetes-validations:
+            - message: defaultStream must reference a stream name from availableStreams
+              rule: self.defaultStream in self.availableStreams.map(s, s.name)
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: osimagestream is a singleton, .metadata.name must be 'cluster'
+          rule: self.metadata.name == 'cluster'
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Because the v1alpha directory of the MCO was not explicitly included in the crd_globs list of the update-payload-crds the freshly added OSImageStream CRD wasn't copied to the payload-manifests directory leading to the CVO not deploying the CRDs.