### PR TITLE
OCPBUGS-32275: Add ingress.spec.domain immutability validation

### DIFF
--- a/config/v1/tests/ingresses.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/tests/ingresses.config.openshift.io/AAA_ungated.yaml
@@ -12,3 +12,45 @@ tests:
         apiVersion: config.openshift.io/v1
         kind: Ingress
         spec: {}
+    - name: Should be able to create an Ingress with domain set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Ingress
+        spec:
+          domain: apps.example.com
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Ingress
+        spec:
+          domain: apps.example.com
+  onUpdate:
+    - name: Should not be able to change domain once set
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Ingress
+        spec:
+          domain: apps.example.com
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Ingress
+        spec:
+          domain: test.example.com
+      expectedError: "domain is immutable once set"
+    - name: Should be able to update other fields without changing domain
+      initial: |
+        apiVersion: config.openshift.io/v1
+        kind: Ingress
+        spec:
+          domain: apps.example.com
+      updated: |
+        apiVersion: config.openshift.io/v1
+        kind: Ingress
+        spec:
+          domain: apps.example.com
+          appsDomain: custom.example.com
+      expected: |
+        apiVersion: config.openshift.io/v1
+        kind: Ingress
+        spec:
+          domain: apps.example.com
+          appsDomain: custom.example.com

--- a/config/v1/types_ingress.go
+++ b/config/v1/types_ingress.go
@@ -43,6 +43,7 @@ type IngressSpec struct {
 	// default ingresscontroller domain will follow this pattern: "*.<domain>".
 	//
 	// Once set, changing domain is not currently supported.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="domain is immutable once set"
 	Domain string `json:"domain"`
 
 	// appsDomain is an optional domain to use instead of the one specified

--- a/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses.crd.yaml
+++ b/config/v1/zz_generated.crd-manifests/0000_10_config-operator_01_ingresses.crd.yaml
@@ -129,6 +129,9 @@ spec:
 
                   Once set, changing domain is not currently supported.
                 type: string
+                x-kubernetes-validations:
+                - message: domain is immutable once set
+                  rule: self == oldSelf
               loadBalancer:
                 description: |-
                   loadBalancer contains the load balancer details in general which are not only specific to the underlying infrastructure

--- a/config/v1/zz_generated.featuregated-crd-manifests/ingresses.config.openshift.io/AAA_ungated.yaml
+++ b/config/v1/zz_generated.featuregated-crd-manifests/ingresses.config.openshift.io/AAA_ungated.yaml
@@ -130,6 +130,9 @@ spec:
 
                   Once set, changing domain is not currently supported.
                 type: string
+                x-kubernetes-validations:
+                - message: domain is immutable once set
+                  rule: self == oldSelf
               loadBalancer:
                 description: |-
                   loadBalancer contains the load balancer details in general which are not only specific to the underlying infrastructure

--- a/payload-manifests/crds/0000_10_config-operator_01_ingresses.crd.yaml
+++ b/payload-manifests/crds/0000_10_config-operator_01_ingresses.crd.yaml
@@ -129,6 +129,9 @@ spec:
 
                   Once set, changing domain is not currently supported.
                 type: string
+                x-kubernetes-validations:
+                - message: domain is immutable once set
+                  rule: self == oldSelf
               loadBalancer:
                 description: |-
                   loadBalancer contains the load balancer details in general which are not only specific to the underlying infrastructure


### PR DESCRIPTION
This PR fixes [OCPBUGS-32275](https://issues.redhat.com/browse/OCPBUGS-32275).

Adds `spec.domain` field validation in the Ingress config CRD to make it immutable and match the documentation. Prior to this commit the domain value could be changed and cause degraded state of some cluster operators.