### PR TITLE
Add listType=map to spec.servers for SSA support

### DIFF
--- a/openapi/generated_openapi/zz_generated.openapi.go
+++ b/openapi/generated_openapi/zz_generated.openapi.go
@@ -49892,6 +49892,14 @@ func schema_openshift_api_operator_v1_DNSSpec(ref common.ReferenceCallback) comm
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"servers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-map-keys": []interface{}{
+									"name",
+								},
+								"x-kubernetes-list-type": "map",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "servers is a list of DNS resolvers that provide name query delegation for one or more subdomains outside the scope of the cluster domain. If servers consists of more than one Server, longest suffix match will be used to determine the Server.\n\nFor example, if there are two Servers, one for \"foo.com\" and another for \"a.foo.com\", and the name query is for \"www.a.foo.com\", it will be routed to the Server with Zone \"a.foo.com\".\n\nIf this field is nil, no servers are created.",
 							Type:        []string{"array"},

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -9881,7 +9881,7 @@
           "$ref": "#/definitions/com.github.openshift.api.config.v1.PKI"
         },
         "policyType": {
-          "description": "policyType is a required field specifies the type of the policy for verification. This field must correspond to how the policy was generated. Allowed values are \"PublicKey\", \"FulcioCAWithRekor\", and \"PKI\". When set to \"PublicKey\", the policy relies on a sigstore publicKey and may optionally use a Rekor verification. When set to \"FulcioCAWithRekor\", the policy is based on the Fulcio certification and incorporates a Rekor verification. When set to \"PKI\", the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI). This value is enabled by turning on the SigstoreImageVerificationPKI feature gate.",
+          "description": "policyType is a required field specifies the type of the policy for verification. This field must correspond to how the policy was generated. Allowed values are \"PublicKey\", \"FulcioCAWithRekor\", and \"PKI\". When set to \"PublicKey\", the policy relies on a sigstore publicKey and may optionally use a Rekor verification. When set to \"FulcioCAWithRekor\", the policy is based on the Fulcio certification and incorporates a Rekor verification. When set to \"PKI\", the policy is based on the certificates from Bring Your Own Public Key Infrastructure (BYOPKI).",
           "type": "string",
           "default": ""
         },
@@ -28979,7 +28979,11 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/com.github.openshift.api.operator.v1.Server"
-          }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "upstreamResolvers": {
           "description": "upstreamResolvers defines a schema for configuring CoreDNS to proxy DNS messages to upstream resolvers for the case of the default (\".\") server\n\nIf this field is not specified, the upstream used will default to /etc/resolv.conf, with policy \"sequential\"",

--- a/operator/v1/types_dns.go
+++ b/operator/v1/types_dns.go
@@ -51,6 +51,8 @@ type DNSSpec struct {
 	//
 	// If this field is nil, no servers are created.
 	//
+	// +listType=map
+	// +listMapKey=name
 	// +optional
 	Servers []Server `json:"servers,omitempty"`
 

--- a/operator/v1/zz_generated.crd-manifests/0000_70_dns_00_dnses.crd.yaml
+++ b/operator/v1/zz_generated.crd-manifests/0000_70_dns_00_dnses.crd.yaml
@@ -352,6 +352,9 @@ spec:
                       type: array
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               upstreamResolvers:
                 default: {}
                 description: |-

--- a/operator/v1/zz_generated.featuregated-crd-manifests/dnses.operator.openshift.io/AAA_ungated.yaml
+++ b/operator/v1/zz_generated.featuregated-crd-manifests/dnses.operator.openshift.io/AAA_ungated.yaml
@@ -353,6 +353,9 @@ spec:
                       type: array
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               upstreamResolvers:
                 description: |-
                   upstreamResolvers defines a schema for configuring CoreDNS


### PR DESCRIPTION
The DNS.spec.servers field was missing list-type markers, causing Server Side Apply SSA to treat the entire list as atomic. This prevented multiple field managers from independently managing different server entries.

This change adds +listType=map and +listMapKey=name markers to the servers field, enabling SSA to merge server entries by their unique name field instead of replacing the entire list.

command ran: `make update-codegen-crds`

Fixes: https://github.com/openshift/api/issues/2514