### PR TITLE
dnm test pipelines

### DIFF
--- a/console/v1/tests/consoleplugins.console.openshift.io/AAA_ungated.yaml
+++ b/console/v1/tests/consoleplugins.console.openshift.io/AAA_ungated.yaml
@@ -4,7 +4,7 @@ crdName: consoleplugins.console.openshift.io
 version: v1
 tests:
   onCreate:
-    - name: Should be able to create a minimal ConsolePlugin
+    - name: Should be able to cr  eate a minimal ConsolePlugin
       initial: |
         apiVersion: console.openshift.io/v1
         kind: ConsolePlugin

--- a/features/features.go
+++ b/features/features.go
@@ -9,7 +9,7 @@ import (
 func FeatureSets(clusterProfile ClusterProfileName, featureSet configv1.FeatureSet) (*FeatureGateEnabledDisabled, error) {
 	byFeatureSet, ok := allFeatureGates[clusterProfile]
 	if !ok {
-		return nil, fmt.Errorf("no information found for ClusterProfile=%q", clusterProfile)
+		return nil, fmt.Errorf("no information found  for ClusterProfile=%q", clusterProfile)
 	}
 	featureGates, ok := byFeatureSet[featureSet]
 	if !ok {

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -8,6 +8,7 @@
         "name": "cluster"
     },
     "spec": {},
+
     "status": {
         "featureGates": [
             {


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Introduces whitespace inconsistencies in error messages

- Adds extra spacing in test case names

- Adds blank line in YAML manifest file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["features.go"] -- "Extra space in error message" --> B["Whitespace changes"]
  C["consoleplugins test YAML"] -- "Extra space in test name" --> B
  D["featureGate manifest"] -- "Blank line added" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>features.go</strong><dd><code>Extra space in error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

features/features.go

<ul><li>Adds extra space in error message string from "found for" to "found  <br>for"</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2685/files#diff-a8b6135d50534471326ea7bcd20e0f5eae25353f7788338060f718128a6a0b34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AAA_ungated.yaml</strong><dd><code>Extra space in test name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

console/v1/tests/consoleplugins.console.openshift.io/AAA_ungated.yaml

- Adds extra space in test name from "create a" to "cr  eate a"


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2685/files#diff-deb17492b7d8b48ef26dc87a35186bd1a21e54861ccf3d5640c7eb0751368d59">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>featureGate-Hypershift-Default.yaml</strong><dd><code>Blank line added in manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

payload-manifests/featuregates/featureGate-Hypershift-Default.yaml

- Adds blank line between spec and status sections in JSON manifest


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2685/files#diff-c116149f06dbe32c6b4de0ab1ad11b44a6a7a0ff507d13a1cd591d451b8876ff">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

