### PR TITLE
Fix payload CRD/FetaureGate ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,15 +114,17 @@ update-scripts: update-compatibility update-openapi update-deepcopy update-proto
 # Update codegen runs all generators in the order they are defined in the root.go file.
 # The per group generators are:[compatibility, deepcopy, swagger-docs, empty-partial-schema, schema-patch, crd-manifest-merge]
 # The multi group generators are:[openapi]
+# The payload generation must come after these generators have run so they are included here as well, rather than in update-non-codegen.
 .PHONY: update-codegen
 update-codegen:
 	hack/update-codegen.sh
+	make update-payload-crds update-payload-featuregates
 
 # Update non-codegen runs all generators that are not part of the codegen utility, or
 # are part of it, but are not run by default when invoking codegen without a specific generator.
 # E.g. the payload feature gates which is not part of the generator style, but is still a subcommand.
 .PHONY: update-non-codegen
-update-non-codegen: update-protobuf tests-vendor update-prerelease-lifecycle-gen update-payload-crds update-payload-featuregates
+update-non-codegen: update-protobuf tests-vendor update-prerelease-lifecycle-gen 
 
 .PHONY: update-compatibility
 update-compatibility:


### PR DESCRIPTION
### **User description**
A recent change to refactor the makefiles moved things into codegen, and non-codegen. Unfortunately this also accidentally re-ordered some things so that their dependencies were not in the right order.

This updates the scripts to move the payload updates, since those depend on codegen to have run, into the codegen target


___

### **PR Type**
Bug fix


___

### **Description**
- Move payload CRD and FeatureGate generation into codegen target

- Ensure payload updates run after codegen generators complete

- Fix dependency ordering in Makefile targets


___

### Diagram Walkthrough


```mermaid
flowchart LR
  codegen["update-codegen target"]
  payload["Payload CRD/FeatureGate generation"]
  noncodegen["update-non-codegen target"]
  codegen -- "now includes" --> payload
  noncodegen -- "no longer includes" --> payload
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Reorder payload generation into codegen target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Moved <code>update-payload-crds</code> and <code>update-payload-featuregates</code> from <br><code>update-non-codegen</code> target to <code>update-codegen</code> target<br> <li> Added explanatory comment clarifying that payload generation must run <br>after codegen generators<br> <li> Ensures proper dependency ordering where payload updates depend on <br>codegen completion</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2667/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

