### PR TITLE
MCO-1870: Update MachineConfigNode printcolumns

### DIFF
--- a/machineconfiguration/v1/types_machineconfignode.go
+++ b/machineconfiguration/v1/types_machineconfignode.go
@@ -23,7 +23,8 @@ import (
 // +kubebuilder:printcolumn:name="UpdatePostActionComplete",type="string",JSONPath=.status.conditions[?(@.type=="UpdatePostActionComplete")].status,priority=1
 // +kubebuilder:printcolumn:name="UpdateComplete",type="string",JSONPath=.status.conditions[?(@.type=="UpdateComplete")].status,priority=1
 // +kubebuilder:printcolumn:name="Resumed",type="string",JSONPath=.status.conditions[?(@.type=="Resumed")].status,priority=1
-// +kubebuilder:printcolumn:name="UpdatedFilesAndOS",type="string",JSONPath=.status.conditions[?(@.type=="AppliedFilesAndOS")].status,priority=1
+// +kubebuilder:printcolumn:name="AppliedOSImage",type="string",JSONPath=.status.conditions[?(@.type=="AppliedOSImage")].status,priority=1
+// +kubebuilder:printcolumn:name="AppliedFiles",type="string",JSONPath=.status.conditions[?(@.type=="AppliedFiles")].status,priority=1
 // +kubebuilder:printcolumn:name="CordonedNode",type="string",JSONPath=.status.conditions[?(@.type=="Cordoned")].status,priority=1
 // +kubebuilder:printcolumn:name="DrainedNode",type="string",JSONPath=.status.conditions[?(@.type=="Drained")].status,priority=1
 // +kubebuilder:printcolumn:name="RebootedNode",type="string",JSONPath=.status.conditions[?(@.type=="RebootedNode")].status,priority=1

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-Default.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-OKD.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-OKD.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-Default.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-Default.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-OKD.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-OKD.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/machineconfiguration/v1/zz_generated.crd-manifests/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests.yaml
@@ -169,8 +169,12 @@ machineconfignodes.machineconfiguration.openshift.io:
     name: Resumed
     priority: 1
     type: string
-  - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-    name: UpdatedFilesAndOS
+  - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+    name: AppliedOSImage
+    priority: 1
+    type: string
+  - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+    name: AppliedFiles
     priority: 1
     type: string
   - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/ImageModeStatusReporting.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/ImageModeStatusReporting.yaml
@@ -55,8 +55,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/IrreconcilableMachineConfig.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/IrreconcilableMachineConfig.yaml
@@ -55,8 +55,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/MachineConfigNodes.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/MachineConfigNodes.yaml
@@ -55,8 +55,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/NoRegistryClusterInstall.yaml
+++ b/machineconfiguration/v1/zz_generated.featuregated-crd-manifests/machineconfignodes.machineconfiguration.openshift.io/NoRegistryClusterInstall.yaml
@@ -55,8 +55,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-CustomNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-Default.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-DevPreviewNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-OKD.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-Hypershift-TechPreviewNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-CustomNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-CustomNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-Default.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-Default.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-OKD.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-OKD.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status

--- a/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
+++ b/payload-manifests/crds/0000_80_machine-config_01_machineconfignodes-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml
@@ -54,8 +54,12 @@ spec:
       name: Resumed
       priority: 1
       type: string
-    - jsonPath: .status.conditions[?(@.type=="AppliedFilesAndOS")].status
-      name: UpdatedFilesAndOS
+    - jsonPath: .status.conditions[?(@.type=="AppliedOSImage")].status
+      name: AppliedOSImage
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="AppliedFiles")].status
+      name: AppliedFiles
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="Cordoned")].status


### PR DESCRIPTION
### **User description**
This updates the printcolumns for MachineConfigNodes to align with the changes made for [MCO-1870](https://issues.redhat.com//browse/MCO-1870):
- Addition of `AppliedOSImage` and `AppliedFiles` conditions
- Removal of `UpdatedFilesAndOS` condition


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `UpdatedFilesAndOS` printcolumn with `AppliedOSImage` and `AppliedFiles`

- Update condition type references from `AppliedFilesAndOS` to separate conditions

- Synchronize changes across all CRD manifest files and feature-gated variants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UpdatedFilesAndOS<br/>printcolumn"] -->|"Replace with"| B["AppliedOSImage<br/>printcolumn"]
  A -->|"Replace with"| C["AppliedFiles<br/>printcolumn"]
  D["AppliedFilesAndOS<br/>condition type"] -->|"Split into"| E["AppliedOSImage<br/>condition"]
  D -->|"Split into"| F["AppliedFiles<br/>condition"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>types_machineconfignode.go</strong><dd><code>Update kubebuilder printcolumn annotations for conditions</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-2cd3dcf78a4a4b634894a2e602c8baaee011c74bd724bbfd591ff355b50b6224">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>25 files</summary><table>
<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-CustomNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in Hypershift CustomNoUpgrade CRD manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-0a941f5baeba544ce01d8674d2d8ea60e452d08fa5748219a9f80a8cf693455b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-Default.crd.yaml</strong><dd><code>Update printcolumns in Hypershift Default CRD manifest</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-e5ca959ef7f5f6ec963cb01921a012fb5f1032a284a5e9d94f7ee3cd61ed3947">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-DevPreviewNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in Hypershift DevPreviewNoUpgrade CRD manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-8e27a9b06b6d72583dfe2bb93e327ea2a5727c8eeaf95823c68e33309eb6ffc5">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-OKD.crd.yaml</strong><dd><code>Update printcolumns in Hypershift OKD CRD manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-8b88bae0bd02be6e698894b2c72ddc41c58d5cf1b3aad0ec9a7b1abb60bcfdbd">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-TechPreviewNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in Hypershift TechPreviewNoUpgrade CRD manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-b4bb30e19982314af6555f62e8f06eb603923f5564d69910ad77f71f8d901aed">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-CustomNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in SelfManagedHA CustomNoUpgrade CRD manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-d443cf0724f18a18679a7a49d2b0c6b19c90fc5d1ce40edee10efa49fd074917">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-Default.crd.yaml</strong><dd><code>Update printcolumns in SelfManagedHA Default CRD manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-946bb5014b14570d1e1597a79cb24225d5981d4cb04ec6813a40b4b6eaa45a8f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in SelfManagedHA DevPreviewNoUpgrade CRD manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-a59dbc29b3b9462f939df7fa07e5b7b15089f4c8f4c9b7e2cfce3a92cc9688b3">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-OKD.crd.yaml</strong><dd><code>Update printcolumns in SelfManagedHA OKD CRD manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-60c5db170e652ec4ee91418b37ae0a203598a3c38f91fb4d88d6e66ac9eb08ae">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in SelfManagedHA TechPreviewNoUpgrade CRD manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-f6735b5cbe179fbd28e9f005ce807958abe2762acee7e46f0eed758da8174c34">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zz_generated.featuregated-crd-manifests.yaml</strong><dd><code>Update printcolumns in featuregated CRD manifests aggregation</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-4bbfc9944dbba47f2d2344db866141c40eeb3bf6bda78c22c39d00e9991b2dd9">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ImageModeStatusReporting.yaml</strong><dd><code>Update printcolumns in ImageModeStatusReporting feature gate</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-3a27cedc17ed547907c0b409dffeadd0a4bbd8ed28734792fd910df3ebca4495">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IrreconcilableMachineConfig.yaml</strong><dd><code>Update printcolumns in IrreconcilableMachineConfig feature gate</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-83a02458605424510611cdd67965308e2f7d3a52bd20d567a766e0890aec0523">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MachineConfigNodes.yaml</strong><dd><code>Update printcolumns in MachineConfigNodes feature gate</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-22c46e6d5b3aa60db12aaf75cc650e791116efd1e5540567091b8ddc3e882508">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NoRegistryClusterInstall.yaml</strong><dd><code>Update printcolumns in NoRegistryClusterInstall feature gate</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-a5e753d3396a0c50a544a242fbb36c7ff81353b8bf8bfba485cb510adab3ef74">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-CustomNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in payload Hypershift CustomNoUpgrade manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-0e2a1ad2a32214823fbec667e991fd269ad46d4ae53a28745d29d99a92505e16">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-Default.crd.yaml</strong><dd><code>Update printcolumns in payload Hypershift Default manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-8d2ce840ce807f201232c316ad6def44d346531d181587c625298b952e308114">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-DevPreviewNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in payload Hypershift DevPreviewNoUpgrade manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-4bd9ccb57de68cbdeb4128bb1d653d93bb61de38ebc80571a5cdd1c4a284a26e">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-OKD.crd.yaml</strong><dd><code>Update printcolumns in payload Hypershift OKD manifest</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-2383b6ffee2e49e1c9b6284bf34d3e45b464700ed68bd6973391170e05d57299">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-Hypershift-TechPreviewNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in payload Hypershift TechPreviewNoUpgrade </code><br><code>manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-989b23f8fee37d9190952583c86b30c64951ebb4522b9896657e25e7b5dbb94c">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-CustomNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in payload SelfManagedHA CustomNoUpgrade manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-985471f323c79de336171e5499bfde429ba310c142acdab6c28fd2f3f3388296">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-Default.crd.yaml</strong><dd><code>Update printcolumns in payload SelfManagedHA Default manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-f24c416d01bead53ce3fa12c55975c49b93f7bd3023d59d979b4a415f7f10387">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-DevPreviewNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in payload SelfManagedHA DevPreviewNoUpgrade </code><br><code>manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-8251fde54a53dccc6def445815d1982534bf066e50b8e98b4e6188968d8fe0a0">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-OKD.crd.yaml</strong><dd><code>Update printcolumns in payload SelfManagedHA OKD manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-aeb5cf5c168ebcfe389a9dbbd06156eca0a50e94b53ed83889f7ed892dd8b16f">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_80_machine-config_01_machineconfignodes-SelfManagedHA-TechPreviewNoUpgrade.crd.yaml</strong><dd><code>Update printcolumns in payload SelfManagedHA TechPreviewNoUpgrade </code><br><code>manifest</code></dd></td>
  <td><a href="https://github.com/openshift/api/pull/2678/files#diff-93d4289b6856666b4d30c5242045f974223c3b7aa1e46b17fca7dd728311530b">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

