### PR TITLE
CodeRabbit should not be looking at openapi generated content

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,6 +14,7 @@ reviews:
   - "!payload-manifests"
   - "!**/zz_generated.crd-manifests/*" # Contains files
   - "!**/zz_generated.featuregated-crd-manifests/**" # Contains folders
+  - "!openapi/**"
   - "!**/vendor/**"
   - "!vendor/**"
   tools:


### PR DESCRIPTION
### **User description**
Coderabbit keeps commenting on openapi files with unactionable comments because it doesn't understand the capabilities or restrictions of the openapi generator today


___

### **PR Type**
Enhancement


___

### **Description**
- Exclude OpenAPI generated files from CodeRabbit reviews

- Prevents unactionable comments on auto-generated content

- Adds path filter to ignore openapi directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CodeRabbit Config"] -- "Add path filter" --> B["Ignore openapi/**"]
  B -- "Result" --> C["Skip OpenAPI files in reviews"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.coderabbit.yaml</strong><dd><code>Add OpenAPI directory to CodeRabbit exclusion filters</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.coderabbit.yaml

<ul><li>Added path filter <code>!openapi/**</code> to exclude OpenAPI generated files<br> <li> Prevents CodeRabbit from reviewing auto-generated OpenAPI content<br> <li> Aligns with existing filters for generated manifests and vendor <br>directories</ul>


</details>


  </td>
  <td><a href="https://github.com/openshift/api/pull/2688/files#diff-c0f93b6ec1bb8a9771fe87219aa22843985ba0cd27a23689b7be274bfb7baf57">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

