### PR TITLE
Disable the statusoptional linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,8 @@ linters:
               - nobools
               - nomaps
               - statussubresource
+            disable:
+              - statusoptional # This is legacy and not something we currently recommend.
           lintersConfig:
             conditions:
               isFirstField: Warn


### PR DESCRIPTION
This is legacy advice that doesn't apply well to types with status subresource, so I'd rather we disable it