### PR TITLE
dnm test pipelines 3

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
+FROM   registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.22 AS builder
 WORKDIR /go/src/github.com/openshift/api
 COPY . .
 ENV GO_PACKAGE github.com/openshift/api

--- a/console/v1/tests/consoleplugins.console.openshift.io/AAA_ungated.yaml
+++ b/console/v1/tests/consoleplugins.console.openshift.io/AAA_ungated.yaml
@@ -4,7 +4,7 @@ crdName: consoleplugins.console.openshift.io
 version: v1
 tests:
   onCreate:
-    - name: Should be able to create a minimal ConsolePlugin
+    - name: Should be able to cr  eate a minimal ConsolePlugin
       initial: |
         apiVersion: console.openshift.io/v1
         kind: ConsolePlugin

--- a/features/features.go
+++ b/features/features.go
@@ -9,7 +9,7 @@ import (
 func FeatureSets(clusterProfile ClusterProfileName, featureSet configv1.FeatureSet) (*FeatureGateEnabledDisabled, error) {
 	byFeatureSet, ok := allFeatureGates[clusterProfile]
 	if !ok {
-		return nil, fmt.Errorf("no information found for ClusterProfile=%q", clusterProfile)
+		return nil, fmt.Errorf("no information found  for ClusterProfile=%q", clusterProfile)
 	}
 	featureGates, ok := byFeatureSet[featureSet]
 	if !ok {

--- a/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
+++ b/payload-manifests/featuregates/featureGate-Hypershift-Default.yaml
@@ -8,6 +8,7 @@
         "name": "cluster"
     },
     "spec": {},
+
     "status": {
         "featureGates": [
             {


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Add extra whitespace in error message string

- Add extra whitespace in Dockerfile FROM statement

- Insert whitespace within word in test name

- Add blank line in YAML manifest file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Source Files"] -- "Add whitespace" --> B["features.go"]
  A -- "Add whitespace" --> C["Dockerfile.ocp"]
  A -- "Add whitespace" --> D["consoleplugins test YAML"]
  A -- "Add blank line" --> E["featureGate manifest"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>features.go</strong><dd><code>Add extra whitespace in error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

features/features.go

<ul><li>Add extra space in error message between "found" and "for"<br> <li> Changes error message formatting in FeatureSets function</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2687/files#diff-a8b6135d50534471326ea7bcd20e0f5eae25353f7788338060f718128a6a0b34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.ocp</strong><dd><code>Add extra whitespace in FROM statement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile.ocp

<ul><li>Add extra spaces after FROM keyword in base image declaration<br> <li> Affects builder image reference line</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2687/files#diff-d720986ad1d8ccfce6ee4cda67e3ca523d8f4eaf7b9ac301d9e7533c51297c84">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AAA_ungated.yaml</strong><dd><code>Insert whitespace within test name word</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

console/v1/tests/consoleplugins.console.openshift.io/AAA_ungated.yaml

<ul><li>Insert whitespace within test name, breaking "create" into "cr  eate"<br> <li> Affects test description for ConsolePlugin creation</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2687/files#diff-deb17492b7d8b48ef26dc87a35186bd1a21e54861ccf3d5640c7eb0751368d59">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>featureGate-Hypershift-Default.yaml</strong><dd><code>Add blank line in manifest structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

payload-manifests/featuregates/featureGate-Hypershift-Default.yaml

<ul><li>Add blank line between spec and status sections<br> <li> Affects JSON manifest structure formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2687/files#diff-c116149f06dbe32c6b4de0ab1ad11b44a6a7a0ff507d13a1cd591d451b8876ff">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

