### PR TITLE
Re-enable NewOLMBoxcutterRuntime featuregate in TPNU

### DIFF
--- a/features.md
+++ b/features.md
@@ -5,13 +5,13 @@
 | EventedPLEG| | | | | | | |  |
 | MachineAPIOperatorDisableMachineHealthCheckController| | | | | | | |  |
 | MultiArchInstallAzure| | | | | | | |  |
-| NewOLMBoxCutterRuntime| | | | | | | |  |
 | ShortCertRotation| | | | | | | |  |
 | ClusterAPIMachineManagementVSphere| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | Example2| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | ExternalSnapshotMetadata| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | IngressControllerDynamicConfigurationManager| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
 | NetworkConnect| | | <span style="background-color: #519450">Enabled</span> | <span style="background-color: #519450">Enabled</span> | | | |  |
+| NewOLMBoxCutterRuntime| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMCatalogdAPIV1Metas| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NewOLMPreflightPermissionChecks| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |
 | NoRegistryClusterInstall| | | | <span style="background-color: #519450">Enabled</span> | | | | <span style="background-color: #519450">Enabled</span>  |

--- a/features/features.go
+++ b/features/features.go
@@ -526,6 +526,7 @@ var (
 						contactPerson("pegoncal").
 						productScope(ocpSpecific).
 						enhancementPR("https://github.com/openshift/enhancements/pull/1890").
+						enableForClusterProfile(SelfManaged, configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade).
 						mustRegister()
 
 	FeatureGateInsightsOnDemandDataGather = newFeatureGate("InsightsOnDemandDataGather").

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml
@@ -33,9 +33,6 @@
                         "name": "MultiArchInstallAzure"
                     },
                     {
-                        "name": "NewOLMBoxCutterRuntime"
-                    },
-                    {
                         "name": "ShortCertRotation"
                     }
                 ],
@@ -270,6 +267,9 @@
                     },
                     {
                         "name": "NewOLM"
+                    },
+                    {
+                        "name": "NewOLMBoxCutterRuntime"
                     },
                     {
                         "name": "NewOLMCatalogdAPIV1Metas"

--- a/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
+++ b/payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml
@@ -48,9 +48,6 @@
                         "name": "NetworkConnect"
                     },
                     {
-                        "name": "NewOLMBoxCutterRuntime"
-                    },
-                    {
                         "name": "ProvisioningRequestAvailable"
                     },
                     {
@@ -273,6 +270,9 @@
                     },
                     {
                         "name": "NewOLM"
+                    },
+                    {
+                        "name": "NewOLMBoxCutterRuntime"
                     },
                     {
                         "name": "NewOLMCatalogdAPIV1Metas"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Re-enable NewOLMBoxCutterRuntime featuregate for self-managed clusters

- Move feature from DevPreviewNoUpgrade to TechPreviewNoUpgrade profile

- Update feature gate configuration and documentation accordingly

- Fix indentation formatting in EVPN feature gate definition


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NewOLMBoxCutterRuntime<br/>Feature Gate"] -->|"Add enableForClusterProfile"| B["SelfManaged<br/>DevPreviewNoUpgrade<br/>TechPreviewNoUpgrade"]
  A -->|"Remove from<br/>DevPreviewNoUpgrade"| C["featureGate-SelfManagedHA-<br/>DevPreviewNoUpgrade.yaml"]
  A -->|"Add to<br/>TechPreviewNoUpgrade"| D["featureGate-SelfManagedHA-<br/>TechPreviewNoUpgrade.yaml"]
  A -->|"Update status"| E["features.md<br/>Documentation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>features.go</strong><dd><code>Enable NewOLMBoxCutterRuntime for self-managed profiles</code>&nbsp; &nbsp; </dd></summary>
<hr>

features/features.go

<ul><li>Added <code>enableForClusterProfile(SelfManaged, </code><br><code>configv1.DevPreviewNoUpgrade, configv1.TechPreviewNoUpgrade)</code> to <br><code>FeatureGateNewOLMBoxCutterRuntime</code> definition<br> <li> Fixed indentation formatting in <code>FeatureGateEVPN</code> definition for <br>consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2659/files#diff-a8b6135d50534471326ea7bcd20e0f5eae25353f7788338060f718128a6a0b34">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>features.md</strong><dd><code>Update feature matrix documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

features.md

<ul><li>Moved <code>NewOLMBoxCutterRuntime</code> row in feature matrix table<br> <li> Updated status to show enabled in TechPreviewNoUpgrade and SelfManaged <br>profiles<br> <li> Reflects new feature gate enablement configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2659/files#diff-445e6d0dc97b93a0f04d914ad7816114ddc175dc462c7eec7961921af17ff0d0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml</strong><dd><code>Remove feature from DevPreviewNoUpgrade manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

payload-manifests/featuregates/featureGate-SelfManagedHA-DevPreviewNoUpgrade.yaml

<ul><li>Removed <code>NewOLMBoxCutterRuntime</code> from DevPreviewNoUpgrade feature gate <br>manifest<br> <li> Feature no longer enabled in this profile</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2659/files#diff-b79740ba15bf6b159dc21b1c2f598b5ca0bacf0465778309ec7618a434ed5c66">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml</strong><dd><code>Add feature to TechPreviewNoUpgrade manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

payload-manifests/featuregates/featureGate-SelfManagedHA-TechPreviewNoUpgrade.yaml

<ul><li>Added <code>NewOLMBoxCutterRuntime</code> to TechPreviewNoUpgrade feature gate <br>manifest<br> <li> Feature now enabled in this profile alongside other OLM features</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2659/files#diff-5a10fc67e48e7114850166f3fa9804d0a66fa4a6934afbc8257620f593cea712">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

