### PR TITLE
Add configuration for coderabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,28 @@
+language: en-US
+reviews:
+  profile: chill
+  high_level_summary: false
+  review_status: true
+  commit_status: true
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  poem: false
+  suggested_labels: false
+  path_filters:
+  - "!payload-manifests"
+  - "!**/zz_generated.crd-manifests/*" # Contains files
+  - "!**/zz_generated.featuregated-crd-manifests/**" # Contains folders
+  - "!**/vendor/**"
+  - "!vendor/**"
+  tools:
+    golangci-lint:
+      enabled: true
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+    - AGENTS.md
+  learnings:
+    scope: local


### PR DESCRIPTION
Based on the [configuration reference](https://docs.coderabbit.ai/reference/configuration), this is an attempt to quieten coderabbit down to exactly the useful content we want.

This includes:
* Disabling walkthrough as much as possible, this doesn't appear useful to reviewers
* Preferring local learnings - this repo acts very differently to others
* Ignoring changes in vendor
* Ignoring changes to some generated files
* Specifically requesting it use our AGENTS.md file